### PR TITLE
3 assets integration tests

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -169,24 +169,7 @@ public final class CategoryITUtils {
      * @return a dummy instance of {@link CustomFieldsDraft} with some hardcoded custom fields and key.
      */
     public static CustomFieldsDraft getCustomFieldsDraft() {
-        return CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons());
-    }
-
-    /**
-     * Builds a {@link Map} for the custom fields to their {@link JsonNode} values that looks as follows in JSON
-     * format:
-     *
-     * <p>"fields": {"invisibleInShop": false, "backgroundColor": { "en": "red", "de": "rot"}}
-     *
-     * @return a Map of the custom fields to their JSON values with dummy data.
-     */
-    public static Map<String, JsonNode> getCustomFieldsJsons() {
-        final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
-        customFieldsJsons.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(false));
-        customFieldsJsons
-            .put(LOCALISED_STRING_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.objectNode()
-                                                                             .put("de", "rot").put("en", "red"));
-        return customFieldsJsons;
+        return CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap());
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -17,9 +17,6 @@ import io.sphere.sdk.queries.QueryExecutionUtils;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.ResourceTypeIdsSetBuilder;
 import io.sphere.sdk.types.Type;
-import io.sphere.sdk.types.TypeDraft;
-import io.sphere.sdk.types.TypeDraftBuilder;
-import io.sphere.sdk.types.commands.TypeCreateCommand;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -36,9 +33,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.createCustomTypeFieldDefinitions;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.createCustomFieldsJsonMap;
-import static com.commercetools.sync.integration.commons.utils.ITUtils.typeExists;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createTypeIfNotAlreadyExisting;
 import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
 
