### PR TITLE
#117: Publish javadoc jars to binary.

### DIFF
--- a/gradle-scripts/maven-publish.gradle
+++ b/gradle-scripts/maven-publish.gradle
@@ -26,6 +26,7 @@ publishing {
         Production(MavenPublication) {
             from components.java
             artifact sourcesJar
+            artifact javadocJar
             groupId rootProject.group
             artifactId project.name
             version rootProject.version


### PR DESCRIPTION
#### Summary
Publish javadoc jars to binary.
