### PR TITLE
98 add remove variant

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
@@ -1,0 +1,57 @@
+package com.commercetools.sync.commons.utils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
+
+public final class CollectionUtils {
+
+    /**
+     * Create a new collection which contains only elements which satisfy {@code includeCondition} predicate.
+     *
+     * @param collection       {@link Collection} to be filtered
+     * @param includeCondition condition which verifies whether the value should be included to the final result.
+     * @param <T>              type of the collection items.
+     * @return new filtered stream with items which satisfy {@code includeCondition} predicate. If {@code collection}
+     * is <b>null</b> or empty - empty stream is returned.
+     */
+    @Nonnull
+    public static <T> Stream<T> filterCollection(@Nullable final Collection<T> collection,
+                                                 @Nonnull Predicate<T> includeCondition) {
+
+        return collection == null ? Stream.empty()
+                : collection.stream()
+                .filter(includeCondition);
+    }
+
+    /**
+     * Convert a {@code collection} to a set of values using {@code entityToKey} mapping.
+     * <p>
+     * If the collection has duplicate keys - only one will be stored, which one is not defined though.
+     *
+     * @param collection {@link Collection} to convert
+     * @param entityToKey function which converts the collection entry to a key.
+     * @param <T> type of collection entries
+     * @param <K> type of Set key
+     * @return new {@link Set} which consists of items, converted from &lt;T&gt; entries to keys using
+     * {@code entryToKey} function.
+     */
+    @Nonnull
+    public static <T, K> Set<K> collectionToSet(@Nullable Collection<T> collection,
+                                                @Nonnull Function<T, K> entityToKey) {
+        return collection == null ? Collections.emptySet()
+                : collection.stream()
+                .map(entityToKey)
+                .collect(toSet());
+    }
+
+    private CollectionUtils() {
+    }
+}

