### PR TITLE
160 product bundles

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -44,30 +44,33 @@ are breaking changes. If there are, then a migration guide should be provided.
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M3/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M3)
 
-**New Features** (1)
+**New Features** (7)
+- **ProductSync** - Support Product TaxCategory reference resolution and syncing. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
+- **ProductSync** - Support Product State reference resolution and syncing. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
+- **ProductSync** - Expose `ProductReferenceReplacementUtils#buildProductQuery` util to create a product query with all needed reference expansions to fetch products from a source CTP project for the sync. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
+- **ProductSync** - Expose `VariantReferenceReplacementUtils#replaceVariantsReferenceIdsWithKeys` which provides utils to replace reference ids with keys on variants (price and attriute references) coming from a source CTP project to make it ready for reference resolution. [#160](https://github.com/commercetools/commercetools-sync-java/issues/160).
+- **ProductSync** - Expose `VariantReferenceResolver` which is a helper that resolves the price and attriute references on a ProductVariantDraft. (Note: This is used now by the already existing ProductReferenceResolver) [#160](https://github.com/commercetools/commercetools-sync-java/issues/160).
+- **CategorySync** - Expose `CategoryReferenceReplacementUtils#buildCategoryQuery` util to create a category query with all needed reference expansions to fetch categories from a source CTP project for the sync. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
 - **Commons** - Expose `replaceCustomTypeIdWithKeys` and `replaceReferenceIdWithKey`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
-- **ProductSync** - Expose `ProductReferenceReplancementUtils#buildProductQuery` util to create a product query with all needed reference expansions to fetch products from a source CTP project for the sync. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
-- **CategorySync** - Expose `CategoryReferenceReplancementUtils#buildCategoryQuery` util to create a category query with all needed reference expansions to fetch categories from a source CTP project for the sync. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
 
 **Bug Fixes** (1)
 - **Category Sync** - Fixes an issue where retrying on concurrent modification exception wasn't re-fetching the latest 
 Category and rebuilding build update actions. [#94](https://github.com/commercetools/commercetools-sync-java/issues/94)
 
 **Doc Fixes** (4)
+- **Product Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
 - **Category Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
 - **Category Sync** - Fix the statistics summary string used in the documentation. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
-- **Product Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
 - **Inventory Sync** - Document the reason behind having the latest batch processing time. [#119](https://github.com/commercetools/commercetools-sync-java/issues/119)
 
-**Compatibility notes** (8)
+**Compatibility notes** (7)
+- **Product Sync** - Move `replaceProductsReferenceIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
+- **Product Sync** - Remove `replaceProductDraftsCategoryReferenceIdsWithKeys` which is not needed anymore. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
+- **Product Sync** - Remove `replaceProductDraftCategoryReferenceIdsWithKeys` which is not needed anymore. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
+- **Product Sync** - Remove `replaceCategoryOrderHintCategoryIdsWithKeys` which is not needed anymore. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
+- **Product Sync** - Move `getDraftBuilderFromStagedProduct` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
 - **Category Sync** - Move `replaceCategoriesReferenceIdsWithKeys` from `SyncUtils` to `CategoryReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
 - **Inventory Sync** - Move `replaceInventoriesReferenceIdsWithKeys` from `SyncUtils` to `InventoryReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `replaceProductsReferenceIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `replaceProductDraftsCategoryReferenceIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `replaceProductDraftCategoryReferenceIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `replaceCategoryOrderHintCategoryIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `replaceProductDraftsCategoryReferenceIdsWithKeys` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
-- **Product Sync** - Move `getDraftBuilderFromStagedProduct` from `SyncUtils` to `ProductReferenceReplacementUtils`. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120)
 -->
 
 ### v1.0.0-M2 -  Oct 12, 2017 

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -160,4 +160,5 @@ More examples of those utils for different fields can be found [here](/src/integ
 ## Caveats
 1. Products are either created or updated. Currently the tool does not support category deletion.
 2. The library doesn't sync product variant assets yet [#3](https://github.com/commercetools/commercetools-sync-java/issues/3), but it will not delete them.
-3. The library will sync all field types of product type attributes/custom fields, except `ReferenceType`. [#87](https://github.com/commercetools/commercetools-sync-java/issues/3).
+3. The library will not sync attribute field types with `ReferenceType` and `SetType` field definitions, except 
+for Product references. (See more: [#87](https://github.com/commercetools/commercetools-sync-java/issues/87) [#160](https://github.com/commercetools/commercetools-sync-java/issues/87))

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
@@ -3,15 +3,23 @@ package com.commercetools.sync.integration.ctpprojectsource.products;
 import com.commercetools.sync.products.ProductSync;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.products.SyncFilter;
 import com.commercetools.sync.products.helpers.ProductSyncStatistics;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.channels.ChannelDraft;
 import io.sphere.sdk.channels.commands.ChannelCreateCommand;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateType;
@@ -22,10 +30,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_NAME;
@@ -42,14 +53,18 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.StateITUtils.createState;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxCategory;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SUPPLY_CHANNEL_KEY_1;
+import static com.commercetools.sync.products.ActionGroup.ATTRIBUTES;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_CHANGED_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_CHANGED_WITH_PRICES_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_WITH_PRICES_RESOURCE_PATH;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_2_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraft;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftBuilder;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createRandomCategoryOrderHints;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceSetAttributeDraft;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceWithId;
 import static com.commercetools.sync.products.utils.ProductReferenceReplacementUtils.buildProductQuery;
 import static com.commercetools.sync.products.utils.ProductReferenceReplacementUtils.replaceProductsReferenceIdsWithKeys;
 import static java.lang.String.format;
@@ -73,6 +88,7 @@ public class ProductSyncIT {
     private ProductSync productSync;
     private List<String> errorCallBackMessages;
     private List<String> warningCallBackMessages;
+    private List<UpdateAction<Product>> updateActions;
     private List<Throwable> errorCallBackExceptions;
 
     /**
@@ -129,6 +145,7 @@ public class ProductSyncIT {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
         warningCallBackMessages = new ArrayList<>();
+        updateActions = new ArrayList<>();
     }
 
     private ProductSyncOptions buildSyncOptions() {
@@ -141,6 +158,10 @@ public class ProductSyncIT {
         return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
                                         .setErrorCallBack(errorCallBack)
                                         .setWarningCallBack(warningCallBack)
+                                        .setUpdateActionsFilterCallBack(builtActions -> {
+                                            updateActions.addAll(builtActions);
+                                            return builtActions;
+                                        })
                                         .build();
     }
 
@@ -251,5 +272,129 @@ public class ProductSyncIT {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(errorCallBackExceptions).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
+    }
+
+    @Test
+    public void sync_withProductTypeReference_ShouldUpdateProducts() {
+        // Create custom options with whitelisting and action filter callback..
+        final BiConsumer<String, Throwable> errorCallBack = (errorMessage, exception) -> {
+            errorCallBackMessages.add(errorMessage);
+            errorCallBackExceptions.add(exception);
+        };
+        final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);
+        final Function<List<UpdateAction<Product>>, List<UpdateAction<Product>>> actionCollector = builtActions -> {
+            updateActions.addAll(builtActions);
+            return builtActions;
+        };
+        final ProductSyncOptions customSyncOptions =
+            ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                     .setErrorCallBack(errorCallBack)
+                                     .setWarningCallBack(warningCallBack)
+                                     .setUpdateActionsFilterCallBack(actionCollector)
+                                     .setSyncFilter(SyncFilter.ofWhiteList(ATTRIBUTES))
+                                     .build();
+        final ProductSync customSync = new ProductSync(customSyncOptions);
+
+
+
+        // Create 3 existing products in target project with keys (productKey1, productKey2 and productKey3)
+        final ProductDraft existingProductDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
+            targetProductType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
+            targetCategoryReferencesWithIds, createRandomCategoryOrderHints(targetCategoryReferencesWithIds));
+        CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)).toCompletableFuture().join();
+
+        final ProductDraft existingProductDraft2 = createProductDraft(PRODUCT_KEY_2_RESOURCE_PATH,
+            targetProductType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
+            targetCategoryReferencesWithIds, createRandomCategoryOrderHints(targetCategoryReferencesWithIds));
+        final Product targetProductWithKey2 = CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft2))
+                                                               .toCompletableFuture().join();
+
+        final ProductDraft existingProductDraft3 = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
+            targetProductType.toReference())
+            .slug(LocalizedString.ofEnglish("newSlug3"))
+            .key("productKey3")
+            .masterVariant(ProductVariantDraftBuilder.of().key("v3").build())
+            .taxCategory(null)
+            .state(null)
+            .categories(Collections.emptySet())
+            .categoryOrderHints(null)
+            .build();
+        CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft3)).toCompletableFuture().join();
+
+        // Create 2 existing products in source project with keys (productKey2 and productKey3)
+        final ProductDraft newProductDraft2 = createProductDraft(PRODUCT_KEY_2_RESOURCE_PATH,
+            sourceProductType.toReference(), sourceTaxCategory.toReference(), sourceProductState.toReference(),
+            sourceCategoryReferencesWithIds, createRandomCategoryOrderHints(sourceCategoryReferencesWithIds));
+        final Product product2 = CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(newProductDraft2))
+                                                 .toCompletableFuture().join();
+        final ProductDraft newProductDraft3 = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
+            sourceProductType.toReference())
+            .slug(LocalizedString.ofEnglish("newSlug3"))
+            .key("productKey3")
+            .masterVariant(ProductVariantDraftBuilder.of().key("v3").build())
+            .taxCategory(null)
+            .state(null)
+            .categories(Collections.emptySet())
+            .categoryOrderHints(null)
+            .build();
+        final Product product3 = CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(newProductDraft3))
+                                                 .toCompletableFuture().join();
+
+
+        final ObjectNode productReferenceValue1 = getProductReferenceWithId(product2.getId());
+        final ObjectNode productReferenceValue2 = getProductReferenceWithId(product3.getId());
+
+        final AttributeDraft productRefAttr = AttributeDraft.of("product-reference", productReferenceValue1);
+        final AttributeDraft productSetRefAttr =
+            getProductReferenceSetAttributeDraft("product-reference-set", productReferenceValue1,
+                productReferenceValue2);
+        final List<AttributeDraft> attributeDrafts = Arrays.asList(productRefAttr, productSetRefAttr);
+
+        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
+                                                                            .key("v1")
+                                                                            .attributes(attributeDrafts).build();
+
+        // Create existing product with productKey1 in source project that has references to products with keys
+        // (productKey2 and productKey3).
+        final ProductDraft newProductDraftWithProductReference =
+            createProductDraftBuilder(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH, sourceProductType.toReference())
+                .masterVariant(masterVariant)
+                .taxCategory(sourceTaxCategory.toReference())
+                .state(sourceProductState.toReference())
+                .categories(Collections.emptySet())
+                .categoryOrderHints(null)
+                .build();
+        CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(newProductDraftWithProductReference))
+                         .toCompletableFuture().join();
+
+        final List<Product> products = CTP_SOURCE_CLIENT.execute(buildProductQuery())
+                                                        .toCompletableFuture().join().getResults();
+
+        final List<ProductDraft> productDrafts = replaceProductsReferenceIdsWithKeys(products);
+
+        final ProductSyncStatistics syncStatistics =  customSync.sync(productDrafts).toCompletableFuture().join();
+
+        assertThat(syncStatistics.getReportMessage())
+            .isEqualTo(format("Summary: %d products were processed in total (%d created, %d updated and %d products"
+                + " failed to sync).", 3, 0, 1, 0));
+
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActions).hasSize(2);
+
+        final UpdateAction<Product> productReferenceAction = updateActions.get(0);
+        assertThat(productReferenceAction).isExactlyInstanceOf(SetAttributeInAllVariants.class);
+        final SetAttributeInAllVariants action1 = (SetAttributeInAllVariants) productReferenceAction;
+        assertThat(action1.getName()).isEqualTo("product-reference");
+        assertThat(action1.getValue()).isNotNull();
+        assertThat(action1.getValue().get("id").asText()).isEqualTo(targetProductWithKey2.getId());
+
+        final UpdateAction<Product> productReferenceSetAction = updateActions.get(1);
+        assertThat(productReferenceSetAction).isExactlyInstanceOf(SetAttributeInAllVariants.class);
+        final SetAttributeInAllVariants action2 = (SetAttributeInAllVariants) productReferenceSetAction;
+        assertThat(action2.getName()).isEqualTo("product-reference-set");
+        assertThat(action2.getValue()).isNotNull();
+        assertThat(action2.getValue().isArray()).isTrue();
     }
 }

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -83,7 +83,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
         this.productService = productService;
         this.productTypeService = productTypeService;
         this.productReferenceResolver = new ProductReferenceResolver(productSyncOptions, productTypeService,
-            categoryService, typeService, channelService, taxCategoryService, stateService);
+            categoryService, typeService, channelService, taxCategoryService, stateService, productService);
     }
 
     @Override

--- a/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
@@ -41,6 +41,7 @@ public final class VariantReferenceResolver extends BaseReferenceResolver<Produc
      *                           and/or configuration and other sync-specific options.
      * @param typeService        the service to fetch the custom types for reference resolution.
      * @param channelService     the service to fetch the channels for reference resolution.
+     * @param productService     the service to fetch the products for reference resolution.
      */
     public VariantReferenceResolver(@Nonnull final ProductSyncOptions productSyncOptions,
                                     @Nonnull final TypeService typeService,

--- a/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
@@ -1,0 +1,190 @@
+package com.commercetools.sync.products.helpers;
+
+import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.helpers.BaseReferenceResolver;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.services.ChannelService;
+import com.commercetools.sync.services.ProductService;
+import com.commercetools.sync.services.TypeService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+
+public final class VariantReferenceResolver extends BaseReferenceResolver<ProductVariantDraft, ProductSyncOptions> {
+    private final PriceReferenceResolver priceReferenceResolver;
+    private final ProductService productService;
+
+    /**
+     * Takes a {@link ProductSyncOptions} instance, {@link TypeService}, a {@link ChannelService} and a
+     * {@link ProductService} to instantiate a {@link VariantReferenceResolver} instance that could be used to resolve
+     * the prices and variants of variant drafts in the CTP project specified in the injected {@link ProductSyncOptions}
+     * instance.
+     *
+     * @param productSyncOptions the container of all the options of the sync process including the CTP project client
+     *                           and/or configuration and other sync-specific options.
+     * @param typeService        the service to fetch the custom types for reference resolution.
+     * @param channelService     the service to fetch the channels for reference resolution.
+     */
+    public VariantReferenceResolver(@Nonnull final ProductSyncOptions productSyncOptions,
+                                    @Nonnull final TypeService typeService,
+                                    @Nonnull final ChannelService channelService,
+                                    @Nonnull final ProductService productService) {
+        super(productSyncOptions);
+        this.priceReferenceResolver = new PriceReferenceResolver(productSyncOptions, typeService, channelService);
+        this.productService = productService;
+    }
+
+
+    /**
+     * Given a {@link ProductVariantDraft} this method attempts to resolve the prices and attributes to
+     * return a {@link CompletionStage} which contains a new instance of the draft with the resolved
+     * references. The keys of the references are either taken from the expanded references or
+     * taken from the id field of the references.
+     *
+     * @param productVariantDraft the product variant draft to resolve it's references.
+     * @return a {@link CompletionStage} that contains as a result a new productDraft instance with resolved references
+     *         or, in case an error occurs during reference resolution, a {@link ReferenceResolutionException}.
+     */
+    @Override
+    public CompletionStage<ProductVariantDraft> resolveReferences(
+        @Nonnull final ProductVariantDraft productVariantDraft) {
+        return resolvePricesReferences(ProductVariantDraftBuilder.of(productVariantDraft))
+            .thenCompose(this::resolveAttributesReferences)
+            .thenApply(ProductVariantDraftBuilder::build);
+    }
+
+    CompletionStage<ProductVariantDraftBuilder> resolvePricesReferences(
+        @Nonnull final ProductVariantDraftBuilder productVariantDraftBuilder) {
+        final List<PriceDraft> productVariantDraftPrices = productVariantDraftBuilder.getPrices();
+        if (productVariantDraftPrices == null) {
+            return completedFuture(productVariantDraftBuilder);
+        }
+
+        final List<CompletableFuture<PriceDraft>> resolvedPriceDraftFutures =
+            productVariantDraftPrices.stream()
+                                     .filter(Objects::nonNull)
+                                     .map(priceReferenceResolver::resolveReferences)
+                                     .map(CompletionStage::toCompletableFuture)
+                                     .collect(Collectors.toList());
+        return CompletableFuture
+            .allOf(resolvedPriceDraftFutures.toArray(new CompletableFuture[resolvedPriceDraftFutures.size()]))
+            .thenApply(result -> resolvedPriceDraftFutures.stream()
+                                                          .map(CompletableFuture::join)
+                                                          .collect(Collectors.toList()))
+            .thenApply(productVariantDraftBuilder::prices);
+    }
+
+    CompletionStage<ProductVariantDraftBuilder> resolveAttributesReferences(
+        @Nonnull final ProductVariantDraftBuilder productVariantDraftBuilder) {
+        final List<AttributeDraft> attributeDrafts = productVariantDraftBuilder.getAttributes();
+        if (attributeDrafts == null) {
+            return completedFuture(productVariantDraftBuilder);
+        }
+
+        final List<CompletableFuture<AttributeDraft>> resolvedAttributeDraftFutures =
+            attributeDrafts.stream()
+                           .filter(Objects::nonNull)
+                           .map(this::resolveAttributeReference)
+                           .map(CompletionStage::toCompletableFuture)
+                           .collect(Collectors.toList());
+        return CompletableFuture
+            .allOf(resolvedAttributeDraftFutures.toArray(new CompletableFuture[resolvedAttributeDraftFutures.size()]))
+            .thenApply(result -> resolvedAttributeDraftFutures.stream()
+                                                              .map(CompletableFuture::join)
+                                                              .collect(Collectors.toList()))
+            .thenApply(productVariantDraftBuilder::attributes);
+    }
+
+    CompletionStage<AttributeDraft> resolveAttributeReference(@Nonnull final AttributeDraft attributeDraft) {
+        final JsonNode attributeDraftValue = attributeDraft.getValue();
+        if (attributeDraftValue == null) {
+            return CompletableFuture.completedFuture(attributeDraft);
+        }
+        if (attributeDraftValue.isArray()) {
+            return resolveAttributeSetReferences(attributeDraft);
+        } else {
+            if (isProductReference(attributeDraftValue)) {
+                return getResolvedIdFromKeyInReference(attributeDraftValue)
+                    .thenApply(productIdOptional ->
+                        productIdOptional.map(productId ->
+                            AttributeDraft.of(attributeDraft.getName(), createProductReferenceJson(productId)))
+                                         .orElse(attributeDraft));
+            }
+            return CompletableFuture.completedFuture(attributeDraft);
+        }
+    }
+
+    private CompletionStage<AttributeDraft> resolveAttributeSetReferences(
+        @Nonnull final AttributeDraft attributeDraft) {
+        final JsonNode attributeDraftValue = attributeDraft.getValue();
+        final Spliterator<JsonNode> attributeReferencesIterator = attributeDraftValue.spliterator();
+        final List<CompletableFuture<JsonNode>> referenceResolutionFutures =
+            StreamSupport.stream(attributeReferencesIterator, false)
+                         .filter(Objects::nonNull)
+                         .filter(reference -> !reference.isNull())
+                         .map(reference -> {
+                             if (isProductReference(reference)) {
+                                 return getResolvedIdFromKeyInReference(reference)
+                                     .thenApply(productIdOptional ->
+                                         productIdOptional.map(this::createProductReferenceJson)
+                                                          .orElse(reference));
+                             }
+                             return CompletableFuture.completedFuture(reference);
+                         })
+                         .map(CompletionStage::toCompletableFuture)
+                         .collect(Collectors.toList());
+        return CompletableFuture
+            .allOf(referenceResolutionFutures.toArray(new CompletableFuture[referenceResolutionFutures.size()]))
+            .thenApply(voidResult -> {
+                final List<JsonNode> resolvedProductReferences =
+                    referenceResolutionFutures.stream()
+                                              .map(CompletionStage::toCompletableFuture)
+                                              .map(CompletableFuture::join)
+                                              .collect(Collectors.toList());
+                return AttributeDraft.of(attributeDraft.getName(), resolvedProductReferences);
+            });
+    }
+
+    static boolean isProductReference(@Nonnull final JsonNode referenceValue) {
+        return getReferenceTypeIdIfReference(referenceValue)
+            .map(referenceTypeId -> Objects.equals(referenceTypeId, "product"))
+            .orElse(false);
+    }
+
+    private static Optional<String> getReferenceTypeIdIfReference(@Nonnull final JsonNode referenceValue) {
+        final JsonNode typeId = referenceValue.get("typeId");
+        return typeId != null ? Optional.ofNullable(typeId.asText()) : Optional.empty();
+    }
+
+    CompletionStage<Optional<String>> getResolvedIdFromKeyInReference(@Nonnull final JsonNode referenceValue) {
+        final JsonNode idField = referenceValue.get("id");
+        return idField != null
+            ? productService.fetchCachedProductId(idField.asText())
+            : CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    private JsonNode createProductReferenceJson(@Nonnull final String productId) {
+        final ObjectNode productReferenceJsonNode = JsonNodeFactory.instance.objectNode();
+        productReferenceJsonNode.put("id", productId);
+        productReferenceJsonNode.put("typeId", "product");
+        return productReferenceJsonNode;
+    }
+}
+

--- a/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
@@ -2,13 +2,9 @@ package com.commercetools.sync.products.utils;
 
 import com.commercetools.sync.commons.helpers.CategoryReferencePair;
 import io.sphere.sdk.categories.Category;
-import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.expansion.ExpansionPath;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.CategoryOrderHints;
-import io.sphere.sdk.products.Price;
-import io.sphere.sdk.products.PriceDraft;
-import io.sphere.sdk.products.PriceDraftBuilder;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductData;
 import io.sphere.sdk.products.ProductDraft;
@@ -67,7 +63,9 @@ public final class ProductReferenceReplacementUtils {
                     categoryReferencePair.getCategoryReferences();
                 final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
-                final List<ProductVariantDraft> variantDraftsWithKeys = replaceProductPriceChannelIdsWithKeys(product);
+                final List<ProductVariant> allVariants = product.getMasterData().getStaged().getAllVariants();
+                final List<ProductVariantDraft> variantDraftsWithKeys =
+                    VariantReferenceReplacementUtils.replaceVariantsReferenceIdsWithKeys(allVariants);
                 final ProductVariantDraft masterVariantDraftWithKeys = variantDraftsWithKeys.remove(0);
 
                 return ProductDraftBuilder.of(productDraft)
@@ -221,39 +219,6 @@ public final class ProductReferenceReplacementUtils {
     }
 
     /**
-     * Takes a product that is supposed to have all its variants' prices' channels expanded in order to be able to fetch
-     * the keys and replace the reference ids with the corresponding keys for the channel references. This method
-     * returns as a result a {@link List} of {@link ProductVariantDraft} that has all prices' channel references with
-     * keys replacing the ids.
-     *
-     * <p>Any channel reference that is not expanded will have it's id in place and not replaced by the key.
-     *
-     * @param product the product to replace its variants' prices' channel' ids with keys.
-     * @return  a {@link List} of {@link ProductVariantDraft} that has all prices' channel references with
-     *          keys replacing the ids.
-     */
-    @Nonnull
-    static List<ProductVariantDraft> replaceProductPriceChannelIdsWithKeys(@Nonnull final Product product) {
-        final List<ProductVariant> allVariants = product.getMasterData().getStaged().getAllVariants();
-        final List<ProductVariantDraft> variantDraftsWithKeys = new ArrayList<>();
-
-        allVariants.forEach(productVariant -> {
-            final List<PriceDraft> priceDrafts = replaceProductVariantPriceChannelIdsWithKeys(productVariant);
-            final ProductVariantDraft variantDraftWithKey = ProductVariantDraftBuilder.of(productVariant)
-                                                                                      .prices(priceDrafts)
-                                                                                      .build();
-            variantDraftsWithKeys.add(variantDraftWithKey);
-        });
-        return variantDraftsWithKeys;
-    }
-
-    /**
-     * Takes a product variant that is supposed to have all its prices' channels expanded in order to be able to fetch
-     * the keys and replace the reference ids with the corresponding keys for the channel references. This method
-     * returns as a result a {@link List} of {@link PriceDraft} that has all channel references with keys replacing the
-     * ids.
-     *
-     * <p>Any channel reference that is not expanded will have it's id in place and not replaced by the key.
      * Builds a {@link ProductQuery} for fetching products from a source CTP project with all the needed references
      * expanded for the sync:
      * <ul>
@@ -266,41 +231,10 @@ public final class ProductReferenceReplacementUtils {
      *     <li>Reference Set Attributes</li>
      * </ul>
      *
-     * @param productVariant the product variant to replace its prices' channel' ids with keys.
-     * @return  a {@link List} of {@link PriceDraft} that has all channel references with keys replacing the ids.
      * @return the query for fetching products from the source CTP project with all the aforementioned references
      *         expanded.
      */
     @Nonnull
-    static List<PriceDraft> replaceProductVariantPriceChannelIdsWithKeys(@Nonnull final ProductVariant productVariant) {
-        final List<Price> variantPrices = productVariant.getPrices();
-        final List<PriceDraft> variantPriceDraftsWithKeys = new ArrayList<>();
-        variantPrices.forEach(price -> {
-            final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
-            final PriceDraft priceDraftWithKey = PriceDraftBuilder.of(price)
-                                                                  .channel(channelReferenceWithKey).build();
-            variantPriceDraftsWithKeys.add(priceDraftWithKey);
-        });
-        return variantPriceDraftsWithKeys;
-    }
-
-    /**
-     * Takes a price that is supposed to have its channel reference expanded in order to be able to fetch the key
-     * and replace the reference id with the corresponding key and then return a new {@link Channel} {@link Reference}
-     * containing the key in the id field.
-     *
-     * <p><b>Note:</b> The Channel reference should be expanded for the {@code price}, otherwise the reference
-     * id will not be replaced with the key and will still have the id in place.
-     *
-     * @param price the price to replace its channel reference id with the key.
-     *
-     * @return a new {@link Channel} {@link Reference} containing the key in the id field.
-     */
-    @Nullable
-    @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
-    static Reference<Channel> replaceChannelReferenceIdWithKey(@Nonnull final Price price) {
-        final Reference<Channel> priceChannel = price.getChannel();
-        return replaceReferenceIdWithKey(priceChannel, () -> Channel.referenceOfId(priceChannel.getObj().getKey()));
     public static ProductQuery buildProductQuery() {
         return ProductQuery.of()
                            .withLimit(QueryExecutionUtils.DEFAULT_PAGE_SIZE)

--- a/src/main/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtils.java
@@ -1,0 +1,164 @@
+package com.commercetools.sync.products.utils;
+
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.json.JsonException;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.PriceDraftBuilder;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.Attribute;
+import io.sphere.sdk.products.attributes.AttributeAccess;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.commercetools.sync.commons.utils.SyncUtils.replaceReferenceIdWithKey;
+import static java.util.stream.Collectors.toSet;
+
+public class VariantReferenceReplacementUtils {
+    /**
+     * Takes a list of Variants that are supposed to have their prices and attributes references expanded in order to be
+     * able to fetch the keys and replace the reference ids with the corresponding keys and then return a new list of
+     * product variant drafts with their references containing keys instead of the ids.
+     *
+     * <p><b>Note:</b>If the references are not expanded for a product variant, the reference ids will not be replaced
+     * with keys and will still have their ids in place.
+     *
+     * @param productVariants the product variants to replace their reference ids with keys
+     * @return a list of product variant drafts with keys instead of ids for references.
+     */
+    @Nonnull
+    public static List<ProductVariantDraft> replaceVariantsReferenceIdsWithKeys(
+        @Nonnull final List<ProductVariant> productVariants) {
+        return productVariants
+            .stream()
+            .filter(Objects::nonNull)
+            .map(productVariant -> {
+                final List<PriceDraft> priceDraftsWithKeys = replacePricesReferencesIdsWithKeys(productVariant);
+                final List<AttributeDraft> attributeDraftsWithKeys =
+                    replaceAttributesReferencesIdsWithKeys(productVariant);
+
+                return ProductVariantDraftBuilder.of(productVariant)
+                                                 .prices(priceDraftsWithKeys)
+                                                 .attributes(attributeDraftsWithKeys)
+                                                 .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Takes a product variant that is supposed to have all its prices' channels expanded in order to be able to fetch
+     * the keys and replace the reference ids with the corresponding keys for the channel references. This method
+     * returns as a result a {@link List} of {@link PriceDraft} that has all channel references with keys replacing the
+     * ids.
+     *
+     * <p>Any channel reference that is not expanded will have it's id in place and not replaced by the key.
+     *
+     * @param productVariant the product variant to replace its prices' channel' ids with keys.
+     * @return  a {@link List} of {@link PriceDraft} that has all channel references with keys replacing the ids.
+     */
+    @Nonnull
+    static List<PriceDraft> replacePricesReferencesIdsWithKeys(@Nonnull final ProductVariant productVariant) {
+        final List<Price> variantPrices = productVariant.getPrices();
+        final List<PriceDraft> variantPriceDraftsWithKeys = new ArrayList<>();
+        variantPrices.forEach(price -> {
+            final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
+            final PriceDraft priceDraftWithKey = PriceDraftBuilder.of(price)
+                                                                  .channel(channelReferenceWithKey).build();
+            variantPriceDraftsWithKeys.add(priceDraftWithKey);
+        });
+        return variantPriceDraftsWithKeys;
+    }
+
+    /**
+     * Takes a price that is supposed to have its channel reference expanded in order to be able to fetch the key
+     * and replace the reference id with the corresponding key and then return a new {@link Channel} {@link Reference}
+     * containing the key in the id field.
+     *
+     * <p><b>Note:</b> The Channel reference should be expanded for the {@code price}, otherwise the reference
+     * id will not be replaced with the key and will still have the id in place.
+     *
+     * @param price the price to replace its channel reference id with the key.
+     *
+     * @return a new {@link Channel} {@link Reference} containing the key in the id field.
+     */
+    @Nullable
+    @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
+    static Reference<Channel> replaceChannelReferenceIdWithKey(@Nonnull final Price price) {
+        final Reference<Channel> priceChannel = price.getChannel();
+        return replaceReferenceIdWithKey(priceChannel, () -> Channel.referenceOfId(priceChannel.getObj().getKey()));
+    }
+
+    /**
+     * Takes a product variant that is supposed to have all its attribute product references and product set references
+     * expanded in order to be able to fetch the keys and replace the reference ids with the corresponding keys for the
+     * references. This method returns as a result a {@link List} of {@link AttributeDraft} that has all product
+     * references with keys replacing the ids.
+     *
+     * <p>Any product reference that is not expanded will have it's id in place and not replaced by the key.
+     *
+     * @param productVariant the product variant to replace its attribute product references ids with keys.
+     * @return  a {@link List} of {@link AttributeDraft} that has all product references with keys replacing the ids.
+     */
+    @Nonnull
+    static List<AttributeDraft> replaceAttributesReferencesIdsWithKeys(@Nonnull final ProductVariant productVariant) {
+        final List<Attribute> variantAttributes = productVariant.getAttributes();
+        final List<AttributeDraft> variantAttributeDraftsWithKeys = new ArrayList<>();
+        variantAttributes.forEach(attribute -> {
+            final AttributeDraft resolvedAttributeDraft = replaceAttributeReferenceIdWithKey(attribute)
+                .map(productReference -> AttributeDraft.of(attribute.getName(), productReference))
+                .orElseGet(() ->
+                    replaceAttributeReferenceSetIdsWithKeys(attribute)
+                        .map(productReferenceSet -> AttributeDraft.of(attribute.getName(), productReferenceSet))
+                        .orElseGet(() -> AttributeDraft.of(attribute.getName(), attribute.getValueAsJsonNode())));
+            variantAttributeDraftsWithKeys.add(resolvedAttributeDraft);
+        });
+        return variantAttributeDraftsWithKeys;
+    }
+
+
+    @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
+    static Optional<Reference<Product>> replaceAttributeReferenceIdWithKey(@Nonnull final Attribute attribute) {
+        return getProductReference(attribute)
+            .map(productReference -> replaceReferenceIdWithKey(productReference,
+                () -> Product.referenceOfId(productReference.getObj().getKey())));
+    }
+
+    private static Optional<Reference<Product>> getProductReference(@Nonnull final Attribute attribute) {
+        try {
+            return Optional.of(attribute.getValue(AttributeAccess.ofProductReference()));
+        } catch (final JsonException exception) {
+            return Optional.empty();
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
+    static Optional<Set<Reference<Product>>> replaceAttributeReferenceSetIdsWithKeys(
+        @Nonnull final Attribute attribute) {
+        return getProductReferenceSet(attribute).map(productReferenceSet ->
+            productReferenceSet.stream()
+                               .map(productReference ->
+                                   replaceReferenceIdWithKey(productReference,
+                                       () -> Product.referenceOfId(productReference.getObj().getKey())))
+                               .collect(toSet()));
+    }
+
+    private static Optional<Set<Reference<Product>>> getProductReferenceSet(@Nonnull final Attribute attribute) {
+        try {
+            return Optional.of(attribute.getValue(AttributeAccess.ofProductReferenceSet()));
+        } catch (final JsonException exception) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/commercetools/sync/services/ProductService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductService.java
@@ -14,6 +14,27 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 public interface ProductService {
+
+    /**
+     * Given a {@code key}, this method first checks if cached map of product keys -&gt; ids is not empty.
+     * If not, it returns a completed future that contains an optional that contains what this key maps to in
+     * the cache. If the cache is empty, the method populates the cache with the mapping of all products' keys
+     * to ids in the CTP project. After that, the method returns a
+     * {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's completion
+     * could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no {@link Product}
+     * was found in the CTP project with this key.
+     *
+     * <p>Note: If the supplied key is null, this method will return an empty optional as a result of the
+     * CompletionStage.
+     *
+     * @param key the key by which a {@link Product} id should be fetched from the CTP project.
+     * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
+     *         completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     *         {@link Product} was found in the CTP project with this key.
+     */
+    @Nonnull
+    CompletionStage<Optional<String>> fetchCachedProductId(@Nullable final String key);
+
     /**
      * If not already done once before, it fetches all the product keys from the CTP project defined in a potentially
      * injected {@link SphereClient} and stores a mapping for every product to id in {@link Map}

--- a/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
@@ -48,6 +48,23 @@ public class ProductServiceImpl implements ProductService {
 
     @Nonnull
     @Override
+    public CompletionStage<Optional<String>> fetchCachedProductId(@Nullable final String key) {
+        if (isBlank(key)) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        if (isCached) {
+            return CompletableFuture.completedFuture(Optional.ofNullable(keyToIdCache.get(key)));
+        }
+        return cacheAndFetch(key);
+    }
+
+    private CompletionStage<Optional<String>> cacheAndFetch(@Nonnull final String key) {
+        return cacheKeysToIds()
+            .thenApply(result -> Optional.ofNullable(keyToIdCache.get(key)));
+    }
+
+    @Nonnull
+    @Override
     public CompletionStage<Map<String, String>> cacheKeysToIds() {
         if (isCached) {
             return CompletableFuture.completedFuture(keyToIdCache);

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.products;
 
+import com.commercetools.sync.services.ProductService;
 import com.commercetools.sync.services.ProductTypeService;
 import com.commercetools.sync.services.StateService;
 import com.commercetools.sync.services.TaxCategoryService;
@@ -203,5 +204,21 @@ public class ProductSyncMockUtils {
         when(stateService.fetchCachedStateId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.of(id)));
         return stateService;
+    }
+
+    /**
+     * Creates a mock {@link ProductService} that returns a completed {@link CompletableFuture} containing an
+     * {@link Optional} containing the id of the supplied value whenever the following method is called on the service:
+     * <ul>
+     * <li>{@link ProductService#fetchCachedProductId(String)}</li>
+     * </ul>
+     *
+     * @return the created mock of the {@link ProductService}.
+     */
+    public static ProductService getMockProductService(@Nonnull final String id) {
+        final ProductService productService = mock(ProductService.class);
+        when(productService.fetchCachedProductId(anyString()))
+            .thenReturn(CompletableFuture.completedFuture(Optional.of(id)));
+        return productService;
     }
 }

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -231,6 +231,11 @@ public class ProductSyncMockUtils {
         return productService;
     }
 
+    /**
+     * Creates a mock {@link Price} with the supplied {@link Channel} {@link Reference}.
+     * @param channelReference the channel reference to attach on the mock {@link Price}.
+     * @return a mock price with the supplied channel reference.
+     */
     @Nonnull
     public static Price getPriceMockWithChannelReference(@Nullable final Reference<Channel> channelReference) {
         final Price price = mock(Price.class);
@@ -238,6 +243,11 @@ public class ProductSyncMockUtils {
         return price;
     }
 
+    /**
+     * Creates a mock {@link ProductVariant} with the supplied {@link Price} {@link List}.
+     * @param prices the prices to attach on the mock {@link ProductVariant}.
+     * @return a mock product variant with the supplied prices.
+     */
     @Nonnull
     public static ProductVariant getProductVariantMockWithPrices(@Nonnull final List<Price> prices) {
         final ProductVariant productVariant = mock(ProductVariant.class);
@@ -245,6 +255,11 @@ public class ProductSyncMockUtils {
         return productVariant;
     }
 
+    /**
+     * Creates a mock {@link Channel} with the supplied {@code key}..
+     * @param key the key to to set on the mock {@link Channel}.
+     * @return a mock channel with the supplied key.
+     */
     @Nonnull
     public static Channel getChannelMock(@Nonnull final String key) {
         final Channel channel = mock(Channel.class);
@@ -253,6 +268,12 @@ public class ProductSyncMockUtils {
         return channel;
     }
 
+    /**
+     * Creates an {@link AttributeDraft} with the supplied {@code attributeName} and {@code references}.
+     * @param attributeName the name to set on the {@link AttributeDraft}.
+     * @param references the references to set on the {@link AttributeDraft}.
+     * @return an {@link AttributeDraft} with the supplied {@code attributeName} and {@code references}.
+     */
     @Nonnull
     public static AttributeDraft getProductReferenceSetAttributeDraft(@Nonnull final String attributeName,
                                                                       @Nonnull final ObjectNode... references) {
@@ -261,6 +282,10 @@ public class ProductSyncMockUtils {
         return AttributeDraft.of(attributeName, referenceSet);
     }
 
+    /**
+     * Creates an {@link ObjectNode} that represents a product reference with a random uuid in the id field.
+     * @return an {@link ObjectNode} that represents a product reference with a random uuid in the id field.
+     */
     @Nonnull
     public static ObjectNode getProductReferenceWithRandomId() {
         final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
@@ -269,6 +294,10 @@ public class ProductSyncMockUtils {
         return productReference;
     }
 
+    /**
+     * Creates an {@link ObjectNode} that represents a product reference with the  supplied {@code id} in the id field.
+     * @return an {@link ObjectNode} that represents a product reference with the  supplied {@code id} in the id field.
+     */
     @Nonnull
     public static ObjectNode getProductReferenceWithId(@Nonnull final String id) {
         final ObjectNode productReference = JsonNodeFactory.instance.objectNode();

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -4,15 +4,22 @@ import com.commercetools.sync.services.ProductService;
 import com.commercetools.sync.services.ProductTypeService;
 import com.commercetools.sync.services.StateService;
 import com.commercetools.sync.services.TaxCategoryService;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.CategoryOrderHints;
+import io.sphere.sdk.products.Price;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductData;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.states.State;
 import io.sphere.sdk.taxcategories.TaxCategory;
@@ -20,10 +27,12 @@ import io.sphere.sdk.taxcategories.TaxCategory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -220,5 +229,51 @@ public class ProductSyncMockUtils {
         when(productService.fetchCachedProductId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.of(id)));
         return productService;
+    }
+
+    @Nonnull
+    public static Price getPriceMockWithChannelReference(@Nullable final Reference<Channel> channelReference) {
+        final Price price = mock(Price.class);
+        when(price.getChannel()).thenReturn(channelReference);
+        return price;
+    }
+
+    @Nonnull
+    public static ProductVariant getProductVariantMockWithPrices(@Nonnull final List<Price> prices) {
+        final ProductVariant productVariant = mock(ProductVariant.class);
+        when(productVariant.getPrices()).thenReturn(prices);
+        return productVariant;
+    }
+
+    @Nonnull
+    public static Channel getChannelMock(@Nonnull final String key) {
+        final Channel channel = mock(Channel.class);
+        when(channel.getKey()).thenReturn(key);
+        when(channel.getId()).thenReturn(UUID.randomUUID().toString());
+        return channel;
+    }
+
+    @Nonnull
+    public static AttributeDraft getProductReferenceSetAttributeDraft(@Nonnull final String attributeName,
+                                                                      @Nonnull final ObjectNode... references) {
+        final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
+        referenceSet.addAll(Arrays.asList(references));
+        return AttributeDraft.of(attributeName, referenceSet);
+    }
+
+    @Nonnull
+    public static ObjectNode getProductReferenceWithRandomId() {
+        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
+        productReference.put("typeId", "product");
+        productReference.put("id", UUID.randomUUID().toString());
+        return productReference;
+    }
+
+    @Nonnull
+    public static ObjectNode getProductReferenceWithId(@Nonnull final String id) {
+        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
+        productReference.put("typeId", "product");
+        productReference.put("id", id);
+        return productReference;
     }
 }

--- a/src/test/java/com/commercetools/sync/products/helpers/ProductReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/ProductReferenceResolverTest.java
@@ -5,6 +5,7 @@ import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.CategoryService;
 import com.commercetools.sync.services.ChannelService;
+import com.commercetools.sync.services.ProductService;
 import com.commercetools.sync.services.ProductTypeService;
 import com.commercetools.sync.services.StateService;
 import com.commercetools.sync.services.TaxCategoryService;
@@ -32,6 +33,7 @@ import static com.commercetools.sync.commons.MockUtils.getMockCategoryService;
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductTypeService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockStateService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockTaxCategoryService;
@@ -47,13 +49,15 @@ public class ProductReferenceResolverTest {
     private ChannelService channelService;
     private TaxCategoryService taxCategoryService;
     private StateService stateService;
+    private ProductService productService;
 
     private static final String CHANNEL_KEY = "channel-key_1";
     private static final String CHANNEL_ID = "1";
     private static final String PRODUCT_TYPE_ID = "productTypeId";
     private static final String TAX_CATEGORY_ID = "taxCategoryId";
     private static final String STATE_ID = "stateId";
-    private ProductSyncOptions syncOptions;
+    private static final String PRODUCT_ID = "productId";
+    private ProductReferenceResolver referenceResolver;
 
     /**
      * Sets up the services and the options needed for reference resolution.
@@ -66,7 +70,11 @@ public class ProductReferenceResolverTest {
         channelService = getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
         taxCategoryService = getMockTaxCategoryService(TAX_CATEGORY_ID);
         stateService = getMockStateService(STATE_ID);
-        syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
+        productService = getMockProductService(PRODUCT_ID);
+        final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
+        referenceResolver = new ProductReferenceResolver(syncOptions,
+            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService,
+            productService);
     }
 
     @Test
@@ -74,10 +82,12 @@ public class ProductReferenceResolverTest {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .setAllowUuidKeys(true)
                                                                                .build();
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid();
 
         final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(productSyncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
+            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService,
+            productService);
+
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid();
 
         final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveProductTypeReference(productBuilder)
                                                                    .toCompletableFuture().join();
@@ -86,36 +96,11 @@ public class ProductReferenceResolverTest {
         assertThat(resolvedDraft.getProductType().getId()).isEqualTo(PRODUCT_TYPE_ID);
     }
 
-    @Nonnull
-    private static ProductDraftBuilder getProductDraftWithRefId(@Nonnull final String refId) {
-        return ProductDraftBuilder.of(ProductType.referenceOfId(refId),
-            LocalizedString.ofEnglish("testName"),
-            LocalizedString.ofEnglish("testSlug"),
-            (ProductVariantDraft)null);
-    }
-
-    @Nonnull
-    private static ProductDraftBuilder getProductDraftWithProductTypeRef(
-            @Nonnull final Reference<ProductType> reference) {
-        return ProductDraftBuilder.of(reference,
-            LocalizedString.ofEnglish("testName"),
-            LocalizedString.ofEnglish("testSlug"),
-            (ProductVariantDraft)null);
-    }
-
-    @Nonnull
-    private static ProductDraftBuilder getProductDraftWithRandomProductTypeUuid() {
-        return getProductDraftWithRefId(UUID.randomUUID().toString());
-    }
-
     @Test
     public void resolveProductTypeReference_WithKeys_ShouldResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRefId("productTypeKey");
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("productTypeKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveProductTypeReference(productBuilder)
+        final ProductDraftBuilder resolvedDraft = referenceResolver.resolveProductTypeReference(productBuilder)
                                                                    .toCompletableFuture().join();
 
         assertThat(resolvedDraft.getProductType()).isNotNull();
@@ -124,13 +109,9 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveProductTypeReference_WithKeysAsUuidSetAndNotAllowed_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid();
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid();
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-
-        assertThat(productReferenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -143,16 +124,13 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveProductTypeReference_WithNonExistentProductType_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRefId("anyKey")
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("anyKey")
             .key("dummyKey");
 
         when(productTypeService.fetchCachedProductTypeId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasNotFailed()
             .isCompletedWithValueMatching(resolvedDraft ->
                 Objects.nonNull(resolvedDraft.getProductType())
@@ -161,14 +139,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveProductTypeReference_WithNullIdOnProductTypeReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithProductTypeRef(
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRef(
             Reference.of(ProductType.referenceTypeId(), (String)null))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -179,13 +154,10 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveProductTypeReference_WithEmptyIdOnProductTypeReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRefId("")
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("")
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -196,17 +168,14 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveProductTypeReference_WithExceptionOnProductTypeFetch_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRefId(PRODUCT_TYPE_ID)
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId(PRODUCT_TYPE_ID)
             .key("dummyKey");
 
         final CompletableFuture<Optional<String>> futureThrowingSphereException = new CompletableFuture<>();
         futureThrowingSphereException.completeExceptionally(new SphereException("CTP error on fetch"));
         when(productTypeService.fetchCachedProductTypeId(anyString())).thenReturn(futureThrowingSphereException);
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(SphereException.class)
@@ -218,11 +187,12 @@ public class ProductReferenceResolverTest {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .setAllowUuidKeys(true)
                                                                                .build();
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId(UUID.randomUUID().toString()));
 
         final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(productSyncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
+            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService,
+            productService);
 
         final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveTaxCategoryReferences(productBuilder)
                                                                    .toCompletableFuture().join();
@@ -233,13 +203,10 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithKeys_ShouldResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("taxCategoryKey"));
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveTaxCategoryReferences(productBuilder)
+        final ProductDraftBuilder resolvedDraft = referenceResolver.resolveTaxCategoryReferences(productBuilder)
                                                                    .toCompletableFuture().join();
 
         assertThat(resolvedDraft.getTaxCategory()).isNotNull();
@@ -248,14 +215,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithKeysAsUuidSetAndNotAllowed_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId(UUID.randomUUID().toString()))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -268,30 +232,24 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithNullTaxCategory_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasNotFailed()
             .isCompletedWithValueMatching(resolvedDraft -> Objects.isNull(resolvedDraft.getTaxCategory()));
     }
 
     @Test
     public void resolveTaxCategoryReference_WithNonExistentTaxCategory_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("nonExistentKey"))
             .key("dummyKey");
 
         when(taxCategoryService.fetchCachedTaxCategoryId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasNotFailed()
             .isCompletedWithValueMatching(resolvedDraft ->
                 Objects.nonNull(resolvedDraft.getTaxCategory())
@@ -300,14 +258,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithNullIdOnTaxCategoryReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(Reference.of(TaxCategory.referenceTypeId(), (String)null))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -318,14 +273,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithEmptyIdOnTaxCategoryReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId(""))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -336,7 +288,7 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveTaxCategoryReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("taxCategoryKey"))
             .key("dummyKey");
 
@@ -344,28 +296,24 @@ public class ProductReferenceResolverTest {
         futureThrowingSphereException.completeExceptionally(new SphereException("CTP error on fetch"));
         when(taxCategoryService.fetchCachedTaxCategoryId(anyString())).thenReturn(futureThrowingSphereException);
 
-
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveTaxCategoryReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(SphereException.class)
             .hasMessageContaining("CTP error on fetch");
     }
 
-
     @Test
     public void resolveStateReference_WithKeysAsUuidSetAndAllowed_ShouldResolveReference() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .setAllowUuidKeys(true)
                                                                                .build();
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId(UUID.randomUUID().toString()));
 
         final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(productSyncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
+            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService,
+            productService);
 
         final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveStateReferences(productBuilder)
                                                                    .toCompletableFuture().join();
@@ -376,13 +324,10 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithKeys_ShouldResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("stateKey"));
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        final ProductDraftBuilder resolvedDraft = productReferenceResolver.resolveStateReferences(productBuilder)
+        final ProductDraftBuilder resolvedDraft = referenceResolver.resolveStateReferences(productBuilder)
                                                                    .toCompletableFuture().join();
 
         assertThat(resolvedDraft.getState()).isNotNull();
@@ -391,14 +336,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithKeysAsUuidSetAndNotAllowed_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId(UUID.randomUUID().toString()))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -411,30 +353,24 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithNullState_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasNotFailed()
             .isCompletedWithValueMatching(resolvedDraft -> Objects.isNull(resolvedDraft.getState()));
     }
 
     @Test
     public void resolveStateReference_WithNonExistentState_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("nonExistentKey"))
             .key("dummyKey");
 
         when(stateService.fetchCachedStateId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasNotFailed()
             .isCompletedWithValueMatching(resolvedDraft ->
                 Objects.nonNull(resolvedDraft.getState())
@@ -443,14 +379,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithNullIdOnStateReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(Reference.of(State.referenceTypeId(), (String)null))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -461,14 +394,11 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithEmptyIdOnStateReference_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId(""))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
@@ -479,7 +409,7 @@ public class ProductReferenceResolverTest {
 
     @Test
     public void resolveStateReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReference() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRandomProductTypeUuid()
+        final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("stateKey"))
             .key("dummyKey");
 
@@ -487,30 +417,23 @@ public class ProductReferenceResolverTest {
         futureThrowingSphereException.completeExceptionally(new SphereException("CTP error on fetch"));
         when(stateService.fetchCachedStateId(anyString())).thenReturn(futureThrowingSphereException);
 
-
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        assertThat(productReferenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
+        assertThat(referenceResolver.resolveStateReferences(productBuilder).toCompletableFuture())
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(SphereException.class)
             .hasMessageContaining("CTP error on fetch");
     }
 
-
     @Test
     public void resolveReferences_WithNoCategoryReferencesAndNoChannelReferences_ShouldResolveAvailableReferences() {
-        final ProductDraftBuilder productBuilder = getProductDraftWithRefId("productTypeKey")
+        final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("productTypeKey")
             .state(State.referenceOfId("stateKey"))
             .taxCategory(TaxCategory.referenceOfId("taxCategoryKey"))
             .key("dummyKey");
 
-        final ProductReferenceResolver productReferenceResolver = new ProductReferenceResolver(syncOptions,
-            productTypeService, categoryService, typeService, channelService, taxCategoryService, stateService);
-
-        final ProductDraft referencesResolvedDraft = productReferenceResolver.resolveReferences(productBuilder.build())
-                                                                             .toCompletableFuture().join();
+        final ProductDraft build = productBuilder.build();
+        final ProductDraft referencesResolvedDraft = referenceResolver.resolveReferences(build)
+                                                                      .toCompletableFuture().join();
 
         assertThat(referencesResolvedDraft).isNotNull();
         assertThat(referencesResolvedDraft.getProductType()).isNotNull();
@@ -521,6 +444,29 @@ public class ProductReferenceResolverTest {
 
         assertThat(referencesResolvedDraft.getState()).isNotNull();
         assertThat(referencesResolvedDraft.getState().getId()).isEqualTo(STATE_ID);
+    }
+
+
+    @Nonnull
+    private static ProductDraftBuilder getBuilderWithProductTypeRefId(@Nonnull final String refId) {
+        return ProductDraftBuilder.of(ProductType.referenceOfId(refId),
+            LocalizedString.ofEnglish("testName"),
+            LocalizedString.ofEnglish("testSlug"),
+            (ProductVariantDraft)null);
+    }
+
+    @Nonnull
+    private static ProductDraftBuilder getBuilderWithProductTypeRef(
+        @Nonnull final Reference<ProductType> reference) {
+        return ProductDraftBuilder.of(reference,
+            LocalizedString.ofEnglish("testName"),
+            LocalizedString.ofEnglish("testSlug"),
+            (ProductVariantDraft)null);
+    }
+
+    @Nonnull
+    private static ProductDraftBuilder getBuilderWithRandomProductTypeUuid() {
+        return getBuilderWithProductTypeRefId(UUID.randomUUID().toString());
     }
 
 }

--- a/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
@@ -1,0 +1,555 @@
+package com.commercetools.sync.products.helpers;
+
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.services.ChannelService;
+import com.commercetools.sync.services.ProductService;
+import com.commercetools.sync.services.TypeService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.models.DefaultCurrencyUnits;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.PriceDraftBuilder;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.utils.MoneyImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
+import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VariantReferenceResolverTest { ;
+    private ProductService productService;
+
+    private static final String CHANNEL_KEY = "channel-key_1";
+    private static final String CHANNEL_ID = "1";
+    private static final String PRODUCT_ID = "productId";
+    private VariantReferenceResolver referenceResolver;
+
+    /**
+     * Sets up the services and the options needed for reference resolution.
+     */
+    @Before
+    public void setup() {
+        final TypeService typeService = getMockTypeService();
+        final ChannelService channelService = getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
+        productService = getMockProductService(PRODUCT_ID);
+        ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
+        referenceResolver = new VariantReferenceResolver(syncOptions, typeService, channelService, productService);
+    }
+
+    @Test
+    public void resolvePricesReferences_WithNullPrices_ShouldNotResolvePrices() {
+        final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of();
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolvePricesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<PriceDraft> resolvedBuilderPrices = resolvedBuilder.getPrices();
+        assertThat(resolvedBuilderPrices).isNull();
+    }
+
+    @Test
+    public void resolvePricesReferences_WithANullPrice_ShouldNotResolvePrices() {
+        final ProductVariantDraftBuilder productVariantDraftBuilder =
+            ProductVariantDraftBuilder.of().prices((PriceDraft) null);
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolvePricesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<PriceDraft> resolvedBuilderPrices = resolvedBuilder.getPrices();
+        assertThat(resolvedBuilderPrices).isEmpty();
+    }
+
+    @Test
+    public void resolvePricesReferences_WithPriceReferences_ShouldResolvePrices() {
+        final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft
+            .ofTypeIdAndJson("customTypeId", new HashMap<>());
+
+        final PriceDraft priceDraft = PriceDraftBuilder.of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
+                                                       .custom(customFieldsDraft).build();
+
+        final ProductVariantDraftBuilder productVariantDraftBuilder =
+            ProductVariantDraftBuilder.of().prices(priceDraft);
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolvePricesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<PriceDraft> resolvedBuilderPrices = resolvedBuilder.getPrices();
+        assertThat(resolvedBuilderPrices).isNotEmpty();
+        final PriceDraft resolvedPriceDraft = resolvedBuilderPrices.get(0);
+        assertThat(resolvedPriceDraft).isNotNull();
+        assertThat(resolvedPriceDraft.getCustom()).isNotNull();
+        assertThat(resolvedPriceDraft.getCustom().getType().getId()).isEqualTo("typeId");
+    }
+
+    @Test
+    public void resolveAttributesReferences_WithNullAttributes_ShouldNotResolveAttributes() {
+        final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of();
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolveAttributesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<AttributeDraft> resolvedBuilderAttributes = resolvedBuilder.getAttributes();
+        assertThat(resolvedBuilderAttributes).isNull();
+    }
+
+    @Test
+    public void resolveAttributesReferences_WithANullAttribute_ShouldNotResolveAttributes() {
+        final ProductVariantDraftBuilder productVariantDraftBuilder =
+            ProductVariantDraftBuilder.of().attributes((AttributeDraft) null);
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolveAttributesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<AttributeDraft> resolvedBuilderAttributes = resolvedBuilder.getAttributes();
+        assertThat(resolvedBuilderAttributes).isEmpty();
+    }
+
+    @Test
+    public void resolveAttributesReferences_WithMixedReference_ShouldResolveProductReferenceAttributes() {
+        final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceSetAttribute =
+            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+
+        final ObjectNode categoryReference1 = JsonNodeFactory.instance.objectNode();
+        categoryReference1.put("typeId", "category");
+        categoryReference1.put("id", UUID.randomUUID().toString());
+
+        final AttributeDraft categoryReferenceAttribute = AttributeDraft.of("attributeName", categoryReference1);
+        final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "textValue");
+
+        final List<AttributeDraft> attributeDrafts =
+            Arrays.asList(productReferenceSetAttribute, categoryReferenceAttribute, textAttribute);
+
+        final ProductVariantDraftBuilder productVariantDraftBuilder =
+            ProductVariantDraftBuilder.of()
+                                      .attributes(attributeDrafts);
+
+
+        final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
+            .resolveAttributesReferences(productVariantDraftBuilder)
+            .toCompletableFuture().join();
+
+        final List<AttributeDraft> resolvedBuilderAttributes = resolvedBuilder.getAttributes();
+
+        assertThat(resolvedBuilderAttributes).hasSize(3);
+        assertThat(resolvedBuilderAttributes).contains(categoryReferenceAttribute);
+        assertThat(resolvedBuilderAttributes).contains(textAttribute);
+        final AttributeDraft resolvedProductReferenceSetAttribute = resolvedBuilderAttributes.get(0);
+        assertThat(resolvedProductReferenceSetAttribute).isNotNull();
+        final JsonNode resolvedProductReferenceSetValue = resolvedProductReferenceSetAttribute.getValue();
+        assertThat(resolvedProductReferenceSetValue).isNotNull();
+        final JsonNode resolvedProductReferenceValue = resolvedProductReferenceSetValue.get(0);
+        assertThat(resolvedProductReferenceValue).isNotNull();
+        final JsonNode resolvedProductReferenceIdTextNode = resolvedProductReferenceValue.get("id");
+        assertThat(resolvedProductReferenceIdTextNode).isNotNull();
+        assertThat(resolvedProductReferenceIdTextNode.asText()).isEqualTo(PRODUCT_ID);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithEmptyValue_ShouldNotResolveAttribute() {
+        final AttributeDraft attributeWithEmptyValue =
+            AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(attributeWithEmptyValue)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isSameAs(attributeWithEmptyValue);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithNullValue_ShouldNotResolveAttribute() {
+        final AttributeDraft attributeWithNullValue =
+            AttributeDraft.of("attributeName", null);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(attributeWithNullValue)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isSameAs(attributeWithNullValue);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithTextValue_ShouldNotResolveAttribute() {
+        final AttributeDraft attributeWithTextValue =
+            AttributeDraft.of("attributeName", "textValue");
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(attributeWithTextValue)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isSameAs(attributeWithTextValue);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithProductReferenceAttribute_ShouldResolveAttribute() {
+        when(productService.fetchCachedProductId(anyString()))
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
+        attributeValue.put("typeId", "product");
+        attributeValue.put("id", "nonExistingProductKey");
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft).isSameAs(productReferenceAttribute);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithNonExistingProductReferenceAttribute_ShouldNotResolveAttribute() {
+        final ObjectNode attributeValue = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft).isNotSameAs(productReferenceAttribute);
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue().get("id")).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue().get("id").asText()).isEqualTo(PRODUCT_ID);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithEmptyReferenceSetAttribute_ShouldNotResolveReferences() {
+        final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
+
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", referenceSet);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+        assertThat(resolvedSet).isEmpty();
+    }
+
+    @Test
+    public void resolveAttributeReference_WithCategoryReferenceSetAttribute_ShouldNotResolveReferences() {
+        final ObjectNode categoryReference = JsonNodeFactory.instance.objectNode();
+        categoryReference.put("typeId", "category");
+        categoryReference.put("id", UUID.randomUUID().toString());
+
+        final ObjectNode categoryReference1 = JsonNodeFactory.instance.objectNode();
+        categoryReference1.put("typeId", "category");
+        categoryReference1.put("id", UUID.randomUUID().toString());
+
+        final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
+        referenceSet.add(categoryReference);
+        referenceSet.add(categoryReference1);
+
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", referenceSet);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+        assertThat(resolvedSet).isNotEmpty();
+        assertThat(resolvedSet).contains(categoryReference, categoryReference1);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithProductReferenceSetAttribute_ShouldResolveReferences() {
+        final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceSetAttributeDraft =
+            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceSetAttributeDraft)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+        assertThat(resolvedSet).isNotEmpty();
+        final ObjectNode resolvedReference = JsonNodeFactory.instance.objectNode();
+        resolvedReference.put("typeId", "product");
+        resolvedReference.put("id", PRODUCT_ID);
+        assertThat(resolvedSet).containsExactly(resolvedReference);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithNullReferenceInSetAttribute_ShouldResolveReferences() {
+        final ObjectNode productReference = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceAttribute =
+            getProductReferenceSetAttributeDraft(productReference, null);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+        assertThat(resolvedSet).isNotEmpty();
+        final ObjectNode resolvedReference = JsonNodeFactory.instance.objectNode();
+        resolvedReference.put("typeId", "product");
+        resolvedReference.put("id", PRODUCT_ID);
+        assertThat(resolvedSet).containsExactly(resolvedReference);
+    }
+
+    @Test
+    public void resolveAttributeReference_WithNonExistingProductReferenceSetAttribute_ShouldNotResolveReferences() {
+        when(productService.fetchCachedProductId(anyString()))
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final ObjectNode productReference = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceAttribute =
+            getProductReferenceSetAttributeDraft(productReference);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+        assertThat(resolvedSet).containsExactly(productReference);
+    }
+
+    @Test
+    public void
+        resolveAttributeReference_WithSomeExistingProductReferenceSetAttribute_ShouldResolveExistingReferences() {
+        when(productService.fetchCachedProductId("existingKey"))
+            .thenReturn(CompletableFuture.completedFuture(Optional.of("existingId")));
+        when(productService.fetchCachedProductId("randomKey"))
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final ObjectNode productReference1 = getProductReferenceWithId("existingKey");
+        final ObjectNode productReference2 = getProductReferenceWithId("randomKey");
+
+        final AttributeDraft productReferenceAttribute =
+            getProductReferenceSetAttributeDraft(productReference1, productReference2);
+
+        final AttributeDraft resolvedAttributeDraft =
+            referenceResolver.resolveAttributeReference(productReferenceAttribute)
+                             .toCompletableFuture().join();
+        assertThat(resolvedAttributeDraft).isNotNull();
+        assertThat(resolvedAttributeDraft.getValue()).isNotNull();
+
+        final Spliterator<JsonNode> attributeReferencesIterator = resolvedAttributeDraft.getValue().spliterator();
+        assertThat(attributeReferencesIterator).isNotNull();
+        final Set<JsonNode> resolvedSet = StreamSupport.stream(attributeReferencesIterator, false)
+                                                       .collect(Collectors.toSet());
+
+        final ObjectNode resolvedReference1 = getProductReferenceWithId("existingId");
+        final ObjectNode resolvedReference2 = getProductReferenceWithId("randomKey");
+        assertThat(resolvedSet).containsExactlyInAnyOrder(resolvedReference1, resolvedReference2);
+    }
+
+    @Test
+    public void isProductReference_WithEmptyValue_ShouldReturnFalse() {
+        final AttributeDraft attributeWithEmptyValue =
+            AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
+        assertThat(VariantReferenceResolver.isProductReference(attributeWithEmptyValue.getValue())).isFalse();
+    }
+
+    @Test
+    public void isProductReference_WithTextAttribute_ShouldReturnFalse() {
+        final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "attributeValue");
+        assertThat(VariantReferenceResolver.isProductReference(textAttribute.getValue())).isFalse();
+    }
+
+    @Test
+    public void isProductReference_WithNonReferenceAttribute_ShouldReturnFalse() {
+        final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
+        attributeValue.put("anyString", "anyValue");
+        final AttributeDraft attribute = AttributeDraft.of("attributeName", attributeValue);
+        assertThat(VariantReferenceResolver.isProductReference(attribute.getValue())).isFalse();
+    }
+
+    @Test
+    public void isProductReference_WithCategoryReferenceAttribute_ShouldReturnFalse() {
+        final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
+        attributeValue.put("typeId", "category");
+        attributeValue.put("id", UUID.randomUUID().toString());
+        final AttributeDraft categoryReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+        assertThat(VariantReferenceResolver.isProductReference(categoryReferenceAttribute.getValue())).isFalse();
+    }
+
+    @Test
+    public void isProductReference_WithProductReferenceAttribute_ShouldReturnTrue() {
+        final ObjectNode attributeValue = getProductReferenceWithRandomId();
+        final AttributeDraft categoryReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+        assertThat(VariantReferenceResolver.isProductReference(categoryReferenceAttribute.getValue())).isTrue();
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithEmptyValue_ShouldGetEmptyId() {
+        final AttributeDraft attributeWithEmptyValue =
+            AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
+        final Optional<String> optionalId =
+            referenceResolver.getResolvedIdFromKeyInReference(attributeWithEmptyValue.getValue())
+                             .toCompletableFuture().join();
+        assertThat(optionalId).isEmpty();
+
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithTextAttribute_ShouldGetEmptyId() {
+        final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "attributeValue");
+        final Optional<String> optionalId = referenceResolver.getResolvedIdFromKeyInReference(textAttribute.getValue())
+                                                             .toCompletableFuture().join();
+        assertThat(optionalId).isEmpty();
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithNonReferenceAttribute_ShouldGetEmptyId() {
+        final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
+        attributeValue.put("anyString", "anyValue");
+        final AttributeDraft attribute = AttributeDraft.of("attributeName", attributeValue);
+
+        final Optional<String> optionalId = referenceResolver.getResolvedIdFromKeyInReference(attribute.getValue())
+                                                             .toCompletableFuture().join();
+        assertThat(optionalId).isEmpty();
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithNonExistingProductReferenceAttribute_ShouldGetEmptyId() {
+        when(productService.fetchCachedProductId(anyString()))
+            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        final ObjectNode attributeValue = getProductReferenceWithRandomId();
+        final AttributeDraft attributeDraft = AttributeDraft.of("attributeName", attributeValue);
+
+        final Optional<String> optionalId = referenceResolver.getResolvedIdFromKeyInReference(attributeDraft.getValue())
+                                                             .toCompletableFuture().join();
+        assertThat(optionalId).isEmpty();
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithNullIdField_ShouldGetEmptyId() {
+        final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
+        attributeValue.put("typeId", "product");
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+
+        final Optional<String> optionalId =
+            referenceResolver.getResolvedIdFromKeyInReference(productReferenceAttribute.getValue())
+                             .toCompletableFuture().join();
+        assertThat(optionalId).isEmpty();
+    }
+
+    @Test
+    public void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithIdField_ShouldGetId() {
+        final ObjectNode attributeValue = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
+
+        final Optional<String> optionalId =
+            referenceResolver.getResolvedIdFromKeyInReference(productReferenceAttribute.getValue())
+                             .toCompletableFuture().join();
+        assertThat(optionalId).contains(PRODUCT_ID);
+    }
+
+    @Test
+    public void resolveReferences_WithNoPriceReferences_ShouldResolveAttributeReferences() {
+        final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
+        final AttributeDraft productReferenceSetAttribute =
+            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+
+        final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "textValue");
+
+        final List<AttributeDraft> attributeDrafts =
+            Arrays.asList(productReferenceSetAttribute, textAttribute);
+
+
+        final ProductVariantDraft variantDraft = ProductVariantDraftBuilder.of()
+                                                                           .attributes(attributeDrafts)
+                                                                           .build();
+
+
+        final ProductVariantDraft resolvedDraft = referenceResolver.resolveReferences(variantDraft)
+                                                                   .toCompletableFuture().join();
+
+        final List<PriceDraft> resolvedDraftPrices = resolvedDraft.getPrices();
+        assertThat(resolvedDraftPrices).isNull();
+
+        final List<AttributeDraft> resolvedBuilderAttributes = resolvedDraft.getAttributes();
+        assertThat(resolvedBuilderAttributes).hasSize(2);
+        assertThat(resolvedBuilderAttributes).contains(textAttribute);
+        final AttributeDraft resolvedProductReferenceSetAttribute = resolvedBuilderAttributes.get(0);
+        assertThat(resolvedProductReferenceSetAttribute).isNotNull();
+        final JsonNode resolvedProductReferenceSetValue = resolvedProductReferenceSetAttribute.getValue();
+        assertThat(resolvedProductReferenceSetValue).isNotNull();
+        final JsonNode resolvedProductReferenceValue = resolvedProductReferenceSetValue.get(0);
+        assertThat(resolvedProductReferenceValue).isNotNull();
+        final JsonNode resolvedProductReferenceIdTextNode = resolvedProductReferenceValue.get("id");
+        assertThat(resolvedProductReferenceIdTextNode).isNotNull();
+        assertThat(resolvedProductReferenceIdTextNode.asText()).isEqualTo(PRODUCT_ID);
+    }
+
+    @Nonnull
+    private AttributeDraft getProductReferenceSetAttributeDraft(@Nonnull final ObjectNode... references) {
+        final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
+        referenceSet.addAll(Arrays.asList(references));
+        return AttributeDraft.of("attributeName", referenceSet);
+    }
+
+    @Nonnull
+    private ObjectNode getProductReferenceWithRandomId() {
+        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
+        productReference.put("typeId", "product");
+        productReference.put("id", UUID.randomUUID().toString());
+        return productReference;
+    }
+
+    @Nonnull
+    private ObjectNode getProductReferenceWithId(@Nonnull final String id) {
+        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
+        productReference.put("typeId", "product");
+        productReference.put("id", id);
+        return productReference;
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
@@ -21,7 +21,6 @@ import io.sphere.sdk.utils.MoneyImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +37,9 @@ import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductService;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceSetAttributeDraft;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceWithId;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceWithRandomId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -140,7 +142,7 @@ public class VariantReferenceResolverTest { ;
     public void resolveAttributesReferences_WithMixedReference_ShouldResolveProductReferenceAttributes() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttribute =
-            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+            getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);
 
         final ObjectNode categoryReference1 = JsonNodeFactory.instance.objectNode();
         categoryReference1.put("typeId", "category");
@@ -295,7 +297,7 @@ public class VariantReferenceResolverTest { ;
     public void resolveAttributeReference_WithProductReferenceSetAttribute_ShouldResolveReferences() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttributeDraft =
-            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+            getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);
 
         final AttributeDraft resolvedAttributeDraft =
             referenceResolver.resolveAttributeReference(productReferenceSetAttributeDraft)
@@ -318,7 +320,7 @@ public class VariantReferenceResolverTest { ;
     public void resolveAttributeReference_WithNullReferenceInSetAttribute_ShouldResolveReferences() {
         final ObjectNode productReference = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute =
-            getProductReferenceSetAttributeDraft(productReference, null);
+            getProductReferenceSetAttributeDraft("foo", productReference, null);
 
         final AttributeDraft resolvedAttributeDraft =
             referenceResolver.resolveAttributeReference(productReferenceAttribute)
@@ -344,7 +346,7 @@ public class VariantReferenceResolverTest { ;
 
         final ObjectNode productReference = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute =
-            getProductReferenceSetAttributeDraft(productReference);
+            getProductReferenceSetAttributeDraft("foo", productReference);
 
         final AttributeDraft resolvedAttributeDraft =
             referenceResolver.resolveAttributeReference(productReferenceAttribute)
@@ -371,7 +373,7 @@ public class VariantReferenceResolverTest { ;
         final ObjectNode productReference2 = getProductReferenceWithId("randomKey");
 
         final AttributeDraft productReferenceAttribute =
-            getProductReferenceSetAttributeDraft(productReference1, productReference2);
+            getProductReferenceSetAttributeDraft("foo", productReference1, productReference2);
 
         final AttributeDraft resolvedAttributeDraft =
             referenceResolver.resolveAttributeReference(productReferenceAttribute)
@@ -496,7 +498,7 @@ public class VariantReferenceResolverTest { ;
     public void resolveReferences_WithNoPriceReferences_ShouldResolveAttributeReferences() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttribute =
-            getProductReferenceSetAttributeDraft(productReferenceWithRandomId);
+            getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);
 
         final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "textValue");
 
@@ -528,28 +530,4 @@ public class VariantReferenceResolverTest { ;
         assertThat(resolvedProductReferenceIdTextNode).isNotNull();
         assertThat(resolvedProductReferenceIdTextNode.asText()).isEqualTo(PRODUCT_ID);
     }
-
-    @Nonnull
-    private AttributeDraft getProductReferenceSetAttributeDraft(@Nonnull final ObjectNode... references) {
-        final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
-        referenceSet.addAll(Arrays.asList(references));
-        return AttributeDraft.of("attributeName", referenceSet);
-    }
-
-    @Nonnull
-    private ObjectNode getProductReferenceWithRandomId() {
-        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
-        productReference.put("typeId", "product");
-        productReference.put("id", UUID.randomUUID().toString());
-        return productReference;
-    }
-
-    @Nonnull
-    private ObjectNode getProductReferenceWithId(@Nonnull final String id) {
-        final ObjectNode productReference = JsonNodeFactory.instance.objectNode();
-        productReference.put("typeId", "product");
-        productReference.put("id", id);
-        return productReference;
-    }
-
 }

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -316,12 +316,15 @@ public class ProductReferenceReplacementUtilsTest {
     @Test
     public void buildProductQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
         final ProductQuery productQuery = ProductReferenceReplacementUtils.buildProductQuery();
-        assertThat(productQuery.expansionPaths()).hasSize(6);
+        assertThat(productQuery.expansionPaths()).hasSize(9);
         assertThat(productQuery.expansionPaths())
             .containsExactly(ExpansionPath.of("productType"), ExpansionPath.of("taxCategory"),
                 ExpansionPath.of("state"), ExpansionPath.of("masterData.staged.categories[*]"),
                 ExpansionPath.of("masterData.staged.masterVariant.prices[*].channel"),
-                ExpansionPath.of("masterData.staged.variants[*].prices[*].channel"));
+                ExpansionPath.of("masterData.staged.variants[*].prices[*].channel"),
+                ExpansionPath.of("masterData.staged.masterVariant.attributes[*].value"),
+                ExpansionPath.of("masterData.staged.variants[*].attributes[*].value"),
+                ExpansionPath.of("masterData.staged.variants[*].attributes[*].value[*]"));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -317,7 +317,7 @@ public class ProductReferenceReplacementUtilsTest {
     @Test
     public void buildProductQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
         final ProductQuery productQuery = ProductReferenceReplacementUtils.buildProductQuery();
-        assertThat(productQuery.expansionPaths()).hasSize(9);
+        assertThat(productQuery.expansionPaths()).hasSize(10);
         assertThat(productQuery.expansionPaths())
             .containsExactly(ExpansionPath.of("productType"), ExpansionPath.of("taxCategory"),
                 ExpansionPath.of("state"), ExpansionPath.of("masterData.staged.categories[*]"),
@@ -325,6 +325,7 @@ public class ProductReferenceReplacementUtilsTest {
                 ExpansionPath.of("masterData.staged.variants[*].prices[*].channel"),
                 ExpansionPath.of("masterData.staged.masterVariant.attributes[*].value"),
                 ExpansionPath.of("masterData.staged.variants[*].attributes[*].value"),
+                ExpansionPath.of("masterData.staged.masterVariant.attributes[*].value[*]"),
                 ExpansionPath.of("masterData.staged.variants[*].attributes[*].value[*]"));
     }
 

--- a/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
@@ -1,0 +1,300 @@
+package com.commercetools.sync.products.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.attributes.Attribute;
+import io.sphere.sdk.products.attributes.AttributeAccess;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getChannelMock;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getPriceMockWithChannelReference;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductVariantMockWithPrices;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replaceAttributeReferenceIdWithKey;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replaceAttributeReferenceSetIdsWithKeys;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replaceAttributesReferencesIdsWithKeys;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replaceChannelReferenceIdWithKey;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replacePricesReferencesIdsWithKeys;
+import static com.commercetools.sync.products.utils.VariantReferenceReplacementUtils.replaceVariantsReferenceIdsWithKeys;
+import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VariantReferenceReplacementUtilsTest {
+   @Test
+    public void replaceVariantsReferenceIdsWithKeys_WithExpandedReferences_ShouldReturnVariantDraftsWithReplacedKeys() {
+        final String channelKey = "channelKey";
+        final Channel channel = getChannelMock(channelKey);
+
+        final Reference<Channel> channelReference = Reference
+            .ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel.getId(), channel);
+
+        final Price price = getPriceMockWithChannelReference(channelReference);
+        final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
+
+       final List<ProductVariantDraft> variantDrafts = replaceVariantsReferenceIdsWithKeys(
+           Collections.singletonList(productVariant));
+
+       assertThat(variantDrafts).hasSize(1);
+        assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
+        final Reference<Channel> channelReferenceAfterReplacement =
+            variantDrafts.get(0).getPrices().get(0).getChannel();
+        assertThat(channelReferenceAfterReplacement).isNotNull();
+        assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelKey);
+    }
+
+
+    @Test
+    public void replaceVariantsReferenceIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceSomeKeys() {
+        final String channelKey1 = "channelKey1";
+        final Channel channel1 = getChannelMock(channelKey1);
+
+        final Reference<Channel> channelReference1 = Reference
+            .ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel1.getId(), channel1);
+        final Reference<Channel> channelReference2 = Channel.referenceOfId(UUID.randomUUID().toString());
+
+        final Price price1 = getPriceMockWithChannelReference(channelReference1);
+        final Price price2 = getPriceMockWithChannelReference(channelReference2);
+
+        final ProductVariant productVariant1 = getProductVariantMockWithPrices(Collections.singletonList(price1));
+        final ProductVariant productVariant2 = getProductVariantMockWithPrices(Collections.singletonList(price2));
+
+        final Product product = readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
+        final String uuid = UUID.randomUUID().toString();
+        final Reference<Product> expandedReference =
+            Reference.ofResourceTypeIdAndIdAndObj(Product.referenceTypeId(), uuid, product);
+        final Attribute expandedProductRefAttribute =
+            Attribute.of("attrName", AttributeAccess.ofProductReference(), expandedReference);
+
+        when(productVariant2.getAttributes()).thenReturn(Collections.singletonList(expandedProductRefAttribute));
+
+        final Reference<Product> nonExpandedReference = Product.referenceOfId(uuid);
+        final Attribute nonExpandedProductRefAttribute =
+            Attribute.of("attrName", AttributeAccess.ofProductReference(), nonExpandedReference);
+        when(productVariant1.getAttributes()).thenReturn(Collections.singletonList(nonExpandedProductRefAttribute));
+
+
+        final List<ProductVariantDraft> variantDrafts = replaceVariantsReferenceIdsWithKeys(
+            Arrays.asList(productVariant1, productVariant2));
+
+        assertThat(variantDrafts).hasSize(2);
+        assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
+        final Reference<Channel> channel1ReferenceAfterReplacement = variantDrafts.get(0).getPrices().get(0)
+                                                                                  .getChannel();
+        assertThat(channel1ReferenceAfterReplacement).isNotNull();
+        assertThat(channel1ReferenceAfterReplacement.getId()).isEqualTo(channelKey1);
+
+        assertThat(variantDrafts.get(1).getPrices()).hasSize(1);
+        final Reference<Channel> channel2ReferenceAfterReplacement = variantDrafts.get(1).getPrices().get(0)
+                                                                                  .getChannel();
+        assertThat(channel2ReferenceAfterReplacement).isNotNull();
+        assertThat(channel2ReferenceAfterReplacement.getId()).isEqualTo(channelReference2.getId());
+
+        final JsonNode productReference1Value = variantDrafts.get(0).getAttributes().get(0).getValue();
+        assertThat(productReference1Value).isNotNull();
+        assertThat(productReference1Value.get("id")).isNotNull();
+        assertThat(productReference1Value.get("id").asText()).isEqualTo(uuid);
+
+
+        final JsonNode productReference2Value = variantDrafts.get(1).getAttributes().get(0).getValue();
+        assertThat(productReference2Value).isNotNull();
+        assertThat(productReference2Value.get("id")).isNotNull();
+        assertThat(productReference2Value.get("id").asText()).isEqualTo("productKey1");
+    }
+
+    @Test
+    public void replaceVariantsReferenceIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
+        final Reference<Channel> channelReference = Channel.referenceOfId(UUID.randomUUID().toString());
+
+        final Price price = getPriceMockWithChannelReference(channelReference);
+        final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
+
+        final List<ProductVariantDraft> variantDrafts =
+            replaceVariantsReferenceIdsWithKeys(Collections.singletonList(productVariant));
+
+        assertThat(variantDrafts).hasSize(1);
+        assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
+        final Reference<Channel> channelReferenceAfterReplacement = variantDrafts.get(0).getPrices().get(0)
+                                                                                 .getChannel();
+        assertThat(channelReferenceAfterReplacement).isNotNull();
+        assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
+    }
+
+    @Test
+    public void replacePricesReferencesIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
+        final Reference<Channel> channelReference = Channel.referenceOfId(UUID.randomUUID().toString());
+
+        final Price price = getPriceMockWithChannelReference(channelReference);
+        final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
+
+        final List<PriceDraft> priceDrafts = replacePricesReferencesIdsWithKeys(productVariant);
+
+        assertThat(priceDrafts).hasSize(1);
+        final Reference<Channel> channelReferenceAfterReplacement = priceDrafts.get(0).getChannel();
+        assertThat(channelReferenceAfterReplacement).isNotNull();
+        assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
+    }
+
+    @Test
+    public void replacePricesReferencesIdsWithKeys_WithAllExpandedReferences_ShouldReplaceIds() {
+        final String channelKey1 = "channelKey1";
+        final String channelKey2 = "channelKey2";
+
+        final Channel channel1 = getChannelMock(channelKey1);
+        final Channel channel2 = getChannelMock(channelKey2);
+
+        final Reference<Channel> channelReference1 =
+            Reference.ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel1.getId(), channel1);
+        final Reference<Channel> channelReference2 =
+            Reference.ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel2.getId(), channel2);
+
+        final Price price1 = getPriceMockWithChannelReference(channelReference1);
+        final Price price2 = getPriceMockWithChannelReference(channelReference2);
+        final ProductVariant productVariant = getProductVariantMockWithPrices(Arrays.asList(price1, price2));
+
+        final List<PriceDraft> priceDrafts = replacePricesReferencesIdsWithKeys(productVariant);
+
+        assertThat(priceDrafts).hasSize(2);
+        final Reference<Channel> channelReference1AfterReplacement = priceDrafts.get(0).getChannel();
+        assertThat(channelReference1AfterReplacement).isNotNull();
+        assertThat(channelReference1AfterReplacement.getId()).isEqualTo(channelKey1);
+        final Reference<Channel> channelReference2AfterReplacement = priceDrafts.get(1).getChannel();
+        assertThat(channelReference2AfterReplacement).isNotNull();
+        assertThat(channelReference2AfterReplacement.getId()).isEqualTo(channelKey2);
+    }
+
+    @Test
+    public void replacePricesReferencesIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedIds() {
+        final String channelKey1 = "channelKey1";
+
+        final Channel channel1 = getChannelMock(channelKey1);
+
+        final Reference<Channel> channelReference1 =
+            Reference.ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel1.getId(), channel1);
+        final Reference<Channel> channelReference2 = Channel.referenceOfId(UUID.randomUUID().toString());
+
+        final Price price1 = getPriceMockWithChannelReference(channelReference1);
+        final Price price2 = getPriceMockWithChannelReference(channelReference2);
+        final ProductVariant productVariant = getProductVariantMockWithPrices(Arrays.asList(price1, price2));
+
+        final List<PriceDraft> priceDrafts = replacePricesReferencesIdsWithKeys(productVariant);
+
+        assertThat(priceDrafts).hasSize(2);
+        final Reference<Channel> channelReference1AfterReplacement = priceDrafts.get(0).getChannel();
+        assertThat(channelReference1AfterReplacement).isNotNull();
+        assertThat(channelReference1AfterReplacement.getId()).isEqualTo(channelKey1);
+        final Reference<Channel> channelReference2AfterReplacement = priceDrafts.get(1).getChannel();
+        assertThat(channelReference2AfterReplacement).isNotNull();
+        assertThat(channelReference2AfterReplacement.getId()).isEqualTo(channelReference2.getId());
+    }
+
+    @Test
+    public void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
+        final String channelId = UUID.randomUUID().toString();
+        final Reference<Channel> channelReference = Channel.referenceOfId(channelId);
+        final Price price = getPriceMockWithChannelReference(channelReference);
+
+
+        final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
+
+        assertThat(channelReferenceWithKey).isNotNull();
+        assertThat(channelReferenceWithKey.getId()).isEqualTo(channelId);
+    }
+
+    @Test
+    public void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
+        final String channelKey = "channelKey";
+        final Channel channel = getChannelMock(channelKey);
+
+        final Reference<Channel> channelReference = Reference
+            .ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel.getId(), channel);
+        final Price price = getPriceMockWithChannelReference(channelReference);
+
+
+        final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
+
+        assertThat(channelReferenceWithKey).isNotNull();
+        assertThat(channelReferenceWithKey.getId()).isEqualTo(channelKey);
+    }
+
+    @Test
+    public void replaceChannelReferenceIdWithKey_WithNullReference_ShouldReturnNull() {
+        final Price price = getPriceMockWithChannelReference(null);
+
+        final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
+
+        assertThat(channelReferenceWithKey).isNull();
+    }
+
+    @Test
+    public void replaceAttributeReferenceIdWithKey_WithTextAttribute_ShouldReturnEmptyOptional() {
+        final Attribute attribute = Attribute.of("attrName", AttributeAccess.ofText(), "value");
+        final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
+
+        assertThat(attributeReferenceIdWithKey).isEmpty();
+    }
+
+    @Test
+    public void replaceAttributeReferenceIdWithKey_WithProductReferenceSetAttribute_ShouldReturnEmptyOptional() {
+        final Attribute attribute =
+            Attribute.of("attrName", AttributeAccess.ofProductReferenceSet(), new HashSet<>());
+        final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
+
+        assertThat(attributeReferenceIdWithKey).isEmpty();
+    }
+
+    @Test
+    public void replaceAttributeReferenceIdWithKey_WithNonExpandedProductReferenceAttribute_ShouldNotReplaceId() {
+        final Reference<Product> nonExpandedReference = Product.referenceOfId(UUID.randomUUID().toString());
+        final Attribute attribute =
+            Attribute.of("attrName", AttributeAccess.ofProductReference(), nonExpandedReference);
+        final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
+
+        assertThat(attributeReferenceIdWithKey).contains(nonExpandedReference);
+    }
+
+    @Test
+    public void replaceAttributeReferenceIdWithKey_WithExpandedProductReferenceAttribute_ShouldReplaceId() {
+        final Product product = readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
+        final Reference<Product> expandedReference =
+            Reference.ofResourceTypeIdAndIdAndObj(Product.referenceTypeId(), UUID.randomUUID().toString(), product);
+        final Attribute attribute =
+            Attribute.of("attrName", AttributeAccess.ofProductReference(), expandedReference);
+        final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
+        assertThat(attributeReferenceIdWithKey).contains(Product.referenceOfId("productKey1"));
+    }
+
+    @Test
+    public void replaceAttributeReferenceSetIdsWithKeys_WithTextAttribute_ShouldReturnEmptyOptional() {
+        final Attribute attribute = Attribute.of("attrName", AttributeAccess.ofText(), "value");
+        final Optional<Set<Reference<Product>>> attributeReferenceSetIdsWithKeys =
+            replaceAttributeReferenceSetIdsWithKeys(attribute);
+
+        assertThat(attributeReferenceSetIdsWithKeys).isEmpty();
+    }
+
+    @Test
+    public void replaceAttributesReferencesIdsWithKeys_WithNoAttributes_ShouldNotReplaceIds() {
+        final ProductVariant variant = mock(ProductVariant.class);
+        when(variant.getAttributes()).thenReturn(new ArrayList<>());
+        final List<AttributeDraft> replacedDrafts = replaceAttributesReferencesIdsWithKeys(variant);
+        assertThat(replacedDrafts).isEmpty();
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
@@ -38,7 +38,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class VariantReferenceReplacementUtilsTest {
-   @Test
+
+    @Test
     public void replaceVariantsReferenceIdsWithKeys_WithExpandedReferences_ShouldReturnVariantDraftsWithReplacedKeys() {
         final String channelKey = "channelKey";
         final Channel channel = getChannelMock(channelKey);
@@ -49,10 +50,10 @@ public class VariantReferenceReplacementUtilsTest {
         final Price price = getPriceMockWithChannelReference(channelReference);
         final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
 
-       final List<ProductVariantDraft> variantDrafts = replaceVariantsReferenceIdsWithKeys(
-           Collections.singletonList(productVariant));
+        final List<ProductVariantDraft> variantDrafts = replaceVariantsReferenceIdsWithKeys(
+            Collections.singletonList(productVariant));
 
-       assertThat(variantDrafts).hasSize(1);
+        assertThat(variantDrafts).hasSize(1);
         assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
         final Reference<Channel> channelReferenceAfterReplacement =
             variantDrafts.get(0).getPrices().get(0).getChannel();

--- a/src/test/resources/product-type.json
+++ b/src/test/resources/product-type.json
@@ -453,6 +453,39 @@
       "isSearchable": true,
       "inputHint": "SingleLine",
       "displayGroup": "Other"
+    },
+    {
+      "name": "product-reference",
+      "label": {
+        "en": "related product reference"
+      },
+      "isRequired": false,
+      "type": {
+        "name": "reference",
+        "referenceTypeId": "product"
+      },
+      "attributeConstraint": "SameForAll",
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "displayGroup": "Other"
+    },
+    {
+      "name": "product-reference-set",
+      "label": {
+        "en": "related products"
+      },
+      "isRequired": false,
+      "type": {
+        "name": "set",
+        "elementType": {
+          "name": "reference",
+          "referenceTypeId": "product"
+        }
+      },
+      "attributeConstraint": "SameForAll",
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "displayGroup": "Other"
     }
   ],
   "createdAt": "2015-06-09T08:51:37.052Z",


### PR DESCRIPTION
#### Summary
Some products could reference other products through having one product [ReferenceType](http://dev.commercetools.com/http-api-projects-productTypes.html#referencetype)  or a set of product references [SetType](http://dev.commercetools.com/http-api-projects-productTypes.html#settype) as attribute types on their variants.

In order to sync products which have such references on their variants, reference resolution needs to be implemented in the sync library. 

This is what this PR addresses mainly. However, this is a beta feature, since it doesn't handle cases where the referenced product doesn't exist yet; i.e. It will only resolve the references if the referenced product is existing. 

#### Relevant Issues
#160 

#### Todo
 - [x] update release notes with compatibility notes, new feature and beta notice on feature.
- [x] Update Caveats sections in usage docs.

#### Hints for Review
1. Implementation of service: fetchCachedProductId in product service: 
[Interface](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-067e13f2fef8f22747c2534c0c8ed046) | [Impl](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-6dfa47f1d198543a343a810f8a0c0ab5) | [Integration test](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-4fcf28164f083f7b0c50764b1a938399)
2. Refactoring of [ProductRefernceResolver](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-0a79a67e66112ba2c9dd95da412f7048) into [VariantRefernceResolver](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-925cd7aab9dfa200affec5299f40b548).
3. Providing Reference replacement utils while also refactoring [ProductReferenceReplacementUtils](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-3efc52803f815cf85a34d7bc93cc0dbe) into [VariantReferenceReplacementUtils](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-c39e1d4e74d08c6b71a90fec82c72826).
4. Provided unit tests for all 4 classes mentioned in points 2 and 3.
5. Provided [integration test](https://github.com/commercetools/commercetools-sync-java/pull/167/files#diff-c055a497d0964e42b389ba30980944ba) for sync scenario 