### PR TITLE
114 variant images

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
@@ -1,0 +1,324 @@
+package com.commercetools.sync.integration.externalsource.products.utils;
+
+import com.commercetools.sync.products.ProductSync;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.Image;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.products.commands.updateactions.AddExternalImage;
+import io.sphere.sdk.products.commands.updateactions.MoveImageToPosition;
+import io.sphere.sdk.products.commands.updateactions.RemoveImage;
+import io.sphere.sdk.products.queries.ProductByKeyGet;
+import io.sphere.sdk.producttypes.ProductType;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class BuildProductVariantImageUpdateActionsIT {
+    private static final String DRAFTS_ROOT = "com/commercetools/sync/integration/externalsource/products/"
+        + "utils/imageUpdateActions/";
+    private static final String PRODUCT_WITH_IMAGES_1_2_3 = DRAFTS_ROOT + "draftWithMVImages-1-2-3.json";
+    private static final String PRODUCT_WITH_IMAGES_3_2_1 = DRAFTS_ROOT + "draftWithMVImages-3-2-1.json";
+    private static final String PRODUCT_WITH_IMAGES_7_1_2 = DRAFTS_ROOT + "draftWithMVImages-7-1-2.json";
+    private static final String PRODUCT_WITH_NULL_IMAGES = DRAFTS_ROOT + "draftWithMVNullImages.json";
+    private static final String PRODUCT_WITH_EMPTY_IMAGES = DRAFTS_ROOT + "draftWithMVEmptyImages.json";
+
+    private static ProductType productType;
+    private ProductSync productSync;
+    private List<String> errorCallBackMessages;
+    private List<UpdateAction<Product>> updateActionsBuiltBySync;
+    private List<String> warningCallBackMessages;
+    private List<Throwable> errorCallBackExceptions;
+
+    /**
+     * Delete all product related test data from target and source projects. Then creates product types in both
+     * CTP projects.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+        productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    /**
+     * Create old product from the draft.
+     */
+    @Before
+    public void setUp() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+        updateActionsBuiltBySync = new ArrayList<>();
+        deleteAllProducts(CTP_TARGET_CLIENT);
+
+
+        final BiConsumer<String, Throwable> errorCallBack = (errorMessage, exception) -> {
+            errorCallBackMessages.add(errorMessage);
+            errorCallBackExceptions.add(exception);
+        };
+
+        final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);
+
+        final Function<List<UpdateAction<Product>>, List<UpdateAction<Product>>> updateActionsCollector =
+            updateActions -> {
+                updateActionsBuiltBySync.addAll(updateActions);
+                return updateActions;
+            };
+
+
+        final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                                                               .setErrorCallBack(errorCallBack)
+                                                                               .setWarningCallBack(warningCallBack)
+                                                                               .setUpdateActionsFilter(
+                                                                                   updateActionsCollector)
+                                                                               .build();
+        productSync = new ProductSync(productSyncOptions);
+    }
+
+    @Test
+    public void sync_WithNullImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
+        assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_NULL_IMAGES, PRODUCT_WITH_NULL_IMAGES);
+
+    }
+
+    private void assertProductSyncShouldNotBuildImageUpdateActions(@Nonnull final String oldProductDraftJsonResource,
+                                                                   @Nonnull final String newProductDraftJsonResource) {
+        // Prepare existing product before sync.
+        final ProductDraft oldProductDraft =
+            ProductDraftBuilder.of(readObjectFromResource(oldProductDraftJsonResource, ProductDraft.class))
+                               .productType(productType.toReference())
+                               .build();
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(oldProductDraft)));
+
+        // Prepare new product to feed into sync.
+        final ProductDraft newProduct =
+            ProductDraftBuilder.of(readObjectFromResource(newProductDraftJsonResource, ProductDraft.class))
+                               .productType(ProductType.referenceOfId(productType.getKey()))
+                               .build();
+
+        // Sync
+        executeBlocking(productSync.sync(Collections.singletonList(newProduct)));
+
+        // Assert Update Actions are built correctly.
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        updateActionsBuiltBySync.forEach(updateAction -> {
+            assertThat(updateAction).isNotExactlyInstanceOf(MoveImageToPosition.class);
+            assertThat(updateAction).isNotExactlyInstanceOf(AddExternalImage.class);
+            assertThat(updateAction).isNotExactlyInstanceOf(RemoveImage.class);
+        });
+
+        // Assert product state after sync.
+        final Product productAfterSync = executeBlocking(
+            CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(oldProductDraft.getKey())));
+        assertImagesAreSyncedCorrectly(newProduct, productAfterSync);
+    }
+
+    @Test
+    public void sync_WithEmptyImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
+        assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_EMPTY_IMAGES, PRODUCT_WITH_EMPTY_IMAGES);
+    }
+
+    @Test
+    public void sync_WithNullNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
+        // Prepare existing product before sync.
+        final ProductDraft oldProductDraft =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))
+                               .productType(productType.toReference())
+                               .build();
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(oldProductDraft)));
+
+        // Prepare new product to feed into sync.
+        final ProductDraft newProduct =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_NULL_IMAGES, ProductDraft.class))
+                               .productType(ProductType.referenceOfId(productType.getKey()))
+                               .build();
+
+        // Sync
+        executeBlocking(productSync.sync(Collections.singletonList(newProduct)));
+
+        // Assert Update Actions are built correctly.
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsBuiltBySync.stream()
+                                           .filter(updateAction -> updateAction instanceof RemoveImage)
+                                           .count()).isEqualTo(3);
+
+        // Assert product state after sync.
+        final Product productAfterSync = executeBlocking(
+            CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(oldProductDraft.getKey())));
+        assertImagesAreSyncedCorrectly(newProduct, productAfterSync);
+    }
+
+    @Test
+    public void sync_WithEmptyNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
+        assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_IMAGES_1_2_3,
+            PRODUCT_WITH_EMPTY_IMAGES, RemoveImage.class);
+
+    }
+
+    private void assertProductSyncShouldBuildRemoveImageUpdateActions(
+        @Nonnull final String oldProductDraftJsonResource,
+        @Nonnull final String newProductDraftJsonResource,
+        @Nonnull final Class<?> updateActionType) {
+        // Prepare existing product before sync.
+        final ProductDraft oldProductDraft =
+            ProductDraftBuilder.of(readObjectFromResource(oldProductDraftJsonResource, ProductDraft.class))
+                               .productType(productType.toReference())
+                               .build();
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(oldProductDraft)));
+
+        // Prepare new product to feed into sync.
+        final ProductDraft newProduct =
+            ProductDraftBuilder.of(readObjectFromResource(newProductDraftJsonResource, ProductDraft.class))
+                               .productType(ProductType.referenceOfId(productType.getKey()))
+                               .build();
+
+        // Sync
+        executeBlocking(productSync.sync(Collections.singletonList(newProduct)));
+
+        // Assert Update Actions are built correctly.
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsBuiltBySync.stream()
+                                           .filter(updateActionType::isInstance)
+                                           .count()).isEqualTo(3);
+
+        // Assert product state after sync.
+        final Product productAfterSync = executeBlocking(
+            CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(oldProductDraft.getKey())));
+        assertImagesAreSyncedCorrectly(newProduct, productAfterSync);
+    }
+
+    @Test
+    public void sync_WithNullOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
+        assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_NULL_IMAGES,
+            PRODUCT_WITH_IMAGES_1_2_3, AddExternalImage.class);
+    }
+
+    @Test
+    public void sync_WithEmpyOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
+        assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_EMPTY_IMAGES,
+            PRODUCT_WITH_IMAGES_1_2_3, AddExternalImage.class);
+    }
+
+    @Test
+    public void sync_WithIdenticalNonNullImageLists_ShouldNotBuildImageUpdateActions() {
+        assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_IMAGES_1_2_3, PRODUCT_WITH_IMAGES_1_2_3);
+    }
+
+    @Test
+    public void sync_WithDifferentImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
+        // Prepare existing product before sync.
+        final ProductDraft oldProductDraft =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))
+                               .productType(productType.toReference())
+                               .build();
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(oldProductDraft)));
+
+        // Prepare new product to feed into sync.
+        final ProductDraft newProduct =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_7_1_2, ProductDraft.class))
+                               .productType(ProductType.referenceOfId(productType.getKey()))
+                               .build();
+
+        // Sync
+        executeBlocking(productSync.sync(Collections.singletonList(newProduct)));
+
+        // Assert Update Actions are built correctly
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsBuiltBySync
+            .stream().anyMatch(updateAction -> updateAction instanceof MoveImageToPosition))
+            .isTrue();
+        assertThat(updateActionsBuiltBySync
+            .stream().anyMatch(updateAction -> updateAction instanceof AddExternalImage))
+            .isTrue();
+        assertThat(updateActionsBuiltBySync
+            .stream().anyMatch(updateAction -> updateAction instanceof RemoveImage))
+            .isTrue();
+
+        // Assert product state after sync.
+        final Product productAfterSync = executeBlocking(
+            CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(oldProductDraft.getKey())));
+        assertImagesAreSyncedCorrectly(newProduct, productAfterSync);
+    }
+
+    @Test
+    public void sync_WithDifferentOrderedImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
+        // Prepare existing product before sync.
+        final ProductDraft oldProductDraft =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))
+                               .productType(productType.toReference())
+                               .build();
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(oldProductDraft)));
+
+        // Prepare new product to feed into sync.
+        final ProductDraft newProduct =
+            ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_3_2_1, ProductDraft.class))
+                               .productType(ProductType.referenceOfId(productType.getKey()))
+                               .build();
+
+        // Sync
+        executeBlocking(productSync.sync(Collections.singletonList(newProduct)));
+
+        // Assert Update Actions are built correctly
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsBuiltBySync
+            .stream().filter(updateAction -> updateAction instanceof MoveImageToPosition).count())
+            .isEqualTo(2);
+        assertThat(updateActionsBuiltBySync
+            .stream().noneMatch(updateAction -> updateAction instanceof AddExternalImage))
+            .isTrue();
+        assertThat(updateActionsBuiltBySync
+            .stream().noneMatch(updateAction -> updateAction instanceof RemoveImage))
+            .isTrue();
+
+        // Assert product state after sync.
+        final Product productAfterSync = executeBlocking(
+            CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(oldProductDraft.getKey())));
+        assertImagesAreSyncedCorrectly(newProduct, productAfterSync);
+    }
+
+    private static void assertImagesAreSyncedCorrectly(@Nonnull final ProductDraft newProduct,
+                                                       @Nonnull final Product productAfterSync) {
+        final List<Image> oldImagesAfterSync =
+            productAfterSync.getMasterData().getStaged().getMasterVariant().getImages();
+        List<Image> newImages = newProduct.getMasterVariant().getImages();
+        newImages = newImages != null ? newImages : Collections.emptyList();
+        assertThat(newImages).isEqualTo(oldImagesAfterSync);
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
@@ -72,12 +72,8 @@ public class BuildProductVariantImageUpdateActionsIT {
      */
     @Before
     public void setUp() {
-        errorCallBackMessages = new ArrayList<>();
-        errorCallBackExceptions = new ArrayList<>();
-        warningCallBackMessages = new ArrayList<>();
-        updateActionsBuiltBySync = new ArrayList<>();
+        clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
-
 
         final BiConsumer<String, Throwable> errorCallBack = (errorMessage, exception) -> {
             errorCallBackMessages.add(errorMessage);
@@ -100,6 +96,13 @@ public class BuildProductVariantImageUpdateActionsIT {
                                                                                    updateActionsCollector)
                                                                                .build();
         productSync = new ProductSync(productSyncOptions);
+    }
+
+    private void clearSyncTestCollections() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+        updateActionsBuiltBySync = new ArrayList<>();
     }
 
     @Test

--- a/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVEmptyImages.json
+++ b/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVEmptyImages.json
@@ -1,0 +1,103 @@
+{
+  "key": "productToSyncKey",
+  "name": {
+    "en": "productNameOld"
+  },
+  "slug": {
+    "en": "productSlugOld"
+  },
+  "masterVariant": {
+    "key": "var-1-key",
+    "sku": "var-1-sku",
+    "prices": [
+    ],
+    "images": [],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+    {
+      "key": "var-2-key",
+      "sku": "var-2-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/2.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-3-key",
+      "sku": "var-3-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/3.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-1-2-3.json
+++ b/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-1-2-3.json
@@ -1,0 +1,125 @@
+{
+  "key": "productToSyncKey",
+  "name": {
+    "en": "productNameOld"
+  },
+  "slug": {
+    "en": "productSlugOld"
+  },
+  "masterVariant": {
+    "key": "var-1-key",
+    "sku": "var-1-sku",
+    "prices": [
+    ],
+    "images": [
+      {
+        "url": "https://xxx.ggg/1.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/2.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/3.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      }
+    ],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+    {
+      "key": "var-2-key",
+      "sku": "var-2-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/2.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-3-key",
+      "sku": "var-3-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/3.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-3-2-1.json
+++ b/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-3-2-1.json
@@ -1,0 +1,125 @@
+{
+  "key": "productToSyncKey",
+  "name": {
+    "en": "productNameOld"
+  },
+  "slug": {
+    "en": "productSlugOld"
+  },
+  "masterVariant": {
+    "key": "var-1-key",
+    "sku": "var-1-sku",
+    "prices": [
+    ],
+    "images": [
+      {
+        "url": "https://xxx.ggg/3.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/2.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/1.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      }
+    ],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+    {
+      "key": "var-2-key",
+      "sku": "var-2-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/2.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-3-key",
+      "sku": "var-3-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/3.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-7-1-2.json
+++ b/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVImages-7-1-2.json
@@ -1,0 +1,125 @@
+{
+  "key": "productToSyncKey",
+  "name": {
+    "en": "productNameOld"
+  },
+  "slug": {
+    "en": "productSlugOld"
+  },
+  "masterVariant": {
+    "key": "var-1-key",
+    "sku": "var-1-sku",
+    "prices": [
+    ],
+    "images": [
+      {
+        "url": "https://xxx.ggg/7.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/1.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      },
+      {
+        "url": "https://xxx.ggg/2.png",
+        "dimensions":{
+          "w": 10,
+          "h": 10
+        }
+      }
+    ],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+    {
+      "key": "var-2-key",
+      "sku": "var-2-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/2.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-3-key",
+      "sku": "var-3-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/3.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVNullImages.json
+++ b/src/integration-test/resources/com/commercetools/sync/integration/externalsource/products/utils/imageUpdateActions/draftWithMVNullImages.json
@@ -1,0 +1,102 @@
+{
+  "key": "productToSyncKey",
+  "name": {
+    "en": "productNameOld"
+  },
+  "slug": {
+    "en": "productSlugOld"
+  },
+  "masterVariant": {
+    "key": "var-1-key",
+    "sku": "var-1-sku",
+    "prices": [
+    ],
+    "attributes": [
+      {
+        "name": "priceInfo",
+        "value": "64,90/kg"
+      },
+      {
+        "name": "size",
+        "value": "ca. 1 x 1000 g"
+      }
+    ]
+  },
+  "variants": [
+    {
+      "key": "var-2-key",
+      "sku": "var-2-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/2.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-3-key",
+      "sku": "var-3-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/3.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    },
+    {
+      "key": "var-4-key",
+      "sku": "var-4-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/4.png",
+          "dimensions":{
+            "w": 10,
+            "h": 10
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java
@@ -61,7 +61,7 @@ public class ClientConfigurationUtils {
      * Creates a {@link BlockingSphereClient} with a default {@code timeout} value of 30 seconds.
      *
      * @param clientConfig the client configuration for the client.
-     * @return the instanted {@link BlockingSphereClient}.
+     * @return the instantiated {@link BlockingSphereClient}.
      */
     public static SphereClient createClient(@Nonnull final SphereClientConfig clientConfig) {
         return createClient(clientConfig, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_TIME_UNIT);

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -138,6 +138,12 @@ public final class ProductVariantUpdateActionUtils {
         final List<Image> oldProductVariantImages = oldProductVariant.getImages();
         final List<Image> newProductVariantImages = newProductVariant.getImages();
 
+        // this implementation is quite straight forward and might be slow on large arrays,
+        // because of quadratic algorithms of remove/add images synchronization.
+        // Unfortunately, there is not easy solution to synchronize 2 ordered lists
+        // having only add/remove/moveToPos actions.
+        // This solution should be re-optimized in the next releases to avoid O(N^2) for large lists.
+
         if (!Objects.equals(oldProductVariantImages, newProductVariantImages)) {
             final List<Image> oldImages = oldProductVariantImages != null
                     ? oldProductVariantImages : Collections.emptyList();
@@ -174,6 +180,10 @@ public final class ProductVariantUpdateActionUtils {
      * <p>This method expects the two lists two contain the same images only in different order. Therefore, be cautios
      * that supplying lists of different (missing/extra) images could results in an index out of bounds exception on the
      * new position of an image.
+     *
+     * <p><b>Note</b>: the solution is still not optimized and may contain {@link MoveImageToPosition} actions
+     * for items which are already on desired positions (after previous moves in the sequence). This will be
+     * re-optimized in the next releases.
      *
      * @param variantId the variantId for the {@link MoveImageToPosition} update actions.
      * @param oldImages the old list of images.

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -40,9 +40,6 @@ public final class ProductVariantUpdateActionUtils {
         + "setAttribute/setAttributeInAllVariants update action for the attribute with the name '%s' in the "
         + "ProductVariantDraft with key '%s' on the product with key '%s'. Reason: %s";
     private static final String NULL_PRODUCT_VARIANT_ATTRIBUTE = "AttributeDraft is null.";
-    private static final String IMAGE_LISTS_NOT_THE_SAME_SIZE = "Old and new image lists must have the same size, but "
-        + "they have %d and %d respectively";
-    private static final String OLD_IMAGE_NOT_FOUND = "Old image [%s] not found in the new images list.";
 
     /**
      * Compares the attributes of a {@link ProductVariantDraft} and a {@link ProductVariant} to build either
@@ -203,7 +200,8 @@ public final class ProductVariantUpdateActionUtils {
         final int newImageListSize = newImages.size();
         if (oldImageListSize != newImageListSize) {
             throw new IllegalArgumentException(
-                format(IMAGE_LISTS_NOT_THE_SAME_SIZE, oldImageListSize, newImageListSize));
+                format("Old and new image lists must have the same size, but they have %d and %d respectively",
+                    oldImageListSize, newImageListSize));
         }
 
         // optimization: to avoid multiple linear image index searching in the loop below - create an [image -> index]
@@ -219,7 +217,8 @@ public final class ProductVariantUpdateActionUtils {
         for (int oldIndex = 0; oldIndex < oldImageListSize; oldIndex++) {
             final Image oldImage = oldImages.get(oldIndex);
             final Integer newIndex = ofNullable(imageIndexMap.get(oldImage)) // constant-time operation
-                .orElseThrow(() -> new IllegalArgumentException(format(OLD_IMAGE_NOT_FOUND, oldImage)));
+                .orElseThrow(() ->
+                    new IllegalArgumentException(format("Old image [%s] not found in the new images list.", oldImage)));
 
             if (oldIndex != newIndex) {
                 updateActions.add(

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -203,11 +203,11 @@ public final class ProductVariantUpdateActionUtils {
                     oldImages.size(), newImages.size()));
         }
 
-        final int SIZE = oldImages.size();
+        final int listSize = oldImages.size();
 
         // optimization: to avoid multiple linear image index searching in the loop below - create an [image -> index]
         // map. This avoids quadratic order of growth of the implementation for large arrays.
-        final Map<Image, Integer> imageIndexMap = new HashMap<>(SIZE);
+        final Map<Image, Integer> imageIndexMap = new HashMap<>(listSize);
         int index = 0;
         for (Image newImage : newImages) {
             imageIndexMap.put(newImage, index++);
@@ -215,7 +215,7 @@ public final class ProductVariantUpdateActionUtils {
 
         final List<MoveImageToPosition> updateActions = new ArrayList<>();
 
-        for (int oldIndex = 0; oldIndex < SIZE; oldIndex++) {
+        for (int oldIndex = 0; oldIndex < listSize; oldIndex++) {
             final Image oldImage = oldImages.get(oldIndex);
 
             final Integer newIndex = ofNullable(imageIndexMap.get(oldImage)) // constant-time operation

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -146,11 +146,7 @@ public final class ProductVariantUpdateActionUtils {
         // TODO: GITHUB ISSUE#133
 
         if (!Objects.equals(oldProductVariantImages, newProductVariantImages)) {
-            final List<Image> oldImages = oldProductVariantImages != null
-                    ? oldProductVariantImages : Collections.emptyList();
-
-            final List<Image> updatedOldImages = new ArrayList<>(oldImages);
-
+            final List<Image> updatedOldImages = new ArrayList<>(oldProductVariantImages);
             final List<Image> newImages = newProductVariantImages != null
                     ? newProductVariantImages : Collections.emptyList();
 
@@ -162,7 +158,7 @@ public final class ProductVariantUpdateActionUtils {
                     });
 
             filterCollection(newProductVariantImages, newVariantImage ->
-                    !oldImages.contains(newVariantImage))
+                    !oldProductVariantImages.contains(newVariantImage))
                     .forEach(newImage -> {
                         updateActions.add(AddExternalImage.ofVariantId(oldProductVariantId, newImage, true));
                         updatedOldImages.add(newImage);

--- a/src/test/java/com/commercetools/sync/products/utils/BuildProductVariantImagesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/BuildProductVariantImagesUpdateActionsTest.java
@@ -1,0 +1,354 @@
+package com.commercetools.sync.products.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.Image;
+import io.sphere.sdk.products.ImageDimensions;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.commands.updateactions.AddExternalImage;
+import io.sphere.sdk.products.commands.updateactions.MoveImageToPosition;
+import io.sphere.sdk.products.commands.updateactions.RemoveImage;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildMoveImageToPositionUpdateActions;
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildProductVariantImagesUpdateActions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BuildProductVariantImagesUpdateActionsTest {
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithNullImageLists_ShouldNotBuildUpdateActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(0);
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithNullNewImageList_ShouldBuildRemoveImageUpdateActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel"));
+        oldImages.add(Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label"));
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(2);
+        updateActions.forEach(
+            productUpdateAction -> {
+                assertThat(productUpdateAction.getAction()).isEqualTo("removeImage");
+                assertThat(productUpdateAction).isExactlyInstanceOf(RemoveImage.class);
+            }
+        );
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithNullOldImageList_ShouldBuildAddExternalImageActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel"));
+        newImages.add(Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label"));
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(2);
+        updateActions.forEach(
+            productUpdateAction -> {
+                assertThat(productUpdateAction.getAction()).isEqualTo("addExternalImage");
+                assertThat(productUpdateAction).isExactlyInstanceOf(AddExternalImage.class);
+            }
+        );
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithIdenticalImageLists_ShouldNotBuildUpdateActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel"));
+        oldImages.add(Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label"));
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel"));
+        newImages.add(Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label"));
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithDifferntImageLists_ShouldBuildAddExternalImageAction() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final Image image = Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel");
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image);
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image);
+        newImages.add(image2);
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(1);
+        assertThat(updateActions.get(0)).isExactlyInstanceOf(AddExternalImage.class);
+        final AddExternalImage updateAction = (AddExternalImage) updateActions.get(0);
+        assertThat(updateAction.getImage()).isEqualTo(image2);
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithDifferntImageLists_ShouldBuildRemoveImageAction() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final Image image = Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel");
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image);
+        oldImages.add(image2);
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image);
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(1);
+        assertThat(updateActions.get(0)).isExactlyInstanceOf(RemoveImage.class);
+        final RemoveImage updateAction = (RemoveImage) updateActions.get(0);
+        assertThat(updateAction.getImageUrl()).isEqualTo(image2.getUrl());
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithDifferentOrderImageLists_ShouldBuildMovePositionActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final Image image = Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel");
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image2);
+        oldImages.add(image);
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image);
+        newImages.add(image2);
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(2);
+        updateActions.forEach(
+            productUpdateAction -> {
+                assertThat(productUpdateAction.getAction()).isEqualTo("moveImageToPosition");
+                assertThat(productUpdateAction).isExactlyInstanceOf(MoveImageToPosition.class);
+            }
+        );
+        final MoveImageToPosition moveImageToPosition = (MoveImageToPosition) updateActions.get(0);
+        final MoveImageToPosition moveImage2ToPosition = (MoveImageToPosition) updateActions.get(1);
+
+        assertThat(moveImageToPosition.getImageUrl()).isEqualTo(image2.getUrl());
+        assertThat(moveImageToPosition.getPosition()).isEqualTo(newImages.indexOf(image2));
+        assertThat(moveImage2ToPosition.getImageUrl()).isEqualTo(image.getUrl());
+        assertThat(moveImage2ToPosition.getPosition()).isEqualTo(newImages.indexOf(image));
+    }
+
+    @Test
+    public void buildProductVariantImagesUpdateActions_WithDifferentOrderAndImages_ShouldBuildActions() {
+        final ProductVariant oldVariant = mock(ProductVariant.class);
+        final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
+
+        final Image image = Image.of("https://image.url.com", ImageDimensions.of(2, 2), "imageLabel");
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+        final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
+        final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
+        final Image image5 = Image.of("https://image5.url.com", ImageDimensions.of(2, 2), "image5Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image5);
+        oldImages.add(image2);
+        oldImages.add(image);
+        oldImages.add(image3);
+        when(oldVariant.getImages()).thenReturn(oldImages);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image4);
+        newImages.add(image5);
+        newImages.add(image2);
+        newImages.add(image3);
+        when(newVariantDraft.getImages()).thenReturn(newImages);
+
+        final List<UpdateAction<Product>> updateActions =
+                buildProductVariantImagesUpdateActions(oldVariant, newVariantDraft);
+        assertThat(updateActions).hasSize(6);
+        final RemoveImage removeImage = (RemoveImage) updateActions.get(0);
+        final AddExternalImage addImage = (AddExternalImage) updateActions.get(1);
+        final MoveImageToPosition moveImage5ToPosition = (MoveImageToPosition) updateActions.get(2);
+        final MoveImageToPosition moveImage2ToPosition = (MoveImageToPosition) updateActions.get(3);
+        final MoveImageToPosition moveImage3ToPosition = (MoveImageToPosition) updateActions.get(4);
+        final MoveImageToPosition moveImage4ToPosition = (MoveImageToPosition) updateActions.get(5);
+
+        assertThat(removeImage).isExactlyInstanceOf(RemoveImage.class);
+        assertThat(removeImage.getImageUrl()).isEqualTo(image.getUrl());
+
+        assertThat(addImage).isExactlyInstanceOf(AddExternalImage.class);
+        assertThat(addImage.getImage()).isEqualTo(image4);
+
+        assertThat(moveImage5ToPosition).isExactlyInstanceOf(MoveImageToPosition.class);
+        assertThat(moveImage5ToPosition.getImageUrl()).isEqualTo(image5.getUrl());
+        assertThat(moveImage5ToPosition.getPosition()).isEqualTo(newImages.indexOf(image5));
+
+        assertThat(moveImage2ToPosition).isExactlyInstanceOf(MoveImageToPosition.class);
+        assertThat(moveImage2ToPosition.getImageUrl()).isEqualTo(image2.getUrl());
+        assertThat(moveImage2ToPosition.getPosition()).isEqualTo(newImages.indexOf(image2));
+
+        assertThat(moveImage3ToPosition).isExactlyInstanceOf(MoveImageToPosition.class);
+        assertThat(moveImage3ToPosition.getImageUrl()).isEqualTo(image3.getUrl());
+        assertThat(moveImage3ToPosition.getPosition()).isEqualTo(newImages.indexOf(image3));
+
+        assertThat(moveImage4ToPosition).isExactlyInstanceOf(MoveImageToPosition.class);
+        assertThat(moveImage4ToPosition.getImageUrl()).isEqualTo(image4.getUrl());
+        assertThat(moveImage4ToPosition.getPosition()).isEqualTo(newImages.indexOf(image4));
+    }
+
+    @Test
+    public void buildMoveImageToPositionUpdateActions_WithDifferentOrder_ShouldBuildActions() {
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+        final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
+        final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
+        final Image image5 = Image.of("https://image5.url.com", ImageDimensions.of(2, 2), "image5Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image5);
+        oldImages.add(image2);
+        oldImages.add(image3);
+        oldImages.add(image4);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image4);
+        newImages.add(image5);
+        newImages.add(image2);
+        newImages.add(image3);
+
+        final List<MoveImageToPosition> updateActions =
+                buildMoveImageToPositionUpdateActions(1, oldImages, newImages);
+        assertThat(updateActions).hasSize(4);
+        updateActions.forEach(
+            productUpdateAction -> assertThat(productUpdateAction.getAction()).isEqualTo("moveImageToPosition"));
+
+        final MoveImageToPosition moveImage5ToPosition = updateActions.get(0);
+        final MoveImageToPosition moveImage2ToPosition = updateActions.get(1);
+        final MoveImageToPosition moveImage3ToPosition = updateActions.get(2);
+        final MoveImageToPosition moveImage4ToPosition = updateActions.get(3);
+
+        assertThat(moveImage5ToPosition.getImageUrl()).isEqualTo(image5.getUrl());
+        assertThat(moveImage5ToPosition.getPosition()).isEqualTo(newImages.indexOf(image5));
+
+        assertThat(moveImage2ToPosition.getImageUrl()).isEqualTo(image2.getUrl());
+        assertThat(moveImage2ToPosition.getPosition()).isEqualTo(newImages.indexOf(image2));
+
+        assertThat(moveImage3ToPosition.getImageUrl()).isEqualTo(image3.getUrl());
+        assertThat(moveImage3ToPosition.getPosition()).isEqualTo(newImages.indexOf(image3));
+
+        assertThat(moveImage4ToPosition.getImageUrl()).isEqualTo(image4.getUrl());
+        assertThat(moveImage4ToPosition.getPosition()).isEqualTo(newImages.indexOf(image4));
+    }
+
+    @Test
+    public void buildMoveImageToPositionUpdateActions_WithSameOrder_ShouldNotBuildActions() {
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+        final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
+        final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
+        final Image image5 = Image.of("https://image5.url.com", ImageDimensions.of(2, 2), "image5Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image5);
+        oldImages.add(image2);
+        oldImages.add(image3);
+        oldImages.add(image4);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image5);
+        newImages.add(image2);
+        newImages.add(image3);
+        newImages.add(image4);
+
+        final List<MoveImageToPosition> updateActions =
+                buildMoveImageToPositionUpdateActions(1, oldImages, newImages);
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildMoveImageToPositionUpdateActions_WitEmptyArrays_ShouldNotBuildActions() {
+        final List<Image> oldImages = new ArrayList<>();
+        final List<Image> newImages = new ArrayList<>();
+
+        final List<MoveImageToPosition> updateActions =
+                buildMoveImageToPositionUpdateActions(1, oldImages, newImages);
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildMoveImageToPositionUpdateActions_WithDifferentImages_ShouldBuildActions() {
+        final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
+        final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
+        final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
+        final Image image5 = Image.of("https://image5.url.com", ImageDimensions.of(2, 2), "image5Label");
+
+        final List<Image> oldImages = new ArrayList<>();
+        oldImages.add(image5);
+        oldImages.add(image2);
+        oldImages.add(image3);
+
+        final List<Image> newImages = new ArrayList<>();
+        newImages.add(image4);
+        newImages.add(image5);
+        newImages.add(image2);
+        newImages.add(image3);
+
+        final List<MoveImageToPosition> updateActions =
+                buildMoveImageToPositionUpdateActions(1, oldImages, newImages);
+        assertThat(updateActions).hasSize(3);
+        updateActions.forEach(
+            productUpdateAction -> assertThat(productUpdateAction.getAction()).isEqualTo("moveImageToPosition"));
+
+        final MoveImageToPosition moveImage5ToPosition = updateActions.get(0);
+        final MoveImageToPosition moveImage2ToPosition = updateActions.get(1);
+        final MoveImageToPosition moveImage3ToPosition = updateActions.get(2);
+
+        assertThat(moveImage5ToPosition.getImageUrl()).isEqualTo(image5.getUrl());
+        assertThat(moveImage5ToPosition.getPosition()).isEqualTo(newImages.indexOf(image5));
+
+        assertThat(moveImage2ToPosition.getImageUrl()).isEqualTo(image2.getUrl());
+        assertThat(moveImage2ToPosition.getPosition()).isEqualTo(newImages.indexOf(image2));
+
+        assertThat(moveImage3ToPosition.getImageUrl()).isEqualTo(image3.getUrl());
+        assertThat(moveImage3ToPosition.getPosition()).isEqualTo(newImages.indexOf(image3));
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/utils/BuildProductVariantImagesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/BuildProductVariantImagesUpdateActionsTest.java
@@ -94,7 +94,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferntImageLists_ShouldBuildAddExternalImageAction() {
+    public void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildAddExternalImageAction() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -119,7 +119,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferntImageLists_ShouldBuildRemoveImageAction() {
+    public void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildRemoveImageAction() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtilsTest.java
@@ -14,8 +14,8 @@ public class ProductVariantUpdateActionUtilsTest {
 
     @Test
     public void buildProductVariantSkuUpdateActions_normalCase() throws Exception {
-        ProductVariant variantOld = mock(ProductVariant.class);
-        ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
+        final ProductVariant variantOld = mock(ProductVariant.class);
+        final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 
         assertThat(buildProductVariantSkuUpdateActions(variantOld, variantDraftNew)).isEmpty();
 
@@ -38,5 +38,4 @@ public class ProductVariantUpdateActionUtilsTest {
         assertThat(buildProductVariantSkuUpdateActions(variantOld, variantDraftNew))
                 .containsExactly(SetSku.of(42, "sku-new", true));
     }
-
 }


### PR DESCRIPTION
#### Summary

1. Refactoring of Implementation of product variant images update actions:  `addExternalImage` and `removeImage`. #100  [(here)](https://github.com/commercetools/commercetools-sync-java/pull/123/files#diff-991246687782cb226352bc27cff57377)
2. Implement update actions  `moveImageToPosition` #114  [(here)](https://github.com/commercetools/commercetools-sync-java/pull/123/files#diff-991246687782cb226352bc27cff57377)
3. Provide unit tests [(here)](https://github.com/commercetools/commercetools-sync-java/pull/123/files#diff-c4ffdd59d518dc272d9e9ecba2cf7724)
4. Provide Integration tests for all cases. [(here)](https://github.com/commercetools/commercetools-sync-java/pull/123/files#diff-fb350d9c49ffc682ca22a66bccdbb9a9)
4. Provide JavaDocs. 

#### Relevant Issues
#114 #100  