--- a/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
@@ -20,11 +20,11 @@ public final class CollectionUtils {
      * @param includeCondition condition which verifies whether the value should be included to the final result.
      * @param <T>              type of the collection items.
      * @return new filtered stream with items which satisfy {@code includeCondition} predicate. If {@code collection}
-     * is <b>null</b> or empty - empty stream is returned.
+     *     is <b>null</b> or empty - empty stream is returned.
      */
     @Nonnull
     public static <T> Stream<T> filterCollection(@Nullable final Collection<T> collection,
-                                                 @Nonnull Predicate<T> includeCondition) {
+                                                 @Nonnull final Predicate<T> includeCondition) {
 
         return collection == null ? Stream.empty()
                 : collection.stream()
@@ -33,8 +33,8 @@ public final class CollectionUtils {
 
     /**
      * Convert a {@code collection} to a set of values using {@code entityToKey} mapping.
-     * <p>
-     * If the collection has duplicate keys - only one will be stored, which one is not defined though.
+     *
+     * <p>If the collection has duplicate keys - only one will be stored, which one is not defined though.
      *
      * @param collection {@link Collection} to convert
      * @param entityToKey function which converts the collection entry to a key.
@@ -44,8 +44,8 @@ public final class CollectionUtils {
      * {@code entryToKey} function.
      */
     @Nonnull
-    public static <T, K> Set<K> collectionToSet(@Nullable Collection<T> collection,
-                                                @Nonnull Function<T, K> entityToKey) {
+    public static <T, K> Set<K> collectionToSet(@Nullable final Collection<T> collection,
+                                                @Nonnull final Function<T, K> entityToKey) {
         return collection == null ? Collections.emptySet()
                 : collection.stream()
                 .map(entityToKey)

--- a/src/main/java/com/commercetools/sync/commons/utils/CommonTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CommonTypeUpdateActionUtils.java
@@ -19,27 +19,46 @@ public final class CommonTypeUpdateActionUtils {
      * {@link Optional}. If both the {@link Object}s have the same values, then no update action is needed and hence an
      * empty {@link Optional} is returned.
      *
-     * @param oldObject            the object which should be updated.
-     * @param newObject            the object with the new information.
-     * @param updateActionSupplier the supplier that returns the update action to return in the optional.
+     * @param oldObject            the object which should be updated
+     * @param newObject            the object with the new information
+     * @param updateActionSupplier the supplier that returns the update action to return in the optional
      * @param <T>                  the type of the {@link UpdateAction}
-     * @param <S>                  the type of the objects to compare.
-     * @return A filled optional with the update action or an empty optional if the object values are identical.
+     * @param <S>                  the type of the objects to compare
+     * @param <U>                  certain {@link UpdateAction} implementation type
+     * @return A filled optional with the update action or an empty optional if the object values are identical
      */
     @Nonnull
-    public static <T, S> Optional<UpdateAction<T>> buildUpdateAction(@Nullable final S oldObject,
-                                                                  @Nullable final S newObject,
-                                                                  @Nonnull final Supplier<UpdateAction<T>>
-                                                                    updateActionSupplier) {
+    public static <T, S, U extends UpdateAction<T>> Optional<U> buildUpdateAction(
+            @Nullable final S oldObject,
+            @Nullable final S newObject,
+            @Nonnull final Supplier<U> updateActionSupplier) {
+
         return !Objects.equals(oldObject, newObject)
-            ? Optional.ofNullable(updateActionSupplier.get()) : Optional.empty();
+                ? Optional.ofNullable(updateActionSupplier.get())
+                : Optional.empty();
     }
 
+    /**
+     * Compares two {@link Object} and returns a supplied list of {@link UpdateAction} as a result.
+     * If both the {@link Object}s have the same values, then no update action is needed
+     * and hence an empty list is returned.
+     *
+     * @param oldObject            the object which should be updated
+     * @param newObject            the object with the new information
+     * @param updateActionSupplier the supplier that returns a list of update actions if the objects are different
+     * @param <T>                  the type of the {@link UpdateAction}
+     * @param <S>                  the type of the objects to compare
+     * @param <U>                  certain {@link UpdateAction} implementation type
+     * @return A filled optional with the update action or an empty optional if the object values are identical
+     */
     @Nonnull
-    public static <T, S> List<UpdateAction<T>> buildUpdateActions(@Nullable final S oldObject,
-                                                                  @Nullable final S newObject,
-                                                                  @Nonnull final Supplier<List<UpdateAction<T>>>
-                                                                      updateActionSupplier) {
-        return !Objects.equals(oldObject, newObject) ? updateActionSupplier.get() : emptyList();
+    public static <T, S, U extends UpdateAction<T>> List<U> buildUpdateActions(
+            @Nullable final S oldObject,
+            @Nullable final S newObject,
+            @Nonnull final Supplier<List<U>> updateActionSupplier) {
+
+        return !Objects.equals(oldObject, newObject)
+                ? updateActionSupplier.get()
+                : emptyList();
     }
 }

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -24,8 +24,8 @@ public final class ProductVariantUpdateActionUtils {
     /**
      * <b>Note:</b> if you do both add/remove product variants - <b>first always remove the variants</b>,
      * and then - add.
-     * The reason of such restriction: if you add first you could have duplication exception on the keys,
-     * which expected to be removed first.
+     * If you add first, the update action could fail due to having a duplicate {@code key} or {@code sku} with variants
+     * which were expected to be removed anyways. So issuing remove update action first will fix such issue.
      *
      * @param oldProduct old product with variants
      * @param newProduct new product draft with variants <b>with resolved references prices references</b>

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -1,0 +1,76 @@
+package com.commercetools.sync.products.utils;
+
+import com.commercetools.sync.commons.utils.CollectionUtils;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.commands.updateactions.AddVariant;
+import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
+import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.*;
+import static java.util.stream.Collectors.toList;
+
+public final class ProductVariantUpdateActionUtils {
+
+    /**
+     * @see #buildAddVariantUpdateAction(Product, ProductDraft)
+     */
+    @Nonnull
+    public static List<UpdateAction<Product>> buildRemoveVariantUpdateAction(@Nonnull final Product oldProduct,
+                                                                             @Nonnull final ProductDraft newProduct) {
+        final List<ProductVariant> oldVariants = oldProduct.getMasterData().getStaged().getVariants();
+        final Set<String> newVariants = CollectionUtils.collectionToSet(newProduct.getVariants(), ProductVariantDraft::getKey);
+
+        return CollectionUtils.filterCollection(oldVariants, oldVariant -> !newVariants.contains(oldVariant.getKey()))
+                .map(RemoveVariant::of)
+                .collect(toList());
+    }
+
+    /**
+     * <b>Note:</b> if you do both add/remove product variants - <b>first always remove the variants</b>, and then - add.
+     * The reason of such restriction: if you add first you could have duplication exception on the keys,
+     * which expected to be removed first.
+     *
+     * @param oldProduct old product with variants
+     * @param newProduct new product draft with variants <b>with resolved references prices references</b>
+     * @return list of update actions to add new variants.
+     * @see #buildRemoveVariantUpdateAction(Product, ProductDraft)
+     */
+    @Nonnull
+    public static List<UpdateAction<Product>> buildAddVariantUpdateAction(@Nonnull final Product oldProduct,
+                                                                          @Nonnull final ProductDraft newProduct) {
+        final List<ProductVariantDraft> newVariants = newProduct.getVariants();
+        final Set<String> oldVariantKeys = CollectionUtils.collectionToSet(oldProduct.getMasterData().getStaged().getVariants(), ProductVariant::getKey);
+
+        return CollectionUtils.filterCollection(newVariants, newVariant -> !oldVariantKeys.contains(newVariant.getKey()))
+                .map(ProductVariantUpdateActionUtils::buildAddVariantUpdateActionFromDraft)
+                .collect(toList());
+    }
+
+    @Nonnull
+    public static Optional<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(@Nonnull final Product oldProduct,
+                                                                                       @Nonnull final ProductDraft newProduct) {
+        return buildUpdateAction(newProduct.getMasterVariant().getKey(), oldProduct.getMasterData().getStaged().getMasterVariant().getKey(),
+                // it might be that the new master variant is from new added variants, so CTP variantId is not set yet,
+                // thus we can't use ChangeMasterVariant.ofVariantId()
+                () -> ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku()));
+    }
+
+    @Nonnull
+    public static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull ProductVariantDraft draft) {
+        return AddVariant.of(draft.getAttributes(), draft.getPrices(), draft.getSku())
+                .withKey(draft.getKey())
+                .withImages(draft.getImages());
+    }
+
+    private ProductVariantUpdateActionUtils() {
+    }
+}

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.products.utils;
 
-import com.commercetools.sync.commons.utils.CollectionUtils;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
@@ -15,27 +14,39 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.*;
+import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToSet;
+import static com.commercetools.sync.commons.utils.CollectionUtils.filterCollection;
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
 import static java.util.stream.Collectors.toList;
 
 public final class ProductVariantUpdateActionUtils {
 
     /**
+     * <b>Note:</b> if you do both add/remove product variants - <b>first always remove the variants</b>,
+     * and then - add.
+     * The reason of such restriction: if you add first you could have duplication exception on the keys,
+     * which expected to be removed first.
+     *
+     * @param oldProduct old product with variants
+     * @param newProduct new product draft with variants <b>with resolved references prices references</b>
+     * @return list of update actions to remove missing variants.
      * @see #buildAddVariantUpdateAction(Product, ProductDraft)
      */
     @Nonnull
     public static List<UpdateAction<Product>> buildRemoveVariantUpdateAction(@Nonnull final Product oldProduct,
                                                                              @Nonnull final ProductDraft newProduct) {
         final List<ProductVariant> oldVariants = oldProduct.getMasterData().getStaged().getVariants();
-        final Set<String> newVariants = CollectionUtils.collectionToSet(newProduct.getVariants(), ProductVariantDraft::getKey);
+        final Set<String> newVariants = collectionToSet(newProduct.getVariants(),
+                ProductVariantDraft::getKey);
 
-        return CollectionUtils.filterCollection(oldVariants, oldVariant -> !newVariants.contains(oldVariant.getKey()))
+        return filterCollection(oldVariants, oldVariant -> !newVariants.contains(oldVariant.getKey()))
                 .map(RemoveVariant::of)
                 .collect(toList());
     }
 
     /**
-     * <b>Note:</b> if you do both add/remove product variants - <b>first always remove the variants</b>, and then - add.
+     * <b>Note:</b> if you do both add/remove product variants - <b>first always remove the variants</b>,
+     * and then - add.
      * The reason of such restriction: if you add first you could have duplication exception on the keys,
      * which expected to be removed first.
      *
@@ -48,24 +59,53 @@ public final class ProductVariantUpdateActionUtils {
     public static List<UpdateAction<Product>> buildAddVariantUpdateAction(@Nonnull final Product oldProduct,
                                                                           @Nonnull final ProductDraft newProduct) {
         final List<ProductVariantDraft> newVariants = newProduct.getVariants();
-        final Set<String> oldVariantKeys = CollectionUtils.collectionToSet(oldProduct.getMasterData().getStaged().getVariants(), ProductVariant::getKey);
+        final Set<String> oldVariantKeys =
+                collectionToSet(oldProduct.getMasterData().getStaged().getVariants(), ProductVariant::getKey);
 
-        return CollectionUtils.filterCollection(newVariants, newVariant -> !oldVariantKeys.contains(newVariant.getKey()))
+        return filterCollection(newVariants, newVariant -> !oldVariantKeys.contains(newVariant.getKey()))
                 .map(ProductVariantUpdateActionUtils::buildAddVariantUpdateActionFromDraft)
                 .collect(toList());
     }
 
+    /**
+     * Create update action, if {@code newProduct} has {@code #masterVariant#key} different than {@code oldProduct}
+     * staged {@code #masterVariant#key}.
+     *
+     * <p>If update action is created - it is created of
+     * {@link ProductVariantDraft newProduct.getMasterVariant().getSku()}
+     *
+     * @param oldProduct old product with variants
+     * @param newProduct new product draft with variants <b>with resolved references prices references</b>
+     * @return {@link ChangeMasterVariant} if the keys are different.
+     */
     @Nonnull
-    public static Optional<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(@Nonnull final Product oldProduct,
-                                                                                       @Nonnull final ProductDraft newProduct) {
-        return buildUpdateAction(newProduct.getMasterVariant().getKey(), oldProduct.getMasterData().getStaged().getMasterVariant().getKey(),
-                // it might be that the new master variant is from new added variants, so CTP variantId is not set yet,
-                // thus we can't use ChangeMasterVariant.ofVariantId()
-                () -> ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku()));
+    public static Optional<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(
+            @Nonnull final Product oldProduct,
+            @Nonnull final ProductDraft newProduct) {
+        final String newKey = newProduct.getMasterVariant().getKey();
+        final String oldKey = oldProduct.getMasterData().getStaged().getMasterVariant().getKey();
+        return buildUpdateAction(newKey, oldKey,
+            // it might be that the new master variant is from new added variants, so CTP variantId is not set yet,
+            // thus we can't use ChangeMasterVariant.ofVariantId()
+            () -> ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku()));
     }
 
+    /**
+     * Factory method to create {@link AddVariant} action from {@link ProductVariantDraft} instance.
+     *
+     * <p>The {@link AddVariant} will include:<ul>
+     *     <li>sku</li>
+     *     <li>keys</li>
+     *     <li>attributes</li>
+     *     <li>prices</li>
+     *     <li>images</li>
+     * </ul>
+     *
+     * @param draft {@link ProductVariantDraft} which to add.
+     * @return new {@link AddVariant} update action with properties from {@code draft}
+     */
     @Nonnull
-    public static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull ProductVariantDraft draft) {
+    public static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull final ProductVariantDraft draft) {
         return AddVariant.of(draft.getAttributes(), draft.getPrices(), draft.getSku())
                 .withKey(draft.getKey())
                 .withImages(draft.getImages());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -104,7 +104,7 @@ public final class ProductVariantUpdateActionUtils {
      * @return new {@link AddVariant} update action with properties from {@code draft}
      */
     @Nonnull
-    public static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull final ProductVariantDraft draft) {
+    static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull final ProductVariantDraft draft) {
         return AddVariant.of(draft.getAttributes(), draft.getPrices(), draft.getSku())
                 .withKey(draft.getKey())
                 .withImages(draft.getImages());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -36,8 +36,7 @@ public final class ProductVariantUpdateActionUtils {
     public static List<UpdateAction<Product>> buildRemoveVariantUpdateAction(@Nonnull final Product oldProduct,
                                                                              @Nonnull final ProductDraft newProduct) {
         final List<ProductVariant> oldVariants = oldProduct.getMasterData().getStaged().getVariants();
-        final Set<String> newVariants = collectionToSet(newProduct.getVariants(),
-                ProductVariantDraft::getKey);
+        final Set<String> newVariants = collectionToSet(newProduct.getVariants(), ProductVariantDraft::getKey);
 
         return filterCollection(oldVariants, oldVariant -> !newVariants.contains(oldVariant.getKey()))
                 .map(RemoveVariant::of)
@@ -56,7 +55,7 @@ public final class ProductVariantUpdateActionUtils {
      * @see #buildRemoveVariantUpdateAction(Product, ProductDraft)
      */
     @Nonnull
-    public static List<UpdateAction<Product>> buildAddVariantUpdateAction(@Nonnull final Product oldProduct,
+    public static List<AddVariant> buildAddVariantUpdateAction(@Nonnull final Product oldProduct,
                                                                           @Nonnull final ProductDraft newProduct) {
         final List<ProductVariantDraft> newVariants = newProduct.getVariants();
         final Set<String> oldVariantKeys =
@@ -79,7 +78,7 @@ public final class ProductVariantUpdateActionUtils {
      * @return {@link ChangeMasterVariant} if the keys are different.
      */
     @Nonnull
-    public static Optional<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(
+    public static Optional<ChangeMasterVariant> buildChangeMasterVariantUpdateAction(
             @Nonnull final Product oldProduct,
             @Nonnull final ProductDraft newProduct) {
         final String newKey = newProduct.getMasterVariant().getKey();
@@ -87,7 +86,7 @@ public final class ProductVariantUpdateActionUtils {
         return buildUpdateAction(newKey, oldKey,
             // it might be that the new master variant is from new added variants, so CTP variantId is not set yet,
             // thus we can't use ChangeMasterVariant.ofVariantId()
-            () -> ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku()));
+            () -> ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku(), true));
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
@@ -42,15 +42,16 @@ public class CollectionUtilsTest {
 
     @Test
     public void collectionToSet_normalCases() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
+        List<Pair<String, Integer>> abcd = Arrays.asList(
+                Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
         assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
         assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4);
     }
 
     @Test
     public void collectionToSet_duplicates() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4),
-                Pair.of("d", 5), Pair.of("b", 6));
+        List<Pair<String, Integer>> abcd = Arrays.asList(
+                Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4), Pair.of("d", 5), Pair.of("b", 6));
         // 2 duplicate keys should be suppressed
         assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
         // no duplicate values - nothing should be suppressed

--- a/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
@@ -1,0 +1,59 @@
+package com.commercetools.sync.commons.utils;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToSet;
+import static com.commercetools.sync.commons.utils.CollectionUtils.filterCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionUtilsTest {
+    @Test
+    public void filterCollection_emptyCases() throws Exception {
+        assertThat(filterCollection(null, i -> true)).isEmpty();
+        assertThat(filterCollection(Collections.emptyList(), i -> true)).isEmpty();
+    }
+
+    @Test
+    public void filterCollection_normalCases() throws Exception {
+        List<String> abcd = Arrays.asList("a", "b", "c", "d");
+        assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "b", "c", "d");
+        assertThat(filterCollection(abcd, s -> false)).isEmpty();
+        assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b')).containsExactlyInAnyOrder("c", "d");
+    }
+
+    @Test
+    public void filterCollection_duplicates() throws Exception {
+        List<String> abcd = Arrays.asList("a", "b", "c", "d", "d", "c", "g", "a");
+        assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "a", "b", "c", "c", "d", "d", "g");
+        assertThat(filterCollection(abcd, s -> false)).isEmpty();
+        assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b')).containsExactlyInAnyOrder("c", "c", "d", "d", "g");
+    }
+
+    @Test
+    public void collectionToSet_emptyCases() throws Exception {
+        assertThat(collectionToSet(null, i -> i)).isEmpty();
+        assertThat(collectionToSet(Collections.emptyList(), i -> i)).isEmpty();
+    }
+
+    @Test
+    public void collectionToSet_normalCases() throws Exception {
+        List<Pair<String, Integer>> abcd = Arrays.asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
+        assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+        assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4);
+    }
+
+    @Test
+    public void collectionToSet_duplicates() throws Exception {
+        List<Pair<String, Integer>> abcd = Arrays.asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4),
+                Pair.of("d", 5), Pair.of("b", 6));
+        // 2 duplicate keys should be suppressed
+        assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+        // no duplicate values - nothing should be suppressed
+        assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -102,4 +102,12 @@ public class ProductSyncMockUtils {
             .categoryOrderHints(categoryOrderHints)
             .build();
     }
+
+    public static Product createProductFromJson(@Nonnull final String jsonResourcePath) {
+        return readObjectFromResource(jsonResourcePath, Product.class);
+    }
+
+    public static ProductDraft createProductDraftFromJson(@Nonnull final String jsonResourcePath) {
+        return readObjectFromResource(jsonResourcePath, ProductDraft.class);
+    }
 }

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
@@ -51,7 +51,7 @@ public class ProductVariantUpdateActionUtilsTest {
         ProductVariantDraft draft5 = productDraftNew.getVariants().get(1);
         ProductVariantDraft draft6 = productDraftNew.getVariants().get(2);
 
-        List<UpdateAction<Product>> updateActions = buildAddVariantUpdateAction(productOld, productDraftNew);
+        List<AddVariant> updateActions = buildAddVariantUpdateAction(productOld, productDraftNew);
         assertThat(updateActions).containsExactlyInAnyOrder(
                 buildAddVariantUpdateActionFromDraft(draft5),
                 buildAddVariantUpdateActionFromDraft(draft6));
@@ -62,11 +62,10 @@ public class ProductVariantUpdateActionUtilsTest {
         Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS);
 
-        Optional<UpdateAction<Product>> changeMaster =
-                buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
-        assertThat(changeMaster).isNotEmpty();
-        assertThat(changeMaster.orElse(null))
-                .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku()));
+        Optional<ChangeMasterVariant> changeMasterVariant = buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
+        assertThat(changeMasterVariant).isNotEmpty();
+        assertThat(changeMasterVariant.orElse(null))
+                .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku(), true));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
@@ -1,7 +1,13 @@
 package com.commercetools.sync.products.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.products.*;
+import io.sphere.sdk.products.Image;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.ProductVariantDraftDsl;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.commands.updateactions.AddVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
@@ -14,7 +20,10 @@ import java.util.Optional;
 
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftFromJson;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductFromJson;
-import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.*;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildAddVariantUpdateAction;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildAddVariantUpdateActionFromDraft;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildChangeMasterVariantUpdateAction;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildRemoveVariantUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductVariantUpdateActionUtilsTest {

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
@@ -28,8 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductVariantUpdateActionUtilsTest {
 
-    public static final String OLD_PROD_WITH_VARIANTS = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld.json";
-    public static final String NEW_PROD_DRAFT_WITH_VARIANTS = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew.json";
+    public static final String OLD_PROD_WITH_VARIANTS =
+            "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld.json";
+    public static final String NEW_PROD_DRAFT_WITH_VARIANTS =
+            "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew.json";
 
 
     @Test
@@ -60,9 +62,11 @@ public class ProductVariantUpdateActionUtilsTest {
         Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS);
 
-        Optional<UpdateAction<Product>> changeMaster = buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
+        Optional<UpdateAction<Product>> changeMaster =
+                buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
         assertThat(changeMaster).isNotEmpty();
-        assertThat(changeMaster.orElse(null)).isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku()));
+        assertThat(changeMaster.orElse(null))
+                .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku()));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
@@ -1,0 +1,80 @@
+package com.commercetools.sync.products.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.*;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+import io.sphere.sdk.products.commands.updateactions.AddVariant;
+import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
+import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftFromJson;
+import static com.commercetools.sync.products.ProductSyncMockUtils.createProductFromJson;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductVariantUpdateActionUtilsTest {
+
+    public static final String OLD_PROD_WITH_VARIANTS = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld.json";
+    public static final String NEW_PROD_DRAFT_WITH_VARIANTS = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew.json";
+
+
+    @Test
+    public void buildRemoveVariantUpdateAction_removesMissedVariants() throws Exception {
+        Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
+        ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS);
+
+        List<UpdateAction<Product>> updateActions = buildRemoveVariantUpdateAction(productOld, productDraftNew);
+        assertThat(updateActions).containsExactlyInAnyOrder(RemoveVariant.of(2), RemoveVariant.of(3));
+    }
+
+    @Test
+    public void buildAddVariantUpdateAction_addsNewVariants() throws Exception {
+        Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
+        ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS);
+
+        ProductVariantDraft draft5 = productDraftNew.getVariants().get(1);
+        ProductVariantDraft draft6 = productDraftNew.getVariants().get(2);
+
+        List<UpdateAction<Product>> updateActions = buildAddVariantUpdateAction(productOld, productDraftNew);
+        assertThat(updateActions).containsExactlyInAnyOrder(
+                buildAddVariantUpdateActionFromDraft(draft5),
+                buildAddVariantUpdateActionFromDraft(draft6));
+    }
+
+    @Test
+    public void buildChangeMasterVariantUpdateAction_changesMasterVariant() throws Exception {
+        Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
+        ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS);
+
+        Optional<UpdateAction<Product>> changeMaster = buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
+        assertThat(changeMaster).isNotEmpty();
+        assertThat(changeMaster.orElse(null)).isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku()));
+    }
+
+    @Test
+    public void buildAddVariantUpdateActionFromDraft_returnsProperties() throws Exception {
+        List<AttributeDraft> attributeList = Collections.emptyList();
+        List<PriceDraft> priceList = Collections.emptyList();
+        List<Image> imageList = Collections.emptyList();
+        ProductVariantDraftDsl draft = ProductVariantDraftBuilder.of()
+                .attributes(attributeList)
+                .prices(priceList)
+                .sku("testSKU")
+                .key("testKey")
+                .images(imageList)
+                .build();
+
+        AddVariant addVariant = buildAddVariantUpdateActionFromDraft(draft);
+        assertThat(addVariant.getAttributes()).isSameAs(attributeList);
+        assertThat(addVariant.getPrices()).isSameAs(priceList);
+        assertThat(addVariant.getSku()).isEqualTo("testSKU");
+        assertThat(addVariant.getKey()).isEqualTo("testKey");
+        assertThat(addVariant.getImages()).isSameAs(imageList);
+    }
+
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew.json
@@ -1,0 +1,89 @@
+{
+  "key": "productKeyKey",
+  "masterVariant": {
+    "key": "var-7-key",
+    "sku": "var-7-sku",
+    "prices": [
+    ],
+    "images": [
+      {
+        "url": "https://xxx.ggg/7.png"
+      }
+    ],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+      {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-5-key",
+      "sku": "var-5-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/5.png"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-6-key",
+      "sku": "var-6-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/6.png"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld.json
@@ -1,0 +1,113 @@
+{
+  "key": "productKeyOld",
+  "masterData": {
+    "staged": {
+      "name": {
+        "en": "Rehrücken ohne Knochen"
+      },
+      "description": {
+        "en": "Die Rückenstücke..."
+      },
+      "categories": [
+        {
+          "typeId": "category",
+          "id": "1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f"
+        }
+      ],
+      "slug": {
+        "en": "rehruecken-o-kn"
+      },
+      "masterVariant": {
+        "id": 1,
+        "key": "var-1-key",
+        "sku": "var-1-sku",
+        "prices": [
+        ],
+        "images": [
+          {
+            "url": "https://xxx.ggg/1.png"
+          }
+        ],
+        "attributes": [
+          {
+            "name": "priceInfo",
+            "value": "64,90/kg"
+          },
+          {
+            "name": "size",
+            "value": "ca. 1 x 1000 g"
+          }
+        ]
+      },
+      "variants": [
+        {
+          "id": 2,
+          "key": "var-2-key",
+          "sku": "var-2-sku",
+          "prices": [
+          ],
+          "images": [
+            {
+              "url": "https://xxx.ggg/2.png"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "priceInfo",
+              "value": "64,90/kg"
+            },
+            {
+              "name": "size",
+              "value": "ca. 1 x 1000 g"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "key": "var-3-key",
+          "sku": "var-3-sku",
+          "prices": [
+          ],
+          "images": [
+            {
+              "url": "https://xxx.ggg/3.png"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "priceInfo",
+              "value": "64,90/kg"
+            },
+            {
+              "name": "size",
+              "value": "ca. 1 x 1000 g"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "key": "var-4-key",
+          "sku": "var-4-sku",
+          "prices": [
+          ],
+          "images": [
+            {
+              "url": "https://xxx.ggg/5.png"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "priceInfo",
+              "value": "64,90/kg"
+            },
+            {
+              "name": "size",
+              "value": "ca. 1 x 1000 g"
+            }
+          ]
+        }
+      ]
+    },
+    "published": true
+  }
+}


### PR DESCRIPTION
#### Summary
In `ProductVariantUpdateActionUtils` added:
  - `buildRemoveVariantUpdateAction()`
  - `buildAddVariantUpdateAction()`
  - `buildChangeMasterVariantUpdateAction()`

Respective unit tests added with Payment mock files.

#### Relevant Issues
  
#98

#### Todo

- [ ] more unit tests for corner cases?

#### Hints for Review

`ProductVariantUpdateActionUtils` is the main implementation

`CollectionUtils` is additional utilities class for filtering and converting collections