### PR TITLE
30, 31 Add repeaters

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/CtpQueryUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/CtpQueryUtilsIT.java
@@ -2,6 +2,7 @@ package com.commercetools.sync.integration.commons;
 
 
 import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.queries.CategoryQuery;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -72,8 +73,10 @@ public class CtpQueryUtilsIT {
     @Test
     public void queryAll_WithKeyCollectorConsumerOn600Categories_ShouldCollectKeys() {
         final int numberOfCategories = 600;
-        createCategories(CTP_TARGET_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
-            null, numberOfCategories));
+        final List<CategoryDraft> categoryDrafts = getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
+            null, numberOfCategories);
+        createCategories(CTP_TARGET_CLIENT, categoryDrafts);
+
         final List<String> categoryKeys = new ArrayList<>();
 
         final Consumer<List<Category>> categoryPageConsumer = categoryPageResults ->

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -63,11 +63,11 @@ public class CategoryITUtils {
                                                         final int numberOfCategories) {
         List<CategoryDraft> categoryDrafts = new ArrayList<>();
         for (int i = 0; i < numberOfCategories; i++) {
-            final LocalizedString name = LocalizedString.of(Locale.ENGLISH, format("draft%s", i));
-            final LocalizedString slug = LocalizedString.of(Locale.ENGLISH, format("slug%s", i));
-            final LocalizedString description = LocalizedString.of(Locale.ENGLISH, format("desc%s", i));
+            final LocalizedString name = LocalizedString.of(Locale.ENGLISH, format("draft%s", i + 1));
+            final LocalizedString slug = LocalizedString.of(Locale.ENGLISH, format("slug%s", i + 1));
+            final LocalizedString description = LocalizedString.of(Locale.ENGLISH, format("desc%s", i + 1));
             final String key = format("key%s", i + 1);
-            final String orderHint = format("0.%s", i);
+            final String orderHint = format("0.%s", i + 1);
             final CategoryDraft categoryDraft = CategoryDraftBuilder.of(name, slug)
                                                                     .parent(parentCategory)
                                                                     .description(description)
@@ -94,8 +94,9 @@ public class CategoryITUtils {
                                                                   @Nonnull final String prefix,
                                                                   @Nullable final Category parentCategory,
                                                                   final int numberOfCategories) {
-        List<CategoryDraft> categoryDrafts = new ArrayList<>();
-        for (CategoryDraft categoryDraft : getCategoryDrafts(parentCategory, numberOfCategories)) {
+        final List<CategoryDraft> categoryDraftsWithPrefix = new ArrayList<>();
+        final List<CategoryDraft> categoryDrafts = getCategoryDrafts(parentCategory, numberOfCategories);
+        for (CategoryDraft categoryDraft : categoryDrafts) {
             final LocalizedString newCategoryName = LocalizedString.of(locale,
                 format("%s%s", prefix, categoryDraft.getName().get(locale)));
             final LocalizedString newCategorySlug = LocalizedString.of(locale,
@@ -106,9 +107,9 @@ public class CategoryITUtils {
                                                                                   .name(newCategoryName)
                                                                                   .slug(newCategorySlug)
                                                                                   .description(newCategoryDescription);
-            categoryDrafts.add(categoryDraftBuilder.build());
+            categoryDraftsWithPrefix.add(categoryDraftBuilder.build());
         }
-        return categoryDrafts;
+        return categoryDraftsWithPrefix;
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/services/CategoryServiceIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/CategoryServiceIT.java
@@ -211,7 +211,7 @@ public class CategoryServiceIT {
 
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackMessages).hasSize(1);
-        assertThat(errorCallBackMessages.get(0)).contains("Invalid category key '1'. Category keys may only contain "
+        assertThat(errorCallBackMessages.get(0)).contains("Invalid key '1'. Keys may only contain "
             + "alphanumeric characters, underscores and hyphens and must have a maximum length of 256 characters.");
         assertThat(createdCategories).hasSize(1);
     }
@@ -243,7 +243,7 @@ public class CategoryServiceIT {
         assertThat(errorCallBackMessages).hasSize(2);
         // Since the order of creation is not ensured by allOf, so we assert in list of error messages (as string):
         LOGGER.debug(errorCallBackMessages.toString());
-        assertThat(errorCallBackMessages.toString()).contains("Invalid category key '1'. Category keys may only contain"
+        assertThat(errorCallBackMessages.toString()).contains("Invalid key '1'. Keys may only contain"
             + " alphanumeric characters, underscores and hyphens and must have a maximum length of 256 characters.");
         assertThat(errorCallBackMessages.toString()).contains(" A duplicate value '\"furniture\"' exists for field "
             + "'slug.en'");
@@ -332,7 +332,7 @@ public class CategoryServiceIT {
         assertThat(createdCategoryOptional).isEmpty();
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackMessages).hasSize(1);
-        assertThat(errorCallBackMessages.get(0)).contains("Invalid category key '1'. Category keys may only contain "
+        assertThat(errorCallBackMessages.get(0)).contains("Invalid key '1'. Keys may only contain "
             + "alphanumeric characters, underscores and hyphens and must have a maximum length of 256 characters.");
 
         //assert CTP state

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -40,6 +40,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     private static final String CATEGORY_DRAFT_IS_NULL = "CategoryDraft is null.";
     private static final String FAILED_TO_RESOLVE_REFERENCES = "Failed to resolve references on "
         + "CategoryDraft with key:'%s'. Reason: %s";
+    private static final String UPDATE_FAILED = "Failed to update Category with key: '%s'. Reason: %s";
 
     private final CategoryService categoryService;
     private final CategoryReferenceResolver referenceResolver;

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -17,6 +17,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -529,10 +530,10 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      */
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
     private CompletionStage<Void> buildUpdateActionsAndUpdate(@Nonnull final Category oldCategory,
-                                                              @Nonnull final CategoryDraft newCategory) {
+                                                                  @Nonnull final CategoryDraft newCategory) {
         final List<UpdateAction<Category>> updateActions = buildActions(oldCategory, newCategory, syncOptions);
         if (!updateActions.isEmpty()) {
-            return updateCategory(oldCategory, updateActions);
+            return updateCategory(oldCategory, newCategory, updateActions);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -541,7 +542,9 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     /**
      * Given a {@link Category} and a {@link List} of {@link UpdateAction} elements, this method issues a request to
      * the CTP project defined by the client configuration stored in the {@code syncOptions} instance
-     * of this class to update the specified category with this list of update actions.
+     * of this class to update the specified category with this list of update actions. If the update request failed
+     * due to a {@link ConcurrentModificationException}, the method recalculates the update actions required for
+     * syncing the {@link Category} amd reissues the update req
      *
      * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was carried
      * out successfully or not. If an exception was thrown on executing the request to CTP,
@@ -552,11 +555,16 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * @return a future which contains an empty result after execution of the update.
      */
     private CompletionStage<Void> updateCategory(@Nonnull final Category category,
+                                                 @Nonnull final CategoryDraft newCategory,
                                                  @Nonnull final List<UpdateAction<Category>> updateActions) {
         final String categoryKey = category.getKey();
         return categoryService.updateCategory(category, updateActions)
-                              .thenAccept(updatedCategory -> {
-                                  if (updatedCategory.isPresent()) {
+                              .handle((updatedCategory, sphereException) -> sphereException)
+                              .thenCompose(sphereException -> {
+                                  if (sphereException != null) {
+                                      return retryIfConcurrentModificationException(sphereException, category,
+                                          newCategory);
+                                  } else {
                                       if (!processedCategoryKeys.contains(categoryKey)) {
                                           statistics.incrementUpdated();
                                           processedCategoryKeys.add(categoryKey);
@@ -564,15 +572,38 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
                                       if (categoryKeysWithResolvedParents.contains(categoryKey)) {
                                           removeUpdatedCategoryFromMissingParentsMap(categoryKey);
                                       }
-                                  } else {
-                                      // TODO: GH ISSUE #30, #31: check if updated category is empty, it means an error
-                                      // TODO: occurred during update.
-                                      if (!processedCategoryKeys.contains(categoryKey)) {
-                                          statistics.incrementFailed();
-                                          processedCategoryKeys.add(categoryKey);
-                                      }
+                                      return CompletableFuture.completedFuture(null);
                                   }
                               });
+    }
+
+    /**
+     * Given a {@link Throwable sphereException}, an old {@link Category} and a new {@link CategoryDraft} that
+     * an update Request was issued to sync both, this method checks if the exception is an instance of
+     * {@link ConcurrentModificationException}. If it is, then recalls the method
+     * {@link CategorySync#buildUpdateActionsAndUpdate(Category, CategoryDraft)} to rebuild update actions and  re
+     * issue the CTP update request. Otherwise, if it is not an instance of a {@link ConcurrentModificationException}
+     * then it is counted as a failed category to sync.
+     *
+     * @param sphereException the sphere exception thrown after issuing an update request.
+     * @param category the category to update.
+     * @param newCategory the new category draft to sync data from.
+     * @return a future which contains an empty result after execution of the update.
+     */
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
+    private CompletionStage<Void> retryIfConcurrentModificationException(
+        @Nonnull final Throwable sphereException, @Nonnull final Category category,
+        @Nonnull final CategoryDraft newCategory) {
+        if (sphereException instanceof ConcurrentModificationException) {
+            return buildUpdateActionsAndUpdate(category, newCategory);
+        } else {
+            final String categoryKey = category.getKey();
+            if (!processedCategoryKeys.contains(categoryKey)) {
+                handleError(format(UPDATE_FAILED, categoryKey, sphereException), sphereException);
+                processedCategoryKeys.add(categoryKey);
+            }
+            return CompletableFuture.completedFuture(null);
+        }
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -544,7 +544,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * the CTP project defined by the client configuration stored in the {@code syncOptions} instance
      * of this class to update the specified category with this list of update actions. If the update request failed
      * due to a {@link ConcurrentModificationException}, the method recalculates the update actions required for
-     * syncing the {@link Category} amd reissues the update req
+     * syncing the {@link Category} and reissues the update request.
      *
      * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was carried
      * out successfully or not. If an exception was thrown on executing the request to CTP,
@@ -578,11 +578,10 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     }
 
     /**
-     * Given a {@link Throwable sphereException}, an old {@link Category} and a new {@link CategoryDraft} that
-     * an update Request was issued to sync both, this method checks if the exception is an instance of
-     * {@link ConcurrentModificationException}. If it is, then recalls the method
-     * {@link CategorySync#buildUpdateActionsAndUpdate(Category, CategoryDraft)} to rebuild update actions and  re
-     * issue the CTP update request. Otherwise, if it is not an instance of a {@link ConcurrentModificationException}
+     * This method checks if the {@code sphereException} (thrown when trying to sync the old {@link Category} and the
+     * new {@link CategoryDraft}) is an instance of {@link ConcurrentModificationException}. If it is, then calls the
+     * method {@link CategorySync#buildUpdateActionsAndUpdate(Category, CategoryDraft)} to rebuild update actions and
+     * reissue the CTP update request. Otherwise, if it is not an instance of a {@link ConcurrentModificationException}
      * then it is counted as a failed category to sync.
      *
      * @param sphereException the sphere exception thrown after issuing an update request.

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -630,7 +630,4 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         syncOptions.applyErrorCallback(errorMessage, exception);
         statistics.incrementFailed();
     }
-
-
-
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
@@ -2,19 +2,30 @@ package com.commercetools.sync.commons.utils;
 
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.client.QueueSphereClientDecorator;
+import io.sphere.sdk.client.RetrySphereClientDecorator;
 import io.sphere.sdk.client.SphereAccessTokenSupplier;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereClientConfig;
 import io.sphere.sdk.http.AsyncHttpClientAdapter;
 import io.sphere.sdk.http.HttpClient;
+import io.sphere.sdk.retry.RetryAction;
+import io.sphere.sdk.retry.RetryPredicate;
+import io.sphere.sdk.retry.RetryRule;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static io.sphere.sdk.http.HttpStatusCode.BAD_GATEWAY_502;
+import static io.sphere.sdk.http.HttpStatusCode.GATEWAY_TIMEOUT_504;
+import static io.sphere.sdk.http.HttpStatusCode.SERVICE_UNAVAILABLE_503;
 
 public class ClientConfigurationUtils {
     private static HttpClient httpClient;
@@ -36,7 +47,8 @@ public class ClientConfigurationUtils {
                 SphereAccessTokenSupplier.ofAutoRefresh(clientConfig, httpClient, false);
             final SphereClient underlying = SphereClient.of(clientConfig, httpClient, tokenSupplier);
             final SphereClient limitedParallelRequestsClient = withLimitedParallelRequests(underlying);
-            delegatesCache.put(clientConfig, limitedParallelRequestsClient);
+            final SphereClient retryClient = withRetry(limitedParallelRequestsClient);
+            delegatesCache.put(clientConfig, retryClient);
         }
         return BlockingSphereClient.of(delegatesCache.get(clientConfig), timeout, timeUnit);
     }
@@ -66,6 +78,16 @@ public class ClientConfigurationUtils {
             httpClient = AsyncHttpClientAdapter.of(asyncHttpClient);
         }
         return httpClient;
+    }
+
+    private static SphereClient withRetry(final SphereClient delegate) {
+        final int maxAttempts = 5;
+        final RetryAction scheduledRetry = RetryAction
+            .ofScheduledRetry(maxAttempts, context -> Duration.ofSeconds(context.getAttempt() * 2));
+        final RetryPredicate http5xxMatcher = RetryPredicate
+            .ofMatchingStatusCodes(BAD_GATEWAY_502, SERVICE_UNAVAILABLE_503, GATEWAY_TIMEOUT_504);
+        final List<RetryRule> retryRules = Collections.singletonList(RetryRule.of(http5xxMatcher, scheduledRetry));
+        return RetrySphereClientDecorator.of(delegate, retryRules);
     }
 
     private static SphereClient withLimitedParallelRequests(final SphereClient delegate) {

--- a/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
@@ -98,7 +98,7 @@ public class ClientConfigurationUtils {
      * @return a computed variable delay in seconds, that grows with the number of attempts with a random component.
      */
     private static Duration calculateVariableDelay(final long triedAttempts) {
-        long timeoutInSeconds = TimeUnit.SECONDS.convert(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+        final long timeoutInSeconds = TimeUnit.SECONDS.convert(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
         final long randomNumberInRange = getRandomNumberInRange(50, timeoutInSeconds);
         final long timeoutMultipliedByTriedAttempts = timeoutInSeconds * triedAttempts;
         return Duration.ofSeconds(timeoutMultipliedByTriedAttempts + randomNumberInRange);

--- a/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
@@ -47,9 +47,9 @@ public class ClientConfigurationUtils {
             final SphereAccessTokenSupplier tokenSupplier =
                 SphereAccessTokenSupplier.ofAutoRefresh(clientConfig, httpClient, false);
             final SphereClient underlying = SphereClient.of(clientConfig, httpClient, tokenSupplier);
-            final SphereClient limitedParallelRequestsClient = withLimitedParallelRequests(underlying);
-            final SphereClient retryClient = withRetry(limitedParallelRequestsClient);
-            delegatesCache.put(clientConfig, retryClient);
+            final SphereClient retryClient = withRetry(underlying);
+            final SphereClient limitedParallelRequestsClient = withLimitedParallelRequests(retryClient);
+            delegatesCache.put(clientConfig, limitedParallelRequestsClient);
         }
         return BlockingSphereClient.of(delegatesCache.get(clientConfig), timeout, timeUnit);
     }

--- a/src/main/java/com/commercetools/sync/commons/utils/CtpQueryUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CtpQueryUtils.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 
 import static io.sphere.sdk.queries.QueryExecutionUtils.DEFAULT_PAGE_SIZE;
 
-public class CtpQueryUtils {
+public final class CtpQueryUtils {
 
     private CtpQueryUtils() {
     }

--- a/src/main/java/com/commercetools/sync/services/CategoryService.java
+++ b/src/main/java/com/commercetools/sync/services/CategoryService.java
@@ -88,6 +88,6 @@ public interface CategoryService {
      *      {@link Category} which was updated in the CTP project or a {@link io.sphere.sdk.models.SphereException}.
      */
     @Nonnull
-    CompletionStage<Optional<Category>> updateCategory(@Nonnull final Category category,
+    CompletionStage<Category> updateCategory(@Nonnull final Category category,
                                                        @Nonnull final List<UpdateAction<Category>> updateActions);
 }

--- a/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
@@ -32,7 +32,6 @@ public final class CategoryServiceImpl implements CategoryService {
     private final Map<String, String> keyToIdCache = new ConcurrentHashMap<>();
     private static final String CREATE_FAILED = "Failed to create CategoryDraft with key: '%s'. Reason: %s";
     private static final String FETCH_FAILED = "Failed to fetch CategoryDrafts with keys: '%s'. Reason: %s";
-    private static final String UPDATE_FAILED = "Failed to update Category with key: '%s'. Reason: %s";
 
     public CategoryServiceImpl(@Nonnull final CategorySyncOptions syncOptions) {
         this.syncOptions = syncOptions;
@@ -124,20 +123,10 @@ public final class CategoryServiceImpl implements CategoryService {
 
     @Nonnull
     @Override
-    public CompletionStage<Optional<Category>> updateCategory(@Nonnull final Category category,
+    public CompletionStage<Category> updateCategory(@Nonnull final Category category,
                                                               @Nonnull final List<UpdateAction<Category>>
                                                                   updateActions) {
         final CategoryUpdateCommand categoryUpdateCommand = CategoryUpdateCommand.of(category, updateActions);
-        return syncOptions.getCtpClient().execute(categoryUpdateCommand)
-                          .handle((updatedCategory, sphereException) -> {
-                              if (sphereException != null) {
-                                  syncOptions
-                                      .applyErrorCallback(format(UPDATE_FAILED, category.getKey(), sphereException),
-                                          sphereException);
-                                  return Optional.empty();
-                              } else {
-                                  return Optional.of(updatedCategory);
-                              }
-                          });
+        return syncOptions.getCtpClient().execute(categoryUpdateCommand);
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/MockUtils.java
+++ b/src/test/java/com/commercetools/sync/commons/MockUtils.java
@@ -93,7 +93,7 @@ public class MockUtils {
 
         final CategoryService categoryService = mock(CategoryService.class);
         when(categoryService.updateCategory(any(), any()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.of(category)));
+            .thenReturn(CompletableFuture.completedFuture(category));
         when(categoryService.createCategory(any()))
             .thenReturn(CompletableFuture.completedFuture(Optional.of(category)));
         when(categoryService.fetchCachedCategoryId(anyString()))


### PR DESCRIPTION
This PR addresses:

- #30: Retry manually on concurrent modification exception, recalculate update actions and retry. 
c6c60b9
- #31 Retry with Exponential backoff strategy on 5xx errors using RetrySphereClientDecorator in the integration tests. ba08c6a, 6a81ef3
- Some refactoring:
f222461, 0423300, 249758d, d34d912, 01a2c0c.

TODO:
1. Test concurrent modification exception case.
2. Test change in category service for updates.

Caveat: Decorating the client with the `RetrySphereClientDecorator` before decorating it with `QueueSphereClientDecorator` causes unexpected behaviour with the CompletebleFutures execution. I asked JVM SDK guys about an explanation for it.



