### PR TITLE
97 sync publish state

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
@@ -39,6 +39,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraft;
+import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftBuilder;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createRandomCategoryOrderHints;
 import static java.lang.String.format;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -118,6 +119,42 @@ public class ProductSyncIT {
 
         final ProductDraft newProductDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             sourceProductType.toReference(), sourceCategories, createRandomCategoryOrderHints(sourceCategories));
+        CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(newProductDraft)).toCompletableFuture().join();
+
+        final ProductQuery productQuery = ProductQuery.of().withLimit(SphereClientUtils.QUERY_MAX_LIMIT)
+                                                      .withExpansionPaths(ProductExpansionModel::productType)
+                                                      .plusExpansionPaths(productProductExpansionModel ->
+                                                          productProductExpansionModel.masterData().staged()
+                                                                                      .categories());
+
+        final List<Product> products = CTP_SOURCE_CLIENT.execute(productQuery)
+                                                        .toCompletableFuture().join().getResults();
+
+        final List<ProductDraft> productDrafts = replaceProductsReferenceIdsWithKeys(products);
+
+        final ProductSyncStatistics syncStatistics =  productSync.sync(productDrafts).toCompletableFuture().join();
+
+        assertThat(syncStatistics.getReportMessage())
+            .isEqualTo(format("Summary: %d products were processed in total (%d created, %d updated and %d products"
+                + " failed to sync).", 1, 0, 1, 0));
+
+        Assertions.assertThat(errorCallBackMessages).isEmpty();
+        Assertions.assertThat(errorCallBackExceptions).isEmpty();
+        Assertions.assertThat(warningCallBackMessages).isEmpty();
+    }
+
+    @Test
+    public void sync_withChangesOnlyAndUnPublish_ShouldUpdateProducts() {
+        final ProductDraft existingProductDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
+            targetProductType.toReference(), targetCategories, createRandomCategoryOrderHints(targetCategories));
+        CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)).toCompletableFuture().join();
+
+        final ProductDraft newProductDraft = createProductDraftBuilder(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
+            sourceProductType.toReference())
+            .categories(sourceCategories)
+            .categoryOrderHints(createRandomCategoryOrderHints(sourceCategories))
+            .publish(false).build();
+
         CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(newProductDraft)).toCompletableFuture().join();
 
         final ProductQuery productQuery = ProductQuery.of().withLimit(SphereClientUtils.QUERY_MAX_LIMIT)

--- a/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildAddToCategoryUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeNameUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeSlugUpdateAction;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildPublishUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildRemoveFromCategoryUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildSetCategoryOrderHintUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildSetDescriptionUpdateAction;
@@ -94,11 +95,13 @@ public final class ProductSyncUtils {
             buildSetMetaDescriptionUpdateAction(oldProduct, newProduct),
             buildSetMetaKeywordsUpdateAction(oldProduct, newProduct)
         ));
-
         updateActions.addAll(buildAddToCategoryUpdateActions(oldProduct, newProduct));
         updateActions.addAll(buildSetCategoryOrderHintUpdateActions(oldProduct, newProduct));
         updateActions.addAll(buildRemoveFromCategoryUpdateActions(oldProduct, newProduct));
         updateActions.addAll(buildVariantsUpdateActions(oldProduct, newProduct, syncOptions, attributesMetaData));
+
+        // lastly publish/unpublish
+        buildPublishUpdateAction(oldProduct, newProduct).ifPresent(updateActions::add);
         return updateActions;
     }
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -17,6 +17,7 @@ import io.sphere.sdk.products.commands.updateactions.AddVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
 import io.sphere.sdk.products.commands.updateactions.ChangeSlug;
+import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
 import io.sphere.sdk.products.commands.updateactions.SetCategoryOrderHint;
@@ -25,6 +26,7 @@ import io.sphere.sdk.products.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.products.commands.updateactions.SetMetaKeywords;
 import io.sphere.sdk.products.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.products.commands.updateactions.SetSearchKeywords;
