### PR TITLE
Remove redundant optionals in GenericCustomActionBuilder

### DIFF
--- a/src/main/java/com/commercetools/sync/categories/helpers/CategoryCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategoryCustomActionBuilder.java
@@ -8,25 +8,29 @@ import io.sphere.sdk.categories.commands.updateactions.SetCustomField;
 import io.sphere.sdk.categories.commands.updateactions.SetCustomType;
 import io.sphere.sdk.commands.UpdateAction;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
 
 public class CategoryCustomActionBuilder extends GenericCustomActionBuilder<Category> {
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Category>> buildRemoveCustomTypeAction() {
-        return Optional.of(SetCustomType.ofRemoveType());
+    public UpdateAction<Category> buildRemoveCustomTypeAction() {
+        return SetCustomType.ofRemoveType();
     }
 
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Category>> buildSetCustomTypeAction(@Nullable final String customTypeKey,
+    public UpdateAction<Category> buildSetCustomTypeAction(@Nullable final String customTypeKey,
                                                                      @Nullable final Map<String, JsonNode> customFieldsJsonMap) {
-        return Optional.of(SetCustomType.ofTypeKeyAndJson(customTypeKey, customFieldsJsonMap));
+        return SetCustomType.ofTypeKeyAndJson(customTypeKey, customFieldsJsonMap);
     }
 
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Category>> buildSetCustomFieldAction(@Nullable final String customFieldName,
+    public UpdateAction<Category> buildSetCustomFieldAction(@Nullable final String customFieldName,
                                                                       @Nullable final JsonNode customFieldValue) {
-        return Optional.of(SetCustomField.ofJson(customFieldName, customFieldValue));
+        return SetCustomField.ofJson(customFieldName, customFieldValue);
     }
 }

--- a/src/main/java/com/commercetools/sync/channels/helpers/ChannelCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/channels/helpers/ChannelCustomActionBuilder.java
@@ -7,6 +7,7 @@ import io.sphere.sdk.channels.commands.updateactions.SetCustomField;
 import io.sphere.sdk.channels.commands.updateactions.SetCustomType;
 import io.sphere.sdk.commands.UpdateAction;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
@@ -14,20 +15,23 @@ import java.util.Optional;
 
 public class ChannelCustomActionBuilder extends GenericCustomActionBuilder<Channel> {
 
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Channel>> buildRemoveCustomTypeAction() {
-        return Optional.of(SetCustomType.ofRemoveType());
+    public UpdateAction<Channel> buildRemoveCustomTypeAction() {
+        return SetCustomType.ofRemoveType();
     }
 
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Channel>> buildSetCustomTypeAction(@Nullable final String customTypeKey,
+    public UpdateAction<Channel> buildSetCustomTypeAction(@Nullable final String customTypeKey,
                                                                     @Nullable final Map<String, JsonNode> customFieldsJsonMap) {
-        return Optional.of(SetCustomType.ofTypeKeyAndJson(customTypeKey, customFieldsJsonMap));
+        return SetCustomType.ofTypeKeyAndJson(customTypeKey, customFieldsJsonMap);
     }
 
+    @Nonnull
     @Override
-    public Optional<UpdateAction<Channel>> buildSetCustomFieldAction(@Nullable final String customFieldName,
+    public UpdateAction<Channel> buildSetCustomFieldAction(@Nullable final String customFieldName,
                                                                      @Nullable final JsonNode customFieldValue) {
-        return Optional.of(SetCustomField.ofJson(customFieldName, customFieldValue));
+        return SetCustomField.ofJson(customFieldName, customFieldValue);
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/helpers/GenericCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/GenericCustomActionBuilder.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.Resource;
 import io.sphere.sdk.types.Custom;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
@@ -26,7 +27,8 @@ public abstract class GenericCustomActionBuilder<T extends Custom & Resource<T>>
      *
      * @return a setCustomType update action that removes the custom type from the resource it's requested on.
      */
-    public abstract Optional<UpdateAction<T>> buildRemoveCustomTypeAction();
+    @Nonnull
+    public abstract UpdateAction<T> buildRemoveCustomTypeAction();
 
     /**
      * Creates a CTP "setCustomType" update action on the given resource {@link T} (which currently could either
@@ -36,7 +38,8 @@ public abstract class GenericCustomActionBuilder<T extends Custom & Resource<T>>
      * @param customFieldsJsonMap the custom fields map of JSON values.
      * @return a setCustomType update action of the type of the resource it's requested on.
      */
-    public abstract Optional<UpdateAction<T>> buildSetCustomTypeAction(@Nullable final String customTypeKey,
+    @Nonnull
+    public abstract UpdateAction<T> buildSetCustomTypeAction(@Nullable final String customTypeKey,
                                                                        @Nullable final Map<String, JsonNode> customFieldsJsonMap);
 
     /**
@@ -49,6 +52,7 @@ public abstract class GenericCustomActionBuilder<T extends Custom & Resource<T>>
      * @return a setCustomField update action on the provided field name, with the provided value
      * on the resource it's requested on.
      */
-    public abstract Optional<UpdateAction<T>> buildSetCustomFieldAction(@Nullable final String customFieldName,
+    @Nonnull
+    public abstract UpdateAction<T> buildSetCustomFieldAction(@Nullable final String customFieldName,
                                                                         @Nullable final JsonNode customFieldValue);
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/GenericUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/GenericUpdateActionUtils.java
@@ -40,9 +40,9 @@ final class GenericUpdateActionUtils {
             @Nonnull final T resource,
             @Nonnull final BaseSyncOptions syncOptions) {
         try {
-            return GenericCustomActionBuilderFactory
+            return Optional.of(GenericCustomActionBuilderFactory
                     .of(resource)
-                    .buildSetCustomTypeAction(customTypeKey, customFieldsJsonMap);
+                    .buildSetCustomTypeAction(customTypeKey, customFieldsJsonMap));
         } catch (BuildUpdateActionException | IllegalAccessException | InstantiationException e) {
             syncOptions.applyErrorCallback(format(SET_CUSTOM_TYPE_BUILD_FAILED.getDescription()
                     , resource.toReference().getTypeId(), resource.getId(), e.getMessage()), e);
@@ -63,9 +63,9 @@ final class GenericUpdateActionUtils {
     static <T extends Custom & Resource<T>> Optional<UpdateAction<T>> buildTypedRemoveCustomTypeUpdateAction(
             @Nonnull final T resource, @Nonnull final BaseSyncOptions syncOptions) {
         try {
-            return GenericCustomActionBuilderFactory
+            return Optional.of(GenericCustomActionBuilderFactory
                     .of(resource)
-                    .buildRemoveCustomTypeAction();
+                    .buildRemoveCustomTypeAction());
         } catch (BuildUpdateActionException | IllegalAccessException | InstantiationException e) {
             syncOptions.applyErrorCallback(format(REMOVE_CUSTOM_TYPE_BUILD_FAILED.getDescription(),
                     resource.toReference().getTypeId(), resource.getId(), e.getMessage()), e);
@@ -93,9 +93,9 @@ final class GenericUpdateActionUtils {
             @Nonnull final T resource,
             @Nonnull final BaseSyncOptions syncOptions) {
         try {
-            return GenericCustomActionBuilderFactory
+            return Optional.of(GenericCustomActionBuilderFactory
                     .of(resource)
-                    .buildSetCustomFieldAction(customFieldName, customFieldValue);
+                    .buildSetCustomFieldAction(customFieldName, customFieldValue));
         } catch (BuildUpdateActionException | IllegalAccessException | InstantiationException e) {
             syncOptions.applyErrorCallback(format(SET_CUSTOM_FIELD_BUILD_FAILED.getDescription(), customFieldName,
                     resource.toReference().getTypeId(), resource.getId(), e.getMessage()), e);


### PR DESCRIPTION
This PR:
1. Removes redundant optionals in GenericCustomActionBuilder
2. Annotates the class methods with `Nonnull` annotations.
3. Wraps the results of these methods in Optionals in `GenericUpdateActionUtils`