### PR TITLE
249 benchmark after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark#1
-      #if: tag IS present
+      if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: benchmark#2
       if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark#1
-      #if: tag IS present
+      if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
       after_success: skip
     - stage: benchmark#2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,23 @@ jobs:
     - stage: benchmark#1
       #if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      after_success: skip
     - stage: benchmark#2
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      after_success: skip
     - stage: benchmark#3
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      after_success: skip
     - stage: benchmark#4
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      after_success: skip
     - stage: benchmark#5
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      after_success: skip
     - stage: full build
       script: ./gradlew clean setLibraryVersion build
 # The before_cache and the cache steps cache the gradle installation on travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,23 @@ jobs:
     - stage: benchmark#1
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-      after_success: skip
     - stage: benchmark#2
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-      after_success: skip
     - stage: benchmark#3
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-      after_success: skip
     - stage: benchmark#4
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-      after_success: skip
     - stage: benchmark#5
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-      after_success: skip
     - stage: full build
       script: ./gradlew clean setLibraryVersion build
+      after_success:
+      - bash <(curl -s https://codecov.io/bash)
+      - ./travis-publish.sh || travis_terminate 1
 # The before_cache and the cache steps cache the gradle installation on travis.
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -36,9 +34,6 @@ cache:
   directories:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
-after_success:
-- bash <(curl -s https://codecov.io/bash)
-- ./travis-publish.sh || travis_terminate 1
 notifications:
   hipchat:
     template:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark#1
-      if: tag IS present
+      #if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: benchmark#2
       if: tag IS present

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
+[![Benchmarks M10](https://img.shields.io/badge/Benchmarks-M10-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
 [![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
@@ -22,6 +23,7 @@ Java API which exposes utilities for building update actions and automatic synci
 - [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
 - [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/)
+- [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Usage

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -52,6 +52,11 @@
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M10...v1.0.0-M11) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M11/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M11)
+
+
+**Bug Fixes** (1)
+- **Build Tools** - Fixed bug where jar and Codecov were triggered on benchmark stages of the build when they should 
+only be triggered on the full build. [#249](https://github.com/commercetools/commercetools-sync-java/issues/249)
 -->
 
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -39,7 +39,7 @@ public class BenchmarkUtils {
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
     static final int THRESHOLD = 120000; //120 seconds in milliseconds
-    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 1;
+    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 10;
 
 
     static void saveNewResult(@Nonnull final String version,

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -39,7 +39,7 @@ public class BenchmarkUtils {
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
     static final int THRESHOLD = 120000; //120 seconds in milliseconds
-    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 10000;
+    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 1;
 
 
     static void saveNewResult(@Nonnull final String version,

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -39,7 +39,7 @@ public class BenchmarkUtils {
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
     static final int THRESHOLD = 120000; //120 seconds in milliseconds
-    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 10;
+    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 10000;
 
 
     static void saveNewResult(@Nonnull final String version,


### PR DESCRIPTION
#### Description
Travis `after_success` which contains code coverage and publishing the jars to maven/bintray script ran in benchmark stages when releasing the library.

However, this should not be the case. It should only run after the `full build` stage.

1. Therefore, now all benchmarking steps `skip` the `after_success` step, so that it's only called in the full build step.

2. Benchmarks badge and link added in README.
3. Release notes entry added.

#### Relevant Issues
#249 
