### PR TITLE
242 fix statistics concurrency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M9/)
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 Java API which exposes utilities for building update actions and automatic syncing of CTP data from external sources 
@@ -21,7 +21,7 @@ Java API which exposes utilities for building update actions and automatic synci
     - [Ivy](#ivy)
 - [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M9/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Usage
@@ -56,20 +56,20 @@ most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>v1.0.0-M9</version>
+  <version>v1.0.0-M10</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:v1.0.0-M9'
+implementation 'com.commercetools:commercetools-sync-java:v1.0.0-M10'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "v1.0.0-M9"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "v1.0.0-M10"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="v1.0.0-M9"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="v1.0.0-M10"/>
 ````
 
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -47,6 +47,14 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+<!--
+### v1.0.0-M11 -  Mar 01, 2018
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M10...v1.0.0-M11) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M11/) | 
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M11)
+-->
+
+
 ### v1.0.0-M10 -  Feb 13, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M9...v1.0.0-M10) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/) | 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -51,6 +51,11 @@
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M9...v1.0.0-M10) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M10)
+
+
+**Changes** (1)
+- **Commons** - Statistics counters are now of type `AtomicInteger` instead of int to support conccurency. [#242](https://github.com/commercetools/commercetools-sync-java/issues/242)
+
 -->
 
 ### v1.0.0-M9 -  Jan 22, 2018

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -55,7 +55,8 @@
 
 **Changes** (1)
 - **Commons** - Statistics counters are now of type `AtomicInteger` instead of int to support conccurency. [#242](https://github.com/commercetools/commercetools-sync-java/issues/242)
-
+- **Category Sync** - `categoryKeysWithMissingParents` in the `CategorySyncStatistics` is now of type `ConcurrentHashMap<String, Set<String>` instead of `Map<String, List<String>`. [#242](https://github.com/commercetools/commercetools-sync-java/issues/242)
+- **Category Sync** - `CategorySyncStatistics` now exposes the methods `removeChildCategoryKeyFromMissingParentsMap`, `getMissingParentKey` and `putMissingParentCategoryChildKey` to support manipulating `categoryKeysWithMissingParents` map. [#242](https://github.com/commercetools/commercetools-sync-java/issues/242)
 -->
 
 ### v1.0.0-M9 -  Jan 22, 2018

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -83,8 +83,8 @@ streams, would look as follows:
 ```java
 final Logger logger = LoggerFactory.getLogger(MySync.class);
 final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder.of(sphereClient)
-                                                                          .setErrorCallBack(logger::error)
-                                                                          .setWarningCallBack(logger::warn)
+                                                                          .errorCallBack(logger::error)
+                                                                          .warningCallBack(logger::warn)
                                                                           .build();
 ```
 

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -100,8 +100,8 @@ streams, would look as follows:
  ```java
  final Logger logger = LoggerFactory.getLogger(MySync.class);
  final ProductSyncOptions productsyncOptions = ProductSyncOptionsBuilder.of(sphereClient)
-                                                                        .setErrorCallBack(logger::error)
-                                                                        .setWarningCallBack(logger::warn)
+                                                                        .errorCallBack(logger::error)
+                                                                        .warningCallBack(logger::warn)
                                                                         .build();
  ```
 

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,11 +1,11 @@
 ext{
     commercetoolsJvmSdkVersion = '1.25.0'
-    mockitoVersion = '2.8.9'
+    mockitoVersion = '2.13.0'
     jUnitVersion = '4.12'
     assertjVersion = '3.9.0'
     checkstyleVersion = '7.7'
     pmdVersion = '5.6.1'
-    jacocoVersion = '0.7.9'
+    jacocoVersion = '0.8.0'
     findbugsVersion = '3.0.1'
 }
 

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -2,7 +2,7 @@ ext{
     commercetoolsJvmSdkVersion = '1.25.0'
     mockitoVersion = '2.8.9'
     jUnitVersion = '4.12'
-    assertjVersion = '3.6.1'
+    assertjVersion = '3.9.0'
     checkstyleVersion = '7.7'
     pmdVersion = '5.6.1'
     jacocoVersion = '0.7.9'

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -710,14 +711,14 @@ public class CategorySyncIT {
 
         assertThat(syncStatistics).hasValues(2, 2, 0, 0);
 
-        final Map<String, List<String>> categoryKeysWithMissingParents = syncStatistics
+        final Map<String, Set<String>> categoryKeysWithMissingParents = syncStatistics
             .getCategoryKeysWithMissingParents();
         assertThat(categoryKeysWithMissingParents).hasSize(1);
 
-        final List<String> missingParentsChildren = categoryKeysWithMissingParents.get(nonExistingParentKey);
+        final Set<String> missingParentsChildren = categoryKeysWithMissingParents.get(nonExistingParentKey);
         assertThat(missingParentsChildren).hasSize(1);
 
-        final String childrenKeys = missingParentsChildren.get(0);
-        assertThat(childrenKeys).isEqualTo(categoryDraftWithMissingParent.getKey());
+        final String childKey = missingParentsChildren.iterator().next();
+        assertThat(childKey).isEqualTo(categoryDraftWithMissingParent.getKey());
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
@@ -28,6 +28,7 @@ import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtil
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductUpdateActionUtilsIT {
@@ -87,10 +88,7 @@ public class ProductUpdateActionUtilsIT {
         assertThat(errors).isEmpty();
         assertThat(warnings).isEmpty();
 
-        assertThat(sync.getCreated()).isEqualTo(0);
-        assertThat(sync.getUpdated()).isEqualTo(1);
-        assertThat(sync.getProcessed()).isEqualTo(1);
-        assertThat(sync.getFailed()).isEqualTo(0);
+        assertThat(sync).hasValues(1, 0, 1, 0);
 
         final Product synced = executeBlocking(CTP_TARGET_CLIENT.execute(ProductByKeyGet.of("productToSyncKey")));
         final ProductVariant syncedMasterVariant = synced.getMasterData().getStaged().getMasterVariant();

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -17,7 +17,6 @@ import io.sphere.sdk.commands.UpdateAction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -334,11 +333,11 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * @param parentKey   the key of the missing parent.
      */
     private void addCategoryKeyToMissingParentsMap(@Nonnull final String categoryKey, @Nonnull final String parentKey) {
-        final List<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(parentKey);
+        final Set<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(parentKey);
         if (childCategoryKeys != null) {
             childCategoryKeys.add(categoryKey);
         } else {
-            final ArrayList<String> newChildCategoryKeys = new ArrayList<>();
+            final Set<String> newChildCategoryKeys = new HashSet<>();
             newChildCategoryKeys.add(categoryKey);
             statistics.putMissingParentCategoryChildrenKeys(parentKey, newChildCategoryKeys);
         }
@@ -377,7 +376,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         createdCategories.forEach(createdCategory -> {
             final String createdCategoryKey = createdCategory.getKey();
             processedCategoryKeys.add(createdCategoryKey);
-            final List<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(createdCategoryKey);
+            final Set<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(createdCategoryKey);
             if (childCategoryKeys != null) {
                 for (String childCategoryKey : childCategoryKeys) {
                     categoryKeysWithResolvedParents.add(childCategoryKey);

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -604,7 +604,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     }
 
     /**
-     * Given a {@code categoryKey} this method removes its occurences from the map
+     * Given a {@code categoryKey} this method removes its occurrences from the map
      * {@code categoryKeysWithMissingParents}.
      *
      * @param categoryKey the category key to remove from {@code categoryKeysWithMissingParents}

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -301,7 +301,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         return getParentCategoryKey(categoryDraft, syncOptions.shouldAllowUuidKeys())
             .map(parentCategoryKey -> {
                 if (isMissingCategory(parentCategoryKey, keyToIdCache)) {
-                    addCategoryKeyToMissingParentsMap(categoryDraft.getKey(), parentCategoryKey);
+                    statistics.putMissingParentCategoryChildKey(parentCategoryKey, categoryDraft.getKey());
                     return CategoryDraftBuilder.of(categoryDraft)
                                                .parent(null)
                                                .build();
@@ -321,26 +321,6 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     private boolean isMissingCategory(@Nonnull final String categoryKey,
                                       @Nonnull final Map<String, String> keyToIdCache) {
         return !keyToIdCache.containsKey(categoryKey);
-    }
-
-    /**
-     * This method checks if there is an entry with the key of the missing parent category {@code parentKey} in the
-     * {@code categoryKeysWithMissingParents}, if there isn't it creates a new entry with this parent key and as a value
-     * a new list containing the {@code categoryKey}. Otherwise, if there is already, it just adds the
-     * {@code categoryKey} to the existing list.
-     *
-     * @param categoryKey the key of the category with a missing parent.
-     * @param parentKey   the key of the missing parent.
-     */
-    private void addCategoryKeyToMissingParentsMap(@Nonnull final String categoryKey, @Nonnull final String parentKey) {
-        final Set<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(parentKey);
-        if (childCategoryKeys != null) {
-            childCategoryKeys.add(categoryKey);
-        } else {
-            final Set<String> newChildCategoryKeys = new HashSet<>();
-            newChildCategoryKeys.add(categoryKey);
-            statistics.putMissingParentCategoryChildrenKeys(parentKey, newChildCategoryKeys);
-        }
     }
 
 

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -178,7 +178,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     /**
      * Given a list of {@code CategoryDraft} elements. Calculates the number of drafts that need to be processed in this
      * batch, given they weren't processed before. Categories which were processed before, will have their keys stored
-     * in {@code processedCategoryKeys}. Added to the number of null categoryDrafts.
+     * in {@code processedCategoryKeys}. Added to the number of null categoryDrafts and categories with null keys.
      *
      * @param categoryDrafts the input list of category drafts in the sync batch.
      * @return the number of drafts that are needed to be processed.
@@ -187,11 +187,13 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         final int numberOfNullCategoryDrafts = categoryDrafts.stream()
                                                              .filter(Objects::isNull)
                                                              .collect(Collectors.toList()).size();
-        final int numberOfCategoryDraftsNotProcessedBefore = categoryDrafts.stream()
-                                       .filter(Objects::nonNull)
-                                       .map(CategoryDraft::getKey)
-                                       .filter(categoryDraftKey -> !processedCategoryKeys.contains(categoryDraftKey))
-                                       .collect(Collectors.toList()).size();
+        final int numberOfCategoryDraftsNotProcessedBefore =
+            categoryDrafts.stream()
+                          .filter(Objects::nonNull)
+                          .map(CategoryDraft::getKey)
+                          .filter(categoryDraftKey ->
+                              categoryDraftKey == null || !processedCategoryKeys.contains(categoryDraftKey))
+                          .collect(Collectors.toList()).size();
 
         return numberOfCategoryDraftsNotProcessedBefore + numberOfNullCategoryDrafts;
     }

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -176,9 +176,10 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     }
 
     /**
-     * Given a list of {@code CategoryDraft} elements. Calculates the number of drafts that need to be processed in this
-     * batch, given they weren't processed before. Categories which were processed before, will have their keys stored
-     * in {@code processedCategoryKeys}. Added to the number of null categoryDrafts and categories with null keys.
+     * Given a list of {@code CategoryDraft} elements, this method calculates the number of drafts that need to be
+     * processed in this batch, given they weren't processed before, plus the number of null categoryDrafts and
+     * categories with null keys. Categories which were processed before, will have their keys stored
+     * in {@code processedCategoryKeys}.
      *
      * @param categoryDrafts the input list of category drafts in the sync batch.
      * @return the number of drafts that are needed to be processed.

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -177,9 +177,8 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
 
     /**
      * Given a list of {@code CategoryDraft} elements, this method calculates the number of drafts that need to be
-     * processed in this batch, given they weren't processed before, plus the number of null categoryDrafts and
-     * categories with null keys. Categories which were processed before, will have their keys stored
-     * in {@code processedCategoryKeys}.
+     * processed in this batch, given they weren't processed before, plus the number of null drafts and drafts with null
+     * keys. Drafts which were processed before, will have their keys stored in {@code processedCategoryKeys}.
      *
      * @param categoryDrafts the input list of category drafts in the sync batch.
      * @return the number of drafts that are needed to be processed.

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -328,7 +328,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * This method does the following on each category created from the provided {@link Set} of categories:
      * <ol>
      * <li>Adds its keys to {@code processedCategoryKeys} in order to not increment updated and processed counters of
-     * statistics more than needed. For example, when updating the parent later on of this created category.\
+     * statistics more than needed. For example, when updating the parent later on of this created category.
      * </li>
      *
      * <li>Check if it exists in {@code categoryKeysWithMissingParents} as a missing parent, if it does then its

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.commercetools.sync.categories.helpers.CategoryReferenceResolver.getParentCategoryKey;
@@ -47,7 +48,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     private final CategoryService categoryService;
     private final CategoryReferenceResolver referenceResolver;
 
-    private final Map<String, List<String>> categoryKeysWithMissingParents = new HashMap<>();
+    private final Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
     private final Set<String> processedCategoryKeys = new HashSet<>();
 
     private Set<CategoryDraft> existingCategoryDrafts = new HashSet<>();

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -145,7 +145,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      */
     @Override
     protected CompletionStage<CategorySyncStatistics> processBatch(@Nonnull final List<CategoryDraft> categoryDrafts) {
-        final int numberOfNewDraftsToProcess = getNumberOfProcessedCategories(categoryDrafts);
+        final int numberOfNewDraftsToProcess = getNumberOfDraftsToProcess(categoryDrafts);
         referencesResolvedDrafts = new HashSet<>();
         existingCategoryDrafts = new HashSet<>();
         newCategoryDrafts = new HashSet<>();
@@ -184,7 +184,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * @param categoryDrafts the input list of category drafts in the sync batch.
      * @return the number of drafts that are needed to be processed.
      */
-    private int getNumberOfProcessedCategories(@Nonnull final List<CategoryDraft> categoryDrafts) {
+    private int getNumberOfDraftsToProcess(@Nonnull final List<CategoryDraft> categoryDrafts) {
         final int numberOfNullCategoryDrafts = categoryDrafts.stream()
                                                              .filter(Objects::isNull)
                                                              .collect(Collectors.toList()).size();

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -49,14 +49,14 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
     private final CategoryReferenceResolver referenceResolver;
 
     private final Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
-    private final Set<String> processedCategoryKeys = new HashSet<>();
+    private final Set<String> processedCategoryKeys = ConcurrentHashMap.newKeySet();
 
     private Set<CategoryDraft> existingCategoryDrafts = new HashSet<>();
     private Set<CategoryDraft> newCategoryDrafts = new HashSet<>();
     private Set<CategoryDraft> referencesResolvedDrafts = new HashSet<>();
-    private Set<String> categoryKeysWithResolvedParents = new HashSet<>();
+    private Set<String> categoryKeysWithResolvedParents = ConcurrentHashMap.newKeySet();
     private Set<String> categoryKeysToFetch = new HashSet<>();
-    private Map<CategoryDraft, Category> categoryDraftsToUpdate = new HashMap<>();
+    private Map<CategoryDraft, Category> categoryDraftsToUpdate = new ConcurrentHashMap<>();
 
     /**
      * Takes a {@link CategorySyncOptions} instance to instantiate a new {@link CategorySync} instance that could be

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -356,7 +356,9 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         createdCategories.forEach(createdCategory -> {
             final String createdCategoryKey = createdCategory.getKey();
             processedCategoryKeys.add(createdCategoryKey);
-            final Set<String> childCategoryKeys = statistics.getMissingParentCategoryChildrenKeys(createdCategoryKey);
+            final Set<String> childCategoryKeys = statistics.getCategoryKeysWithMissingParents()
+                                                            .get(createdCategoryKey);
+
             if (childCategoryKeys != null) {
                 for (String childCategoryKey : childCategoryKeys) {
                     categoryKeysWithResolvedParents.add(childCategoryKey);

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -224,7 +224,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      *     <li>Checks if the draft is {@code null}, then the error callback is triggered and the
      *     draft is skipped.</li>
      *     <li>Then for each draft adds each with a non-existing parent in keyToId cached map to a map
-     *     {@code categoryKeysWithMissingParents} (mapping from parent key to list of subcategory keys)</li>
+     *     {@code statistics#categoryKeysWithMissingParents} (mapping from parent key to list of subcategory keys)</li>
      *     <li>Then it resolves the references (parent category reference and custom type reference) on each draft. For
      *     each draft with resolved references:
      *      <ol>
@@ -285,7 +285,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * This method first gets the parent key either from the expanded category object or from the id field on the
      * reference and validates it. If its valid, then it checks if the parent category is missing, this is done by
      * checking if the key exists in the {@code keyToIdCache} map. If it is missing, then it adds the key to the map
-     * {@code categoryKeysWithMissingParents}, then it returns a category draft identical to the supplied one
+     * {@code statistics#categoryKeysWithMissingParents}, then it returns a category draft identical to the supplied one
      * but with a {@code null} parent. If it is not missing, then the same identical category draft is returned with the
      * same parent.
      *
@@ -331,14 +331,14 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * statistics more than needed. For example, when updating the parent later on of this created category.
      * </li>
      *
-     * <li>Check if it exists in {@code categoryKeysWithMissingParents} as a missing parent, if it does then its
-     * children are now ready to update their parent field references with the created parent category. For each of
+     * <li>Check if it exists in {@code statistics#categoryKeysWithMissingParents} as a missing parent, if it does then
+     * its children are now ready to update their parent field references with the created parent category. For each of
      * these child categories do the following:
      * <ol>
      * <li>Add its key to the list {@code categoryKeysWithResolvedParents}.</li>
      * <li>If the key was in the {@code newCategoryDrafts} list, then it means it should have just been created.
      * Then it adds the category created to the {@code categoryDraftsToUpdate}. The draft is created from the
-     * created Category response from CTP but parent is taken from the {@code categoryKeysWithMissingParents}
+     * created Category response from CTP but parent is taken from the {@code statistics#categoryKeysWithMissingParents}
      * </li>
      * <li>Otherwise, if it wasn't in the {@code newCategoryDrafts} list, then it means it needs to be
      * fetched. Therefore, its key is added it to the {@code categoryKeysToFetch}</li>
@@ -391,7 +391,7 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
      * </li>
      * <li>If not, the draft is copied from the fetched category. </li>
      * <li>If the key of this draft exists in the {@code categoryKeysWithResolvedParents}, overwrite the parent with
-     * the parent saved in {@code categoryKeysWithMissingParents} for the draft.</li>
+     * the parent saved in {@code statistics#categoryKeysWithMissingParents} for the draft.</li>
      * <li>After a draft has been created, it is added to {@code categoryDraftsToUpdate} map as a key and
      * the value is the fetched {@link Category}.</li>
      * </ol>

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -4,10 +4,10 @@ package com.commercetools.sync.categories.helpers;
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
 
@@ -16,7 +16,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      * Map that represents categories with missing parents; the keys of the map are the keys of the missing parent
      * categories and the value of each is a list of the children category keys.
      */
-    private Map<String, List<String>> categoryKeysWithMissingParents = new HashMap<>();
+    private Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
 
     public CategorySyncStatistics() {
         super();

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -2,11 +2,16 @@ package com.commercetools.sync.categories.helpers;
 
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
@@ -14,12 +19,17 @@ import static java.lang.String.format;
 public class CategorySyncStatistics extends BaseSyncStatistics {
 
     /**
-     * Map that represents categories with missing parents.
+     * The following {@link Map} ({@code categoryKeysWithMissingParents}) represents categories with
+     * missing parents.
      *
      * <ul>
      *     <li>key: key of the missing parent category</li>
      *     <li>value: a list of the parent's children category keys</li>
      * </ul>
+     *
+     * <p>The map is thread-safe (by instantiating it with {@link ConcurrentHashMap}) because it is accessed/modified in
+     * a concurrent context, specifically when updating products in parallel in
+     * {@link com.commercetools.sync.categories.CategorySync#updateCategory(Category, CategoryDraft, List)}.
      *
      */
     private Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
@@ -57,11 +67,52 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
     }
 
     public Map<String, List<String>> getCategoryKeysWithMissingParents() {
-        return categoryKeysWithMissingParents;
+        return Collections.unmodifiableMap(categoryKeysWithMissingParents);
     }
 
-    public void setCategoryKeysWithMissingParents(@Nonnull final
-                                                  Map<String, List<String>> categoryKeysWithMissingParents) {
+    public void setCategoryKeysWithMissingParents(@Nonnull final ConcurrentHashMap<String, List<String>>
+                                                      categoryKeysWithMissingParents) {
         this.categoryKeysWithMissingParents = categoryKeysWithMissingParents;
+    }
+
+    @Nullable
+    public List<String> getMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey) {
+        return categoryKeysWithMissingParents.get(missingParentCategoryKey);
+    }
+
+    public void putMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey,
+                                                     @Nonnull final List<String> childrenKeys) {
+        categoryKeysWithMissingParents.put(missingParentCategoryKey, childrenKeys);
+    }
+
+    /**
+     * Given a categoryKey {@code childCategoryKey} this method, checks in the {@code categoryKeysWithMissingParents}
+     * if it exists as a child to a missing parent, and returns the key of that missing parent. Otherwise, it returns
+     * null.
+     * @param childCategoryKey key of the category to look if it has a missing parent.
+     * @return the key of the parent category.
+     */
+    @Nonnull
+    public Optional<String> getMissingParentKey(@Nonnull final String childCategoryKey) {
+        return categoryKeysWithMissingParents.entrySet()
+                                             .stream()
+                                             .filter(missingParentEntry -> missingParentEntry.getValue().contains(
+                                                 childCategoryKey))
+                                             .findFirst()
+                                             .map(Map.Entry::getKey);
+    }
+
+    /**
+     * Given a child {@code categoryKey} this method removes its occurrences from the map
+     * {@code categoryKeysWithMissingParents}.
+     *
+     * <p>NOTE: When all the children keys of a missing parent are removed, the value of the map entry will be
+     * an empty list. i.e. the entry itself will not be removed. However, this could be investigated whether removing
+     * the entry at all when the list is empty will affect the algorithm. TODO: GITHUB ISSUE#
+     *
+     * @param childCategoryKey the child category key to remove from {@code categoryKeysWithMissingParents}
+     */
+    public void removeChildCategoryKeyFromMissingParentsMap(@Nonnull final String childCategoryKey) {
+        categoryKeysWithMissingParents.forEach((key, value) -> value.remove(childCategoryKey));
     }
 }

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
@@ -24,7 +25,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      *
      * <ul>
      *     <li>key: key of the missing parent category</li>
-     *     <li>value: a list of the parent's children category keys</li>
+     *     <li>value: a set of the parent's children category keys</li>
      * </ul>
      *
      * <p>The map is thread-safe (by instantiating it with {@link ConcurrentHashMap}) because it is accessed/modified in
@@ -32,7 +33,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      * {@link com.commercetools.sync.categories.CategorySync#updateCategory(Category, CategoryDraft, List)}.
      *
      */
-    private Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+    private Map<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
 
     public CategorySyncStatistics() {
         super();
@@ -62,26 +63,26 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
         return categoryKeysWithMissingParents.values()
                                              .stream()
                                              .filter(Objects::nonNull)
-                                             .mapToInt(List::size)
+                                             .mapToInt(Set::size)
                                              .sum();
     }
 
-    public Map<String, List<String>> getCategoryKeysWithMissingParents() {
+    public Map<String, Set<String>> getCategoryKeysWithMissingParents() {
         return Collections.unmodifiableMap(categoryKeysWithMissingParents);
     }
 
-    public void setCategoryKeysWithMissingParents(@Nonnull final ConcurrentHashMap<String, List<String>>
+    public void setCategoryKeysWithMissingParents(@Nonnull final ConcurrentHashMap<String, Set<String>>
                                                       categoryKeysWithMissingParents) {
         this.categoryKeysWithMissingParents = categoryKeysWithMissingParents;
     }
 
     @Nullable
-    public List<String> getMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey) {
+    public Set<String> getMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey) {
         return categoryKeysWithMissingParents.get(missingParentCategoryKey);
     }
 
     public void putMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey,
-                                                     @Nonnull final List<String> childrenKeys) {
+                                                     @Nonnull final Set<String> childrenKeys) {
         categoryKeysWithMissingParents.put(missingParentCategoryKey, childrenKeys);
     }
 

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -6,11 +6,10 @@ import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +32,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      * {@link com.commercetools.sync.categories.CategorySync#updateCategory(Category, CategoryDraft, List)}.
      *
      */
-    private Map<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
 
     public CategorySyncStatistics() {
         super();
@@ -62,7 +61,6 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
     public int getNumberOfCategoriesWithMissingParents() {
         return categoryKeysWithMissingParents.values()
                                              .stream()
-                                             .filter(Objects::nonNull)
                                              .mapToInt(Set::size)
                                              .sum();
     }

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -76,14 +76,26 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
         this.categoryKeysWithMissingParents = categoryKeysWithMissingParents;
     }
 
-    @Nullable
-    public Set<String> getMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey) {
-        return categoryKeysWithMissingParents.get(missingParentCategoryKey);
-    }
-
-    public void putMissingParentCategoryChildrenKeys(@Nonnull final String missingParentCategoryKey,
-                                                     @Nonnull final Set<String> childrenKeys) {
-        categoryKeysWithMissingParents.put(missingParentCategoryKey, childrenKeys);
+    /**
+     * This method checks if there is an entry with the key of the {@code missingParentCategoryKey} in the
+     * {@code categoryKeysWithMissingParents}, if there isn't it creates a new entry with this parent key and as a value
+     * a new set containing the {@code childKey}. Otherwise, if there is already, it just adds the
+     * {@code categoryKey} to the existing set.
+     *
+     * @param missingParentCategoryKey the key of the missing parent.
+     * @param childKey                 the key of the category with a missing parent.
+     */
+    public void putMissingParentCategoryChildKey(@Nonnull final String missingParentCategoryKey,
+                                                 @Nonnull final String childKey) {
+        final Set<String> missingParentCategoryChildrenKeys =
+            categoryKeysWithMissingParents.get(missingParentCategoryKey);
+        if (missingParentCategoryChildrenKeys != null) {
+            missingParentCategoryChildrenKeys.add(childKey);
+        } else {
+            final Set<String> newChildCategoryKeys = new HashSet<>();
+            newChildCategoryKeys.add(childKey);
+            categoryKeysWithMissingParents.put(missingParentCategoryKey, newChildCategoryKeys);
+        }
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -52,8 +52,8 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
         return categoryKeysWithMissingParents.values()
                                              .stream()
                                              .filter(Objects::nonNull)
-                                             .map(List::size)
-                                             .reduce(0, Integer::sum);
+                                             .mapToInt(List::size)
+                                             .sum();
     }
 
     public Map<String, List<String>> getCategoryKeysWithMissingParents() {

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -99,11 +99,12 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
     }
 
     /**
-     * Given a categoryKey {@code childCategoryKey} this method, checks in the {@code categoryKeysWithMissingParents}
-     * if it exists as a child to a missing parent, and returns the key of that missing parent. Otherwise, it returns
-     * null.
-     * @param childCategoryKey key of the category to look if it has a missing parent.
-     * @return the key of the parent category.
+     * Given a {@code childCategoryKey} this method, checks in the {@code categoryKeysWithMissingParents}
+     * if it exists as a child to a missing parent, and returns the key of first found (since a category can have only
+     * one parent) missing parent in an optional. Otherwise, it returns an empty optional.
+     *
+     * @param childCategoryKey key of the category to find it's has a missing parent key.
+     * @return the key of that missing parent in an optional, if it exists. Otherwise, it returns an empty optional.
      */
     @Nonnull
     public Optional<String> getMissingParentKey(@Nonnull final String childCategoryKey) {
@@ -121,7 +122,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      *
      * <p>NOTE: When all the children keys of a missing parent are removed, the value of the map entry will be
      * an empty list. i.e. the entry itself will not be removed. However, this could be investigated whether removing
-     * the entry at all when the list is empty will affect the algorithm. TODO: GITHUB ISSUE#
+     * the entry at all when the list is empty will affect the algorithm. TODO: RELATED BUT NOT SAME AS GITHUB ISSUE#77
      *
      * @param childCategoryKey the child category key to remove from {@code categoryKeysWithMissingParents}
      */

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -12,9 +12,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import static java.lang.String.format;
 
 public class CategorySyncStatistics extends BaseSyncStatistics {
+
     /**
-     * Map that represents categories with missing parents; the keys of the map are the keys of the missing parent
-     * categories and the value of each is a list of the children category keys.
+     * Map that represents categories with missing parents.
+     *
+     * <ul>
+     *     <li>key: key of the missing parent category</li>
+     *     <li>value: a list of the parent's children category keys</li>
+     * </ul>
+     *
      */
     private Map<String, List<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -213,6 +213,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the human readable processing time in the following format @{code "0d, 0h, 0m, 2s, 545ms"}.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return the human readable processing time in the following format @{code "0d, 0h, 0m, 2s, 545ms"}
@@ -223,6 +224,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of days it took to process.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of days taken to process.
@@ -242,6 +244,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of minutes it took to process.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of minutes taken to process.
@@ -252,6 +255,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of seconds it took to process.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of seconds taken to process.
@@ -262,6 +266,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of milliseconds it took to process.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of milliseconds taken to process.
@@ -272,6 +277,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets a summary message of the statistics report.
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return a summary message of the statistics report.

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -235,6 +235,8 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of hours it took to process.
+     * 
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of hours taken to process.
      */

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -39,6 +39,9 @@ public abstract class BaseSyncStatistics {
      * Stores the current time of instantiation in the {@code latestBatchStartTime} instance variable that will be used
      * later when {@link BaseSyncStatistics#calculateProcessingTime()} is called to calculate the total time of
      * processing.
+     *
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
+     *
      */
     public void startTimer() {
         latestBatchStartTime = System.currentTimeMillis();
@@ -154,6 +157,9 @@ public abstract class BaseSyncStatistics {
      * {@code latestBatchProcessingTimeInMillis}. It also builds a human readable processing time, as string, in the
      * following format @{code "0d, 0h, 0m, 2s, 545ms"} and stores it in the publicly exposed
      * variable {@code latestBatchHumanReadableProcessingTime}.
+     *
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
+     *
      */
     public void calculateProcessingTime() {
         setProcessingTimeInAllUnits();
@@ -166,6 +172,9 @@ public abstract class BaseSyncStatistics {
      * {@code latestBatchProcessingTimeInDays}, {@code latestBatchProcessingTimeInHours},
      * {@code latestBatchProcessingTimeInMinutes},
      * {@code latestBatchProcessingTimeInSeconds} and {@code latestBatchProcessingTimeInMillis}.
+     *
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
+     *
      */
     private void setProcessingTimeInAllUnits() {
         latestBatchProcessingTimeInMillis = System.currentTimeMillis() - this.latestBatchStartTime;
@@ -178,6 +187,9 @@ public abstract class BaseSyncStatistics {
     /**
      * Builds a human readable processing time, as string, in the following format @{code "0d, 0h, 0m, 2s, 545ms"}
      * and stores it in the publicly exposed variable {@code latestBatchHumanReadableProcessingTime}.
+     *
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
+     *
      */
     private void setHumanReadableProcessingTime() {
         final long completeDaysInHours = TimeUnit.DAYS.toHours(latestBatchProcessingTimeInDays);
@@ -201,6 +213,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the human readable processing time in the following format @{code "0d, 0h, 0m, 2s, 545ms"}.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return the human readable processing time in the following format @{code "0d, 0h, 0m, 2s, 545ms"}
      */
@@ -210,6 +223,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of days it took to process.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of days taken to process.
      */
@@ -228,6 +242,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of minutes it took to process.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of minutes taken to process.
      */
@@ -237,6 +252,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of seconds it took to process.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of seconds taken to process.
      */
@@ -246,6 +262,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of milliseconds it took to process.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of milliseconds taken to process.
      */
@@ -255,6 +272,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets a summary message of the statistics report.
+     * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return a summary message of the statistics report.
      */

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -3,15 +3,16 @@ package com.commercetools.sync.commons.helpers;
 import io.netty.util.internal.StringUtil;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 
 public abstract class BaseSyncStatistics {
     protected String reportMessage;
-    private int updated;
-    private int created;
-    private int failed;
-    private int processed;
+    private AtomicInteger updated;
+    private AtomicInteger created;
+    private AtomicInteger failed;
+    private AtomicInteger processed;
     private long latestBatchStartTime;
     private long latestBatchProcessingTimeInDays;
     private long latestBatchProcessingTimeInHours;
@@ -21,7 +22,15 @@ public abstract class BaseSyncStatistics {
     private String latestBatchHumanReadableProcessingTime;
 
 
+    /**
+     * Creates a new {@link BaseSyncStatistics} with initial values {@code 0} of created, updated, failed and processed
+     * counters, an empty reportMessage and latestBatchHumanReadableProcessingTime.
+     */
     public BaseSyncStatistics() {
+        updated = new AtomicInteger();
+        created = new AtomicInteger();
+        failed = new AtomicInteger();
+        processed = new AtomicInteger();
         reportMessage = StringUtil.EMPTY_STRING;
         latestBatchHumanReadableProcessingTime = StringUtil.EMPTY_STRING;
     }
@@ -40,7 +49,7 @@ public abstract class BaseSyncStatistics {
      *
      * @return total number of resources that were updated.
      */
-    public int getUpdated() {
+    public AtomicInteger getUpdated() {
         return updated;
     }
 
@@ -48,7 +57,7 @@ public abstract class BaseSyncStatistics {
      * Increments the total number of resource that were updated.
      */
     public void incrementUpdated() {
-        this.updated++;
+        updated.incrementAndGet();
     }
 
     /**
@@ -57,7 +66,7 @@ public abstract class BaseSyncStatistics {
      * @param times the total number of times to increment.
      */
     public void incrementUpdated(final int times) {
-        this.updated += times;
+        updated.addAndGet(times);
     }
 
     /**
@@ -65,7 +74,7 @@ public abstract class BaseSyncStatistics {
      *
      * @return total number of resources that were created.
      */
-    public int getCreated() {
+    public AtomicInteger getCreated() {
         return created;
     }
 
@@ -73,7 +82,7 @@ public abstract class BaseSyncStatistics {
      * Increments the total number of resource that were created.
      */
     public void incrementCreated() {
-        this.created++;
+        created.incrementAndGet();
     }
 
     /**
@@ -82,7 +91,7 @@ public abstract class BaseSyncStatistics {
      * @param times the total number of times to increment.
      */
     public void incrementCreated(final int times) {
-        this.created += times;
+        created.addAndGet(times);
     }
 
     /**
@@ -90,7 +99,7 @@ public abstract class BaseSyncStatistics {
      *
      * @return total number of resources that were processed/synced.
      */
-    public int getProcessed() {
+    public AtomicInteger getProcessed() {
         return processed;
     }
 
@@ -98,7 +107,7 @@ public abstract class BaseSyncStatistics {
      * Increments the total number of resources that were processed/synced.
      */
     public void incrementProcessed() {
-        this.processed++;
+        processed.incrementAndGet();
     }
 
     /**
@@ -107,7 +116,7 @@ public abstract class BaseSyncStatistics {
      * @param times the total number of times to increment.
      */
     public void incrementProcessed(final int times) {
-        this.processed += times;
+        processed.addAndGet(times);
     }
 
     /**
@@ -115,7 +124,7 @@ public abstract class BaseSyncStatistics {
      *
      * @return total number of resources that failed to sync.
      */
-    public int getFailed() {
+    public AtomicInteger getFailed() {
         return failed;
     }
 
@@ -124,7 +133,7 @@ public abstract class BaseSyncStatistics {
      *
      */
     public void incrementFailed() {
-        this.failed++;
+        failed.incrementAndGet();
     }
 
     /**
@@ -133,7 +142,7 @@ public abstract class BaseSyncStatistics {
      * @param times the total number of times to increment.
      */
     public void incrementFailed(final int times) {
-        this.failed += times;
+        failed.addAndGet(times);
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/inventories/helpers/InventorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/inventories/helpers/InventorySyncStatistics.java
@@ -20,8 +20,8 @@ public class InventorySyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format("Summary: %d inventory entries were processed in total "
-                + "(%d created, %d updated and %d failed to sync).",
+        reportMessage = format("Summary: %s inventory entries were processed in total "
+                + "(%s created, %s updated and %s failed to sync).",
             getProcessed(), getCreated(), getUpdated(), getFailed());
         return reportMessage;
     }

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
@@ -4,13 +4,14 @@ package com.commercetools.sync.categories.helpers;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CategorySyncStatisticsTest {
 
@@ -77,26 +78,17 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void setAndGetCategoryKeysWithMissingParents_WithAnyMap_ShouldSetAndGetMapCorrectly() {
-        final HashMap<String, List<String>> catKeysWithMissingParents = new HashMap<>();
-        categorySyncStatistics.setCategoryKeysWithMissingParents(catKeysWithMissingParents);
-
-        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isSameAs(catKeysWithMissingParents);
-    }
-
-    @Test
     public void getNumberOfCategoriesWithMissingParents_WithEmptyMap_ShouldReturn0() {
-        final HashMap<String, List<String>> catKeysWithMissingParents = new HashMap<>();
+        final ConcurrentHashMap<String, Set<String>> catKeysWithMissingParents = new ConcurrentHashMap<>();
         categorySyncStatistics.setCategoryKeysWithMissingParents(catKeysWithMissingParents);
 
         assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isZero();
     }
 
     @Test
-    public void getNumberOfCategoriesWithMissingParents_WithEmptyAndNullValues_ShouldReturn0() {
-        final Map<String, List<String>> categoryKeysWithMissingParents = new HashMap<>();
-        categoryKeysWithMissingParents.put("parent1", null);
-        categoryKeysWithMissingParents.put("parent2", emptyList());
+    public void getNumberOfCategoriesWithMissingParents_WithEmptyValue_ShouldReturn0() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        categoryKeysWithMissingParents.put("parent2", emptySet());
 
         categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
         assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isEqualTo(0);
@@ -104,12 +96,12 @@ public class CategorySyncStatisticsTest {
 
     @Test
     public void getNumberOfCategoriesWithMissingParents_WithNonEmptyMap_ShouldReturnCorrectNumberOfChildren() {
-        final Map<String, List<String>> categoryKeysWithMissingParents = new HashMap<>();
-        final ArrayList<String> firstMissingParentChildrenKeys = new ArrayList<>();
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> firstMissingParentChildrenKeys = new HashSet<>();
         firstMissingParentChildrenKeys.add("key1");
         firstMissingParentChildrenKeys.add("key2");
 
-        final ArrayList<String> secondMissingParentChildrenKeys = new ArrayList<>();
+        final Set<String> secondMissingParentChildrenKeys = new HashSet<>();
         secondMissingParentChildrenKeys.add("key3");
         secondMissingParentChildrenKeys.add("key4");
 
@@ -120,5 +112,162 @@ public class CategorySyncStatisticsTest {
         categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
 
         assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isEqualTo(4);
+    }
+
+    @Test
+    public void getCategoryKeysWithMissingParents_WithAnyMap_ShouldGetUnmodifiableMapCorrectly() {
+        final ConcurrentHashMap<String, Set<String>> catKeysWithMissingParents = new ConcurrentHashMap<>();
+        categorySyncStatistics.setCategoryKeysWithMissingParents(catKeysWithMissingParents);
+
+        final Map<String, Set<String>> fetchedMap = categorySyncStatistics.getCategoryKeysWithMissingParents();
+
+        assertThatThrownBy(() -> fetchedMap.put("e", emptySet()))
+            .isExactlyInstanceOf(UnsupportedOperationException.class);
+
+        assertThat(fetchedMap).isEqualTo(catKeysWithMissingParents);
+    }
+
+    @Test
+    public void putMissingParentCategoryChildKey_OnAnEmptyList_ShouldAddNewParentEntryInTheMap() {
+        final String parentKey = "parentKey";
+        final String childKey = "childKey";
+        categorySyncStatistics.putMissingParentCategoryChildKey(parentKey, childKey);
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isNotEmpty();
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        final Set<String> childrenKeySet = categorySyncStatistics.getCategoryKeysWithMissingParents().get(parentKey);
+        assertThat(childrenKeySet).isNotNull();
+        assertThat(childrenKeySet).hasSize(1);
+        assertThat(childrenKeySet.iterator().next()).isEqualTo(childKey);
+    }
+
+    @Test
+    public void putMissingParentCategoryChildKey_OnANonEmptyListWithNewParent_ShouldAddNewParentEntryInTheMap() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> existingChildrenKeys = new HashSet<>();
+        existingChildrenKeys.add("key1");
+        existingChildrenKeys.add("key2");
+
+        final String existingParentKey = "existingParent";
+        categoryKeysWithMissingParents.put(existingParentKey, existingChildrenKeys);
+        categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
+
+        final String newParentKey = "parentKey";
+        final String newChildKey = "childKey";
+        categorySyncStatistics.putMissingParentCategoryChildKey(newParentKey, newChildKey);
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isNotEmpty();
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(2);
+        final Set<String> newChildrenKeySet = categorySyncStatistics.getCategoryKeysWithMissingParents()
+                                                                    .get(newParentKey);
+        assertThat(newChildrenKeySet).isNotNull();
+        assertThat(newChildrenKeySet).hasSize(1);
+        assertThat(newChildrenKeySet.iterator().next()).isEqualTo(newChildKey);
+
+        final Set<String> existingChildrenKeySet = categorySyncStatistics.getCategoryKeysWithMissingParents()
+                                                                         .get(existingParentKey);
+        assertThat(existingChildrenKeySet).isNotNull();
+        assertThat(existingChildrenKeySet).hasSize(2);
+        assertThat(existingChildrenKeySet).isEqualTo(existingChildrenKeys);
+    }
+
+    @Test
+    public void putMissingParentCategoryChildKey_OnNonEmptyListWithExistingParent_ShouldAddParentToExistingEntry() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> existingChildrenKeys = new HashSet<>();
+        existingChildrenKeys.add("key1");
+        existingChildrenKeys.add("key2");
+
+        final String existingParentKey = "existingParent";
+        categoryKeysWithMissingParents.put(existingParentKey, existingChildrenKeys);
+        categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
+
+        final String newChildKey = "childKey";
+        categorySyncStatistics.putMissingParentCategoryChildKey(existingParentKey, newChildKey);
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isNotEmpty();
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        final Set<String> newChildrenKeySet = categorySyncStatistics.getCategoryKeysWithMissingParents()
+                                                                    .get(existingParentKey);
+        assertThat(newChildrenKeySet).isNotNull();
+        assertThat(newChildrenKeySet).hasSize(3);
+        assertThat(newChildrenKeySet).containsOnly(newChildKey, "key1", "key2");
+    }
+
+    @Test
+    public void getMissingParentKey_OAnEmptyList_ShouldReturnAnEmptyOptional() {
+        assertThat(categorySyncStatistics.getMissingParentKey("foo")).isEmpty();
+    }
+
+    @Test
+    public void getMissingParentKey_OnANonEmptyList_ShouldReturnCorrectParentKeyInOptional() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> existingChildrenKeys = new HashSet<>();
+        existingChildrenKeys.add("key1");
+        existingChildrenKeys.add("key2");
+
+        final String existingParentKey = "existingParent";
+        categoryKeysWithMissingParents.put(existingParentKey, existingChildrenKeys);
+        categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
+
+        assertThat(categorySyncStatistics.getMissingParentKey("key1")).contains(existingParentKey);
+        assertThat(categorySyncStatistics.getMissingParentKey("key2")).contains(existingParentKey);
+    }
+
+    @Test
+    public void removeChildCategoryKeyFromMissingParentsMap_OnAEmptyList_ShouldNotAffectTheMap() {
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isEmpty();
+        categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("foo");
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isEmpty();
+    }
+
+    @Test
+    public void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListButNonExistingKey_ShouldNotAffectTheMap() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> existingChildrenKeys = new HashSet<>();
+        existingChildrenKeys.add("key1");
+        existingChildrenKeys.add("key2");
+
+        final String existingParentKey = "existingParent";
+        categoryKeysWithMissingParents.put(existingParentKey, existingChildrenKeys);
+        categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey)).hasSize(2);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey))
+            .containsOnly("key2", "key1");
+
+        categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("foo");
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey)).hasSize(2);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey))
+            .containsOnly("key2", "key1");
+    }
+
+    @Test
+    public void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListWithExistingKey_ShouldNotAffectTheMap() {
+        final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
+        final Set<String> existingChildrenKeys = new HashSet<>();
+        existingChildrenKeys.add("key1");
+        existingChildrenKeys.add("key2");
+
+        final String existingParentKey = "existingParent";
+        categoryKeysWithMissingParents.put(existingParentKey, existingChildrenKeys);
+        categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey)).hasSize(2);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey))
+            .isEqualTo(existingChildrenKeys);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey))
+            .containsOnly("key2", "key1");
+
+        categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("key1");
+
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).hasSize(1);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey)).hasSize(1);
+        assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents().get(existingParentKey))
+            .doesNotContain("key1").containsOnly("key2");
     }
 }

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
@@ -23,46 +23,46 @@ public class CategorySyncStatisticsTest {
 
     @Test
     public void getUpdated_WithNoUpdated_ShouldReturnZero() {
-        assertThat(categorySyncStatistics.getUpdated()).isEqualTo(0);
+        assertThat(categorySyncStatistics.getUpdated()).hasValue(0);
     }
 
     @Test
     public void incrementUpdated_ShouldIncrementUpdatedValue() {
         categorySyncStatistics.incrementUpdated();
-        assertThat(categorySyncStatistics.getUpdated()).isEqualTo(1);
+        assertThat(categorySyncStatistics.getUpdated()).hasValue(1);
     }
 
     @Test
     public void getCreated_WithNoCreated_ShouldReturnZero() {
-        assertThat(categorySyncStatistics.getCreated()).isEqualTo(0);
+        assertThat(categorySyncStatistics.getCreated()).hasValue(0);
     }
 
     @Test
     public void incrementCreated_ShouldIncrementCreatedValue() {
         categorySyncStatistics.incrementCreated();
-        assertThat(categorySyncStatistics.getCreated()).isEqualTo(1);
+        assertThat(categorySyncStatistics.getCreated()).hasValue(1);
     }
 
     @Test
     public void getProcessed_WithNoProcessed_ShouldReturnZero() {
-        assertThat(categorySyncStatistics.getProcessed()).isEqualTo(0);
+        assertThat(categorySyncStatistics.getProcessed()).hasValue(0);
     }
 
     @Test
     public void incrementProcessed_ShouldIncrementProcessedValue() {
         categorySyncStatistics.incrementProcessed();
-        assertThat(categorySyncStatistics.getProcessed()).isEqualTo(1);
+        assertThat(categorySyncStatistics.getProcessed()).hasValue(1);
     }
 
     @Test
     public void getFailed_WithNoFailed_ShouldReturnZero() {
-        assertThat(categorySyncStatistics.getFailed()).isEqualTo(0);
+        assertThat(categorySyncStatistics.getFailed()).hasValue(0);
     }
 
     @Test
     public void incrementFailed_ShouldIncrementFailedValue() {
         categorySyncStatistics.incrementFailed();
-        assertThat(categorySyncStatistics.getFailed()).isEqualTo(1);
+        assertThat(categorySyncStatistics.getFailed()).hasValue(1);
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/AbstractSyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/AbstractSyncStatisticsAssert.java
@@ -30,10 +30,10 @@ class AbstractSyncStatisticsAssert<S extends AbstractSyncStatisticsAssert<S, A>,
      */
     public S hasValues(final int processed, final int created, final int updated, final int failed) {
         assertThat(actual).isNotNull();
-        assertThat(actual.getProcessed()).isEqualTo(processed);
-        assertThat(actual.getCreated()).isEqualTo(created);
-        assertThat(actual.getUpdated()).isEqualTo(updated);
-        assertThat(actual.getFailed()).isEqualTo(failed);
+        assertThat(actual.getProcessed()).hasValue(processed);
+        assertThat(actual.getCreated()).hasValue(created);
+        assertThat(actual.getUpdated()).hasValue(updated);
+        assertThat(actual.getFailed()).hasValue(failed);
         return myself;
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
@@ -20,70 +20,70 @@ public class BaseSyncStatisticsTest {
 
     @Test
     public void getUpdated_WithNoUpdated_ShouldReturnZero() {
-        assertThat(baseSyncStatistics.getUpdated()).isEqualTo(0);
+        assertThat(baseSyncStatistics.getUpdated()).hasValue(0);
     }
 
     @Test
     public void incrementUpdated_WithNoSpecifiedTimes_ShouldIncrementUpdatedValue() {
         baseSyncStatistics.incrementUpdated();
-        assertThat(baseSyncStatistics.getUpdated()).isEqualTo(1);
+        assertThat(baseSyncStatistics.getUpdated()).hasValue(1);
     }
 
     @Test
     public void incrementUpdated_WithSpecifiedTimes_ShouldIncrementUpdatedValue() {
         baseSyncStatistics.incrementUpdated(5);
-        assertThat(baseSyncStatistics.getUpdated()).isEqualTo(5);
+        assertThat(baseSyncStatistics.getUpdated()).hasValue(5);
     }
 
     @Test
     public void getCreated_WithNoCreated_ShouldReturnZero() {
-        assertThat(baseSyncStatistics.getCreated()).isEqualTo(0);
+        assertThat(baseSyncStatistics.getCreated()).hasValue(0);
     }
 
     @Test
     public void incrementCreated_WithNoSpecifiedTimes_ShouldIncrementCreatedValue() {
         baseSyncStatistics.incrementCreated();
-        assertThat(baseSyncStatistics.getCreated()).isEqualTo(1);
+        assertThat(baseSyncStatistics.getCreated()).hasValue(1);
     }
 
     @Test
     public void incrementCreated_WithSpecifiedTimes_ShouldIncrementCreatedValue() {
         baseSyncStatistics.incrementCreated(2);
-        assertThat(baseSyncStatistics.getCreated()).isEqualTo(2);
+        assertThat(baseSyncStatistics.getCreated()).hasValue(2);
     }
 
     @Test
     public void getProcessed_WithNoProcessed_ShouldReturnZero() {
-        assertThat(baseSyncStatistics.getProcessed()).isEqualTo(0);
+        assertThat(baseSyncStatistics.getProcessed()).hasValue(0);
     }
 
     @Test
     public void incrementProcessed_WithNoSpecifiedTimes_ShouldIncrementProcessedValue() {
         baseSyncStatistics.incrementProcessed();
-        assertThat(baseSyncStatistics.getProcessed()).isEqualTo(1);
+        assertThat(baseSyncStatistics.getProcessed()).hasValue(1);
     }
 
     @Test
     public void incrementProcessed_WithSpecifiedTimes_ShouldIncrementProcessedValue() {
         baseSyncStatistics.incrementProcessed(2);
-        assertThat(baseSyncStatistics.getProcessed()).isEqualTo(2);
+        assertThat(baseSyncStatistics.getProcessed()).hasValue(2);
     }
 
     @Test
     public void getFailed_WithNoFailed_ShouldReturnZero() {
-        assertThat(baseSyncStatistics.getFailed()).isEqualTo(0);
+        assertThat(baseSyncStatistics.getFailed()).hasValue(0);
     }
 
     @Test
     public void incrementFailed_WithNoSpecifiedTimes_ShouldIncrementFailedValue() {
         baseSyncStatistics.incrementFailed();
-        assertThat(baseSyncStatistics.getFailed()).isEqualTo(1);
+        assertThat(baseSyncStatistics.getFailed()).hasValue(1);
     }
 
     @Test
     public void incrementFailed_WithSpecifiedTimes_ShouldIncrementFailedValue() {
         baseSyncStatistics.incrementFailed(3);
-        assertThat(baseSyncStatistics.getFailed()).isEqualTo(3);
+        assertThat(baseSyncStatistics.getFailed()).hasValue(3);
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,6 +33,9 @@ import java.util.stream.Collectors;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getChannelMock;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getPriceMockWithChannelReference;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getProductVariantMockWithPrices;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -63,33 +65,31 @@ public class ProductReferenceReplacementUtilsTest {
         final Reference<Channel> channelReference = Reference
             .ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel.getId(), channel);
         final Price price = getPriceMockWithChannelReference(channelReference);
-        final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
+        final ProductVariant productVariant = getProductVariantMockWithPrices(singletonList(price));
 
-        final Product productWithNonExpandedProductType = getProductMock(Collections.singletonList(productVariant));
+        final Product productWithNonExpandedProductType = getProductMock(singletonList(productVariant));
 
         when(productWithNonExpandedProductType.getProductType())
             .thenReturn(nonExpandedProductTypeReference);
         when(productWithNonExpandedProductType.getTaxCategory()).thenReturn(taxCategoryReference);
         when(productWithNonExpandedProductType.getState()).thenReturn(stateReference);
 
-        final Product productWithNonExpandedTaxCategory =
-            getProductMock(Collections.singletonList(productVariant));
+        final Product productWithNonExpandedTaxCategory = getProductMock(singletonList(productVariant));
 
         when(productWithNonExpandedTaxCategory.getProductType()).thenReturn(productTypeReference);
         when(productWithNonExpandedTaxCategory.getTaxCategory())
             .thenReturn(nonExpandedTaxCategoryReference);
         when(productWithNonExpandedTaxCategory.getState()).thenReturn(stateReference);
 
-        final Product productWithNonExpandedSate =
-            getProductMock(Collections.singletonList(productVariant));
+        final Product productWithNonExpandedSate = getProductMock(singletonList(productVariant));
 
         when(productWithNonExpandedSate.getProductType()).thenReturn(productTypeReference);
         when(productWithNonExpandedSate.getTaxCategory()).thenReturn(taxCategoryReference);
         when(productWithNonExpandedSate.getState()).thenReturn(nonExpandedStateReference);
 
 
-        final List<Product> products = Arrays
-            .asList(productWithNonExpandedProductType, productWithNonExpandedTaxCategory, productWithNonExpandedSate);
+        final List<Product> products =
+            asList(productWithNonExpandedProductType, productWithNonExpandedTaxCategory, productWithNonExpandedSate);
 
 
         final List<ProductDraft> productDraftsWithKeysOnReferences = ProductReferenceReplacementUtils
@@ -133,31 +133,29 @@ public class ProductReferenceReplacementUtilsTest {
         final Reference<Channel> channelReference = Reference
             .ofResourceTypeIdAndIdAndObj(Channel.referenceTypeId(), channel.getId(), channel);
         final Price price = getPriceMockWithChannelReference(channelReference);
-        final ProductVariant productVariant = getProductVariantMockWithPrices(Collections.singletonList(price));
+        final ProductVariant productVariant = getProductVariantMockWithPrices(singletonList(price));
 
         final Category category = getCategoryMock(resourceKey);
         final Reference<Category> categoryReference =
             Reference.ofResourceTypeIdAndIdAndObj(Category.referenceTypeId(), category.getId(), category);
 
         final Product productWithNonExpandedProductType =
-            getProductMock(Collections.singleton(categoryReference), null,
-                Collections.singletonList(productVariant));
+            getProductMock(singleton(categoryReference), null, singletonList(productVariant));
 
         when(productWithNonExpandedProductType.getProductType())
             .thenReturn(nonExpandedProductTypeReference);
         when(productWithNonExpandedProductType.getTaxCategory()).thenReturn(taxCategoryReference);
         when(productWithNonExpandedProductType.getState()).thenReturn(stateReference);
 
-        final Product productWithNonExpandedTaxCategory =
-            getProductMock(Collections.singletonList(productVariant));
+        final Product productWithNonExpandedTaxCategory = getProductMock(singletonList(productVariant));
 
         when(productWithNonExpandedTaxCategory.getProductType()).thenReturn(productTypeReference);
         when(productWithNonExpandedTaxCategory.getTaxCategory())
             .thenReturn(nonExpandedTaxCategoryReference);
         when(productWithNonExpandedTaxCategory.getState()).thenReturn(stateReference);
 
-        final List<Product> products = Arrays
-            .asList(productWithNonExpandedProductType, productWithNonExpandedTaxCategory, null);
+        final List<Product> products =
+            asList(productWithNonExpandedProductType, productWithNonExpandedTaxCategory, null);
 
 
         final List<ProductDraft> productDraftsWithKeysOnReferences = ProductReferenceReplacementUtils
@@ -335,7 +333,7 @@ public class ProductReferenceReplacementUtilsTest {
     public void
         replaceCategoryReferencesIdsWithKeys_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String categoryId = UUID.randomUUID().toString();
-        final Set<Reference<Category>> categoryReferences = Collections.singleton(Category.referenceOfId(categoryId));
+        final Set<Reference<Category>> categoryReferences = singleton(Category.referenceOfId(categoryId));
         final CategoryOrderHints categoryOrderHints = getCategoryOrderHintsMock(categoryReferences);
 
         final Product product = getProductMock(categoryReferences, categoryOrderHints);
@@ -356,7 +354,7 @@ public class ProductReferenceReplacementUtilsTest {
     public void
         replaceCategoryReferencesIdsWithKeys_WithNonExpandedReferencesAndNoCategoryOrderHints_ShouldNotReplaceIds() {
         final String categoryId = UUID.randomUUID().toString();
-        final Set<Reference<Category>> categoryReferences = Collections.singleton(Category.referenceOfId(categoryId));
+        final Set<Reference<Category>> categoryReferences = singleton(Category.referenceOfId(categoryId));
         final Product product = getProductMock(categoryReferences, null);
 
         final CategoryReferencePair categoryReferencePair =
@@ -378,7 +376,7 @@ public class ProductReferenceReplacementUtilsTest {
         final Reference<Category> categoryReference =
             Reference.ofResourceTypeIdAndIdAndObj(Category.referenceTypeId(), category.getId(), category);
 
-        final Set<Reference<Category>> categoryReferences = Collections.singleton(categoryReference);
+        final Set<Reference<Category>> categoryReferences = singleton(categoryReference);
         final CategoryOrderHints categoryOrderHints = getCategoryOrderHintsMock(categoryReferences);
 
         final Product product = getProductMock(categoryReferences, categoryOrderHints);
@@ -404,7 +402,7 @@ public class ProductReferenceReplacementUtilsTest {
         final Category category = getCategoryMock(categoryKey);
         final Reference<Category> categoryReference =
             Reference.ofResourceTypeIdAndIdAndObj(Category.referenceTypeId(), category.getId(), category);
-        final Product product = getProductMock(Collections.singleton(categoryReference), null);
+        final Product product = getProductMock(singleton(categoryReference), null);
 
         final CategoryReferencePair categoryReferencePair =
             ProductReferenceReplacementUtils.replaceCategoryReferencesIdsWithKeys(product);
@@ -436,8 +434,7 @@ public class ProductReferenceReplacementUtilsTest {
         categoryReferences.add(categoryReference1);
         categoryReferences.add(categoryReference2);
 
-        final CategoryOrderHints categoryOrderHints =
-            getCategoryOrderHintsMock(Collections.singleton(categoryReference1));
+        final CategoryOrderHints categoryOrderHints = getCategoryOrderHintsMock(singleton(categoryReference1));
 
         final Product product = getProductMock(categoryReferences, categoryOrderHints);
 

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -175,7 +175,9 @@ public class ProductReferenceReplacementUtilsTest {
             productDraftsWithKeysOnReferences.get(0).getCategories();
 
         assertThat(categoryResourceIdentifiers).hasSize(1);
-        assertThat(categoryResourceIdentifiers).containsExactly(Category.referenceOfId(category.getKey()));
+
+        assertThat(categoryResourceIdentifiers)
+            .containsOnlyElementsOf(singletonList(Category.referenceOfId(category.getKey())));
 
         assertThat(productDraftsWithKeysOnReferences.get(1).getProductType().getId()).isEqualTo(productType.getKey());
         assertThat(productDraftsWithKeysOnReferences.get(1).getTaxCategory().getId()).isEqualTo(taxCategory.getId());
@@ -319,14 +321,14 @@ public class ProductReferenceReplacementUtilsTest {
         final ProductQuery productQuery = ProductReferenceReplacementUtils.buildProductQuery();
         assertThat(productQuery.expansionPaths()).hasSize(10);
         assertThat(productQuery.expansionPaths())
-            .containsExactly(ExpansionPath.of("productType"), ExpansionPath.of("taxCategory"),
+            .containsOnlyElementsOf(asList(ExpansionPath.of("productType"), ExpansionPath.of("taxCategory"),
                 ExpansionPath.of("state"), ExpansionPath.of("masterData.staged.categories[*]"),
                 ExpansionPath.of("masterData.staged.masterVariant.prices[*].channel"),
                 ExpansionPath.of("masterData.staged.variants[*].prices[*].channel"),
                 ExpansionPath.of("masterData.staged.masterVariant.attributes[*].value"),
                 ExpansionPath.of("masterData.staged.variants[*].attributes[*].value"),
                 ExpansionPath.of("masterData.staged.masterVariant.attributes[*].value[*]"),
-                ExpansionPath.of("masterData.staged.variants[*].attributes[*].value[*]"));
+                ExpansionPath.of("masterData.staged.variants[*].attributes[*].value[*]")));
     }
 
     @Test


### PR DESCRIPTION
#### Description
The counters in BaseSyncStatistics weren't thread-safe, even though there were parts in the code where they were being modified in parallel by multiple threads like here: https://github.com/commercetools/commercetools-sync-java/blob/b61de4b097fa87cf487f17cecf4260f8045fcc81/src/main/java/com/commercetools/sync/products/ProductSync.java#L248
This PR addresses this issue by making the counters atomic integers instead of ints, some maps and that were also accessed in parallel were changed to the concurrency-supporting ones. Moreover, some documentation update was made.
 

#### Summary
- [Bump dependencies of assertJ, mockito and jacoco](https://github.com/commercetools/commercetools-sync-java/pull/244/files#diff-771e2d81321cde33fec338d366924359). Bumping the rest of the dependencies cause some breaking changes, so they will be bumped in a separate PR to avoid confusion for fixing what they break.
- Make statistics' counters in [BaseSyncStatistics](https://github.com/commercetools/commercetools-sync-java/pull/244/files#diff-dfda92e7db082817e6e5c96dd809efde) all `AtomicInteger`s instead of `int` to be thread-safe.
- Make some [sets and maps to be `ConcurrentHashMap`/`ConcurrentHashMap.newKeySet`](https://github.com/commercetools/commercetools-sync-java/pull/244/files#diff-44d2fa184e625bcc0900b105f60d8677) which are used concurrently in `CategorySync` to be thread-safe.
- [Update documentation](https://github.com/commercetools/commercetools-sync-java/pull/244/commits/233d5f0d19a2404d8530ddd306e7826474357013) according to #243 

#### Relevant Issues
#242 #217 #243 

- [x] Tests
- [x] Documentation
- [x] Add Release Notes entry.