### PR TITLE
207 improve product deletion

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -84,8 +84,7 @@ public final class ITUtils {
             .thenAccept(ITUtils::joinFutureStream);
     }
 
-    private static <T> void joinFutureStream(@Nonnull final Stream<CompletableFuture<T>> futureStream) {
-        CompletableFuture.allOf(futureStream.toArray(CompletableFuture[]::new))
-                         .toCompletableFuture().join();
+    private static <T> CompletionStage<Void> toAllOf(@Nonnull final Stream<CompletableFuture<T>> futureStream) {
+        return CompletableFuture.allOf(futureStream.toArray(CompletableFuture[]::new));
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -29,7 +29,7 @@ public final class ITUtils {
      * @param ctpClient defines the CTP project to delete the Types from.
      */
     public static void deleteTypes(@Nonnull final SphereClient ctpClient) {
-        queryAndApply(ctpClient, TypeQuery::of, TypeDeleteCommand::of);
+        queryAndExecute(ctpClient, TypeQuery::of, TypeDeleteCommand::of);
     }
 
     /**
@@ -64,7 +64,7 @@ public final class ITUtils {
      * @param resourceMapper       defines a mapper function that should be applied on each resource in the fetched page
      *                             from the query on the specified CTP project.
      */
-    public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndApply(
+    public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndExecute(
         @Nonnull final SphereClient ctpClient,
         @Nonnull final Supplier<QueryDsl<T, C>> queryRequestSupplier,
         @Nonnull final Function<T, SphereRequest<T>> resourceMapper) {

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -55,14 +55,16 @@ public final class ITUtils {
     }
 
     /**
-     * Applies the {@code pageMapper} function on each page fetched from the supplied {@code queryRequestSupplier} on
-     * the supplied {@code ctpClient}.
+     * Applies the {@code resourceToRequestMapper} function on each page, fetched from the supplied
+     * {@code queryRequestSupplier} on the supplied {@code ctpClient}, to map each resource to a {@link SphereRequest}
+     * and then executes these requests in parallel within each page.
      *
-     * @param ctpClient            defines the CTP project to apply the query on.
-     * @param queryRequestSupplier defines a supplier which, when executed, returns the query that should be made on
-     *                             the CTP project.
-     * @param resourceMapper       defines a mapper function that should be applied on each resource in the fetched page
-     *                             from the query on the specified CTP project.
+     * @param ctpClient               defines the CTP project to apply the query on.
+     * @param queryRequestSupplier    defines a supplier which, when executed, returns the query that should be made on
+     *                                the CTP project.
+     * @param resourceToRequestMapper defines a mapper function that should be applied on each resource, in the fetched
+     *                                page from the query on the specified CTP project, to map it to a
+     *                                {@link SphereRequest}.
      */
     public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndExecute(
         @Nonnull final SphereClient ctpClient,

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -72,7 +72,8 @@ public final class ITUtils {
             .thenApply(sphereRequests -> sphereRequests.stream()
                                                        .map(ctpClient::execute)
                                                        .map(CompletionStage::toCompletableFuture))
-            .thenAccept(ITUtils::joinFutureStream);
+            .thenCompose(ITUtils::toAllOf)
+            .toCompletableFuture().join();
     }
 
     public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndCompose(
@@ -81,7 +82,8 @@ public final class ITUtils {
         @Nonnull final Function<T, CompletionStage> resourceMapper) {
         queryAll(ctpClient, queryRequestSupplier.get(), resourceMapper)
             .thenApply(stage -> stage.stream().map(CompletionStage::toCompletableFuture))
-            .thenAccept(ITUtils::joinFutureStream);
+            .thenCompose(ITUtils::toAllOf)
+            .toCompletableFuture().join();
     }
 
     private static <T> CompletionStage<Void> toAllOf(@Nonnull final Stream<CompletableFuture<T>> futureStream) {

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -95,13 +95,12 @@ public final class ITUtils {
         @Nonnull final SphereClient ctpClient,
         @Nonnull final Supplier<QueryDsl<T, C>> queryRequestSupplier,
         @Nonnull final Function<T, CompletionStage<S>> resourceMapper) {
-        queryAll(ctpClient, queryRequestSupplier.get(), resourceMapper)
-            .thenApply(stage -> stage.stream().map(CompletionStage::toCompletableFuture))
+        queryAll(ctpClient, queryRequestSupplier.get(), resourceToStageMapper)
             .thenCompose(ITUtils::toAllOf)
             .toCompletableFuture().join();
     }
 
-    private static <T> CompletionStage<Void> toAllOf(@Nonnull final Stream<CompletableFuture<T>> futureStream) {
-        return CompletableFuture.allOf(futureStream.toArray(CompletableFuture[]::new));
+    private static <T> CompletionStage<Void> toAllOf(@Nonnull final Stream<? extends CompletionStage<T>> stageStream) {
+        return CompletableFuture.allOf(stageStream.toArray(CompletableFuture[]::new));
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -77,6 +77,18 @@ public final class ITUtils {
     }
 
 
+    /**
+     * Applies the {@code resourceToStageMapper} function on each page, fetched from the supplied
+     * {@code queryRequestSupplier} on the supplied {@code ctpClient}, to map each resource to a {@link CompletionStage}
+     * and then executes these stages in parallel within each page.
+     *
+     * @param ctpClient             defines the CTP project to apply the query on.
+     * @param queryRequestSupplier  defines a supplier which, when executed, returns the query that should be made on
+     *                              the CTP project.
+     * @param resourceToStageMapper defines a mapper function that should be applied on each resource, in the fetched
+     *                              page from the query on the specified CTP project, to map it to a
+     *                              {@link CompletionStage}.
+     */
     public static <T extends Resource, C extends QueryDsl<T, C>, S> void queryAndCompose(
         @Nonnull final SphereClient ctpClient,
         @Nonnull final Supplier<QueryDsl<T, C>> queryRequestSupplier,

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -76,7 +76,7 @@ public final class ITUtils {
             .toCompletableFuture().join();
     }
 
-    public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndApplyFuture(
+    public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndCompose(
         @Nonnull final SphereClient ctpClient,
         @Nonnull final Supplier<QueryDsl<T, C>> queryRequestSupplier,
         @Nonnull final Function<T, CompletionStage> resourceMapper) {

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -1,8 +1,5 @@
 package com.commercetools.sync.integration.commons.utils;
 
-import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereRequest;
 import io.sphere.sdk.models.Resource;
@@ -39,20 +36,6 @@ public final class ITUtils {
     public static void deleteTypesFromTargetAndSource() {
         deleteTypes(CTP_TARGET_CLIENT);
         deleteTypes(CTP_SOURCE_CLIENT);
-    }
-
-    /**
-     * Builds a JSON String that represents the fields of the supplied instance of {@link BaseSyncStatistics}.
-     * Note: The order of the fields in the built JSON String depends on the order of the instance variables in this
-     * class.
-     *
-     * @param statistics the instance of {@link BaseSyncStatistics} from which to create a JSON String.
-     * @return a JSON String representation of the statistics object.
-     */
-    public static String getStatisticsAsJSONString(@Nonnull final BaseSyncStatistics statistics)
-        throws JsonProcessingException {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(statistics);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -76,10 +76,11 @@ public final class ITUtils {
             .toCompletableFuture().join();
     }
 
-    public static <T extends Resource, C extends QueryDsl<T, C>> void queryAndCompose(
+
+    public static <T extends Resource, C extends QueryDsl<T, C>, S> void queryAndCompose(
         @Nonnull final SphereClient ctpClient,
         @Nonnull final Supplier<QueryDsl<T, C>> queryRequestSupplier,
-        @Nonnull final Function<T, CompletionStage> resourceMapper) {
+        @Nonnull final Function<T, CompletionStage<S>> resourceMapper) {
         queryAll(ctpClient, queryRequestSupplier.get(), resourceMapper)
             .thenApply(stage -> stage.stream().map(CompletionStage::toCompletableFuture))
             .thenCompose(ITUtils::toAllOf)

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -19,11 +19,11 @@ import io.sphere.sdk.states.StateType;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.function.Function;
+import java.util.concurrent.CompletionStage;
 
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.deleteAllCategories;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypes;
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndApply;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndCompose;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.deleteProductTypes;
 import static com.commercetools.sync.integration.commons.utils.StateITUtils.deleteStates;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.deleteTaxCategories;
@@ -54,16 +54,64 @@ public final class ProductITUtils {
      * @param ctpClient defines the CTP project to delete the products from.
      */
     public static void deleteAllProducts(@Nonnull final SphereClient ctpClient) {
-        unPublishAllPublishedProducts(ctpClient);
-        queryAndApply(ctpClient, ProductQuery::of, ProductDeleteCommand::of);
+        queryAndCompose(ctpClient, ProductQuery::of, product -> deleteProduct(ctpClient, product));
     }
 
-    private static void unPublishAllPublishedProducts(@Nonnull final SphereClient ctpClient) {
-        final Function<Product, SphereRequest<Product>> unPublish = product ->
-                ProductUpdateCommand.of(product, Unpublish.of());
-        final ProductQuery publishedProductsQuery = ProductQuery.of()
-                .withPredicates(p -> p.masterData().isPublished().is(true));
-        queryAndApply(ctpClient, () -> publishedProductsQuery, unPublish);
+    /**
+     * If the {@code product} is published, issues an unpublish request followed by a delete. Otherwise,
+     * issues a delete request right away.
+     *
+     * @param ctpClient defines the CTP project to delete the product from.
+     * @param product the product to be deleted.
+     * @return a {@link CompletionStage} containing the deleted product.
+     */
+    @Nonnull
+    private static CompletionStage<Product> deleteProduct(@Nonnull final SphereClient ctpClient,
+                                                          @Nonnull final Product product) {
+        if (product.getMasterData().isPublished()) {
+            return unPublishAndDelete(ctpClient, product);
+        } else {
+            return deleteUnPublishedProduct(ctpClient, product);
+        }
+    }
+
+    /**
+     * Issues an unpublish request followed by a delete.
+     *
+     * @param ctpClient defines the CTP project to delete the product from.
+     * @param product the product to be unpublished and deleted.
+     * @return a {@link CompletionStage} containing the deleted product.
+     */
+    @Nonnull
+    private static CompletionStage<Product> unPublishAndDelete(@Nonnull final SphereClient ctpClient,
+                                                               @Nonnull final Product product) {
+        return ctpClient.execute(buildUnPublishRequest(product))
+                        .thenCompose(unPublishedProduct ->
+                            deleteUnPublishedProduct(ctpClient, unPublishedProduct));
+    }
+
+    /**
+     * Note: This method assumes the product is unpublished.
+     *
+     * @param ctpClient the client defining the CTP project to delete the product from.
+     * @param product   the product to be deleted.
+     * @return a {@link CompletionStage} containing the deleted product. If the product supplied was already unpublished
+     *          the method will return a completion stage that completed exceptionally.
+     */
+    @Nonnull
+    private static CompletionStage<Product> deleteUnPublishedProduct(@Nonnull final SphereClient ctpClient,
+                                                                     @Nonnull final Product product) {
+        return ctpClient.execute(ProductDeleteCommand.of(product));
+    }
+
+    /**
+     * Builds an unpublish request for the supplied product.
+     *
+     * @param product defines the product to build an un publish request for.
+     * @return an unpublish request for the supplied product.
+     */
+    public static SphereRequest<Product> buildUnPublishRequest(@Nonnull final Product product) {
+        return ProductUpdateCommand.of(product, Unpublish.of());
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -54,7 +54,7 @@ public final class ProductITUtils {
      * @param ctpClient defines the CTP project to delete the products from.
      */
     public static void deleteAllProducts(@Nonnull final SphereClient ctpClient) {
-        queryAndCompose(ctpClient, ProductQuery::of, product -> deleteProduct(ctpClient, product));
+        queryAndCompose(ctpClient, ProductQuery.of(), product -> deleteProduct(ctpClient, product));
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -54,7 +54,7 @@ public final class ProductITUtils {
      * @param ctpClient defines the CTP project to delete the products from.
      */
     public static void deleteAllProducts(@Nonnull final SphereClient ctpClient) {
-        queryAndCompose(ctpClient, ProductQuery.of(), product -> deleteProduct(ctpClient, product));
+        queryAndCompose(ctpClient, ProductQuery.of(), product -> safeDeleteProduct(ctpClient, product));
     }
 
     /**
@@ -66,10 +66,10 @@ public final class ProductITUtils {
      * @return a {@link CompletionStage} containing the deleted product.
      */
     @Nonnull
-    private static CompletionStage<Product> deleteProduct(@Nonnull final SphereClient ctpClient,
-                                                          @Nonnull final Product product) {
+    private static CompletionStage<Product> safeDeleteProduct(@Nonnull final SphereClient ctpClient,
+                                                              @Nonnull final Product product) {
         return product.getMasterData().isPublished()
-            ? unpublishAndDelete(ctpClient, product) : deleteUnpublishedProduct(ctpClient, product);
+            ? unpublishAndDeleteProduct(ctpClient, product) : deleteProduct(ctpClient, product);
     }
 
     /**
@@ -80,11 +80,11 @@ public final class ProductITUtils {
      * @return a {@link CompletionStage} containing the deleted product.
      */
     @Nonnull
-    private static CompletionStage<Product> unpublishAndDelete(@Nonnull final SphereClient ctpClient,
-                                                               @Nonnull final Product product) {
+    private static CompletionStage<Product> unpublishAndDeleteProduct(@Nonnull final SphereClient ctpClient,
+                                                                      @Nonnull final Product product) {
         return ctpClient.execute(buildUnpublishRequest(product))
                         .thenCompose(unpublishedProduct ->
-                            deleteUnpublishedProduct(ctpClient, unpublishedProduct));
+                            deleteProduct(ctpClient, unpublishedProduct));
     }
 
     /**
@@ -96,8 +96,8 @@ public final class ProductITUtils {
      *          the method will return a completion stage that completed exceptionally.
      */
     @Nonnull
-    private static CompletionStage<Product> deleteUnpublishedProduct(@Nonnull final SphereClient ctpClient,
-                                                                     @Nonnull final Product product) {
+    private static CompletionStage<Product> deleteProduct(@Nonnull final SphereClient ctpClient,
+                                                          @Nonnull final Product product) {
         return ctpClient.execute(ProductDeleteCommand.of(product));
     }
 

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -83,11 +83,11 @@ public final class ProductITUtils {
      * @return a {@link CompletionStage} containing the deleted product.
      */
     @Nonnull
-    private static CompletionStage<Product> unPublishAndDelete(@Nonnull final SphereClient ctpClient,
+    private static CompletionStage<Product> unpublishAndDelete(@Nonnull final SphereClient ctpClient,
                                                                @Nonnull final Product product) {
-        return ctpClient.execute(buildUnPublishRequest(product))
-                        .thenCompose(unPublishedProduct ->
-                            deleteUnPublishedProduct(ctpClient, unPublishedProduct));
+        return ctpClient.execute(buildUnpublishRequest(product))
+                        .thenCompose(unpublishedProduct ->
+                            deleteUnpublishedProduct(ctpClient, unpublishedProduct));
     }
 
     /**
@@ -99,7 +99,7 @@ public final class ProductITUtils {
      *          the method will return a completion stage that completed exceptionally.
      */
     @Nonnull
-    private static CompletionStage<Product> deleteUnPublishedProduct(@Nonnull final SphereClient ctpClient,
+    private static CompletionStage<Product> deleteUnpublishedProduct(@Nonnull final SphereClient ctpClient,
                                                                      @Nonnull final Product product) {
         return ctpClient.execute(ProductDeleteCommand.of(product));
     }
@@ -110,7 +110,8 @@ public final class ProductITUtils {
      * @param product defines the product to build an un publish request for.
      * @return an unpublish request for the supplied product.
      */
-    public static SphereRequest<Product> buildUnPublishRequest(@Nonnull final Product product) {
+    @Nonnull
+    private static SphereRequest<Product> buildUnpublishRequest(@Nonnull final Product product) {
         return ProductUpdateCommand.of(product, Unpublish.of());
     }
 

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -68,11 +68,8 @@ public final class ProductITUtils {
     @Nonnull
     private static CompletionStage<Product> deleteProduct(@Nonnull final SphereClient ctpClient,
                                                           @Nonnull final Product product) {
-        if (product.getMasterData().isPublished()) {
-            return unPublishAndDelete(ctpClient, product);
-        } else {
-            return deleteUnPublishedProduct(ctpClient, product);
-        }
+        return product.getMasterData().isPublished()
+            ? unpublishAndDelete(ctpClient, product) : deleteUnpublishedProduct(ctpClient, product);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndApply;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
@@ -44,7 +44,7 @@ public final class ProductTypeITUtils {
      * @param ctpClient defines the CTP project to delete the categories from.
      */
     public static void deleteProductTypes(@Nonnull final SphereClient ctpClient) {
-        queryAndApply(ctpClient, ProductTypeQuery::of, ProductTypeDeleteCommand::of);
+        queryAndExecute(ctpClient, ProductTypeQuery::of, ProductTypeDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -44,7 +44,7 @@ public final class ProductTypeITUtils {
      * @param ctpClient defines the CTP project to delete the categories from.
      */
     public static void deleteProductTypes(@Nonnull final SphereClient ctpClient) {
-        queryAndExecute(ctpClient, ProductTypeQuery::of, ProductTypeDeleteCommand::of);
+        queryAndExecute(ctpClient, ProductTypeQuery.of(), ProductTypeDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
@@ -10,7 +10,7 @@ import io.sphere.sdk.states.commands.StateDeleteCommand;
 
 import javax.annotation.Nonnull;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndApply;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.services.impl.StateServiceImpl.buildStateQuery;
@@ -36,7 +36,7 @@ public class StateITUtils {
      */
     public static void deleteStates(@Nonnull final SphereClient ctpClient,
                                     @Nonnull final StateType stateType) {
-        queryAndApply(ctpClient, () -> buildStateQuery(stateType), StateDeleteCommand::of);
+        queryAndExecute(ctpClient, () -> buildStateQuery(stateType), StateDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
@@ -36,7 +36,7 @@ public class StateITUtils {
      */
     public static void deleteStates(@Nonnull final SphereClient ctpClient,
                                     @Nonnull final StateType stateType) {
-        queryAndExecute(ctpClient, () -> buildStateQuery(stateType), StateDeleteCommand::of);
+        queryAndExecute(ctpClient, buildStateQuery(stateType), StateDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
@@ -41,7 +41,7 @@ public class TaxCategoryITUtils {
      * @param ctpClient defines the CTP project to delete the tax categories from.
      */
     public static void deleteTaxCategories(@Nonnull final SphereClient ctpClient) {
-        queryAndExecute(ctpClient, TaxCategoryQuery::of, TaxCategoryDeleteCommand::of);
+        queryAndExecute(ctpClient, TaxCategoryQuery.of(), TaxCategoryDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
@@ -13,7 +13,7 @@ import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
 
 import javax.annotation.Nonnull;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndApply;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
@@ -41,7 +41,7 @@ public class TaxCategoryITUtils {
      * @param ctpClient defines the CTP project to delete the tax categories from.
      */
     public static void deleteTaxCategories(@Nonnull final SphereClient ctpClient) {
-        queryAndApply(ctpClient, TaxCategoryQuery::of, TaxCategoryDeleteCommand::of);
+        queryAndExecute(ctpClient, TaxCategoryQuery::of, TaxCategoryDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
@@ -70,7 +70,7 @@ public class InventoryITUtils {
      * @param ctpClient represents the CTP project the inventory entries will be deleted from.
      */
     public static void deleteInventoryEntries(@Nonnull final SphereClient ctpClient) {
-        queryAndExecute(ctpClient, InventoryEntryQuery::of, InventoryEntryDeleteCommand::of);
+        queryAndExecute(ctpClient, InventoryEntryQuery.of(), InventoryEntryDeleteCommand::of);
     }
 
     /**
@@ -79,7 +79,7 @@ public class InventoryITUtils {
      * @param ctpClient represents the CTP project the channels will be deleted from.
      */
     public static void deleteSupplyChannels(@Nonnull final SphereClient ctpClient) {
-        queryAndExecute(ctpClient, ChannelQuery::of, ChannelDeleteCommand::of);
+        queryAndExecute(ctpClient, ChannelQuery.of(), ChannelDeleteCommand::of);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
@@ -39,7 +39,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndApply;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static java.util.Collections.singletonList;
@@ -70,7 +70,7 @@ public class InventoryITUtils {
      * @param ctpClient represents the CTP project the inventory entries will be deleted from.
      */
     public static void deleteInventoryEntries(@Nonnull final SphereClient ctpClient) {
-        queryAndApply(ctpClient, InventoryEntryQuery::of, InventoryEntryDeleteCommand::of);
+        queryAndExecute(ctpClient, InventoryEntryQuery::of, InventoryEntryDeleteCommand::of);
     }
 
     /**
@@ -79,7 +79,7 @@ public class InventoryITUtils {
      * @param ctpClient represents the CTP project the channels will be deleted from.
      */
     public static void deleteSupplyChannels(@Nonnull final SphereClient ctpClient) {
-        queryAndApply(ctpClient, ChannelQuery::of, ChannelDeleteCommand::of);
+        queryAndExecute(ctpClient, ChannelQuery::of, ChannelDeleteCommand::of);
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/commons/MockUtils.java
+++ b/src/test/java/com/commercetools/sync/commons/MockUtils.java
@@ -1,11 +1,8 @@
 package com.commercetools.sync.commons;
 
-import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 import com.commercetools.sync.services.CategoryService;
 import com.commercetools.sync.services.TypeService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.types.CustomFieldsDraft;
@@ -78,19 +75,5 @@ public class MockUtils {
         when(typeService.fetchCachedTypeId(anyString()))
             .thenReturn(completedFuture(Optional.of("typeId")));
         return typeService;
-    }
-
-    /**
-     * Builds a JSON String that represents the fields of the supplied instance of {@link BaseSyncStatistics}.
-     * Note: The order of the fields in the built JSON String depends on the order of the instance variables in this
-     * class.
-     *
-     * @param statistics the instance of {@link BaseSyncStatistics} from which to create a JSON String.
-     * @return a JSON representation of the given {@code statistics} as a String.
-     */
-    public static String getStatisticsAsJsonString(@Nonnull final BaseSyncStatistics statistics)
-        throws JsonProcessingException {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(statistics);
     }
 }


### PR DESCRIPTION
#### Summary

In the Integration tests cleanup instead of unpublishing every product (if it's published) then deleting it, now all published products are unpublished in parallel and then deleted in parallel.

----
#### Update:

Now both unpublishing and deleting is done in parallel.