### PR TITLE
Introduce a util method for CompletableFuture of an empty Optional

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-public class CompletableFutureUtils {
+public final class CompletableFutureUtils {
 
     private static final CompletableFuture<Optional<?>> EMPTY = CompletableFuture.completedFuture(Optional.empty());
 

--- a/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
@@ -8,6 +8,8 @@ public final class CompletableFutureUtils {
 
     private static final CompletableFuture<Optional<?>> EMPTY = CompletableFuture.completedFuture(Optional.empty());
 
+    private CompletableFutureUtils() { }
+
     /**
      * Returns a {@link CompletableFuture} of an empty {@link Optional}. There is no guarantee
      * that it is a singleton.

--- a/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
@@ -1,0 +1,21 @@
+package com.commercetools.sync.commons.utils;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class CompletableFutureUtils {
+
+    private static final CompletableFuture<Optional<?>> EMPTY = CompletableFuture.completedFuture(Optional.empty());
+
+    /**
+     * Returns a {@link CompletableFuture} of an empty {@link Optional}. There is no guarantee
+     * that it is a singleton.
+     * @return {@link CompletableFuture} of an empty {@link Optional}
+     * */
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static <T> CompletableFuture<T> emptyOptionalCompletedFuture() {
+        return (CompletableFuture<T>)EMPTY;
+    }
+}

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static com.commercetools.sync.products.utils.ProductSyncUtils.buildActions;
 import static io.sphere.sdk.states.StateType.PRODUCT_STATE;
@@ -242,7 +243,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                                              final String productKey = oldProduct.getKey();
                                              handleError(format(UPDATE_FAILED, productKey, sphereException),
                                                  sphereException);
-                                             return CompletableFuture.completedFuture(Optional.empty());
+                                             return emptyOptionalCompletedFuture();
                                          });
                                  } else {
                                      statistics.incrementUpdated();

--- a/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 
@@ -156,7 +157,7 @@ public final class VariantReferenceResolver extends BaseReferenceResolver<Produc
         final JsonNode idField = referenceValue.get(REFERENCE_ID_FIELD);
         return idField != null
             ? productService.getIdFromCacheOrFetch(idField.asText())
-            : CompletableFuture.completedFuture(Optional.empty());
+            : emptyOptionalCompletedFuture();
     }
 
     private JsonNode createProductReferenceJson(@Nonnull final String productId) {

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.services.impl;
 
 import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import io.sphere.sdk.commands.DraftBasedCreateCommand;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.commands.UpdateCommand;
@@ -17,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -56,7 +58,7 @@ class BaseService<U extends Resource<U>, V> {
         @Nonnull final Function<V, DraftBasedCreateCommand<U, V>> createCommandFunction) {
         if (isBlank(draftKey)) {
             syncOptions.applyErrorCallback(format(CREATE_FAILED, draftKey, "Draft key is blank!"));
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         } else {
             final BiFunction<U, Throwable, Optional<U>> responseHandler =
                 (createdResource, sphereException) ->
@@ -67,7 +69,7 @@ class BaseService<U extends Resource<U>, V> {
                                              .execute(createCommandFunction.apply(mappedDraft))
                                              .handle(responseHandler)
                               )
-                              .orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()));
+                              .orElseGet(CompletableFutureUtils::emptyOptionalCompletedFuture);
         }
     }
 

--- a/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -93,7 +94,7 @@ public final class CategoryServiceImpl extends BaseService<Category, CategoryDra
     @Override
     public CompletionStage<Optional<Category>> fetchCategory(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         }
 
         return syncOptions.getCtpClient()

