### PR TITLE
191: fix lib version header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ buildscript {
 }
 
 apply from: "$rootDir/gradle-scripts/plugins.gradle"
-apply from: "$rootDir/gradle-scripts/package.gradle"
 apply from: "$rootDir/gradle-scripts/extensions.gradle"
 apply from: "$rootDir/gradle-scripts/project-info.gradle"
+apply from: "$rootDir/gradle-scripts/package.gradle"
 apply from: "$rootDir/gradle-scripts/java-compile.gradle"
 apply from: "$rootDir/gradle-scripts/repositories.gradle"
 apply from: "$rootDir/gradle-scripts/integration-tests.gradle"

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
    **New Features** (n)
    **Beta Features** (n)
    **Major Enhancements** (n)
+   **Changes** (n)
    **Breaking Changes** (n)
    **Enhancements** (n)
    **Doc Fixes** (n)
@@ -40,7 +41,20 @@
 - [v1.0.0-M1 -  Sep 06, 2017](#v100-m1----sep-06-2017)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!--
+### v1.0.0-M6 -  Nov 16, 2017
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M5...v1.0.0-M6) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M6/) | 
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M6)
 
+**Changes** (1)
+- **Commons** - Removed website and emergency contact e-mail appened in User-Agent headers of JVM SDK clients using the 
+library. [#191](https://github.com/commercetools/commercetools-sync-java/issues/191)
+
+**Bug Fixes** (1)
+- **Commons** - Fixed library version in User-Agent headers of JVM SDK clients using the library. [#191](https://github.com/commercetools/commercetools-sync-java/issues/191)
+
+-->
 ### v1.0.0-M5 -  Nov 16, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M4...v1.0.0-M5) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M5/) | 

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -23,7 +23,7 @@ gitPublish {
     }
 
     // message used when committing changes
-    commitMessage = "Publishing a new java doc for $rootProject.version version"
+    commitMessage = "Publishing a new java doc for $rootProject.version version."
 }
 
 gitPublishReset {

--- a/gradle-scripts/package.gradle
+++ b/gradle-scripts/package.gradle
@@ -3,6 +3,7 @@
  */
 jar {
     manifest {
+        // These attribute are used in the SyncSolutionInfo.java. Please don't remove!
         attributes("Implementation-Title": rootProject.name, "Implementation-Version": rootProject.version)
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
@@ -161,7 +161,7 @@ public class ProductSyncIT {
     }
 
     private List<UpdateAction<Product>> beforeUpdateCallback(@Nonnull final List<UpdateAction<Product>> updateActions,
-                                                             @Nonnull final ProductDraft productDraft,
+                                                             @Nonnull final ProductDraft newProductDraft,
                                                              @Nonnull final Product oldProduct) {
         this.updateActions.addAll(updateActions);
         return updateActions;

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
@@ -7,6 +7,8 @@ import javax.annotation.Nullable;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class SyncSolutionInfo extends SolutionInfo {
+    static final String UNSPECIFIED = "unspecified";
+
     /**
      * Extends {@link SolutionInfo} class of the JVM SDK to append to the User-Agent header with information of the
      * commercetools-sync-java library
@@ -27,7 +29,7 @@ public class SyncSolutionInfo extends SolutionInfo {
         setVersion(solutionVersion);
     }
 
-    private boolean isAttributeUnspecified(@Nullable final String attributeValue) {
-        return isBlank(attributeValue) || "unspecified".equals(attributeValue);
+    static boolean isAttributeUnspecified(@Nullable final String attributeValue) {
+        return isBlank(attributeValue) || UNSPECIFIED.equals(attributeValue);
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
@@ -2,7 +2,9 @@ package com.commercetools.sync.commons.utils;
 
 import io.sphere.sdk.client.SolutionInfo;
 
-import static java.util.Optional.ofNullable;
+import javax.annotation.Nullable;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class SyncSolutionInfo extends SolutionInfo {
     /**
@@ -15,11 +17,17 @@ public class SyncSolutionInfo extends SolutionInfo {
      *
      */
     public SyncSolutionInfo() {
-        final String implementationTitle = ofNullable(getClass().getPackage().getImplementationTitle())
-            .orElse("commercetools-sync-java");
-        final String implementationVersion = ofNullable(getClass().getPackage().getImplementationVersion())
-            .orElse("DEBUG-VERSION");
-        setName(implementationTitle);
-        setVersion(implementationVersion);
+        final String implementationTitle = getClass().getPackage().getImplementationTitle();
+        final String implementationVersion = getClass().getPackage().getImplementationVersion();
+        final String solutionName = isAttributeUnspecified(implementationTitle)
+            ? "commercetools-sync-java" : implementationTitle;
+        final String solutionVersion = isAttributeUnspecified(implementationVersion)
+            ? "DEBUG-VERSION" : implementationVersion;
+        setName(solutionName);
+        setVersion(solutionVersion);
+    }
+
+    private boolean isAttributeUnspecified(@Nullable final String attributeValue) {
+        return isBlank(attributeValue) || "unspecified".equals(attributeValue);
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
@@ -2,7 +2,6 @@ package com.commercetools.sync.commons.utils;
 
 import io.sphere.sdk.client.SolutionInfo;
 
-import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
 public class SyncSolutionInfo extends SolutionInfo {
@@ -12,19 +11,15 @@ public class SyncSolutionInfo extends SolutionInfo {
      *
      * <p>A User-Agent header with a solution information looks like this:
      * {@code commercetools-jvm-sdk/1.4.1 (AHC/2.0) Java/1.8.0_92-b14 (Mac OS X; x86_64)
-     * {@code implementationTitle}/{@code implementationVersion}
-     * (+https://github.com/commercetools/commercetools-sync-java; +ps-dev@commercetools.com)}</p>
+     * {implementationTitle}/{implementationVersion}}</p>
      *
      */
     public SyncSolutionInfo() {
-        final String libraryName = "commercetools-sync-java";
         final String implementationTitle = ofNullable(getClass().getPackage().getImplementationTitle())
-            .orElse(libraryName);
+            .orElse("commercetools-sync-java");
         final String implementationVersion = ofNullable(getClass().getPackage().getImplementationVersion())
             .orElse("DEBUG-VERSION");
         setName(implementationTitle);
         setVersion(implementationVersion);
-        setWebsite(format("https://github.com/commercetools/%s", libraryName));
-        setEmergencyContact("ps-dev@commercetools.com");
     }
 }

--- a/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
+++ b/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
@@ -35,7 +35,7 @@ final class SyncSingleLocale {
      * @param oldProduct    the old existing {@link Product}.
      * @return a new list of update actions that corresponds to changes on French localizations only.
      */
-    public static List<UpdateAction<Product>> syncFrenchDataOnly(
+    private static List<UpdateAction<Product>> syncFrenchDataOnly(
         @Nonnull final List<UpdateAction<Product>> updateActions,
         @Nonnull final ProductDraft newProductDraft,
         @Nonnull final Product oldProduct,

--- a/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
+++ b/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
@@ -26,24 +26,24 @@ import static java.util.stream.Collectors.toMap;
 
 final class SyncSingleLocale {
     /**
-     * Takes in a {@link List} of product update actions that was built from comparing a {@code newDraft} and an
+     * Takes in a {@link List} of product update actions that was built from comparing a {@code newProductDraft} and an
      * {@code oldProduct} and maps the update actions so that only localizations with value {@link Locale#FRENCH}
      * are synced and all the other locales are left untouched.
      *
-     * @param updateActions the update actions built from comparing {@code newDraft} and {@code oldProduct}.
-     * @param newDraft      the new {@link ProductDraft} being synced.
+     * @param updateActions the update actions built from comparing {@code newProductDraft} and {@code oldProduct}.
+     * @param newProductDraft      the new {@link ProductDraft} being synced.
      * @param oldProduct    the old existing {@link Product}.
      * @return a new list of update actions that corresponds to changes on French localizations only.
      */
-    private static List<UpdateAction<Product>> syncFrenchDataOnly(
+    public static List<UpdateAction<Product>> syncFrenchDataOnly(
         @Nonnull final List<UpdateAction<Product>> updateActions,
-        @Nonnull final ProductDraft newDraft,
-        @Nonnull final Product oldProduct) {
-        final ProductType productType = oldProduct.getProductType().getObj();
-        assert productType != null;
+        @Nonnull final ProductDraft newProductDraft,
+        @Nonnull final Product oldProduct,
+        @Nonnull final ProductType productType) {
         return updateActions.stream()
                             .map(action ->
-                                filterSingleLocalization(action, newDraft, oldProduct, productType, Locale.FRENCH))
+                                filterSingleLocalization(action, newProductDraft, oldProduct, productType,
+                                    Locale.FRENCH))
                             .filter(Optional::isPresent)
                             .map(Optional::get)
                             .collect(toList());
@@ -67,41 +67,41 @@ final class SyncSingleLocale {
      * other hand, if the change was in the supplied locale value then the update action is modified so that it only
      * corresponds to the change in that locale value.
      *
-     * @param updateAction the update action built from comparing {@code newDraft} and {@code oldProduct}.
-     * @param newDraft     the new {@link ProductDraft} being synced.
+     * @param updateAction the update action built from comparing {@code newProductDraft} and {@code oldProduct}.
+     * @param newProductDraft     the new {@link ProductDraft} being synced.
      * @param oldProduct   the old existing {@link Product}.
      * @param locale       the locale value to only compare and map the update action to accordingly.
      * @return an optional containing the mapped update action or empty value if an update action is not needed.
      */
     private static Optional<UpdateAction<Product>> filterSingleLocalization(
         @Nonnull final UpdateAction<Product> updateAction,
-        @Nonnull final ProductDraft newDraft,
+        @Nonnull final ProductDraft newProductDraft,
         @Nonnull final Product oldProduct,
         @Nonnull final ProductType productType,
         //TODO: RIGHT NOW NOT USED BUT WILL BE EXTENDED LATER WITH USAGE AND TESTS. GITHUB ISSUE #189
         @Nonnull final Locale locale) {
         if (updateAction instanceof ChangeName) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getName, ProductData::getName,
-                ChangeName::of);
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getName,
+                ProductData::getName, ChangeName::of);
         }
         if (updateAction instanceof SetDescription) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getDescription,
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getDescription,
                 ProductData::getDescription, SetDescription::of);
         }
         if (updateAction instanceof ChangeSlug) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getSlug, ProductData::getSlug,
-                ChangeSlug::of);
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getSlug,
+                ProductData::getSlug, ChangeSlug::of);
         }
         if (updateAction instanceof SetMetaTitle) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getMetaTitle,
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getMetaTitle,
                 ProductData::getMetaTitle, SetMetaTitle::of);
         }
         if (updateAction instanceof SetMetaDescription) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getMetaDescription,
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getMetaDescription,
                 ProductData::getMetaDescription, SetMetaDescription::of);
         }
         if (updateAction instanceof SetMetaKeywords) {
-            return filterLocalizedField(newDraft, oldProduct, locale, ProductDraft::getMetaKeywords,
+            return filterLocalizedField(newProductDraft, oldProduct, locale, ProductDraft::getMetaKeywords,
                 ProductData::getMetaKeywords, SetMetaKeywords::of);
         }
         return Optional.of(updateAction);

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncSolutionInfoTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncSolutionInfoTest.java
@@ -8,22 +8,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SyncSolutionInfoTest {
 
     @Test
-    public void isAttributeUnspecified_WithNullAttribute_ShouldReturnTrue(){
+    public void isAttributeUnspecified_WithNullAttribute_ShouldReturnTrue() {
         assertThat(SyncSolutionInfo.isAttributeUnspecified(null)).isTrue();
     }
 
     @Test
-    public void isAttributeUnspecified_WithEmptyAttribute_ShouldReturnTrue(){
+    public void isAttributeUnspecified_WithEmptyAttribute_ShouldReturnTrue() {
         assertThat(SyncSolutionInfo.isAttributeUnspecified("")).isTrue();
     }
 
     @Test
-    public void isAttributeUnspecified_WithUnspecifiedAttribute_ShouldReturnTrue(){
+    public void isAttributeUnspecified_WithUnspecifiedAttribute_ShouldReturnTrue() {
         assertThat(SyncSolutionInfo.isAttributeUnspecified(UNSPECIFIED)).isTrue();
     }
 
     @Test
-    public void isAttributeUnspecified_WithAttribute_ShouldReturnFalse(){
+    public void isAttributeUnspecified_WithAttribute_ShouldReturnFalse() {
         assertThat(SyncSolutionInfo.isAttributeUnspecified("v1.0.0-M6")).isFalse();
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncSolutionInfoTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncSolutionInfoTest.java
@@ -1,0 +1,29 @@
+package com.commercetools.sync.commons.utils;
+
+import org.junit.Test;
+
+import static com.commercetools.sync.commons.utils.SyncSolutionInfo.UNSPECIFIED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SyncSolutionInfoTest {
+
+    @Test
+    public void isAttributeUnspecified_WithNullAttribute_ShouldReturnTrue(){
+        assertThat(SyncSolutionInfo.isAttributeUnspecified(null)).isTrue();
+    }
+
+    @Test
+    public void isAttributeUnspecified_WithEmptyAttribute_ShouldReturnTrue(){
+        assertThat(SyncSolutionInfo.isAttributeUnspecified("")).isTrue();
+    }
+
+    @Test
+    public void isAttributeUnspecified_WithUnspecifiedAttribute_ShouldReturnTrue(){
+        assertThat(SyncSolutionInfo.isAttributeUnspecified(UNSPECIFIED)).isTrue();
+    }
+
+    @Test
+    public void isAttributeUnspecified_WithAttribute_ShouldReturnFalse(){
+        assertThat(SyncSolutionInfo.isAttributeUnspecified("v1.0.0-M6")).isFalse();
+    }
+}


### PR DESCRIPTION
#### Summary
1. Fixes the `unspecified ` version in the header of the client requests using the sync lib: 
1521af7

2. Removes the emergency contact and website from the header: 0fcdd69
3. Other boy-scout-behaviour issues: 
    i. Add trailing dot to javadoc publishing commit message: e0b50c6
    ii. Improve var namings: 8818f71, a5004c5
4. Update release notes: 146f16b

#### Relevant Issues
#191 
