### PR TITLE
137 variant update actions

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -154,7 +154,9 @@ public class BaseSyncOptions {
     }
 
     /**
-     * @see #applyErrorCallback(String, Throwable) applyErrorCallback(String, Throwable) .
+     *
+     * @param errorMessage the error message to supply as first param to the {@code errorCallBack} function.
+     * @see #applyErrorCallback(String, Throwable) applyErrorCallback(String, Throwable)
      */
     public void applyErrorCallback(@Nonnull final String errorMessage) {
         applyErrorCallback(errorMessage, null);

--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -144,13 +144,20 @@ public class BaseSyncOptions {
      * this method does nothing.
      *
      * @param errorMessage the error message to supply as first param to the {@code errorCallBack} function.
-     * @param exception    the {@link Throwable} instance to supply to the {@code errorCallBack} function as a
+     * @param exception    optional {@link Throwable} instance to supply to the {@code errorCallBack} function as a
      *                     second param.
      */
     public void applyErrorCallback(@Nonnull final String errorMessage, @Nullable final Throwable exception) {
         if (this.errorCallBack != null) {
             this.errorCallBack.accept(errorMessage, exception);
         }
+    }
+
+    /**
+     * @see #applyErrorCallback(String, Throwable) applyErrorCallback(String, Throwable) .
+     */
+    public void applyErrorCallback(@Nonnull final String errorMessage) {
+        applyErrorCallback(errorMessage, null);
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
@@ -114,9 +114,7 @@ public final class ProductSyncUtils {
                 buildCategoryActions(oldProduct, newProduct));
         updateActions.addAll(productCatgoryUpdateActions);
 
-        final List<UpdateAction<Product>> variantUpdateActions =
-            buildVariantsUpdateActions(oldProduct, newProduct, syncOptions, attributesMetaData);
-        updateActions.addAll(variantUpdateActions);
+        updateActions.addAll(buildVariantsUpdateActions(oldProduct, newProduct, syncOptions, attributesMetaData));
 
         // lastly publish/unpublish product
         buildPublishUpdateAction(oldProduct, newProduct).ifPresent(updateActions::add);

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -73,6 +73,7 @@ public final class ProductUpdateActionUtils {
     private static final String NULL_VARIANT = "The variant is null.";
     private static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank";
     private static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key";
+    private static final String BLANK_SKU = "New master variant has blank SKU";
 
     /**
      * Compares the {@link LocalizedString} names of a {@link ProductDraft} and a {@link Product}. The name of the
@@ -548,8 +549,15 @@ public final class ProductUpdateActionUtils {
             // thus we can't use ChangeMasterVariant.ofVariantId(),
             // but it could be re-factored as soon as ChangeMasterVariant.ofKey() happens in the SDK
             () -> {
+
+                final String newSku = newProduct.getMasterVariant().getSku();
+                if (isBlank(newSku)) {
+                    handleBuildVariantsUpdateActionsError(syncOptions, oldProduct, BLANK_SKU);
+                    return emptyList();
+                }
+
                 final List<UpdateAction<Product>> updateActions = new ArrayList<>(2);
-                updateActions.add(ChangeMasterVariant.ofSku(newProduct.getMasterVariant().getSku(), true));
+                updateActions.add(ChangeMasterVariant.ofSku(newSku, true));
 
                 // verify whether the old master variant should be removed:
                 // if the new variant list doesn't contain the old master variant key.

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -527,10 +527,11 @@ public final class ProductUpdateActionUtils {
      *
      * <p>If old master variant is missing in the new variants list - add {@link RemoveVariant} action at the end.
      *
-     * @param oldProduct old product with variants
-     * @param newProduct new product draft with variants <b>with resolved references prices references</b>
+     * @param oldProduct  old product with variants
+     * @param newProduct  new product draft with variants <b>with resolved references prices references</b>
+     * @param syncOptions the sync options wrapper which contains options related to the sync process
      * @return a list of maximum two elements: {@link ChangeMasterVariant} if the keys are different,
-     *     optionally followed by {@link RemoveVariant} if the changed variant does not exist in the new variants list.
+     * optionally followed by {@link RemoveVariant} if the changed variant does not exist in the new variants list.
      */
     @Nonnull
     public static List<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -652,7 +652,8 @@ public final class ProductUpdateActionUtils {
     private static void handleBuildVariantsUpdateActionsError(@Nonnull final Product product,
                                                               @Nonnull final String reason,
                                                               @Nonnull final ProductSyncOptions syncOptions) {
-        syncOptions.applyErrorCallback(format("Failed to build update actions on the product with key '%s'. Reason: %s",
+        syncOptions.applyErrorCallback(format("Failed to build variants update actions on the product with key '%s'. "
+                + "Reason: %s",
             product.getKey(), reason));
     }
 }

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -71,9 +71,9 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public final class ProductUpdateActionUtils {
     private static final String BLANK_VARIANT_KEY = "The variant key is blank.";
     private static final String NULL_VARIANT = "The variant is null.";
-    static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank";
-    static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key";
-    static final String BLANK_NEW_MASTER_VARIANT_SKU = "New master variant has blank SKU";
+    static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank.";
+    static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key.";
+    static final String BLANK_NEW_MASTER_VARIANT_SKU = "New master variant has blank SKU.";
 
     /**
      * Compares the {@link LocalizedString} names of a {@link ProductDraft} and a {@link Product}. The name of the

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -395,7 +395,7 @@ public final class ProductUpdateActionUtils {
             collectionToMap(oldProduct.getMasterData().getStaged().getVariants(), ProductVariant::getKey);
 
         final Map<String, ProductVariant> oldProductVariantsWithMaster = new HashMap<>(oldProductVariantsNoMaster);
-        ProductVariant masterVariant = oldProduct.getMasterData().getStaged().getMasterVariant();
+        final ProductVariant masterVariant = oldProduct.getMasterData().getStaged().getMasterVariant();
         oldProductVariantsWithMaster.put(masterVariant.getKey(), masterVariant);
 
         final List<ProductVariantDraft> newAllProductVariants = new ArrayList<>(newProduct.getVariants());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -71,9 +71,9 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public final class ProductUpdateActionUtils {
     private static final String BLANK_VARIANT_KEY = "The variant key is blank.";
     private static final String NULL_VARIANT = "The variant is null.";
-    private static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank";
-    private static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key";
-    private static final String BLANK_SKU = "New master variant has blank SKU";
+    static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank";
+    static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key";
+    static final String BLANK_NEW_MASTER_VARIANT_SKU = "New master variant has blank SKU";
 
     /**
      * Compares the {@link LocalizedString} names of a {@link ProductDraft} and a {@link Product}. The name of the
@@ -552,7 +552,7 @@ public final class ProductUpdateActionUtils {
 
                 final String newSku = newProduct.getMasterVariant().getSku();
                 if (isBlank(newSku)) {
-                    handleBuildVariantsUpdateActionsError(oldProduct, BLANK_SKU, syncOptions);
+                    handleBuildVariantsUpdateActionsError(oldProduct, BLANK_NEW_MASTER_VARIANT_SKU, syncOptions);
                     return emptyList();
                 }
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -531,7 +531,7 @@ public final class ProductUpdateActionUtils {
      * @param newProduct  new product draft with variants <b>with resolved references prices references</b>
      * @param syncOptions the sync options wrapper which contains options related to the sync process
      * @return a list of maximum two elements: {@link ChangeMasterVariant} if the keys are different,
-     * optionally followed by {@link RemoveVariant} if the changed variant does not exist in the new variants list.
+     *     optionally followed by {@link RemoveVariant} if the changed variant does not exist in the new variants list.
      */
     @Nonnull
     public static List<UpdateAction<Product>> buildChangeMasterVariantUpdateAction(

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -173,7 +173,7 @@ public class ProductUpdateActionUtilsTest {
         ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
 
         List<UpdateAction<Product>> changeMasterVariant =
-                buildChangeMasterVariantUpdateAction(mock(ProductSyncOptions.class), productOld, productDraftNew);
+                buildChangeMasterVariantUpdateAction(productOld, productDraftNew, mock(ProductSyncOptions.class));
         assertThat(changeMasterVariant).hasSize(2);
         assertThat(changeMasterVariant.get(0))
                 .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku(), true));

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -173,7 +173,7 @@ public class ProductUpdateActionUtilsTest {
         ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
 
         List<UpdateAction<Product>> changeMasterVariant =
-                buildChangeMasterVariantUpdateAction(productOld, productDraftNew);
+                buildChangeMasterVariantUpdateAction(mock(ProductSyncOptions.class), productOld, productDraftNew);
         assertThat(changeMasterVariant).hasSize(2);
         assertThat(changeMasterVariant.get(0))
                 .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku(), true));

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -42,7 +42,6 @@ import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.bui
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeMasterVariantUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildRemoveVariantUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildVariantsUpdateActions;
-import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -201,8 +200,9 @@ public class ProductUpdateActionUtilsTest {
         // verify all expected error messages
         for (int i = 0; i < errorMessages.length; i++) {
             assertThat(errorsCatcher.get(i))
-                .contains(format("Failed to build update actions on the product with key '%s'", productOld.getKey()))
-                .contains(errorMessages[i]);
+                .containsIgnoringCase("failed")
+                .contains(productOld.getKey())
+                .containsIgnoringCase(errorMessages[i]);
         }
     }
 
@@ -263,8 +263,9 @@ public class ProductUpdateActionUtilsTest {
         assertThat(changeMasterVariant).hasSize(0);
         assertThat(errorsCatcher).hasSize(1);
         assertThat(errorsCatcher.get(0))
-            .contains(format("Failed to build update actions on the product with key '%s'", productOld.getKey()))
-            .contains(expectedErrorReason);
+            .containsIgnoringCase("failed")
+            .contains(productOld.getKey())
+            .containsIgnoringCase(expectedErrorReason);
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -2,7 +2,9 @@ package com.commercetools.sync.products.utils;
 
 import com.commercetools.sync.products.AttributeMetaData;
 import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.SyncFilter;
+import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Image;
 import io.sphere.sdk.products.PriceDraft;
@@ -33,10 +35,15 @@ import java.util.Objects;
 import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToMap;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftFromJson;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductFromJson;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_NEW_MASTER_VARIANT_KEY;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_NEW_MASTER_VARIANT_SKU;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_OLD_MASTER_VARIANT_KEY;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildAddVariantUpdateActionFromDraft;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeMasterVariantUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildRemoveVariantUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildVariantsUpdateActions;
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,6 +53,7 @@ public class ProductUpdateActionUtilsTest {
 
     private static final String RES_ROOT = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/";
     private static final String OLD_PROD_WITH_VARIANTS = RES_ROOT + "productOld.json";
+    private static final String OLD_PROD_WITHOUT_MV_KEY_SKU = RES_ROOT + "productOld_noMasterVariantKeySku.json";
 
     // this product's variants don't contain old master variant
     private static final String NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER =
@@ -54,6 +62,12 @@ public class ProductUpdateActionUtilsTest {
     // this product's variants contain old master variant, but not as master any more
     private static final String NEW_PROD_DRAFT_WITH_VARIANTS_MOVE_MASTER =
         RES_ROOT + "productDraftNew_moveMasterVariant.json";
+
+    private static final String NEW_PROD_DRAFT_WITHOUT_MV = RES_ROOT + "productDraftNew_noMasterVariant.json";
+
+    private static final String NEW_PROD_DRAFT_WITHOUT_MV_KEY = RES_ROOT + "productDraftNew_noMasterVariantKey.json";
+
+    private static final String NEW_PROD_DRAFT_WITHOUT_MV_SKU = RES_ROOT + "productDraftNew_noMasterVariantSku.json";
 
     @Test
     public void buildVariantsUpdateActions_updatesVariants() throws Exception {
@@ -150,6 +164,49 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
+    public void buildVariantsUpdateActions_withEmptyOldMasterVariantKey() throws Exception {
+        assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITH_VARIANTS_MOVE_MASTER,
+            BLANK_OLD_MASTER_VARIANT_KEY);
+    }
+
+    @Test
+    public void buildVariantsUpdateActions_withEmptyNewMasterVariantOrKey() throws Exception {
+        assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV, BLANK_NEW_MASTER_VARIANT_KEY);
+        assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
+            BLANK_NEW_MASTER_VARIANT_KEY);
+    }
+
+    @Test
+    public void buildVariantsUpdateActions_withEmptyBothMasterVariantKey() throws Exception {
+        assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
+            BLANK_OLD_MASTER_VARIANT_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
+    }
+
+    private void assertMissingMasterVariantKey(final String oldProduct,
+                                               final String newProduct,
+                                               final String ... errorMessages) {
+        final Product productOld = createProductFromJson(oldProduct);
+        final ProductDraft productDraftNew = createProductDraftFromJson(newProduct);
+
+        final List<String> errorsCatcher = new ArrayList<>();
+        final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
+            .setErrorCallBack((message, exception) -> errorsCatcher.add(message))
+            .build();
+
+        final List<UpdateAction<Product>> updateActions =
+            buildVariantsUpdateActions(productOld, productDraftNew, syncOptions, emptyMap());
+        assertThat(updateActions).isEmpty();
+        assertThat(errorsCatcher).hasSize(errorMessages.length);
+
+        // verify all expected error messages
+        for (int i = 0; i < errorMessages.length; i++) {
+            assertThat(errorsCatcher.get(i))
+                .contains(format("Failed to build update actions on the product with key '%s'", productOld.getKey()))
+                .contains(errorMessages[i]);
+        }
+    }
+
+    @Test
     public void buildRemoveVariantUpdateAction_removesMissedVariants() throws Exception {
         Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
@@ -179,6 +236,35 @@ public class ProductUpdateActionUtilsTest {
                 .isEqualTo(ChangeMasterVariant.ofSku(productDraftNew.getMasterVariant().getSku(), true));
         assertThat(changeMasterVariant.get(1))
             .isEqualTo(RemoveVariant.of(productOld.getMasterData().getStaged().getMasterVariant()));
+    }
+
+    @Test
+    public void buildChangeMasterVariantUpdateAction_withEmptyKey() throws Exception {
+        assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
+    }
+
+    @Test
+    public void buildChangeMasterVariantUpdateAction_withEmptySku() throws Exception {
+        assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_SKU, BLANK_NEW_MASTER_VARIANT_SKU);
+    }
+
+    private void assertChangeMasterVariantEmptyErrorCatcher(final String productMockName,
+                                                            final String expectedErrorReason) {
+        final Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
+        final ProductDraft productDraftNew_withoutKey = createProductDraftFromJson(productMockName);
+
+        final List<String> errorsCatcher = new ArrayList<>();
+        final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
+            .setErrorCallBack((message, exception) -> errorsCatcher.add(message))
+            .build();
+
+        final List<UpdateAction<Product>> changeMasterVariant =
+            buildChangeMasterVariantUpdateAction(productOld, productDraftNew_withoutKey, syncOptions);
+        assertThat(changeMasterVariant).hasSize(0);
+        assertThat(errorsCatcher).hasSize(1);
+        assertThat(errorsCatcher.get(0))
+            .contains(format("Failed to build update actions on the product with key '%s'", productOld.getKey()))
+            .contains(expectedErrorReason);
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -170,14 +170,14 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyNewMasterVariantOrKey() throws Exception {
+    public void buildVariantsUpdateActions_withEmptyNewMasterVariantOrKey_ShouldNotBuildActionAndTriggerCallback() {
         assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV, BLANK_NEW_MASTER_VARIANT_KEY);
         assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
             BLANK_NEW_MASTER_VARIANT_KEY);
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyBothMasterVariantKey() throws Exception {
+    public void buildVariantsUpdateActions_withEmptyBothMasterVariantKey_ShouldNotBuildActionAndTriggerCallback() {
         assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
             BLANK_OLD_MASTER_VARIANT_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
     }
@@ -239,12 +239,12 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeMasterVariantUpdateAction_withEmptyKey() throws Exception {
+    public void buildVariantsUpdateActions_withEmptyKey_ShouldNotBuildActionAndTriggerCallback() throws Exception {
         assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
     }
 
     @Test
-    public void buildChangeMasterVariantUpdateAction_withEmptySku() throws Exception {
+    public void buildVariantsUpdateActions_withEmptySku_ShouldNotBuildActionAndTriggerCallback() throws Exception {
         assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_SKU, BLANK_NEW_MASTER_VARIANT_SKU);
     }
 

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariant.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariant.json
@@ -1,0 +1,4 @@
+{
+  "key": "productToSyncKey",
+  "variants": []
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariantKey.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariantKey.json
@@ -1,0 +1,7 @@
+{
+  "key": "productToSyncKey",
+  "masterVariant": {
+    "sku": "newMasterSku"
+  },
+  "variants": []
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariantSku.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_noMasterVariantSku.json
@@ -1,0 +1,7 @@
+{
+  "key": "productToSyncKey",
+  "masterVariant": {
+    "key": "newMasterKey"
+  },
+  "variants": []
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld_noMasterVariantKeySku.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld_noMasterVariantKeySku.json
@@ -1,0 +1,27 @@
+{
+  "key": "productToSyncKey",
+  "masterData": {
+    "staged": {
+      "name": {
+        "en": "Rehrücken ohne Knochen"
+      },
+      "description": {
+        "en": "Die Rückenstücke..."
+      },
+      "categories": [
+        {
+          "typeId": "category",
+          "id": "1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f"
+        }
+      ],
+      "slug": {
+        "en": "rehruecken-o-kn"
+      },
+      "masterVariant": {
+        "id": 1
+      },
+      "variants": []
+    },
+    "published": true
+  }
+}


### PR DESCRIPTION
fixes #137:
  - verify master variants/keys before `buildVariantsUpdateActions()` ([ProductUpdateActionUtils](https://github.com/commercetools/commercetools-sync-java/pull/140/files#diff-540361586e271c4157d1afe06f9c8636))
  - verify master variants/keys, new variant SKU before `buildChangeMasterVariantUpdateAction()` ([ProductUpdateActionUtils](https://github.com/commercetools/commercetools-sync-java/pull/140/files#diff-540361586e271c4157d1afe06f9c8636R537))
  - add null/empty corner test cases ([ProductUpdateActionUtilsTest](https://github.com/commercetools/commercetools-sync-java/pull/140/files#diff-8c90c82014038e4c9b8161fc777b48d8R167))
  