### PR TITLE
Safe null collections wrappers

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import static com.commercetools.sync.commons.utils.CollectionUtils.emptyIfNull;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
@@ -320,8 +321,7 @@ public class BuildProductVariantImageUpdateActionsIT {
                                                        @Nonnull final Product productAfterSync) {
         final List<Image> oldImagesAfterSync =
             productAfterSync.getMasterData().getStaged().getMasterVariant().getImages();
-        List<Image> newImages = newProduct.getMasterVariant().getImages();
-        newImages = newImages != null ? newImages : Collections.emptyList();
+        List<Image> newImages = emptyIfNull(newProduct.getMasterVariant().getImages());
         assertThat(newImages).isEqualTo(oldImagesAfterSync);
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/services/ProductServiceIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/ProductServiceIT.java
@@ -730,7 +730,6 @@ public class ProductServiceIT {
         assertThat(fetchedProductOptional).isNotEmpty();
 
         final Product fetchedProduct = fetchedProductOptional.get();
-        assertThat(fetchedProduct.getVersion()).isEqualTo(numberOfImages + 1);
         // Test that the fetched product has exactly the 600 images added before.
         final List<Image> currentMasterVariantImages = fetchedProduct.getMasterData().getStaged()
                                                                      .getMasterVariant().getImages();

--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -12,7 +12,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static java.util.Collections.emptyList;
+import static com.commercetools.sync.commons.utils.CollectionUtils.emptyIfNull;
+import static java.util.Optional.ofNullable;
 
 public class BaseSyncOptions<U, V> {
     private final SphereClient ctpClient;
@@ -186,13 +187,9 @@ public class BaseSyncOptions<U, V> {
     public List<UpdateAction<U>> applyBeforeUpdateCallBack(@Nonnull final List<UpdateAction<U>> updateActions,
                                                            @Nonnull final V newResourceDraft,
                                                            @Nonnull final U oldResource) {
-        if (beforeUpdateCallback == null) {
-            return updateActions;
-        } else {
-            final List<UpdateAction<U>> callbackResult =
-                    beforeUpdateCallback.apply(updateActions, newResourceDraft, oldResource);
-            return callbackResult != null ? callbackResult : emptyList();
-        }
+        return ofNullable(beforeUpdateCallback)
+            .map(callBack -> emptyIfNull(callBack.apply(updateActions, newResourceDraft, oldResource)))
+            .orElse(updateActions);
     }
 
     /**
@@ -212,7 +209,7 @@ public class BaseSyncOptions<U, V> {
      */
     @Nonnull
     public Optional<V> applyBeforeCreateCallBack(@Nonnull final V newResourceDraft) {
-        return Optional.ofNullable(
+        return ofNullable(
                 beforeCreateCallback != null ? beforeCreateCallback.apply(newResourceDraft) : newResourceDraft);
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
@@ -3,7 +3,6 @@ package com.commercetools.sync.commons.utils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,6 +12,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
@@ -51,8 +51,7 @@ public final class CollectionUtils {
     @Nonnull
     public static <T, K> Set<K> collectionToSet(@Nullable final Collection<T> collection,
                                                 @Nonnull final Function<? super T, ? extends K> keyMapper) {
-        return collection == null ? Collections.emptySet()
-                : collection.stream()
+        return emptyIfNull(collection).stream()
                 .map(keyMapper)
                 .collect(toSet());
     }
@@ -74,9 +73,9 @@ public final class CollectionUtils {
     public static <T, K, V> Map<K, V> collectionToMap(@Nullable final Collection<T> collection,
                                                       @Nonnull final Function<? super T, ? extends K> keyMapper,
                                                       @Nonnull final Function<? super T, ? extends V> valueMapper) {
-        return collection == null ? Collections.emptyMap()
-                : collection.stream()
-                .collect(toMap(keyMapper, valueMapper,  (k1, k2) -> k1)); // ignore duplicates
+        return emptyIfNull(collection)
+                .stream()
+                .collect(toMap(keyMapper, valueMapper, (k1, k2) -> k1)); // ignore duplicates
     }
 
     /**
@@ -95,6 +94,21 @@ public final class CollectionUtils {
         return collectionToMap(collection, keyMapper, value -> value);
     }
 
+    /**
+     * Safe wrapper around nullable collection instances: returns {@code collection} argument itself,
+     * if the {@code collection} is non-null, otherwise returns (immutable) empty collection.
+     *
+     * @param collection {@link Collection} instance to process
+     * @param <T>        collection entities type
+     * @return original {@code collection} instance, if non-null; otherwise immutable empty collection instance.
+     * @see #emptyIfNull(List)
+     * @see #emptyIfNull(Set)
+     * @see #emptyIfNull(Map)
+     */
+    @Nonnull
+    public static <T> Collection<T> emptyIfNull(@Nullable final Collection<T> collection) {
+        return collection == null ? emptyList() : collection;
+    }
 
     /**
      * Safe wrapper around nullable list instances: returns {@code list} argument itself,
@@ -103,10 +117,30 @@ public final class CollectionUtils {
      * @param list {@link List} instance to process
      * @param <T>  list entities type
      * @return original {@code list} instance, if non-null; otherwise immutable empty list instance.
+     * @see #emptyIfNull(Collection)
+     * @see #emptyIfNull(Set)
+     * @see #emptyIfNull(Map)
      */
     @Nonnull
     public static <T> List<T> emptyIfNull(@Nullable final List<T> list) {
         return list == null ? emptyList() : list;
+    }
+
+
+    /**
+     * Safe wrapper around nullable set instances: returns {@code set} argument itself,
+     * if the {@code set} is non-null, otherwise returns (immutable) empty set.
+     *
+     * @param set {@link Set} instance to process
+     * @param <T> set entities type
+     * @return original {@code set} instance, if non-null; otherwise immutable empty set instance.
+     * @see #emptyIfNull(Collection)
+     * @see #emptyIfNull(List)
+     * @see #emptyIfNull(Map)
+     */
+    @Nonnull
+    public static <T> Set<T> emptyIfNull(@Nullable final Set<T> set) {
+        return set == null ? emptySet() : set;
     }
 
     /**
@@ -117,6 +151,9 @@ public final class CollectionUtils {
      * @param <K> map key type
      * @param <V> map value type
      * @return original {@code map} instance, if non-null; otherwise immutable empty map instance.
+     * @see #emptyIfNull(Collection)
+     * @see #emptyIfNull(List)
+     * @see #emptyIfNull(Set)
      */
     @Nonnull
     public static <K, V> Map<K, V> emptyIfNull(@Nullable final Map<K, V> map) {

--- a/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CollectionUtils.java
@@ -4,12 +4,15 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
@@ -90,6 +93,34 @@ public final class CollectionUtils {
     public static <T, K> Map<K, T> collectionToMap(@Nullable final Collection<T> collection,
                                                    @Nonnull final Function<? super T, ? extends K> keyMapper) {
         return collectionToMap(collection, keyMapper, value -> value);
+    }
+
+
+    /**
+     * Safe wrapper around nullable list instances: returns {@code list} argument itself,
+     * if the {@code list} is non-null, otherwise returns (immutable) empty list.
+     *
+     * @param list {@link List} instance to process
+     * @param <T>  list entities type
+     * @return original {@code list} instance, if non-null; otherwise immutable empty list instance.
+     */
+    @Nonnull
+    public static <T> List<T> emptyIfNull(@Nullable final List<T> list) {
+        return list == null ? emptyList() : list;
+    }
+
+    /**
+     * Safe wrapper around nullable map instances: returns {@code map} argument itself, if the {@code map} is non-null,
+     * otherwise returns (immutable) empty map.
+     *
+     * @param map {@link Map} instance to process
+     * @param <K> map key type
+     * @param <V> map value type
+     * @return original {@code map} instance, if non-null; otherwise immutable empty map instance.
+     */
+    @Nonnull
+    public static <K, V> Map<K, V> emptyIfNull(@Nullable final Map<K, V> map) {
+        return map == null ? emptyMap() : map;
     }
 
     private CollectionUtils() {

--- a/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
@@ -149,7 +149,7 @@ public final class VariantReferenceResolver extends BaseReferenceResolver<Produc
 
     private static Optional<String> getReferenceTypeIdIfReference(@Nonnull final JsonNode referenceValue) {
         final JsonNode typeId = referenceValue.get(REFERENCE_TYPE_ID_FIELD);
-        return typeId != null ? Optional.ofNullable(typeId.asText()) : Optional.empty();
+        return Optional.ofNullable(typeId).map(JsonNode::asText);
     }
 
     CompletionStage<Optional<String>> getResolvedIdFromKeyInReference(@Nonnull final JsonNode referenceValue) {

--- a/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
+++ b/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
@@ -142,7 +142,7 @@ final class SyncSingleLocale {
                 final String newLocaleValue = newLocalizedField.get(locale);
                 final String oldLocaleValue = oldLocalizedField.get(locale);
                 if (!Objects.equals(newLocaleValue, oldLocaleValue)) {
-                    // if old locale value is set, remove it from old localized field, otherwise use oldLocalizedField
+                    // if old locale value is set, remove it from old localized field
                     final LocalizedString withLocaleChange = ofNullable(oldLocaleValue)
                         .map(value -> LocalizedString.of(
                             oldLocalizedField.stream()
@@ -151,7 +151,8 @@ final class SyncSingleLocale {
                                     LocalizedStringEntry::getValue))))
                         .orElse(oldLocalizedField);
 
-                    // If old locale value is not set, only update if the new locale value is set.
+                    // Only if old locale value is not set and the new locale value is set,
+                    // update the old localized field with the new locale value
                     return ofNullable(newLocaleValue)
                         .map(val -> updateActionMapper.apply(withLocaleChange.plus(locale, val)));
                 }

--- a/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
+++ b/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -141,32 +142,31 @@ final class SyncSingleLocale {
                 final String newLocaleValue = newLocalizedField.get(locale);
                 final String oldLocaleValue = oldLocalizedField.get(locale);
                 if (!Objects.equals(newLocaleValue, oldLocaleValue)) {
-                    LocalizedString withLocaleChange = oldLocalizedField;
-                    // if old locale value is set, remove it from old localized field.
-                    if (oldLocaleValue != null) {
-                        withLocaleChange = LocalizedString.of(
+                    // if old locale value is set, remove it from old localized field, otherwise use oldLocalizedField
+                    final LocalizedString withLocaleChange = ofNullable(oldLocaleValue)
+                        .map(value -> LocalizedString.of(
                             oldLocalizedField.stream()
-                                             .filter(localization -> !localization.getLocale().equals(locale))
-                                             .collect(toMap(LocalizedStringEntry::getLocale,
-                                                 LocalizedStringEntry::getValue)));
-                    }
+                                .filter(localization -> !localization.getLocale().equals(locale))
+                                .collect(toMap(LocalizedStringEntry::getLocale,
+                                    LocalizedStringEntry::getValue))))
+                        .orElse(oldLocalizedField);
+
                     // If old locale value is not set, only update if the new locale value is set.
-                    return Optional.ofNullable(newLocaleValue != null
-                        ? updateActionMapper.apply(withLocaleChange.plus(locale, newLocaleValue)) : null);
+                    return ofNullable(newLocaleValue)
+                        .map(val -> updateActionMapper.apply(withLocaleChange.plus(locale, val)));
                 }
                 return Optional.empty();
             } else {
                 if (oldLocalizedField != null) {
                     // If old localized field is set but the new one is unset, only update if the locale value is set in
                     // the old field.
-                    return Optional.ofNullable(oldLocalizedField.get(locale) != null
-                        ? updateActionMapper.apply(LocalizedString.empty()) : null);
+                    return ofNullable(oldLocalizedField.get(locale))
+                        .map(localValue -> updateActionMapper.apply(LocalizedString.empty()));
                 } else {
                     // If old localized field is unset but the new one is set, only update if the locale value is set in
                     // the new field.
-                    final String newLocaleValue = newLocalizedField.get(locale);
-                    return Optional.ofNullable(newLocaleValue != null
-                        ? updateActionMapper.apply(LocalizedString.of(locale, newLocaleValue)) : null);
+                    return ofNullable(newLocalizedField.get(locale))
+                        .map(newLocalValue -> updateActionMapper.apply(LocalizedString.of(locale, newLocalValue)));
                 }
             }
         }

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.commercetools.sync.commons.utils.CollectionUtils.emptyIfNull;
 import static com.commercetools.sync.commons.utils.CollectionUtils.filterCollection;
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
 import static com.commercetools.sync.products.utils.ProductVariantAttributeUpdateActionUtils.buildProductVariantAttributeUpdateAction;
@@ -160,8 +161,7 @@ public final class ProductVariantUpdateActionUtils {
 
         if (!Objects.equals(oldProductVariantImages, newProductVariantImages)) {
             final List<Image> updatedOldImages = new ArrayList<>(oldProductVariantImages);
-            final List<Image> newImages = newProductVariantImages != null
-                    ? newProductVariantImages : Collections.emptyList();
+            final List<Image> newImages = emptyIfNull(newProductVariantImages);
 
             filterCollection(oldProductVariantImages, oldVariantImage ->
                     !newImages.contains(oldVariantImage))

--- a/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
@@ -3,10 +3,14 @@ package com.commercetools.sync.commons.utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToMap;
 import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToSet;
@@ -113,22 +117,57 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withListInstances_returnsNonNull() {
-        List<String> nonNullEmptyList = emptyIfNull((List<String>)null);
+    public void emptyIfNull_withNullInstances_returnsNonNullInstances() {
+        Collection<String> nonNullEmptyCollection = emptyIfNull((Collection<String>)null);
+        assertThat(nonNullEmptyCollection).isNotNull();
+        assertThat(nonNullEmptyCollection).isEmpty();
+
+        Set<Exception> nonNullEmptySet = emptyIfNull((Set<Exception>)null);
+        assertThat(nonNullEmptySet).isNotNull();
+        assertThat(nonNullEmptySet).isEmpty();
+
+        List<Integer> nonNullEmptyList = emptyIfNull((List<Integer>)null);
         assertThat(nonNullEmptyList).isNotNull();
         assertThat(nonNullEmptyList).isEmpty();
 
-        List<String> listToTest = asList("a", "b");
-        assertThat(emptyIfNull(listToTest)).isSameAs(listToTest);
-        assertThat(listToTest).containsExactly("a", "b"); // verify list is not mutated
+        Map<Double, CharSequence> nonNullEmptyMap = emptyIfNull((Map<Double, CharSequence>)null);
+        assertThat(nonNullEmptyMap).isNotNull();
+        assertThat(nonNullEmptyMap).isEmpty();
     }
 
     @Test
-    public void emptyIfNull_withMapInstances_returnsNonNull() {
-        Map<String, String> nonNullEmptyMap = emptyIfNull((Map<String, String>)null);
-        assertThat(nonNullEmptyMap).isNotNull();
-        assertThat(nonNullEmptyMap).isEmpty();
+    public void emptyIfNull_withArrayList_returnsSameInstance() {
+        ArrayList<String> arrayListCollection = new ArrayList<>();
+        arrayListCollection.add("a");
+        arrayListCollection.add("b");
 
+        List<String> actualCollection = emptyIfNull(arrayListCollection);
+        assertThat(actualCollection).isSameAs(arrayListCollection);
+        assertThat(actualCollection).containsExactly("a", "b"); // verify ArrayList is not mutated
+    }
+
+    @Test
+    public void emptyIfNull_withHashSet_returnsSameInstance() {
+        HashSet<String> arrayListCollection = new HashSet<>();
+        arrayListCollection.add("woot");
+        arrayListCollection.add("hack");
+
+        Set<String> actualCollection = emptyIfNull(arrayListCollection);
+        assertThat(actualCollection).isSameAs(arrayListCollection);
+        assertThat(actualCollection).containsExactlyInAnyOrder("woot", "hack"); // verify HashSet is not mutated
+    }
+
+    @Test
+    public void emptyIfNull_withListInstances_returnsNonNullList() {
+        List<String> originalListToTest = asList("a", "b");
+
+        List<String> actualListToTest = emptyIfNull(originalListToTest);
+        assertThat(actualListToTest).isSameAs(originalListToTest);
+        assertThat(actualListToTest).containsExactly("a", "b"); // verify list is not mutated
+    }
+
+    @Test
+    public void emptyIfNull_withMapInstances_returnsNonNullMap() {
         Map<String, Integer> mapToTest = new HashMap<>();
         mapToTest.put("X", 10);
         mapToTest.put("Y", 11);

--- a/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
@@ -3,14 +3,18 @@ package com.commercetools.sync.commons.utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToMap;
 import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToSet;
+import static com.commercetools.sync.commons.utils.CollectionUtils.emptyIfNull;
 import static com.commercetools.sync.commons.utils.CollectionUtils.filterCollection;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class CollectionUtilsTest {
 
@@ -22,7 +26,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void filterCollection_normalCases() throws Exception {
-        List<String> abcd = Arrays.asList("a", "b", "c", "d");
+        List<String> abcd = asList("a", "b", "c", "d");
         assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "b", "c", "d");
         assertThat(filterCollection(abcd, s -> false)).isEmpty();
         assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b')).containsExactlyInAnyOrder("c", "d");
@@ -30,7 +34,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void filterCollection_duplicates() throws Exception {
-        List<String> abcd = Arrays.asList("a", "b", "c", "d", "d", "c", "g", "a");
+        List<String> abcd = asList("a", "b", "c", "d", "d", "c", "g", "a");
         assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "a", "b", "c", "c", "d", "d", "g");
         assertThat(filterCollection(abcd, s -> false)).isEmpty();
         assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b')).containsExactlyInAnyOrder("c", "c", "d", "d", "g");
@@ -44,7 +48,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void collectionToSet_normalCases() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(
+        List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
         assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
         assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4);
@@ -52,7 +56,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void collectionToSet_duplicates() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(
+        List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4), Pair.of("d", 5), Pair.of("b", 6));
         // 2 duplicate keys should be suppressed
         assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
@@ -70,7 +74,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void collectionToMap_normalCases() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(
+        List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
 
         assertThat(collectionToMap(abcd, Pair::getKey, Pair::getValue))
@@ -90,7 +94,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void collectionToMap_duplicates() throws Exception {
-        List<Pair<String, Integer>> abcd = Arrays.asList(
+        List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4), Pair.of("d", 5), Pair.of("b", 6));
 
         // 2 duplicate keys should be suppressed
@@ -108,4 +112,28 @@ public class CollectionUtilsTest {
                         Pair.of(4, Pair.of("d", 4)), Pair.of(5, Pair.of("d", 5)), Pair.of(6, Pair.of("b", 6)));
     }
 
+    @Test
+    public void emptyIfNull_withListInstances_returnsNonNull() {
+        List<String> nonNullEmptyList = emptyIfNull((List<String>)null);
+        assertThat(nonNullEmptyList).isNotNull();
+        assertThat(nonNullEmptyList).isEmpty();
+
+        List<String> listToTest = asList("a", "b");
+        assertThat(emptyIfNull(listToTest)).isSameAs(listToTest);
+        assertThat(listToTest).containsExactly("a", "b"); // verify list is not mutated
+    }
+
+    @Test
+    public void emptyIfNull_withMapInstances_returnsNonNull() {
+        Map<String, String> nonNullEmptyMap = emptyIfNull((Map<String, String>)null);
+        assertThat(nonNullEmptyMap).isNotNull();
+        assertThat(nonNullEmptyMap).isEmpty();
+
+        Map<String, Integer> mapToTest = new HashMap<>();
+        mapToTest.put("X", 10);
+        mapToTest.put("Y", 11);
+
+        assertThat(emptyIfNull(mapToTest)).isSameAs(mapToTest);
+        assertThat(mapToTest).containsExactly(entry("X", 10), entry("Y", 11)); // verify map is not mutated
+    }
 }


### PR DESCRIPTION
Extend `CollectionUtils` with _safe wrappers_, which return empty collections (List, Set, HashMap) if the passed instance is **`null`**. 

This allows to avoid ternary operators.

  -  [new `CollectionUtil`](https://github.com/commercetools/commercetools-sync-java/pull/252/files#diff-c1854058c59ea8d4200582685a4ee2f5R97) functions
  - [Unit tests](https://github.com/commercetools/commercetools-sync-java/pull/252/files#diff-7e7c93e224538e2813ad8af3a08d4847R119)
  - re-factored sources avoiding ternary operators with collection checks.
  - re-factor some `Optionals` misuse:
    - https://github.com/commercetools/commercetools-sync-java/pull/252/files#diff-925cd7aab9dfa200affec5299f40b548L152
    - https://github.com/commercetools/commercetools-sync-java/pull/252/files#diff-a13d6c119192ae82d66e3a6c9028163bL143

@heshamMassoud 
This code https://github.com/commercetools/commercetools-sync-java/pull/252/files#diff-a13d6c119192ae82d66e3a6c9028163bL145 
was (and remains) confusing:
first it says _if old locale value is set_ and then (in the same condition branch without `oldLocaleValue` change) it says _If old locale value is not set_. Guess it should be clarified.