+import io.sphere.sdk.products.commands.updateactions.Unpublish;
 import io.sphere.sdk.search.SearchKeywords;
 
 import javax.annotation.Nonnull;
@@ -459,7 +461,7 @@ public final class ProductUpdateActionUtils {
      */
     @Nonnull
     public static List<AddVariant> buildAddVariantUpdateAction(@Nonnull final Product oldProduct,
-                                                                          @Nonnull final ProductDraft newProduct) {
+                                                               @Nonnull final ProductDraft newProduct) {
         final List<ProductVariantDraft> newVariants = newProduct.getVariants();
         final Set<String> oldVariantKeys =
                 collectionToSet(oldProduct.getMasterData().getStaged().getVariants(), ProductVariant::getKey);
@@ -468,6 +470,30 @@ public final class ProductUpdateActionUtils {
                 .map(ProductUpdateActionUtils::buildAddVariantUpdateActionFromDraft)
                 .collect(toList());
     }
+
+    /**
+     * Compares the 'published' field of a {@link ProductDraft} and a {@link Product} and accordingly returns
+     * a {@link Publish} or {@link Unpublish} update action as a result in an {@link Optional}. If the new product's
+     * 'published' field is null, then the default false value is assumed.
+     *
+     * If both the {@link Product} and the {@link ProductDraft} have the same 'published' flag value, then no update
+     * action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldProduct the product which should be updated.
+     * @param newProduct the product draft where we get the new meta description.
+     * @return A filled optional with the update action or an empty optional if the flag values are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<Product>> buildPublishUpdateAction(@Nonnull final Product oldProduct,
+                                                                           @Nonnull final ProductDraft newProduct) {
+        final Boolean isNewProductPublished = newProduct.isPublish();
+        final Boolean isOldProductPublished = oldProduct.getMasterData().isPublished();
+        if (Boolean.TRUE.equals(isNewProductPublished)) {
+            return buildUpdateAction(isOldProductPublished, isNewProductPublished, Publish::of);
+        }
+        return buildUpdateAction(isOldProductPublished, isNewProductPublished, Unpublish::of);
+    }
+
 
     /**
      * Create update action, if {@code newProduct} has {@code #masterVariant#key} different than {@code oldProduct}

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -476,7 +476,7 @@ public final class ProductUpdateActionUtils {
      * a {@link Publish} or {@link Unpublish} update action as a result in an {@link Optional}. If the new product's
      * 'published' field is null, then the default false value is assumed.
      *
-     * If both the {@link Product} and the {@link ProductDraft} have the same 'published' flag value, then no update
+     * <p>If both the {@link Product} and the {@link ProductDraft} have the same 'published' flag value, then no update
      * action is needed and hence an empty {@link Optional} is returned.
      *
      * @param oldProduct the product which should be updated.

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -39,7 +39,7 @@ public class ProductSyncMockUtils {
                                                                 @Nonnull final Reference<ProductType>
                                                                     productTypeReference) {
         final Product productFromJson = readObjectFromResource(jsonResourcePath, Product.class);
-        final ProductData productData = productFromJson.getMasterData().getCurrent();
+        final ProductData productData = productFromJson.getMasterData().getStaged();
 
         @SuppressWarnings("ConstantConditions") final List<ProductVariantDraft> allVariants = productData
             .getAllVariants().stream()

--- a/src/test/resources/product-key-1-changed.json
+++ b/src/test/resources/product-key-1-changed.json
@@ -174,6 +174,7 @@
       "masterVariant": {
         "id": 1,
         "sku": "3065831",
+        "key": "v1",
         "prices": [
         ],
         "images": [


### PR DESCRIPTION
#### Summary
1. Builds a publish/unpublish update action depending on the the `published` flag of a productDraft. If it is null, then its treated as if it is `false` (the default value). If the flag value is the same in the new draft and the old product, then no update action is built, otherwise the  product is published/unpublished accordingly. 

#### Relevant Issues
#97 

#### Todo

- Tests
    - [ ] Unit 
    - [ ] Integration
    - [ ] Javadocs
- [ ] Documentation
