### PR TITLE
#98: fix javadoc publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ cache:
   - $HOME/.gradle/wrapper/
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- ./gradlew clean -Dbuild.version=$TRAVIS_TAG gitPublishPush
-- ./travis-build.sh
+- ./travis-publish.sh
 notifications:
   hipchat:
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
   - $HOME/.gradle/wrapper/
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- ./travis-publish.sh
+- ./travis-publish.sh || travis_terminate 1
 notifications:
   hipchat:
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Java API which exposes utilities for building update actions and automatic synci
       - [Package JARs and run tests](#package-jars-and-run-tests)
       - [Full build with tests, but without install to maven local repo (Recommended)](#full-build-with-tests-but-without-install-to-maven-local-repo-recommended)
       - [Install to local maven repo](#install-to-local-maven-repo)
-      - [Build and publish JavaDoc](#build-and-publish-javadoc)
-      - [Publish to Bintray](#publish-to-bintray)
+      - [Publish JavaDoc](#publish-javadoc)
+      - [Build and publish to Bintray](#build-and-publish-to-bintray)
   - [Integration Tests](#integration-tests)
     - [Running](#running)
 
@@ -119,14 +119,17 @@ For example, `#65: Remove redundant space.`
 ./gradlew clean install
 ````
 
-##### Build and publish JavaDoc
+##### Publish JavaDoc
 ````bash
-./gradlew clean -Dbuild.version={version} gitPublishPush
+./gradlew clean javadoc gitPublishPush -Dbuild.version={version}
 ````
 
-##### Publish to Bintray
+**Note**: in current [Travis build](/.travis.yml) workflow the command looks different: `clean` and `javadoc` 
+are omitted because `javadoc` is previously created in `build` task, we just should not clean it now.
+
+##### Build and publish to Bintray
 ````bash
-./gradlew clean -Dbuild.version={version} bintrayUpload
+./gradlew clean build bintrayUpload -Dbuild.version={version} 
 ````
 
 For more detailed information on build and release process, see [Build and Release](BUILD.md) documentation.

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -4,7 +4,7 @@ gitPublish {
     http://ajoberstar.org/grgit/index.html
      */
 
-    repoUri = scmSshUrl
+    repoUri = scmHttpsUrl
     branch = 'gh-pages'
 
     // what to publish, this is a standard CopySpec

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -1,8 +1,9 @@
 gitPublish {
-    /*
-    NOTE: $GRGIT_USER environment variable must be set to actual github token
-    http://ajoberstar.org/grgit/index.html
-     */
+    // NOTE:
+    // 1) $GRGIT_USER environment variable must be set to actual github token
+    //    see http://ajoberstar.org/grgit/docs/groovydoc/index.html?org/ajoberstar/grgit/auth/AuthConfig.html
+    //    https://github.com/ajoberstar/grgit#usage
+    // 2) to use GH token `repoUri` must have an https (not git or ssh) protocol
 
     repoUri = scmHttpsUrl
     branch = 'gh-pages'
@@ -18,6 +19,7 @@ gitPublish {
     // what to keep in the existing branch (include=keep)
     preserve {
         include 'v/**'
+        exclude 'v/test**' // always remove documentation of test releases
     }
 
     // message used when committing changes

--- a/gradle-scripts/project-info.gradle
+++ b/gradle-scripts/project-info.gradle
@@ -2,3 +2,5 @@ group = 'com.commercetools'
 version = System.getProperty('build.version') ?: versionWIP
 description = "Java library that provides different modules to synchronise your new commercetools project data to your " +
         "existing commercetools project."
+
+logger.lifecycle("\nActual Build Version: [{}]\n", version)

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -9,7 +9,7 @@ export TAG=`if [ "$TRAVIS_PULL_REQUEST" = "false" -a -n "$TRAVIS_TAG" ] ; then e
 
 if [ "$TAG" ]; then
   echo "Build is tagged. Uploading artifact $TAG to Bintray."
-  ./gradlew --info -Dbuild.version=$TRAVIS_TAG bintrayUpload
+  ./gradlew --info -Dbuild.version="$TAG" gitPublishPush bintrayUpload
 else
   echo "This build doesn't publish the library since it is not tagged."
 fi

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -1,6 +1,4 @@
-#! /bin/bash
-
-set -e
+#!/bin/bash
 
 echo "TRAVIS_PULL_REQUEST $TRAVIS_PULL_REQUEST"
 echo "TRAVIS_TAG $TRAVIS_TAG"
@@ -9,7 +7,12 @@ export TAG=`if [ "$TRAVIS_PULL_REQUEST" = "false" -a -n "$TRAVIS_TAG" ] ; then e
 
 if [ "$TAG" ]; then
   echo "Build is tagged. Uploading artifact $TAG to Bintray."
-  ./gradlew --info -Dbuild.version="$TAG" gitPublishPush bintrayUpload
+  ./gradlew --info -Dbuild.version="$TAG" gitPublishPush || exit 1
+  ./gradlew --info -Dbuild.version="$TAG" bintrayUpload
+  if [[ $? != 0 ]]; then
+    printf "\nWARNING: javadoc $TAG is published to github, but bintray upload failed.\n\n"
+    exit 1
+  fi
 else
   echo "This build doesn't publish the library since it is not tagged."
 fi


### PR DESCRIPTION
  - fix #117. The main problem was in `clean` task after the build before `gitPublishPush` and `bintrayUpload`
  - rename _travis-build.sh_ to _travis-publish.sh_
  - [print actual build version during gradle build](https://github.com/commercetools/commercetools-sync-java/pull/129/files#diff-9c0be52e80e6470229a9f697ecee0ce1R6)