@@ -191,26 +187,18 @@ public final class CategoryITUtils {
     /**
      * This method blocks to create a category custom Type on the CTP project defined by the supplied
      * {@code ctpClient}, with the supplied data.
-     *
-     * @param typeKey   the type key
+     *  @param typeKey   the type key
      * @param locale    the locale to be used for specifying the type name and field definitions names.
      * @param name      the name of the custom type.
      * @param ctpClient defines the CTP project to create the type on.
      */
-    public static void createCategoriesCustomType(@Nonnull final String typeKey,
+    public static Type createCategoriesCustomType(@Nonnull final String typeKey,
                                                   @Nonnull final Locale locale,
                                                   @Nonnull final String name,
                                                   @Nonnull final SphereClient ctpClient) {
-        if (!typeExists(typeKey, ctpClient)) {
-            final TypeDraft typeDraft = TypeDraftBuilder
-                .of(typeKey, LocalizedString.of(locale, name), ResourceTypeIdsSetBuilder.of().addCategories())
-                .fieldDefinitions(buildCategoryCustomTypeFieldDefinitions(locale))
-                .build();
-            ctpClient.execute(TypeCreateCommand.of(typeDraft)).toCompletableFuture().join();
-        }
-    }
 
-
+        return createTypeIfNotAlreadyExisting(typeKey, locale, name, ResourceTypeIdsSetBuilder.of().addCategories(),
+            ctpClient);
     }
 
 

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -48,6 +48,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -351,9 +352,14 @@ public final class ITUtils {
                      assertThat(createdAsset.getName()).isEqualTo(assetDraft.getName());
                      assertThat(createdAsset.getDescription()).isEqualTo(assetDraft.getDescription());
                      assertThat(createdAsset.getKey()).isEqualTo(assetDraft.getKey());
-                     assertThat(createdAsset.getCustom()).isNotNull();
-                     assertThat(createdAsset.getCustom().getFieldsJsonMap())
-                         .isEqualTo(assetDraft.getCustom().getFields());
+
+                     ofNullable(assetDraft.getCustom())
+                         .ifPresent(customFields -> {
+                             assertThat(createdAsset.getCustom()).isNotNull();
+                             assertThat(createdAsset.getCustom().getFieldsJsonMap())
+                                 .isEqualTo(assetDraft.getCustom().getFields());
+                         });
+
                      assertThat(createdAsset.getTags()).isEqualTo(assetDraft.getTags());
                      assertThat(createdAsset.getSources()).isEqualTo(assetDraft.getSources());
                  });

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -19,6 +19,48 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 
 public final class ITUtils {
+    /**
+     * Builds a list of two field definitions; one for a {@link LocalizedStringFieldType} and one for a
+     * {@link BooleanFieldType}. The JSON of the created field definition list looks as follows:
+     *
+     * <p>"fieldDefinitions": [
+     * {
+     * "name": "backgroundColor",
+     * "label": {
+     * "en": "backgroundColor"
+     * },
+     * "required": false,
+     * "type": {
+     * "name": "LocalizedString"
+     * },
+     * "inputHint": "SingleLine"
+     * },
+     * {
+     * "name": "invisibleInShop",
+     * "label": {
+     * "en": "invisibleInShop"
+     * },
+     * "required": false,
+     * "type": {
+     * "name": "Boolean"
+     * },
+     * "inputHint": "SingleLine"
+     * }
+     * ]
+     *
+     * @param locale defines the locale for which the field definition names are going to be bound to.
+     * @return the list of field definitions.
+     */
+    static List<FieldDefinition> createCustomTypeFieldDefinitions(@Nonnull final Locale locale) {
+        return asList(
+            FieldDefinition
+                .of(LocalizedStringFieldType.of(), LOCALISED_STRING_CUSTOM_FIELD_NAME,
+                    LocalizedString.of(locale, LOCALISED_STRING_CUSTOM_FIELD_NAME), false),
+            FieldDefinition
+                .of(BooleanFieldType.of(), BOOLEAN_CUSTOM_FIELD_NAME,
+                    LocalizedString.of(locale, BOOLEAN_CUSTOM_FIELD_NAME), false));
+
+    }
 
     /**
      * Deletes all Types from CTP projects defined by the {@code sphereClient}

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -19,6 +19,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 
 public final class ITUtils {
+    public static final String LOCALISED_STRING_CUSTOM_FIELD_NAME = "backgroundColor";
+    public static final String BOOLEAN_CUSTOM_FIELD_NAME = "invisibleInShop";
+    static Optional<Type> typeExists(@Nonnull final String typeKey, @Nonnull final SphereClient ctpClient) {
+        return ctpClient
+            .execute(TypeQueryBuilder.of().predicates(QueryPredicate.of(format("key=\"%s\"", typeKey))).build())
+            .toCompletableFuture()
+            .join().head();
+    }
+
     /**
      * Builds a list of two field definitions; one for a {@link LocalizedStringFieldType} and one for a
      * {@link BooleanFieldType}. The JSON of the created field definition list looks as follows:
@@ -60,6 +69,22 @@ public final class ITUtils {
                 .of(BooleanFieldType.of(), BOOLEAN_CUSTOM_FIELD_NAME,
                     LocalizedString.of(locale, BOOLEAN_CUSTOM_FIELD_NAME), false));
 
+    }
+
+    /**
+     * Builds a {@link Map} for the custom fields to their {@link JsonNode} values that looks as follows in JSON
+     * format:
+     *
+     * <p>"fields": {"invisibleInShop": false, "backgroundColor": { "en": "red", "de": "rot"}}
+     *
+     * @return a Map of the custom fields to their JSON values with dummy data.
+     */
+    public static Map<String, JsonNode> createCustomFieldsJsonMap() {
+        final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
+        customFieldsJsons.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(false));
+        customFieldsJsons.put(LOCALISED_STRING_CUSTOM_FIELD_NAME,
+            JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
+        return customFieldsJsons;
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -250,27 +250,8 @@ public final class ITUtils {
     }
 
     /**
-     * Creates an {@link AssetDraftBuilder} with the with the given key and name. The builder created will contain one
-     * tag with the same value as the key and will contain one {@link io.sphere.sdk.models.AssetSource}
-     * with the uri {@code sourceUri}.
-     *
-     * @param assetKey  asset draft key.
-     * @param assetName asset draft name.
-     * @return an {@link AssetDraftBuilder} with the with the given key and name. The builder created will contain one
-     *         tag with the same value as the key and will contain one {@link io.sphere.sdk.models.AssetSource} with the
-     *         uri {@code sourceUri}.
-     */
-    private static AssetDraftBuilder createAssetDraftBuilder(@Nonnull final String assetKey,
-                                                             @Nonnull final LocalizedString assetName) {
-        return AssetDraftBuilder.of(emptyList(), assetName)
-                                .key(assetKey)
-                                .tags(singleton(assetKey))
-                                .sources(singletonList(AssetSourceBuilder.ofUri("sourceUri").build()));
-    }
-
-    /**
-     * Creates an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom field
-     * with the type id supplied ({@code assetCustomTypeId} and the fields built from the method
+     * Creates an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom
+     * field with the type id supplied ({@code assetCustomTypeId} and the fields built from the method
      * {@link ITUtils#createCustomFieldsJsonMap()}.
      *
      * @param assetKey          asset draft key.
@@ -287,16 +268,16 @@ public final class ITUtils {
     }
 
     /**
-     * Creates an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom field
-     * with the type id supplied ({@code assetCustomTypeId} and the custom fields will be defined by the
+     * Creates an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom
+     * field with the type id supplied ({@code assetCustomTypeId} and the custom fields will be defined by the
      * {@code customFieldsJsonMap} supplied.
      *
      * @param assetKey          asset draft key.
      * @param assetName         asset draft name.
      * @param assetCustomTypeId the asset custom type id.
      * @param customFieldsJsonMap the custom fields of the asset custom type.
-     * @return an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom field
-     *         with the type id supplied ({@code assetCustomTypeId} and the custom fields will be defined by the
+     * @return an {@link AssetDraft} with the with the given key and name. The asset draft created will have custom
+     *         field with the type id supplied ({@code assetCustomTypeId} and the custom fields will be defined by the
      *         {@code customFieldsJsonMap} supplied.
      */
     public static AssetDraft createAssetDraft(@Nonnull final String assetKey,
@@ -306,6 +287,25 @@ public final class ITUtils {
         return createAssetDraftBuilder(assetKey, assetName)
             .custom(CustomFieldsDraft.ofTypeIdAndJson(assetCustomTypeId, customFieldsJsonMap))
             .build();
+    }
+
+    /**
+     * Creates an {@link AssetDraftBuilder} with the with the given key and name. The builder created will contain one
+     * tag with the same value as the key and will contain one {@link io.sphere.sdk.models.AssetSource}
+     * with the uri {@code sourceUri}.
+     *
+     * @param assetKey  asset draft key.
+     * @param assetName asset draft name.
+     * @return an {@link AssetDraftBuilder} with the with the given key and name. The builder created will contain one
+     *         tag with the same value as the key and will contain one {@link io.sphere.sdk.models.AssetSource} with the
+     *         uri {@code sourceUri}.
+     */
+    private static AssetDraftBuilder createAssetDraftBuilder(@Nonnull final String assetKey,
+                                                             @Nonnull final LocalizedString assetName) {
+        return AssetDraftBuilder.of(emptyList(), assetName)
+                                .key(assetKey)
+                                .tags(singleton(assetKey))
+                                .sources(singletonList(AssetSourceBuilder.ofUri("sourceUri").build()));
     }
 
     /**
@@ -332,7 +332,7 @@ public final class ITUtils {
      * are matched by key). It asserts that the matching assets have the same name, description, custom fields, tags,
      * and asset sources.
      *
-     * TODO: This should be refactored into Asset asserts helpers. GITHUB ISSUE#261
+     * <p>TODO: This should be refactored into Asset asserts helpers. GITHUB ISSUE#261
      *
      * @param assets      the list of assets to compare to the list of asset drafts.
      * @param assetDrafts the list of asset drafts to compare to the list of assets.

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
@@ -38,7 +38,7 @@ import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.d
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCategoryDrafts;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCategoryDraftsWithPrefix;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCustomFieldsDraft;
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCustomFieldsJsons;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createCustomFieldsJsonMap;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.syncBatches;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
@@ -333,7 +333,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "parent"),
                 LocalizedString.of(Locale.ENGLISH, "parent"))
             .key("parent")
-            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
         final Category parentCreated = CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(parentDraft))
                                                         .toCompletableFuture().join();
@@ -343,7 +343,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "child"))
             .key("child")
             .parent(parentCreated)
-            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
         CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(childDraft)).toCompletableFuture().join();
         //------------------------------------------------------------------------------------------------------------
@@ -353,7 +353,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "new-parent"),
                 LocalizedString.of(Locale.ENGLISH, "new-parent"))
             .key("new-parent")
-            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
         final Category sourceParentCreated = CTP_SOURCE_CLIENT.execute(CategoryCreateCommand.of(sourceParentDraft))
                                                         .toCompletableFuture().join();
@@ -363,7 +363,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "child"))
             .key("child")
             .parent(sourceParentCreated)
-            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
         CTP_SOURCE_CLIENT.execute(CategoryCreateCommand.of(sourceChildDraft)).toCompletableFuture().join();
         //---------------------------------------------------------------

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
@@ -1,0 +1,244 @@
+package com.commercetools.sync.integration.ctpprojectsource.products;
+
+import com.commercetools.sync.products.ProductSync;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.products.helpers.ProductSyncStatistics;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.ProductProjectionType;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.products.commands.updateactions.AddAsset;
+import io.sphere.sdk.products.commands.updateactions.ChangeAssetName;
+import io.sphere.sdk.products.commands.updateactions.ChangeAssetOrder;
+import io.sphere.sdk.products.commands.updateactions.RemoveAsset;
+import io.sphere.sdk.products.commands.updateactions.SetPrices;
+import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.types.Type;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.assertAssetsAreEqual;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetDraft;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetsCustomType;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createVariantDraft;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.sync.products.utils.ProductReferenceReplacementUtils.buildProductQuery;
+import static com.commercetools.sync.products.utils.ProductReferenceReplacementUtils.replaceProductsReferenceIdsWithKeys;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductSyncWithAssetsIT {
+    private static final String ASSETS_CUSTOM_TYPE_KEY = "assetsCustomTypeKey";
+    private static ProductType sourceProductType;
+    private static ProductType targetProductType;
+
+    private static Type targetAssetCustomType;
+    private static Type sourceAssetCustomType;
+
+    private ProductSync productSync;
+    private List<String> errorCallBackMessages;
+    private List<String> warningCallBackMessages;
+    private List<UpdateAction<Product>> updateActions;
+    private List<Throwable> errorCallBackExceptions;
+
+    /**
+     * Delete all product related test data from target and source projects. Then creates for both CTP projects product
+     * types and asset custom types.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+        deleteProductSyncTestData(CTP_SOURCE_CLIENT);
+
+        targetProductType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+        sourceProductType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_SOURCE_CLIENT);
+
+
+        targetAssetCustomType = createAssetsCustomType(ASSETS_CUSTOM_TYPE_KEY, Locale.ENGLISH,
+            "assetsCustomTypeName", CTP_TARGET_CLIENT);
+        sourceAssetCustomType = createAssetsCustomType(ASSETS_CUSTOM_TYPE_KEY, Locale.ENGLISH,
+            "assetsCustomTypeName", CTP_SOURCE_CLIENT);
+    }
+
+    /**
+     * Deletes Products from the source and target CTP projects, clears the callback collections then it instantiates a
+     * new {@link ProductSync} instance.
+     */
+    @Before
+    public void setupTest() {
+        clearSyncTestCollections();
+        deleteAllProducts(CTP_TARGET_CLIENT);
+        deleteAllProducts(CTP_SOURCE_CLIENT);
+        final ProductSyncOptions syncOptions = buildSyncOptions();
+        productSync = new ProductSync(syncOptions);
+    }
+
+    private void clearSyncTestCollections() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+        updateActions = new ArrayList<>();
+    }
+
+    private ProductSyncOptions buildSyncOptions() {
+        return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                        .errorCallback(this::errorCallback)
+                                        .warningCallback(warningCallBackMessages::add)
+                                        .beforeUpdateCallback(this::beforeUpdateCallback)
+                                        .build();
+    }
+
+    private void errorCallback(@Nonnull final String errorMessage, @Nullable final Throwable exception) {
+        errorCallBackMessages.add(errorMessage);
+        errorCallBackExceptions.add(exception);
+    }
+
+    private List<UpdateAction<Product>> beforeUpdateCallback(@Nonnull final List<UpdateAction<Product>> updateActions,
+                                                             @Nonnull final ProductDraft newProductDraft,
+                                                             @Nonnull final Product oldProduct) {
+        this.updateActions.addAll(updateActions);
+        return updateActions;
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+        deleteProductSyncTestData(CTP_SOURCE_CLIENT);
+    }
+
+    @Test
+    public void sync_withNewProductWithAssets_shouldCreateProduct() {
+        final List<AssetDraft> assetDraftsToCreateOnExistingProduct = asList(
+            createAssetDraft("1", ofEnglish("1"), sourceAssetCustomType.getId()),
+            createAssetDraft("2", ofEnglish("2"), sourceAssetCustomType.getId()),
+            createAssetDraft("3", ofEnglish("3"), sourceAssetCustomType.getId()));
+
+        final ProductDraft draftToCreateOnTargetProject = ProductDraftBuilder
+            .of(targetProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInTarget"),
+                ProductVariantDraftBuilder.of().key("k1").sku("sku1").build())
+            .key("existingProductInTarget")
+            .build();
+        CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnTargetProject)).toCompletableFuture().join();
+
+        final ProductDraft draftToCreateOnSourceProject = ProductDraftBuilder
+            .of(sourceProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInSource"),
+                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProduct))
+            .key("existingProductInSource")
+            .build();
+        CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnSourceProject)).toCompletableFuture().join();
+
+        final List<Product> products = CTP_SOURCE_CLIENT.execute(buildProductQuery())
+                                                        .toCompletableFuture().join().getResults();
+
+        final List<ProductDraft> productDrafts = replaceProductsReferenceIdsWithKeys(products);
+
+        final ProductSyncStatistics syncStatistics =  productSync.sync(productDrafts).toCompletableFuture().join();
+
+        // Assert results of sync
+        assertThat(syncStatistics).hasValues(1, 1, 0, 0);
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+
+        // Assert that the product was created with the assets.
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of("existingProductInSource", ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        final List<Asset> createdAssets = productProjection.getMasterVariant().getAssets();
+        assertAssetsAreEqual(createdAssets, assetDraftsToCreateOnExistingProduct);
+    }
+
+    @Test
+    public void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
+        final List<AssetDraft> assetDraftsToCreateOnExistingProductOnTargetProject = asList(
+            createAssetDraft("1", ofEnglish("1"), targetAssetCustomType.getId()),
+            createAssetDraft("2", ofEnglish("2"), targetAssetCustomType.getId()),
+            createAssetDraft("3", ofEnglish("3"), targetAssetCustomType.getId()));
+
+        final List<AssetDraft> assetDraftsToCreateOnExistingProductOnSourceProject = asList(
+            createAssetDraft("4", ofEnglish("4"), sourceAssetCustomType.getId()),
+            createAssetDraft("3", ofEnglish("3"), sourceAssetCustomType.getId()),
+            createAssetDraft("2", ofEnglish("new name"), sourceAssetCustomType.getId()));
+
+        final String productKey = "same-product";
+        final ProductDraft draftToCreateOnTargetProject = ProductDraftBuilder
+            .of(targetProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInTarget"),
+                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProductOnTargetProject))
+            .key(productKey)
+            .build();
+        CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnTargetProject)).toCompletableFuture().join();
+
+        final ProductDraft draftToCreateOnSourceProject = ProductDraftBuilder
+            .of(sourceProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInSource"),
+                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProductOnSourceProject))
+            .key(productKey)
+            .build();
+        CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnSourceProject)).toCompletableFuture().join();
+
+        final List<Product> products = CTP_SOURCE_CLIENT.execute(buildProductQuery())
+                                                        .toCompletableFuture().join().getResults();
+
+        final List<ProductDraft> productDrafts = replaceProductsReferenceIdsWithKeys(products);
+
+        final ProductSyncStatistics syncStatistics =  productSync.sync(productDrafts).toCompletableFuture().join();
+
+        // Assert results of sync
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+
+        final Map<String, String> assetsKeyToIdMap = products.get(0).getMasterData()
+                                                             .getStaged()
+                                                             .getMasterVariant()
+                                                             .getAssets()
+                                                             .stream().collect(toMap(Asset::getKey, Asset::getId));
+
+        assertThat(updateActions).containsExactly(
+            SetPrices.of(1, emptyList()),
+            RemoveAsset.ofVariantIdWithKey(1, "1", true),
+            ChangeAssetName.ofAssetKeyAndVariantId(1, "3", ofEnglish("newName"), true),
+            ChangeAssetOrder.ofVariantId(1, asList(assetsKeyToIdMap.get("3"), assetsKeyToIdMap.get("2")), true),
+            AddAsset.ofVariantId(1, createAssetDraft("4", ofEnglish("4"),
+                targetAssetCustomType.getId()))
+                    .withStaged(true).withPosition(0)
+        );
+
+        // Assert that assets got updated correctly
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(productKey, ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        final List<Asset> createdAssets = productProjection.getMasterVariant().getAssets();
+        assertAssetsAreEqual(createdAssets, assetDraftsToCreateOnExistingProductOnTargetProject);
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
@@ -95,8 +95,7 @@ public class ProductSyncWithAssetsIT {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         deleteAllProducts(CTP_SOURCE_CLIENT);
-        final ProductSyncOptions syncOptions = buildSyncOptions();
-        productSync = new ProductSync(syncOptions);
+        productSync = new ProductSync(buildSyncOptions());
     }
 
     private void clearSyncTestCollections() {

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -37,14 +37,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.BOOLEAN_CUSTOM_FIELD_NAME;
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.LOCALISED_STRING_CUSTOM_FIELD_NAME;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_NAME;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategoriesCustomType;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.deleteAllCategories;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCustomFieldsDraft;
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCustomFieldsJsons;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.BOOLEAN_CUSTOM_FIELD_NAME;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.LOCALISED_STRING_CUSTOM_FIELD_NAME;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createCustomFieldsJsonMap;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypes;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
@@ -116,7 +116,7 @@ public class CategorySyncIT {
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture"))
             .key("newCategoryKey")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncStatistics syncStatistics = categorySync.sync(Collections.singletonList(categoryDraft))
@@ -131,7 +131,7 @@ public class CategorySyncIT {
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "furniture"))
             .key("newCategoryKey")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncStatistics syncStatistics = categorySync.sync(Collections.singletonList(categoryDraft))
@@ -147,7 +147,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"),
                 LocalizedString.of(Locale.ENGLISH, "furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncStatistics syncStatistics = categorySync.sync(Collections.singletonList(categoryDraft))
@@ -163,7 +163,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncStatistics syncStatistics = categorySync.sync(Collections.singletonList(categoryDraft))
@@ -179,7 +179,7 @@ public class CategorySyncIT {
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(newCategoryName, LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncOptions categorySyncOptions =
@@ -228,7 +228,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<String> errorMessages = new ArrayList<>();
@@ -298,7 +298,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key("newCategory")
             .parent(Category.referenceOfId(oldCategoryKey))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategorySyncStatistics syncStatistics = categorySync.sync(Collections.singletonList(categoryDraft))
@@ -359,7 +359,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
             .parent(Category.referenceOfId("cat7"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> batch1 = new ArrayList<>();
@@ -369,7 +369,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat7"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture1"))
             .key("cat7")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> batch2 = new ArrayList<>();
@@ -380,7 +380,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat6")
             .parent(Category.referenceOfId("cat5"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> batch3 = new ArrayList<>();
@@ -390,7 +390,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat5"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat5")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> batch4 = new ArrayList<>();
@@ -413,7 +413,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "new name"),
                 LocalizedString.of(Locale.ENGLISH, "new-slug"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> batch1 = new ArrayList<>();
@@ -450,7 +450,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
 
@@ -458,7 +458,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat1"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture1"))
             .key("cat1")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft3 = CategoryDraftBuilder
@@ -466,7 +466,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
             .parent(Category.referenceOfId("cat1"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft4 = CategoryDraftBuilder
@@ -474,14 +474,14 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
             .parent(Category.referenceOfId("cat1"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft5 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat4"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture4"))
             .key("cat4")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft6 = CategoryDraftBuilder
@@ -489,7 +489,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
             .parent(Category.referenceOfId("cat4"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         newCategoryDrafts.add(categoryDraft1);
@@ -513,7 +513,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         // Same slug draft
@@ -521,7 +521,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat1"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key("cat1")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft3 = CategoryDraftBuilder
@@ -529,7 +529,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
             .parent(Category.referenceOfId("cat1"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft4 = CategoryDraftBuilder
@@ -537,14 +537,14 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
             .parent(Category.referenceOfId("cat1"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft5 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat4"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture4"))
             .key("cat4")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft6 = CategoryDraftBuilder
@@ -552,7 +552,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
             .parent(Category.referenceOfId("cat4"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         newCategoryDrafts.add(categoryDraft1);
@@ -576,14 +576,14 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft2 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat1"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture1"))
             .key("cat1")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         // With invalid parent key
@@ -592,7 +592,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
             .parent(Category.referenceOfId(UUID.randomUUID().toString()))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft4 = CategoryDraftBuilder
@@ -600,14 +600,14 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
             .parent(Category.referenceOfId("cat1"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft5 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat4"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture4"))
             .key("cat4")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft6 = CategoryDraftBuilder
@@ -615,7 +615,7 @@ public class CategorySyncIT {
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
             .parent(Category.referenceOfId("cat4"))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         newCategoryDrafts.add(categoryDraft1);
@@ -640,14 +640,14 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .custom(CustomFieldsDraft.ofTypeIdAndJson("nonExistingKey", getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson("nonExistingKey", createCustomFieldsJsonMap()))
             .build();
 
         final CategoryDraft categoryDraft2 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture-2"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture-2"))
             .key("newCategoryKey")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(newCustomTypeKey, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(newCustomTypeKey, createCustomFieldsJsonMap()))
             .build();
 
         newCategoryDrafts.add(categoryDraft1);
@@ -690,7 +690,7 @@ public class CategorySyncIT {
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture"))
             .key("newCategoryKey")
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final String nonExistingParentKey = "nonExistingParent";
@@ -698,7 +698,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture1"))
             .key("cat1")
             .parent(Category.referenceOfId(nonExistingParentKey))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
+            .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, createCustomFieldsJsonMap()))
             .build();
 
         final List<CategoryDraft> categoryDrafts = new ArrayList<>();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
@@ -1,0 +1,95 @@
+package com.commercetools.sync.integration.externalsource.categories.utils;
+
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
+import io.sphere.sdk.categories.CategoryDraftBuilder;
+import io.sphere.sdk.categories.commands.CategoryCreateCommand;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.types.Type;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.commercetools.sync.categories.utils.CategoryReferenceReplacementUtils.buildCategoryQuery;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategoriesCustomType;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.deleteAllCategories;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCustomFieldsDraft;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetDraft;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetsCustomType;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.util.Collections.singletonList;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CategoryReferenceReplacementUtilsIT {
+
+    /**
+     * Delete all categories and types from source and target project. Then create custom types for source and target
+     * CTP project categories.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteAllCategories(CTP_TARGET_CLIENT);
+        deleteTypesFromTargetAndSource();
+    }
+
+    /**
+     * Cleans up the target and source test data that were built in this test class.
+     */
+    @AfterClass
+    public static void tearDown() {
+        deleteAllCategories(CTP_TARGET_CLIENT);
+        deleteTypesFromTargetAndSource();
+    }
+
+    @Test
+    public void buildCategoryQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
+        final CategoryDraft parentDraft = CategoryDraftBuilder.of(ofEnglish("parent"), ofEnglish("parent"))
+                                                                .build();
+        final Category parentCategory =
+            executeBlocking(CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(parentDraft)));
+
+        createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, ENGLISH, "anyName", CTP_TARGET_CLIENT);
+
+        final Type assetsCustomType = createAssetsCustomType("assetsCustomTypeKey", ENGLISH,
+            "assetsCustomTypeName", CTP_TARGET_CLIENT);
+        final List<AssetDraft> assetDrafts = singletonList(
+            createAssetDraft("1", ofEnglish("1"), assetsCustomType.getId()));
+
+        final CategoryDraft categoryDraft = CategoryDraftBuilder.of(ofEnglish("name"), ofEnglish("slug"))
+                                                                .parent(parentCategory)
+                                                                .custom(getCustomFieldsDraft())
+                                                                .assets(assetDrafts)
+                                                                .build();
+
+        executeBlocking(CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(categoryDraft)));
+
+        final List<Category> categories =
+            executeBlocking(CTP_TARGET_CLIENT.execute(buildCategoryQuery().bySlug(ENGLISH, "slug"))).getResults();
+
+        assertThat(categories).hasSize(1);
+        final Category fetchedCategory = categories.get(0);
+
+        // Assert category parent references are expanded.
+        assertThat(fetchedCategory.getParent()).isNotNull();
+        assertThat(fetchedCategory.getParent().getObj()).isNotNull();
+
+        // Assert category custom type references are expanded.
+        assertThat(fetchedCategory.getCustom()).isNotNull();
+        assertThat(fetchedCategory.getCustom().getType().getObj()).isNotNull();
+
+        // Assert category assets custom type references are expanded.
+        assertThat(fetchedCategory.getAssets()).hasSize(1);
+        final Asset masterVariantAsset = fetchedCategory.getAssets().get(0);
+        assertThat(masterVariantAsset.getCustom()).isNotNull();
+        assertThat(masterVariantAsset.getCustom().getType().getObj()).isNotNull();
+
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
@@ -64,7 +64,7 @@ public class CategoryReferenceReplacementUtilsIT {
             createAssetDraft("1", ofEnglish("1"), assetsCustomType.getId()));
 
         final CategoryDraft categoryDraft = CategoryDraftBuilder.of(ofEnglish("name"), ofEnglish("slug"))
-                                                                .parent(parentCategory)
+                                                                .parent(parentCategory.toResourceIdentifier())
                                                                 .custom(getCustomFieldsDraft())
                                                                 .assets(assetDrafts)
                                                                 .build();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -1,0 +1,310 @@
+package com.commercetools.sync.integration.externalsource.products;
+
+import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.commons.utils.TriFunction;
+import com.commercetools.sync.products.ProductSync;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.products.helpers.ProductSyncStatistics;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.sphere.sdk.client.ErrorResponseException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.ProductProjectionType;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.products.commands.updateactions.AddAsset;
+import io.sphere.sdk.products.commands.updateactions.ChangeAssetName;
+import io.sphere.sdk.products.commands.updateactions.ChangeAssetOrder;
+import io.sphere.sdk.products.commands.updateactions.RemoveAsset;
+import io.sphere.sdk.products.commands.updateactions.SetPrices;
+import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.types.Type;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.BOOLEAN_CUSTOM_FIELD_NAME;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.assertAssetsAreEqual;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetDraft;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetsCustomType;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createVariantDraft;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductSyncWithAssetsIT {
+    private static final String ASSETS_CUSTOM_TYPE_KEY = "assetsCustomTypeKey";
+
+    private static ProductType productType;
+    private static Type assetsCustomType;
+    private ProductSyncOptions syncOptions;
+    private Product product;
+    private List<AssetDraft> assetDraftsToCreateOnExistingProduct;
+    private List<String> errorCallBackMessages;
+    private List<String> warningCallBackMessages;
+    private List<Throwable> errorCallBackExceptions;
+    private List<UpdateAction<Product>> updateActionsFromSync;
+
+    /**
+     * Delete all product related test data from the target project. Then creates for the target CTP project a product
+     * type and an asset custom type.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+        assetsCustomType = createAssetsCustomType(ASSETS_CUSTOM_TYPE_KEY, Locale.ENGLISH,
+            "assetsCustomTypeName", CTP_TARGET_CLIENT);
+
+        productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    }
+
+    /**
+     * Deletes Products and Types from the target CTP project, then it populates target CTP project with product test
+     * data.
+     */
+    @Before
+    public void setupTest() {
+        clearSyncTestCollections();
+        deleteAllProducts(CTP_TARGET_CLIENT);
+        syncOptions = buildSyncOptions();
+
+
+        assetDraftsToCreateOnExistingProduct = asList(
+            createAssetDraft("1", ofEnglish("1"), assetsCustomType.getId()),
+            createAssetDraft("2", ofEnglish("2"), assetsCustomType.getId()),
+            createAssetDraft("3", ofEnglish("3"), assetsCustomType.getId()));
+
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                createVariantDraft("v1", assetDraftsToCreateOnExistingProduct))
+            .key("existingProduct")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
+    }
+
+    private void clearSyncTestCollections() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+        updateActionsFromSync = new ArrayList<>();
+    }
+
+    private ProductSyncOptions buildSyncOptions() {
+        final BiConsumer<String, Throwable> errorCallBack = (errorMessage, exception) -> {
+            errorCallBackMessages.add(errorMessage);
+            errorCallBackExceptions.add(exception);
+        };
+        final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);
+
+        final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
+            actionsCallBack = (updateActions, newDraft, oldProduct) -> {
+            updateActionsFromSync.addAll(updateActions);
+            return updateActions;
+        };
+
+        return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                        .errorCallback(errorCallBack)
+                                        .warningCallback(warningCallBack)
+                                        .beforeUpdateCallback(actionsCallBack)
+                                        .build();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    @Test
+    public void sync_withNewProductWithAssets_shouldCreateProduct() {
+        final List<AssetDraft> assetDrafts =
+            singletonList(createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY));
+
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
+                createVariantDraft("masterVariant", assetDrafts))
+            .key("draftKey")
+            .build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        assertThat(syncStatistics).hasValues(1, 1, 0, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).isEmpty();
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(productDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        final List<Asset> createdAssets = productProjection.getMasterVariant().getAssets();
+        assertAssetsAreEqual(createdAssets, assetDrafts);
+    }
+
+    @Test
+    public void sync_withNewProductWithAssetsWithDuplicateKeys_shouldNotCreateProductAndTriggerErrorCallback() {
+        final List<AssetDraft> assetDrafts = asList(
+            createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
+            createAssetDraft("4", ofEnglish("duplicate asset"), ASSETS_CUSTOM_TYPE_KEY));
+
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
+                createVariantDraft("masterVariant", assetDrafts))
+            .key("draftKey")
+            .build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        // Assert results of sync
+        assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).isEmpty();
+        assertThat(errorCallBackMessages).hasSize(1);
+        assertThat(errorCallBackMessages.get(0)).contains("The key '4' was used by multiple assets in product variant"
+            + " 'masterVariant'.");
+        assertThat(errorCallBackExceptions).hasSize(1);
+        assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ErrorResponseException.class);
+        assertThat(errorCallBackExceptions.get(0).getMessage()).contains("The key '4' was used by multiple assets in"
+            + " product variant 'masterVariant'.");
+
+
+        // Assert that the product wasn't created.
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(productDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNull();
+    }
+
+    @Test
+    public void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
+
+        final Map<String, JsonNode> customFieldsJsonMap = new HashMap<>();
+        customFieldsJsonMap.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(true));
+
+        // new asset drafts with different kind of asset actions (change order, add asset, remove asset, change asset
+        // name, set asset custom fields, change
+        final List<AssetDraft> assetDrafts = asList(
+            createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
+            createAssetDraft("3", ofEnglish("3"), ASSETS_CUSTOM_TYPE_KEY, customFieldsJsonMap),
+            createAssetDraft("2", ofEnglish("new name")));
+
+
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                createVariantDraft("v1", assetDrafts))
+            .key(product.getKey())
+            .build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        // Assert results of sync
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).isNotEmpty();
+
+        final Map<String, String> assetsKeyToIdMap = product.getMasterData()
+                                                            .getStaged()
+                                                            .getMasterVariant()
+                                                            .getAssets()
+                                                            .stream().collect(toMap(Asset::getKey, Asset::getId));
+
+        assertThat(updateActionsFromSync).containsExactly(
+            SetPrices.of(1, emptyList()),
+            RemoveAsset.ofVariantIdWithKey(1, "1", true),
+            ChangeAssetName.ofAssetKeyAndVariantId(1, "3", ofEnglish("newName"), true),
+            ChangeAssetOrder.ofVariantId(1, asList(assetsKeyToIdMap.get("3"), assetsKeyToIdMap.get("2")), true),
+            AddAsset.ofVariantId(1, createAssetDraft("4", ofEnglish("4"), assetsCustomType.getId()))
+                    .withStaged(true).withPosition(0)
+        );
+
+        // Assert that assets got updated correctly
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(productDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertAssetsAreEqual(productProjection.getMasterVariant().getAssets(), assetDrafts);
+    }
+
+    @Test
+    public void sync_withMatchingProductWithDuplicateAssets_shouldFailToUpdateProductAndTriggerErrorCallback() {
+        final List<AssetDraft> assetDrafts = asList(
+            createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
+            createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
+            createAssetDraft("2", ofEnglish("2"), ASSETS_CUSTOM_TYPE_KEY));
+
+
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                createVariantDraft("v1", assetDrafts))
+            .key(product.getKey())
+            .build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        // Assert results of sync
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(errorCallBackMessages).hasSize(1);
+        assertThat(errorCallBackMessages.get(0)).matches("Failed to build update actions for the assets of the product "
+            + "variant with the sku 'v1'. Reason: .*BuildUpdateActionException: Supplied asset drafts "
+            + "have duplicate keys. Asset keys are expected to be unique inside their container \\(a product variant "
+            + "or a category\\).");
+        assertThat(errorCallBackExceptions).hasSize(1);
+        assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+        assertThat(errorCallBackExceptions.get(0).getMessage()).contains("Supplied asset drafts have duplicate "
+            + "keys. Asset keys are expected to be unique inside their container (a product variant or a category).");
+        assertThat(errorCallBackExceptions.get(0).getCause()).isExactlyInstanceOf(IllegalStateException.class);
+        assertThat(updateActionsFromSync).containsExactly(SetPrices.of(1, emptyList()));
+
+
+        // Assert that existing assets haven't changed.
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(productDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+
+        assertAssetsAreEqual(productProjection.getMasterVariant().getAssets(), assetDraftsToCreateOnExistingProduct);
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -64,8 +64,8 @@ public class ProductSyncWithAssetsIT {
 
     private static ProductType productType;
     private static Type assetsCustomType;
-    private ProductSyncOptions syncOptions;
     private Product product;
+    private ProductSync productSync;
     private List<AssetDraft> assetDraftsToCreateOnExistingProduct;
     private List<String> errorCallBackMessages;
     private List<String> warningCallBackMessages;
@@ -93,7 +93,7 @@ public class ProductSyncWithAssetsIT {
     public void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
-        syncOptions = buildSyncOptions();
+        productSync = new ProductSync(buildSyncOptions());
 
 
         assetDraftsToCreateOnExistingProduct = asList(
@@ -153,7 +153,6 @@ public class ProductSyncWithAssetsIT {
             .key("draftKey")
             .build();
 
-        final ProductSync productSync = new ProductSync(syncOptions);
         final ProductSyncStatistics syncStatistics =
             executeBlocking(productSync.sync(singletonList(productDraft)));
 
@@ -184,7 +183,6 @@ public class ProductSyncWithAssetsIT {
             .key("draftKey")
             .build();
 
-        final ProductSync productSync = new ProductSync(syncOptions);
         final ProductSyncStatistics syncStatistics =
             executeBlocking(productSync.sync(singletonList(productDraft)));
 
@@ -229,7 +227,6 @@ public class ProductSyncWithAssetsIT {
             .key(product.getKey())
             .build();
 
-        final ProductSync productSync = new ProductSync(syncOptions);
         final ProductSyncStatistics syncStatistics =
             executeBlocking(productSync.sync(singletonList(productDraft)));
 
@@ -278,7 +275,6 @@ public class ProductSyncWithAssetsIT {
             .key(product.getKey())
             .build();
 
-        final ProductSync productSync = new ProductSync(syncOptions);
         final ProductSyncStatistics syncStatistics =
             executeBlocking(productSync.sync(singletonList(productDraft)));
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -126,9 +126,9 @@ public class ProductSyncWithAssetsIT {
 
         final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
             actionsCallBack = (updateActions, newDraft, oldProduct) -> {
-            updateActionsFromSync.addAll(updateActions);
-            return updateActions;
-        };
+                updateActionsFromSync.addAll(updateActions);
+                return updateActions;
+            };
 
         return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
                                         .errorCallback(errorCallBack)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -133,12 +133,17 @@ public class ProductReferenceReplacementUtilsIT {
                                                                             .attributes(attributeDrafts)
                                                                             .build();
 
+        final ProductVariantDraft variant2 = ProductVariantDraftBuilder.of().sku("v2")
+                                                                       .assets(assetDrafts)
+                                                                       .prices(priceDraft)
+                                                                       .attributes(attributeDrafts)
+                                                                       .build();
 
         // Create Product Draft with all kind of references that are needed to be checked for expansion.
         final ProductDraft productDraft = ProductDraftBuilder
             .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
                 masterVariant)
-            .plusVariants(ProductVariantDraftBuilder.of().sku("v2").assets(assetDrafts).build())
+            .plusVariants(variant2)
             .key("existingProduct")
             .taxCategory(taxCategory)
             .state(state)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -1,0 +1,222 @@
+package com.commercetools.sync.integration.externalsource.products.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.channels.ChannelDraft;
+import io.sphere.sdk.channels.commands.ChannelCreateCommand;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.models.DefaultCurrencyUnits;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.PriceDraftBuilder;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductData;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.attributes.Attribute;
+import io.sphere.sdk.products.attributes.AttributeDraft;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.states.State;
+import io.sphere.sdk.states.StateType;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.types.Type;
+import io.sphere.sdk.utils.MoneyImpl;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_NAME;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategories;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategoriesCustomType;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getCategoryDrafts;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.getReferencesWithIds;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetDraft;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createAssetsCustomType;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createVariantDraft;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.getDraftWithPriceChannelReferences;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.StateITUtils.createState;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxCategory;
+import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SUPPLY_CHANNEL_KEY_1;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceSetAttributeDraft;
+import static com.commercetools.sync.products.ProductSyncMockUtils.getProductReferenceWithId;
+import static com.commercetools.sync.products.utils.ProductReferenceReplacementUtils.buildProductQuery;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static io.sphere.sdk.products.ProductProjectionType.STAGED;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductReferenceReplacementUtilsIT {
+    /**
+     * Delete all product related test data from the target project.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    /**
+     * Delete all product related test data from the target project.
+     */
+    @AfterClass
+    public static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    @Test
+    public void buildProductQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
+        final ProductType productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+        final TaxCategory taxCategory = createTaxCategory(CTP_TARGET_CLIENT);
+        final State state = createState(CTP_TARGET_CLIENT, StateType.PRODUCT_STATE);
+
+        final Type assetsCustomType = createAssetsCustomType("assetsCustomTypeKey", ENGLISH,
+            "assetsCustomTypeName", CTP_TARGET_CLIENT);
+        final List<AssetDraft> assetDrafts = singletonList(
+            createAssetDraft("1", ofEnglish("1"), assetsCustomType.getId()));
+
+        createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, ENGLISH, OLD_CATEGORY_CUSTOM_TYPE_NAME,
+            CTP_TARGET_CLIENT);
+        final List<Category> targetCategories =
+            createCategories(CTP_TARGET_CLIENT, getCategoryDrafts(null, 1));
+        final List<Reference<Category>> categoryReferences = getReferencesWithIds(targetCategories);
+
+
+        final Channel priceChannel =
+            executeBlocking(CTP_TARGET_CLIENT.execute(ChannelCreateCommand.of(ChannelDraft.of(SUPPLY_CHANNEL_KEY_1))));
+        final PriceDraft priceDraft = PriceDraftBuilder.of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
+                                                       .channel(priceChannel)
+                                                       .build();
+
+
+
+        final ProductDraft parentProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("parentProduct"), ofEnglish("parentProduct"),
+                createVariantDraft("parent", emptyList()))
+            .key("parentProduct")
+            .build();
+
+        // Create Parent Product.
+        final Product parentProduct = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(parentProductDraft)));
+
+
+        final String attribute1Name = "product-reference";
+        final AttributeDraft productRefAttr = AttributeDraft.of(attribute1Name,
+            getProductReferenceWithId(parentProduct.getId()));
+        final String attribute2Name = "product-reference-set";
+        final AttributeDraft productSetRefAttr = getProductReferenceSetAttributeDraft(attribute2Name,
+            getProductReferenceWithId(parentProduct.getId()));
+        final List<AttributeDraft> attributeDrafts = Arrays.asList(productRefAttr, productSetRefAttr);
+
+        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
+                                                                            .key("v1")
+                                                                            .sku("v1")
+                                                                            .assets(assetDrafts)
+                                                                            .prices(priceDraft)
+                                                                            .attributes(attributeDrafts)
+                                                                            .build();
+
+
+        // Create Product Draft with all kind of references that are needed to be checked for expansion.
+        final ProductDraft productDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                masterVariant)
+            .plusVariants(ProductVariantDraftBuilder.of().sku("v2").assets(assetDrafts).build())
+            .key("existingProduct")
+            .taxCategory(taxCategory)
+            .state(state)
+            .categories(categoryReferences)
+            .build();
+
+        final ProductDraft draftWithPriceChannelReferences = getDraftWithPriceChannelReferences(productDraft,
+            priceChannel.toReference());
+
+
+        // Create Product.
+        executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(draftWithPriceChannelReferences)));
+
+
+        // Fetch Products with reference expansions.
+        final List<Product> products = CTP_TARGET_CLIENT.execute(buildProductQuery().bySku("v1", STAGED))
+                                                        .toCompletableFuture().join().getResults();
+
+
+        // Assert Product is fetched with all the references expanded.
+        assertThat(products).hasSize(1);
+        final Product createdProduct = products.get(0);
+        // Asset product type references are expanded
+        assertThat(createdProduct.getProductType().getObj()).isNotNull();
+        // Asset tax category references are expanded
+        assertThat(createdProduct.getTaxCategory()).isNotNull();
+        assertThat(createdProduct.getTaxCategory().getObj()).isNotNull();
+        // Asset state references are expanded
+        assertThat(createdProduct.getState()).isNotNull();
+        assertThat(createdProduct.getState().getObj()).isNotNull();
+
+        final ProductData stagedProjection = createdProduct.getMasterData().getStaged();
+
+        // Asset category references are expanded
+        assertThat(stagedProjection.getCategories()).hasSize(1);
+        final Reference<Category> category = stagedProjection.getCategories().iterator().next();
+        assertThat(category).isNotNull();
+        assertThat(category.getObj()).isNotNull();
+
+        // Asset variants' assets custom types references are expanded
+        final ProductVariant variant = stagedProjection.getVariant(2);
+        assertThat(variant).isNotNull();
+        assertThat(variant.getAssets()).hasSize(1);
+        final Asset asset = variant.getAssets().get(0);
+        assertThat(asset.getCustom()).isNotNull();
+        assertThat(asset.getCustom().getType().getObj()).isNotNull();
+
+        final ProductVariant stagedProjectionMasterVariant = stagedProjection.getMasterVariant();
+
+        // Asset variants' price channel references are expanded.
+        assertThat(stagedProjectionMasterVariant.getPrices()).hasSize(1);
+        final Price price = stagedProjectionMasterVariant.getPrices().get(0);
+        assertThat(price.getChannel()).isNotNull();
+        assertThat(price.getChannel().getObj()).isNotNull();
+
+        // Asset master variant assets custom type references are expanded.
+        assertThat(stagedProjectionMasterVariant.getAssets()).hasSize(1);
+        final Asset masterVariantAsset = stagedProjectionMasterVariant.getAssets().get(0);
+        assertThat(masterVariantAsset.getCustom()).isNotNull();
+        assertThat(masterVariantAsset.getCustom().getType().getObj()).isNotNull();
+
+
+        // Asset variants attribute references are expanded.
+        final Attribute attribute1 = stagedProjectionMasterVariant.getAttribute(attribute1Name);
+        assertThat(attribute1).isNotNull();
+        final JsonNode attribute1ValueAsJsonNode = attribute1.getValueAsJsonNode();
+        assertThat(attribute1ValueAsJsonNode).isNotNull();
+        assertThat(attribute1ValueAsJsonNode.get("obj")).isNotNull();
+
+        final Attribute attribute2 = stagedProjectionMasterVariant.getAttribute(attribute2Name);
+        assertThat(attribute2).isNotNull();
+        final JsonNode attribute2ValueAsJsonNode = attribute2.getValueAsJsonNode();
+        assertThat(attribute2ValueAsJsonNode).isNotNull();
+        assertThat(attribute2ValueAsJsonNode.isArray()).isTrue();
+        assertThat(attribute2ValueAsJsonNode).hasSize(1);
+
+        final JsonNode firstReferenceInSet = attribute2ValueAsJsonNode.get(0);
+        assertThat(firstReferenceInSet).isNotNull();
+        assertThat(firstReferenceInSet.get("obj")).isNotNull();
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -161,24 +161,24 @@ public class ProductReferenceReplacementUtilsIT {
         // Assert Product is fetched with all the references expanded.
         assertThat(products).hasSize(1);
         final Product createdProduct = products.get(0);
-        // Asset product type references are expanded
+        // Assert product type references are expanded
         assertThat(createdProduct.getProductType().getObj()).isNotNull();
-        // Asset tax category references are expanded
+        // Assert tax category references are expanded
         assertThat(createdProduct.getTaxCategory()).isNotNull();
         assertThat(createdProduct.getTaxCategory().getObj()).isNotNull();
-        // Asset state references are expanded
+        // Assert state references are expanded
         assertThat(createdProduct.getState()).isNotNull();
         assertThat(createdProduct.getState().getObj()).isNotNull();
 
         final ProductData stagedProjection = createdProduct.getMasterData().getStaged();
 
-        // Asset category references are expanded
+        // Assert category references are expanded
         assertThat(stagedProjection.getCategories()).hasSize(1);
         final Reference<Category> category = stagedProjection.getCategories().iterator().next();
         assertThat(category).isNotNull();
         assertThat(category.getObj()).isNotNull();
 
-        // Asset variants' assets custom types references are expanded
+        // Assert variants' assets custom types references are expanded
         final ProductVariant variant = stagedProjection.getVariant(2);
         assertThat(variant).isNotNull();
         assertThat(variant.getAssets()).hasSize(1);
@@ -188,20 +188,20 @@ public class ProductReferenceReplacementUtilsIT {
 
         final ProductVariant stagedProjectionMasterVariant = stagedProjection.getMasterVariant();
 
-        // Asset variants' price channel references are expanded.
+        // Assert variants' price channel references are expanded.
         assertThat(stagedProjectionMasterVariant.getPrices()).hasSize(1);
         final Price price = stagedProjectionMasterVariant.getPrices().get(0);
         assertThat(price.getChannel()).isNotNull();
         assertThat(price.getChannel().getObj()).isNotNull();
 
-        // Asset master variant assets custom type references are expanded.
+        // Assert master variant assets custom type references are expanded.
         assertThat(stagedProjectionMasterVariant.getAssets()).hasSize(1);
         final Asset masterVariantAsset = stagedProjectionMasterVariant.getAssets().get(0);
         assertThat(masterVariantAsset.getCustom()).isNotNull();
         assertThat(masterVariantAsset.getCustom().getType().getObj()).isNotNull();
 
 
-        // Asset variants attribute references are expanded.
+        // Assert variants attribute references are expanded.
         final Attribute attribute1 = stagedProjectionMasterVariant.getAttribute(attribute1Name);
         assertThat(attribute1).isNotNull();
         final JsonNode attribute1ValueAsJsonNode = attribute1.getValueAsJsonNode();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -114,8 +114,8 @@ public class ProductReferenceReplacementUtilsIT {
             .build();
 
         // Create Parent Product.
-        final Product parentProduct = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(parentProductDraft)));
-
+        final Product parentProduct =
+            executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(parentProductDraft)));
 
         final String attribute1Name = "product-reference";
         final AttributeDraft productRefAttr = AttributeDraft.of(attribute1Name,


### PR DESCRIPTION
#### Summary
This PR is only about adding Integration tests to the asset sync.

#### Hints for Review
1. Add integration tests for syncing assets from one source CTP project to target CTP project: [`../ctpprojectsource/products/ProductSyncWithAssetsIT`](https://github.com/commercetools/commercetools-sync-java/pull/263/files#diff-1089fcedd890af55d4e74d1aa30c3687)
2. Add integration tests for syncing assets from external source to target CTP project: [`../externalsource/products/ProductSyncWithAssetsIT`](https://github.com/commercetools/commercetools-sync-java/pull/263/files#diff-dd9ec00e90b9aa63f903d4dc3e99ce71)
3. [Add integration tests for `buildProductQuery()`](https://github.com/commercetools/commercetools-sync-java/pull/263/files#diff-efffa0f584e88476c80d4fa9be235c18) to assert that products are actually fetched with the references expanded.
4. [Add integration tests for `buildCategoryQuery()`](https://github.com/commercetools/commercetools-sync-java/pull/263/files#diff-48f49a3a73b7118b5282c50874109e5d) to assert that categories are actually fetched with the references expanded.
5. The rest is some IT utils refactoring/adding.

NOTE: Some ITs are now failing due to a bug in the JVM SDK: https://github.com/commercetools/commercetools-jvm-sdk/issues/1720
#### Relevant Issues
#3

- Tests 
    - [x] Integration

