### PR TITLE
#119: Document the sync processing times.

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -48,6 +48,12 @@ are breaking changes. If there are, then a migration guide should be provided.
 **Bug Fixes** (1)
 - **Category Sync** - Fixes an issue where retrying on concurrent modification exception wasn't re-fetching the latest 
 Category and rebuilding build update actions. [#94](https://github.com/commercetools/commercetools-sync-java/issues/94)
+
+**Doc Fixes** (4)
+- **Category Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
+- **Category Sync** - Fix the statistics summary string used in the documentation. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
+- **Product Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
+- **Inventory Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
 -->
 
 ### v1.0.0-M2 -  Oct 12, 2017 

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -102,14 +102,18 @@ CompletionStage<CategorySyncStatistics> syncStatisticsStage = categorySync.sync(
 ````
 The result of the completing the `syncStatisticsStage` in the previous code snippet contains a `CategorySyncStatistics`
 which contains all the stats of the sync process; which includes a report message, the total number of updated, created, 
-failed, processed categories and the processing time of the sync in different time units and in a
+failed, processed categories and the processing time of the last sync batch in different time units and in a
 human readable format.
+
 ````java
 final CategorySyncStatistics stats = syncStatisticsStage.toCompletebleFuture().join();
 stats.getReportMessage(); 
-/*"Summary: 2000 categories were processed in total (1000 created, 995 updated and 5 categories failed to sync)."*/
+/*"Summary: 2000 categories were processed in total (1000 created, 995 updated, 5 failed to sync and 0 categories with a missing parent)."*/
 ````
 
+__Note__ The statistics object contains the processing time of the last batch only. This is due to two reasons:
+ 1. The sync processing time should not take into account the time between supplying batches to the sync. 
+ 2. It is not not known by the sync which batch is going to be the last one supplied.
 
 More examples of how to use the sync 
 1. From another CTP project as source can be found [here](/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java).

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -81,6 +81,10 @@ inventorySync.sync(inventoryEntryDrafts)
 //"Summary: 2000 inventory entries were processed in total (1000 created, 995 updated, 5 failed to sync)"
 ````
 
+__Note__ The statistics object contains the processing time of the last batch only. This is due to two reasons:
+ 1. The sync processing time should not take into account the time between supplying batches to the sync. 
+ 2. It is not not known by the sync which batch is going to be the last one supplied.
+
 Additional optional configuration for the sync can be configured on the `InventorySyncOptions` instance, according to your need:
 
 - `ensureChannels`

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -124,6 +124,10 @@ stats.getReportMessage();
 /*"Summary: 2000 products were processed in total (1000 created, 995 updated and 5 products failed to sync)."*/
 ````
 
+__Note__ The statistics object contains the processing time of the last batch only. This is due to two reasons:
+ 1. The sync processing time should not take into account the time between supplying batches to the sync. 
+ 2. It is not not known by the sync which batch is going to be the last one supplied.
+
 
 More examples of how to use the sync
 1. From another CTP project as source can be found [here](/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java).


### PR DESCRIPTION
#### Summary

Document the description of the processing time calculated by the sync, that it is the last batch's processing time and the reason behind it.


#### Relevant Issues
#119 

#### Todo
@butenkor We discussed before, that it could be enough to have the `latestBatchProcessingTimeInMillis` in the statistics for the user and the other time units could just be calculated from the user side.

 currently the statistics look like this:
````
{
  "reportMessage": "Summary: 500 categories were processed in total (0 created, 485 updated, 0 failed to sync and 0 categories with a missing parent).",
  "updated": 485,
  "created": 0,
  "failed": 0,
  "processed": 500,
  "latestBatchProcessingTimeInDays": 0,
  "latestBatchProcessingTimeInHours": 0,
  "latestBatchProcessingTimeInMinutes": 0,
  "latestBatchProcessingTimeInSeconds": 0,
  "latestBatchProcessingTimeInMillis": 397,
  "latestBatchHumanReadableProcessingTime": "0d, 0h, 0m, 0s, 397ms",
  "categoryKeysWithMissingParents": {
    
  }
}
``````
Is it final that we remove the other time unit calculations:   
- latestBatchProcessingTimeInDays
- latestBatchProcessingTimeInHours
- latestBatchProcessingTimeInMinutes
- latestBatchProcessingTimeInSeconds
- latestBatchHumanReadableProcessingTime

Or is there a reason we might need them?