--- a/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static java.lang.String.format;
 import static java.util.Collections.singleton;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -42,7 +43,7 @@ public class ProductServiceImpl extends BaseService<Product, ProductDraft> imple
     @Override
     public CompletionStage<Optional<String>> getIdFromCacheOrFetch(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.containsKey(key)) {
             return CompletableFuture.completedFuture(Optional.of(keyToIdCache.get(key)));
@@ -120,7 +121,7 @@ public class ProductServiceImpl extends BaseService<Product, ProductDraft> imple
     @Override
     public CompletionStage<Optional<Product>> fetchProduct(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         }
         final QueryPredicate<Product> queryPredicate = buildProductKeysQueryPredicate(singleton(key));
         return syncOptions.getCtpClient().execute(ProductQuery.of().withPredicates(queryPredicate))

--- a/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -36,7 +37,7 @@ public class StateServiceImpl implements StateService {
     @Override
     public CompletionStage<Optional<String>> fetchCachedStateId(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.isEmpty()) {
             return cacheAndFetch(key);

--- a/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -32,7 +33,7 @@ public class TaxCategoryServiceImpl implements TaxCategoryService {
     @Override
     public CompletionStage<Optional<String>> fetchCachedTaxCategoryId(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.isEmpty()) {
             return cacheAndFetch(key);

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.categories.CategorySyncMockUtils.getMockCategoryDraftBuilder;
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -115,7 +116,7 @@ public class CategoryReferenceResolverTest {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(categoryService.fetchCachedCategoryId(CACHED_CATEGORY_KEY))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final CategoryReferenceResolver categoryReferenceResolver =
             new CategoryReferenceResolver(syncOptions, typeService, categoryService);
@@ -175,7 +176,7 @@ public class CategoryReferenceResolverTest {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final CategoryReferenceResolver categoryReferenceResolver =
             new CategoryReferenceResolver(syncOptions, typeService, categoryService);

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -162,7 +162,7 @@ public class InventorySyncTest {
             mock(InventoryEntry.class), mock(InventoryEntry.class));
         final ChannelService channelService = mock(ChannelService.class);
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventorySync inventorySync = new InventorySync(options, inventoryService, channelService,
             mock(TypeService.class));
@@ -192,7 +192,7 @@ public class InventorySyncTest {
             mock(InventoryEntry.class), mock(InventoryEntry.class));
         final ChannelService channelService = mock(ChannelService.class);
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventorySync inventorySync = new InventorySync(options, inventoryService, channelService,
             mock(TypeService.class));

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getCompletionStageWithException;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockInventoryEntry;
@@ -445,7 +446,7 @@ public class InventorySyncTest {
 
         final ChannelService channelService = getMockChannelService(getMockSupplyChannel(REF_3, KEY_3));
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft
             .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, Channel.referenceOfId(KEY_3));
@@ -469,7 +470,7 @@ public class InventorySyncTest {
 
         final ChannelService channelService = getMockChannelService(getMockSupplyChannel(REF_3, KEY_3));
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
         when(channelService.createAndCacheChannel(anyString())).thenReturn(failed(new SphereException()));
 
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -119,7 +120,7 @@ public class InventoryReferenceResolverTest {
     public void
         resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
@@ -148,7 +149,7 @@ public class InventoryReferenceResolverTest {
                                                                                           .ensureChannels(true)
                                                                                           .build();
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
@@ -212,7 +213,7 @@ public class InventoryReferenceResolverTest {
     @Test
     public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final InventoryEntryDraftBuilder draftBuilder = InventoryEntryDraftBuilder
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -21,9 +21,7 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,7 +110,7 @@ public class PriceReferenceResolverTest {
             .custom(customFieldsDraft);
 
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final PriceReferenceResolver priceReferenceResolver =
             new PriceReferenceResolver(syncOptions, typeService, channelService);

--- a/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductService;
@@ -215,7 +216,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void resolveAttributeReference_WithProductReferenceAttribute_ShouldResolveAttribute() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("typeId", "product");
@@ -342,7 +343,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void resolveAttributeReference_WithNonExistingProductReferenceSetAttribute_ShouldNotResolveReferences() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final ObjectNode productReference = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute =
@@ -367,7 +368,7 @@ public class VariantReferenceResolverTest { ;
         when(productService.getIdFromCacheOrFetch("existingKey"))
             .thenReturn(CompletableFuture.completedFuture(Optional.of("existingId")));
         when(productService.getIdFromCacheOrFetch("randomKey"))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final ObjectNode productReference1 = getProductReferenceWithId("existingKey");
         final ObjectNode productReference2 = getProductReferenceWithId("randomKey");
@@ -461,7 +462,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void getResolvedIdFromKeyInReference_WithNonExistingProductReferenceAttribute_ShouldGetEmptyId() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         final ObjectNode attributeValue = getProductReferenceWithRandomId();
         final AttributeDraft attributeDraft = AttributeDraft.of("attributeName", attributeValue);

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithProductTypeRef;
@@ -111,7 +112,7 @@ public class ProductTypeReferenceResolverTest {
             .key("dummyKey");
 
         when(productTypeService.fetchCachedProductTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasNotFailed()

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithRandomProductTypeUuid;
@@ -122,7 +123,7 @@ public class StateReferenceResolverTest {
             .key("dummyKey");
 
         when(stateService.fetchCachedStateId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveStateReference(productBuilder).toCompletableFuture())
             .hasNotFailed()

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.utils.CompletableFutureUtils.emptyOptionalCompletedFuture;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithRandomProductTypeUuid;
@@ -122,7 +123,7 @@ public class TaxCategoryReferenceResolverTest {
             .key("dummyKey");
 
         when(taxCategoryService.fetchCachedTaxCategoryId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveTaxCategoryReference(productBuilder).toCompletableFuture())
             .hasNotFailed()


### PR DESCRIPTION
#### Summary
Create a static util method for `CompletableFuture.completedFuture(Optional.empty())` usages

#### Relevant Issues
Fixes https://github.com/commercetools/commercetools-sync-java/issues/164

#### Todo
- Tests
    - [ ] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.