### PR TITLE
262 bump jvm sdk

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -56,7 +56,8 @@
 **New Features** (3)
 - **Commons** - Introduced `AssetReferenceResolver` which is a helper that can resolve all the references of an AssetDraft. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
 - **Commons** - `VariantReferenceResolver` and `CategoryReferenceResolver` now also resolve all the containing AssetDrafts references. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
-- **Commons** - Support for custom update actions calculation for secondary resources (e.g. prices, product assets and category assets). [#3](https://github.com/commercetools/commercetools-sync-java/issues/3) 
+- **Commons** - Support for custom update actions calculation for secondary resources (e.g. prices, product assets and category assets). [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
+- **Commons** - Introduced new ResourceIdentifierUtils#toResourceIdentifierIfNotNull. [#262](https://github.com/commercetools/commercetools-sync-java/issues/262) 
 
 **Changes** (3)
 - **Commons** - `CustomUpdateActionUtils#buildCustomUpdateActions` is now 
@@ -66,6 +67,9 @@ implementors of the `GenericCustomActionBuilder` interface. [#3](https://github.
 - **Commons** - `CustomUpdateActionUtils#buildCustomUpdateActions` can now be used to build custom update actions
 for secondary resources (e.g. assets and prices). [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
 - **Commons** - New Custom Type Id is now validated against being empty/null. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
+
+**Enhancements** (1)
+- **Build Tools** - Bumped commercetools-jvm-sdk to version 1.29.0. [#262](https://github.com/commercetools/commercetools-sync-java/issues/262)
 
 **Bug Fixes** (1)
 - **Build Tools** - Fixed bug where jar and Codecov were triggered on benchmark stages of the build when they should 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -69,7 +69,7 @@ for secondary resources (e.g. assets and prices). [#3](https://github.com/commer
 - **Commons** - New Custom Type Id is now validated against being empty/null. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
 
 **Enhancements** (1)
-- **Build Tools** - Bumped commercetools-jvm-sdk to version 1.29.0. [#262](https://github.com/commercetools/commercetools-sync-java/issues/262)
+- **Build Tools** - Bumped commercetools-jvm-sdk to version [1.29.0](http://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/ReleaseNotes.html#v1_29_0). [#262](https://github.com/commercetools/commercetools-sync-java/issues/262)
 
 **Bug Fixes** (1)
 - **Build Tools** - Fixed bug where jar and Codecov were triggered on benchmark stages of the build when they should 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -53,7 +53,7 @@
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M11/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M11)
 
-**New Features** (3)
+**New Features** (4)
 - **Commons** - Introduced `AssetReferenceResolver` which is a helper that can resolve all the references of an AssetDraft. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
 - **Commons** - `VariantReferenceResolver` and `CategoryReferenceResolver` now also resolve all the containing AssetDrafts references. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
 - **Commons** - Support for custom update actions calculation for secondary resources (e.g. prices, product assets and category assets). [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,5 +1,5 @@
 ext{
-    commercetoolsJvmSdkVersion = '1.27.0'
+    commercetoolsJvmSdkVersion = '1.29.0'
     mockitoVersion = '2.13.0'
     jUnitVersion = '4.12'
     assertjVersion = '3.9.0'

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
+import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.toResourceIdentifierIfNotNull;
 import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -73,7 +74,8 @@ public final class CategoryITUtils {
             final String key = format("key%s", i + 1);
             final String orderHint = format("0.%s", i + 1);
             final CategoryDraft categoryDraft = CategoryDraftBuilder.of(name, slug)
-                                                                    .parent(parentCategory)
+                                                                    .parent(
+                                                                        toResourceIdentifierIfNotNull(parentCategory))
                                                                     .description(description)
                                                                     .key(key)
                                                                     .orderHint(orderHint)
@@ -142,7 +144,7 @@ public final class CategoryITUtils {
                 .of(LocalizedString.of(Locale.ENGLISH, categoryName),
                     LocalizedString.of(Locale.ENGLISH, categoryName))
                 .key(categoryName)
-                .parent(parent)
+                .parent(toResourceIdentifierIfNotNull(parent))
                 .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
                 .orderHint("sameOrderHint")
                 .build();

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
@@ -342,7 +342,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "child"),
                 LocalizedString.of(Locale.ENGLISH, "child"))
             .key("child")
-            .parent(parentCreated)
+            .parent(parentCreated.toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
         CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(childDraft)).toCompletableFuture().join();
@@ -362,7 +362,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "child-new-name"),
                 LocalizedString.of(Locale.ENGLISH, "child"))
             .key("child")
-            .parent(sourceParentCreated)
+            .parent(sourceParentCreated.toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeKeyAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
         CTP_SOURCE_CLIENT.execute(CategoryCreateCommand.of(sourceChildDraft)).toCompletableFuture().join();

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
@@ -54,7 +54,7 @@ public class ChangeParentIT {
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture"))
-            .parent(oldCategoryParent)
+            .parent(oldCategoryParent.toResourceIdentifier())
             .build();
 
         oldCategory = CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(oldCategoryDraft))
@@ -96,7 +96,7 @@ public class ChangeParentIT {
 
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
-            .parent(parentCategory)
+            .parent(parentCategory.toResourceIdentifier())
             .build();
         final Category newCategory = CTP_SOURCE_CLIENT.execute(CategoryCreateCommand.of(newCategoryDraft))
                                                       .toCompletableFuture()
@@ -128,7 +128,7 @@ public class ChangeParentIT {
         // Prepare new category draft with a same parent. The parent is substituted with the target project's
         // parnet id, because the utils assume reference resolution has already been done at this point.
         final CategoryDraft draftFromCategory = CategoryDraftBuilder.of(newCategory)
-                                                                    .parent(oldCategoryParent)
+                                                                    .parent(oldCategoryParent.toResourceIdentifier())
                                                                     .build();
 
         // Build change parent update action

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
@@ -167,8 +167,8 @@ public class ProductReferenceResolverIT {
         assertThat(syncStatistics).hasValues(1, 0, 0, 1);
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on ProductDraft with"
-            + " key:'%s'. Reason: %s: Failed to resolve product type reference on ProductDraft with key:'%s'."
-                + " Reason: Reference 'id' field value is blank (null/empty).",
+                + " key:'%s'. Reason: %s: Failed to resolve product type reference on ProductDraft with key:'%s'."
+                + " Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
             productDraft.getKey(), ReferenceResolutionException.class.getCanonicalName(), productDraft.getKey()));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_NAME;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategories;
@@ -168,8 +169,9 @@ public class ProductReferenceResolverIT {
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on ProductDraft with"
                 + " key:'%s'. Reason: %s: Failed to resolve product type reference on ProductDraft with key:'%s'."
-                + " Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
-            productDraft.getKey(), ReferenceResolutionException.class.getCanonicalName(), productDraft.getKey()));
+                + " Reason: %s",
+            productDraft.getKey(), ReferenceResolutionException.class.getCanonicalName(), productDraft.getKey(),
+            BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);
         assertThat(warningCallBackMessages).isEmpty();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -297,7 +297,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key("newCategory")
-            .parent(Category.referenceOfId(oldCategoryKey))
+            .parent(Category.referenceOfId(oldCategoryKey).toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -358,7 +358,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "oldCategoryKey"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
             .key(oldCategoryKey)
-            .parent(Category.referenceOfId("cat7"))
+            .parent(Category.referenceOfId("cat7").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -379,7 +379,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat6"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat6")
-            .parent(Category.referenceOfId("cat5"))
+            .parent(Category.referenceOfId("cat5").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -465,7 +465,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat2"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
-            .parent(Category.referenceOfId("cat1"))
+            .parent(Category.referenceOfId("cat1").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -473,7 +473,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat3"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
-            .parent(Category.referenceOfId("cat1"))
+            .parent(Category.referenceOfId("cat1").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -488,7 +488,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat5"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
-            .parent(Category.referenceOfId("cat4"))
+            .parent(Category.referenceOfId("cat4").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -528,7 +528,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat2"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
-            .parent(Category.referenceOfId("cat1"))
+            .parent(Category.referenceOfId("cat1").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -536,7 +536,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat3"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
-            .parent(Category.referenceOfId("cat1"))
+            .parent(Category.referenceOfId("cat1").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -551,7 +551,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat5"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
-            .parent(Category.referenceOfId("cat4"))
+            .parent(Category.referenceOfId("cat4").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -591,7 +591,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat2"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
             .key("cat2")
-            .parent(Category.referenceOfId(UUID.randomUUID().toString()))
+            .parent(Category.referenceOfId(UUID.randomUUID().toString()).toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -599,7 +599,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat3"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
             .key("cat3")
-            .parent(Category.referenceOfId("cat1"))
+            .parent(Category.referenceOfId("cat1").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -614,7 +614,7 @@ public class CategorySyncIT {
             .of(LocalizedString.of(Locale.ENGLISH, "cat5"),
                 LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
             .key("cat5")
-            .parent(Category.referenceOfId("cat4"))
+            .parent(Category.referenceOfId("cat4").toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 
@@ -697,7 +697,7 @@ public class CategorySyncIT {
         final CategoryDraft categoryDraftWithMissingParent = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture1"))
             .key("cat1")
-            .parent(Category.referenceOfId(nonExistingParentKey))
+            .parent(Category.referenceOfId(nonExistingParentKey).toResourceIdentifier())
             .custom(CustomFieldsDraft.ofTypeIdAndJson(OLD_CATEGORY_CUSTOM_TYPE_KEY, getCustomFieldsJsons()))
             .build();
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
@@ -51,7 +51,7 @@ public class ChangeParentIT {
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "furniture1"))
             .key("oldCategory")
-            .parent(oldCategoryParent)
+            .parent(oldCategoryParent.toResourceIdentifier())
             .build();
         oldCategory = CTP_TARGET_CLIENT.execute(CategoryCreateCommand.of(oldCategoryDraft))
                                        .toCompletableFuture()
@@ -84,7 +84,7 @@ public class ChangeParentIT {
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture"))
-            .parent(oldCategory)
+            .parent(oldCategory.toResourceIdentifier())
             .build();
 
         // Build change parent update action between parent and new category.
@@ -106,7 +106,7 @@ public class ChangeParentIT {
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture"))
-            .parent(oldCategory.getParent())
+            .parent(oldCategory.getParent().toResourceIdentifier())
             .build();
 
         // Build change parent update action

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolver.java
@@ -137,7 +137,8 @@ public final class CategoryReferenceResolver
             @Nonnull final String parentCategoryKey) {
         return categoryService.fetchCachedCategoryId(parentCategoryKey)
             .thenApply(resolvedParentIdOptional -> resolvedParentIdOptional
-                .map(resolvedParentId -> draftBuilder.parent(Category.referenceOfId(resolvedParentId)))
+                .map(resolvedParentId ->
+                    draftBuilder.parent(Category.referenceOfId(resolvedParentId).toResourceIdentifier()))
                 .orElse(draftBuilder));
     }
 

--- a/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.categories.CategoryDraftBuilder;
 import io.sphere.sdk.categories.expansion.CategoryExpansionModel;
 import io.sphere.sdk.categories.queries.CategoryQuery;
 import io.sphere.sdk.expansion.ExpansionPath;
-import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.queries.QueryExecutionUtils;
 import io.sphere.sdk.types.CustomFieldsDraft;
 
@@ -36,8 +36,9 @@ public final class CategoryReferenceReplacementUtils {
             .map(category -> {
                 final CustomFieldsDraft customTypeWithKeysInReference = replaceCustomTypeIdWithKeys(category);
                 @SuppressWarnings("ConstantConditions") // NPE checked in replaceReferenceIdWithKey
-                final Reference<Category> parentWithKeyInReference = replaceReferenceIdWithKey(category.getParent(),
-                    () -> Category.referenceOfId(category.getParent().getObj().getKey()));
+                final ResourceIdentifier<Category> parentWithKeyInReference = replaceReferenceIdWithKey(
+                    category.getParent(), () -> Category.referenceOfId(category.getParent().getObj().getKey()));
+
                 return CategoryDraftBuilder.of(category)
                                            .custom(customTypeWithKeysInReference)
                                            .parent(parentWithKeyInReference)

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseReferenceResolver.java
@@ -24,7 +24,6 @@ public abstract class BaseReferenceResolver<T, S extends BaseSyncOptions> {
     private static final String UUID_NOT_ALLOWED = "Found a UUID in the id field. Expecting a key without a UUID value."
         + " If you want to allow UUID values for reference keys, please use the allowUuidKeys(true) option in the"
         + " sync options.";
-    private static final String UNSET_ID_FIELD = "Reference 'id' field value is blank (null/empty).";
     private static final String KEY_NOT_SET_ON_EXPANSION_OR_ID_FIELD = "Key is blank (null/empty) on both expanded"
         + " reference object and reference id field.";
     private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
@@ -68,7 +67,8 @@ public abstract class BaseReferenceResolver<T, S extends BaseSyncOptions> {
                                                          final boolean allowUuidKeys)
         throws ReferenceResolutionException {
         final String key = resourceIdentifier.getId();
-        validateKey(key, allowUuidKeys, UNSET_ID_FIELD);
+        validateKey(key, allowUuidKeys, "The value of 'id' field of the Resource Identifier is blank "
+            + "(null/empty).");
         return key;
     }
 

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseReferenceResolver.java
@@ -26,6 +26,8 @@ public abstract class BaseReferenceResolver<T, S extends BaseSyncOptions> {
         + " sync options.";
     private static final String KEY_NOT_SET_ON_EXPANSION_OR_ID_FIELD = "Key is blank (null/empty) on both expanded"
         + " reference object and reference id field.";
+    public static final String BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER = "The value of 'id' field of the Resource"
+        + " Identifier is blank (null/empty).";
     private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
 
     protected S options;
@@ -67,8 +69,7 @@ public abstract class BaseReferenceResolver<T, S extends BaseSyncOptions> {
                                                          final boolean allowUuidKeys)
         throws ReferenceResolutionException {
         final String key = resourceIdentifier.getId();
-        validateKey(key, allowUuidKeys, "The value of 'id' field of the Resource Identifier is blank "
-            + "(null/empty).");
+        validateKey(key, allowUuidKeys, BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER);
         return key;
     }
 

--- a/src/main/java/com/commercetools/sync/commons/helpers/CategoryReferencePair.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/CategoryReferencePair.java
@@ -2,33 +2,35 @@ package com.commercetools.sync.commons.helpers;
 
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.CategoryOrderHints;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Container for a {@link List} of {@link Category} {@link Reference}s and a {@link CategoryOrderHints}.
  */
 public final class CategoryReferencePair {
-    private List<Reference<Category>> categoryReferences;
+    private Set<ResourceIdentifier<Category>> categoryResourceIdentifiers;
     private CategoryOrderHints categoryOrderHints;
 
-    private CategoryReferencePair(@Nonnull final List<Reference<Category>> categoryReferences,
+    private CategoryReferencePair(@Nonnull final Set<ResourceIdentifier<Category>> categoryResourceIdentifiers,
                                   @Nullable final CategoryOrderHints categoryOrderHints) {
-        this.categoryReferences = categoryReferences;
+        this.categoryResourceIdentifiers = categoryResourceIdentifiers;
         this.categoryOrderHints = categoryOrderHints;
     }
 
-    public static CategoryReferencePair of(@Nonnull final List<Reference<Category>> categoryReferences,
+    public static CategoryReferencePair of(@Nonnull final Set<ResourceIdentifier<Category>> categoryReferences,
                                            @Nullable final CategoryOrderHints categoryOrderHints) {
         return new CategoryReferencePair(categoryReferences, categoryOrderHints);
     }
 
 
-    public List<Reference<Category>> getCategoryReferences() {
-        return categoryReferences;
+    public Set<ResourceIdentifier<Category>> getCategoryResourceIdentifiers() {
+        return categoryResourceIdentifiers;
     }
 
     public CategoryOrderHints getCategoryOrderHints() {

--- a/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
@@ -17,7 +17,8 @@ public final class ResourceIdentifierUtils {
      * @param resource represents the resource to return as a {@link ResourceIdentifier} if not {@code null}.
      * @param <T>      type of the resource supplied.
      * @param <S>      represents the type of the {@link ResourceIdentifier} returned.
-     * @return the supplied resource in the as a {@link ResourceIdentifier} if not {@code null}.
+     * @return the supplied resource in the as a {@link ResourceIdentifier} if not {@code null}. If it is {@code null},
+     *         this method returns {@code null}.
      */
     @Nullable
     public static <T extends Referenceable<S>, S> ResourceIdentifier<S> toResourceIdentifierIfNotNull(

--- a/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
@@ -10,8 +10,8 @@ import static java.util.Optional.ofNullable;
 public final class ResourceIdentifierUtils {
 
     /**
-     * Given a {@link Referenceable} {@code resource} of the type {@code T}, if it is not null, this method returns
-     * applies the {@link Referenceable#toResourceIdentifier()} method to return it as a {@link ResourceIdentifier} of
+     * Given a {@link Referenceable} {@code resource} of the type {@code T}, if it is not null, this method applies the
+     * {@link Referenceable#toResourceIdentifier()} method to return it as a {@link ResourceIdentifier} of
      * the type {@code T}. If it is {@code null}, this method returns {@code null}.
      *
      * @param resource represents the resource to return as a {@link ResourceIdentifier} if not {@code null}.

--- a/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
@@ -15,10 +15,12 @@ final public class ResourceIdentifierUtils {
      * the type {@code T}. If it is {@code null}, this method returns {@code null}.
      *
      * @param resource represents the resource to return as a {@link ResourceIdentifier} if not {@code null}.
+     * @param <T>      type of the resource supplied.
+     * @param <S>      represents the type of the {@link ResourceIdentifier} returned.
      * @return the supplied resource in the as a {@link ResourceIdentifier} if not {@code null}.
      */
     @Nullable
-    public static <T extends Referenceable<T>> ResourceIdentifier<T> toResourceIdentifierIfNotNull(
+    public static <T extends Referenceable<S>, S> ResourceIdentifier<S> toResourceIdentifierIfNotNull(
         @Nullable final T resource) {
         return ofNullable(resource)
             .map(Referenceable::toResourceIdentifier)

--- a/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 
 import static java.util.Optional.ofNullable;
 
-final public class ResourceIdentifierUtils {
+public final class ResourceIdentifierUtils {
 
     /**
      * Given a {@link Referenceable} {@code resource} of the type {@code T}, if it is not null, this method returns

--- a/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtils.java
@@ -1,0 +1,30 @@
+package com.commercetools.sync.commons.utils;
+
+import io.sphere.sdk.models.Referenceable;
+import io.sphere.sdk.models.ResourceIdentifier;
+
+import javax.annotation.Nullable;
+
+import static java.util.Optional.ofNullable;
+
+final public class ResourceIdentifierUtils {
+
+    /**
+     * Given a {@link Referenceable} {@code resource} of the type {@code T}, if it is not null, this method returns
+     * applies the {@link Referenceable#toResourceIdentifier()} method to return it as a {@link ResourceIdentifier} of
+     * the type {@code T}. If it is {@code null}, this method returns {@code null}.
+     *
+     * @param resource represents the resource to return as a {@link ResourceIdentifier} if not {@code null}.
+     * @return the supplied resource in the as a {@link ResourceIdentifier} if not {@code null}.
+     */
+    @Nullable
+    public static <T extends Referenceable<T>> ResourceIdentifier<T> toResourceIdentifierIfNotNull(
+        @Nullable final T resource) {
+        return ofNullable(resource)
+            .map(Referenceable::toResourceIdentifier)
+            .orElse(null);
+    }
+
+    private ResourceIdentifierUtils() {
+    }
+}

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
@@ -73,9 +73,10 @@ public final class SyncUtils {
      *         Otherwise, it returns the supplied reference as is.
      */
     @Nullable
-    public static <T> Reference<T> replaceReferenceIdWithKey(@Nullable final Reference<T> reference,
-                                                             @Nonnull final Supplier<Reference<T>>
-                                                                 keyInReferenceSupplier) {
+    public static <T> Reference<T> replaceReferenceIdWithKey(
+        @Nullable final Reference<T> reference,
+        @Nonnull final Supplier<Reference<T>> keyInReferenceSupplier) {
+
         if (reference != null && reference.getObj() != null) {
             return keyInReferenceSupplier.get();
         }

--- a/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
@@ -4,6 +4,7 @@ import com.commercetools.sync.commons.helpers.CategoryReferencePair;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.expansion.ExpansionPath;
 import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.CategoryOrderHints;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductData;
@@ -23,6 +24,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,8 +61,8 @@ public final class ProductReferenceReplacementUtils {
                 final Reference<State> stateReferenceWithKey = replaceProductStateReferenceIdWithKey(product);
 
                 final CategoryReferencePair categoryReferencePair = replaceCategoryReferencesIdsWithKeys(product);
-                final List<Reference<Category>> categoryReferencesWithKeys =
-                    categoryReferencePair.getCategoryReferences();
+                final Set<ResourceIdentifier<Category>> categoryResourceIdentifiers =
+                    categoryReferencePair.getCategoryResourceIdentifiers();
                 final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
                 final List<ProductVariant> allVariants = product.getMasterData().getStaged().getAllVariants();
@@ -72,7 +74,7 @@ public final class ProductReferenceReplacementUtils {
                                           .masterVariant(masterVariantDraftWithKeys)
                                           .variants(variantDraftsWithKeys)
                                           .productType(productTypeReferenceWithKey)
-                                          .categories(categoryReferencesWithKeys)
+                                          .categories(categoryResourceIdentifiers)
                                           .categoryOrderHints(categoryOrderHintsWithKeys)
                                           .taxCategory(taxCategoryReferenceWithKey)
                                           .state(stateReferenceWithKey)
@@ -191,13 +193,13 @@ public final class ProductReferenceReplacementUtils {
     @Nonnull
     static CategoryReferencePair replaceCategoryReferencesIdsWithKeys(@Nonnull final Product product) {
         final Set<Reference<Category>> categoryReferences = product.getMasterData().getStaged().getCategories();
-        final List<Reference<Category>> categoryReferencesWithKeys = new ArrayList<>();
+        final Set<ResourceIdentifier<Category>> categoryResourceIdentifiers = new HashSet<>();
 
         final CategoryOrderHints categoryOrderHints = product.getMasterData().getStaged().getCategoryOrderHints();
         final Map<String, String> categoryOrderHintsMapWithKeys = new HashMap<>();
 
         categoryReferences.forEach(categoryReference ->
-            categoryReferencesWithKeys.add(
+            categoryResourceIdentifiers.add(
                 replaceReferenceIdWithKey(categoryReference, () -> {
                     final String categoryId = categoryReference.getId();
                     @SuppressWarnings("ConstantConditions") // NPE is checked in replaceReferenceIdWithKey.
@@ -215,7 +217,7 @@ public final class ProductReferenceReplacementUtils {
 
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryOrderHintsMapWithKeys.isEmpty()
             ? categoryOrderHints : CategoryOrderHints.of(categoryOrderHintsMapWithKeys);
-        return CategoryReferencePair.of(categoryReferencesWithKeys, categoryOrderHintsWithKeys);
+        return CategoryReferencePair.of(categoryResourceIdentifiers, categoryOrderHintsWithKeys);
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncMockUtils.java
@@ -207,8 +207,8 @@ public class CategorySyncMockUtils {
                                                                    @Nonnull final String customTypeId,
                                                                    @Nonnull final Map<String, JsonNode> customFields) {
         return CategoryDraftBuilder.of(LocalizedString.of(locale, name), LocalizedString.of(locale, "testSlug"))
-            .key(key)
-            .parent(Category.referenceOfId(parentId))
-            .custom(CustomFieldsDraft.ofTypeIdAndJson(customTypeId, customFields));
+                                   .key(key)
+                                   .parent(Category.referenceOfId(parentId).toResourceIdentifier())
+                                   .custom(CustomFieldsDraft.ofTypeIdAndJson(customTypeId, customFields));
     }
 }

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -26,6 +26,7 @@ import static com.commercetools.sync.categories.CategorySyncMockUtils.getMockCat
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
 import static com.commercetools.sync.commons.MockUtils.mockCategoryService;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -203,8 +204,8 @@ public class CategorySyncTest {
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
             + " key:'key'. Reason: %s: Failed to resolve parent reference on CategoryDraft"
-            + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
-            ReferenceResolutionException.class.getCanonicalName()));
+            + " with key:'key'. Reason: %s",
+            ReferenceResolutionException.class.getCanonicalName(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);
     }
@@ -247,9 +248,9 @@ public class CategorySyncTest {
         assertThat(syncStatistics).hasValues(1, 0, 0, 1);
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
-            + " key:'key'. Reason: %s: Failed to resolve parent reference on CategoryDraft"
-            + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
-            ReferenceResolutionException.class.getCanonicalName()));
+                + " key:'key'. Reason: %s: Failed to resolve parent reference on CategoryDraft with key:'key'. "
+                + "Reason: %s", ReferenceResolutionException.class.getCanonicalName(),
+            BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);
     }
@@ -270,9 +271,8 @@ public class CategorySyncTest {
         assertThat(syncStatistics).hasValues(1, 0, 0, 1);
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
-            + " key:'key'. Reason: %s: Failed to resolve custom type reference on "
-            + "CategoryDraft with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank "
-            + "(null/empty).", ReferenceResolutionException.class.getCanonicalName()));
+            + " key:'key'. Reason: %s: Failed to resolve custom type reference on CategoryDraft with key:'key'. Reason:"
+                + " %s", ReferenceResolutionException.class.getCanonicalName(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(CompletionException.class);
         assertThat(errorCallBackExceptions.get(0).getCause()).isExactlyInstanceOf(ReferenceResolutionException.class);

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -203,8 +203,8 @@ public class CategorySyncTest {
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
             + " key:'key'. Reason: %s: Failed to resolve parent reference on CategoryDraft"
-            + " with key:'key'. Reason: Key is blank (null/empty) on both expanded reference object"
-            + " and reference id field.", ReferenceResolutionException.class.getCanonicalName()));
+            + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
+            ReferenceResolutionException.class.getCanonicalName()));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);
     }
@@ -248,8 +248,8 @@ public class CategorySyncTest {
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
             + " key:'key'. Reason: %s: Failed to resolve parent reference on CategoryDraft"
-            + " with key:'key'. Reason: Key is blank (null/empty) on both expanded reference object"
-            + " and reference id field.", ReferenceResolutionException.class.getCanonicalName()));
+            + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).",
+            ReferenceResolutionException.class.getCanonicalName()));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(ReferenceResolutionException.class);
     }
@@ -271,8 +271,8 @@ public class CategorySyncTest {
         assertThat(errorCallBackMessages).hasSize(1);
         assertThat(errorCallBackMessages.get(0)).isEqualTo(format("Failed to resolve references on CategoryDraft with"
             + " key:'key'. Reason: %s: Failed to resolve custom type reference on "
-            + "CategoryDraft with key:'key'. Reason: Reference 'id' field value is blank (null/"
-            + "empty).", ReferenceResolutionException.class.getCanonicalName()));
+            + "CategoryDraft with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank "
+            + "(null/empty).", ReferenceResolutionException.class.getCanonicalName()));
         assertThat(errorCallBackExceptions).hasSize(1);
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(CompletionException.class);
         assertThat(errorCallBackExceptions.get(0).getCause()).isExactlyInstanceOf(ReferenceResolutionException.class);

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -334,7 +334,7 @@ public class CategorySyncTest {
 
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "name"), LocalizedString.of(Locale.ENGLISH, "slug"))
-            .parent(Category.referenceOfId("differentParent"))
+            .parent(Category.referenceOfId("differentParent").toResourceIdentifier())
             .build();
         final boolean doesRequire = CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
         assertThat(doesRequire).isTrue();
@@ -348,7 +348,7 @@ public class CategorySyncTest {
 
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "name"), LocalizedString.of(Locale.ENGLISH, "slug"))
-            .parent(Category.referenceOfId(parentId))
+            .parent(Category.referenceOfId(parentId).toResourceIdentifier())
             .build();
         final boolean doesRequire = CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
         assertThat(doesRequire).isFalse();

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -191,7 +191,6 @@ public class CategoryReferenceResolverTest {
                                  .thenAccept(resolvedDraft -> {
                                      assertThat(resolvedDraft.getParent()).isNotNull();
                                      assertThat(resolvedDraft.getParent().getId()).isEqualTo(CACHED_CATEGORY_ID);
-                                     assertThat(resolvedDraft.getParent().getObj()).isNull();
                                  }).toCompletableFuture().join();
     }
 

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -29,7 +29,9 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.categories.CategorySyncMockUtils.getMockCategoryDraftBuilder;
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -256,8 +258,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve parent reference on CategoryDraft"
-                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve parent reference on CategoryDraft with key:'key'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -271,8 +273,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve parent reference on CategoryDraft"
-                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve parent reference on CategoryDraft with key:'key'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -292,8 +294,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on CategoryDraft"
-                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on CategoryDraft with key:'key'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -308,8 +310,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on CategoryDraft"
-                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on CategoryDraft with key:'key'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -257,8 +257,7 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve parent reference on CategoryDraft"
-                + " with key:'key'. Reason: Key is blank (null/empty) on both expanded"
-                + " reference object and reference id field.");
+                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
     }
 
     @Test
@@ -273,8 +272,7 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve parent reference on CategoryDraft"
-                + " with key:'key'. Reason: Key is blank (null/empty) on both expanded"
-                + " reference object and reference id field.");
+                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
     }
 
     @Test
@@ -295,7 +293,7 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on CategoryDraft"
-                + " with key:'key'. Reason: Reference 'id' field value is blank (null/empty).");
+                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
     }
 
     @Test
@@ -311,7 +309,7 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on CategoryDraft"
-                + " with key:'key'. Reason: Reference 'id' field value is blank (null/empty).");
+                + " with key:'key'. Reason: The value of 'id' field of the Resource Identifier is blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -250,7 +250,7 @@ public class CategoryReferenceResolverTest {
     public void resolveParentReference_WithEmptyIdOnParentReference_ShouldNotResolveParentReference() {
         final CategoryDraftBuilder categoryDraft = CategoryDraftBuilder.of(ofEnglish("foo"), ofEnglish("bar"));
         categoryDraft.key("key");
-        categoryDraft.parent(Category.referenceOfId(""));
+        categoryDraft.parent(Category.referenceOfId("").toResourceIdentifier());
 
         assertThat(referenceResolver.resolveParentReference(categoryDraft)
             .toCompletableFuture())
@@ -266,7 +266,7 @@ public class CategoryReferenceResolverTest {
     public void resolveParentReference_WithNullIdOnParentReference_ShouldNotResolveParentReference() {
         final CategoryDraftBuilder categoryDraft = CategoryDraftBuilder.of(ofEnglish("foo"), ofEnglish("bar"));
         categoryDraft.key("key");
-        categoryDraft.parent(Category.referenceOfId(null));
+        categoryDraft.parent(Category.referenceOfId(null).toResourceIdentifier());
 
         assertThat(referenceResolver.resolveParentReference(categoryDraft)
             .toCompletableFuture())

--- a/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
@@ -21,7 +21,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -146,9 +148,8 @@ public class AssetReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on AssetDraft"
-                + " with key:'assetKey'. Reason: The value of 'id' field of the Resource Identifier is blank "
-                + "(null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on AssetDraft with key:'assetKey'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -164,9 +165,8 @@ public class AssetReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on AssetDraft"
-                + " with key:'assetKey'. Reason: The value of 'id' field of the Resource Identifier is blank"
-                + " (null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on AssetDraft with key:'assetKey'. Reason: %s",
+                BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
@@ -147,7 +147,8 @@ public class AssetReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on AssetDraft"
-                + " with key:'assetKey'. Reason: Reference 'id' field value is blank (null/empty).");
+                + " with key:'assetKey'. Reason: The value of 'id' field of the Resource Identifier is blank "
+                + "(null/empty).");
     }
 
     @Test
@@ -164,7 +165,8 @@ public class AssetReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on AssetDraft"
-                + " with key:'assetKey'. Reason: Reference 'id' field value is blank (null/empty).");
+                + " with key:'assetKey'. Reason: The value of 'id' field of the Resource Identifier is blank"
+                + " (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/commons/helpers/CategoryReferencePairTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/CategoryReferencePairTest.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.products.CategoryOrderHints;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -18,10 +19,11 @@ public class CategoryReferencePairTest {
             Arrays.asList(Category.referenceOfId("cat1"), Category.referenceOfId("cat2"));
         final CategoryOrderHints categoryOrderHints = CategoryOrderHints.of("cat1", "0.12");
         final CategoryReferencePair categoryReferencePair =
-            CategoryReferencePair.of(categoryReferences, categoryOrderHints);
+            CategoryReferencePair.of(new HashSet<>(categoryReferences), categoryOrderHints);
 
         assertThat(categoryReferencePair).isNotNull();
-        assertThat(categoryReferencePair.getCategoryReferences()).isEqualTo(categoryReferences);
+        assertThat(categoryReferencePair.getCategoryResourceIdentifiers())
+            .containsExactlyInAnyOrderElementsOf(categoryReferences);
         assertThat(categoryReferencePair.getCategoryOrderHints()).isEqualTo(categoryOrderHints);
     }
 
@@ -30,10 +32,11 @@ public class CategoryReferencePairTest {
         final List<Reference<Category>> categoryReferences =
             Arrays.asList(Category.referenceOfId("cat1"), Category.referenceOfId("cat2"));
         final CategoryReferencePair categoryReferencePair =
-            CategoryReferencePair.of(categoryReferences, null);
+            CategoryReferencePair.of(new HashSet<>(categoryReferences), null);
 
         assertThat(categoryReferencePair).isNotNull();
-        assertThat(categoryReferencePair.getCategoryReferences()).isEqualTo(categoryReferences);
+        assertThat(categoryReferencePair.getCategoryResourceIdentifiers())
+            .containsExactlyInAnyOrderElementsOf(categoryReferences);
         assertThat(categoryReferencePair.getCategoryOrderHints()).isNull();
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/utils/QueryAllTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/QueryAllTest.java
@@ -10,7 +10,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,6 +18,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static io.sphere.sdk.queries.QueryExecutionUtils.DEFAULT_PAGE_SIZE;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -40,8 +40,9 @@ public class QueryAllTest {
         when(mockCategory.getKey()).thenReturn(CATEGORY_KEY);
         when(mockCategory.getId()).thenReturn(CATEGORY_ID);
 
-        final PagedQueryResult<Category> pagedQueryResult =
-            PagedQueryResult.of(Arrays.asList(mockCategory, mockCategory, mockCategory, mockCategory));
+        final PagedQueryResult pagedQueryResult = mock(PagedQueryResult.class);
+        when(pagedQueryResult.getResults()).thenReturn(asList(mockCategory, mockCategory, mockCategory, mockCategory));
+
         when(sphereClient.execute(any())).thenReturn(CompletableFuture.completedFuture(pagedQueryResult));
     }
 

--- a/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
@@ -1,0 +1,37 @@
+package com.commercetools.sync.commons.utils;
+
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.models.ResourceIdentifier;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.toResourceIdentifierIfNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ResourceIdentifierUtilsTest {
+
+    @Test
+    public void toResourceIdentifierIfNotNull_WithNullResource_ShouldReturnNull() {
+        assertThat(toResourceIdentifierIfNotNull(null)).isNull();
+    }
+
+    @Test
+    public void toResourceIdentifierIfNotNull_WithNonNullResource_ShouldReturnCorrectResourceIdentifier() {
+        final Category category = mock(Category.class);
+        when(category.getId()).thenReturn(UUID.randomUUID().toString());
+        when(category.toResourceIdentifier()).thenCallRealMethod();
+        when(category.toReference()).thenCallRealMethod();
+
+        final ResourceIdentifier<Category> categoryResourceIdentifier = toResourceIdentifierIfNotNull(category);
+
+        assertThat(categoryResourceIdentifier).isNotNull();
+        assertThat(categoryResourceIdentifier.getId()).isEqualTo(category.getId());
+        assertThat(categoryResourceIdentifier.getTypeId()).isEqualTo(Category.resourceTypeId());
+    }
+
+
+
+}

--- a/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils;
 
 import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
 import org.junit.Test;
 
@@ -29,6 +30,18 @@ public class ResourceIdentifierUtilsTest {
 
         assertThat(categoryResourceIdentifier).isNotNull();
         assertThat(categoryResourceIdentifier.getId()).isEqualTo(category.getId());
+        assertThat(categoryResourceIdentifier.getTypeId()).isEqualTo(Category.resourceTypeId());
+    }
+
+    @Test
+    public void toResourceIdentifierIfNotNull_WithNonNullReference_ShouldReturnCorrectResourceIdentifier() {
+        final Reference<Category> categoryReference = Category.referenceOfId("foo");
+
+        final ResourceIdentifier<Category> categoryResourceIdentifier = toResourceIdentifierIfNotNull(
+            categoryReference);
+
+        assertThat(categoryResourceIdentifier).isNotNull();
+        assertThat(categoryResourceIdentifier.getId()).isEqualTo("foo");
         assertThat(categoryResourceIdentifier.getTypeId()).isEqualTo(Category.resourceTypeId());
     }
 

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -366,8 +366,8 @@ public class InventorySyncTest {
         assertThat(errorCallBackMessages).isNotEmpty();
         assertThat(errorCallBackMessages.get(0)).contains(format("Failed to resolve references on"
             + " InventoryEntryDraft with SKU:'%s'. Reason: %s: Failed to resolve custom type reference on "
-            + "InventoryEntryDraft with SKU:'1000'. Reason: Reference 'id' field value is"
-            + " blank (null/empty).", SKU_1, ReferenceResolutionException.class.getCanonicalName()));
+            + "InventoryEntryDraft with SKU:'1000'. Reason: The value of 'id' field of the Resource Identifier is blank"
+            + " (null/empty).", SKU_1, ReferenceResolutionException.class.getCanonicalName()));
         assertThat(errorCallBackExceptions).isNotEmpty();
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(CompletionException.class);
         assertThat(errorCallBackExceptions.get(0).getCause()).isExactlyInstanceOf(ReferenceResolutionException.class);

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getCompletionStageWithException;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockInventoryEntry;
@@ -366,8 +367,8 @@ public class InventorySyncTest {
         assertThat(errorCallBackMessages).isNotEmpty();
         assertThat(errorCallBackMessages.get(0)).contains(format("Failed to resolve references on"
             + " InventoryEntryDraft with SKU:'%s'. Reason: %s: Failed to resolve custom type reference on "
-            + "InventoryEntryDraft with SKU:'1000'. Reason: The value of 'id' field of the Resource Identifier is blank"
-            + " (null/empty).", SKU_1, ReferenceResolutionException.class.getCanonicalName()));
+            + "InventoryEntryDraft with SKU:'1000'. Reason: %s", SKU_1,
+            ReferenceResolutionException.class.getCanonicalName(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
         assertThat(errorCallBackExceptions).isNotEmpty();
         assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(CompletionException.class);
         assertThat(errorCallBackExceptions.get(0).getCause()).isExactlyInstanceOf(ReferenceResolutionException.class);

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -27,7 +27,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -286,9 +288,8 @@ public class InventoryReferenceResolverTest {
                              assertThat(exception.getCause())
                                  .isExactlyInstanceOf(ReferenceResolutionException.class);
                              assertThat(exception.getCause().getMessage())
-                                 .isEqualTo("Failed to resolve custom type reference on InventoryEntryDraft"
-                                     + " with SKU:'1000'. Reason: The value of 'id' field of the Resource Identifier is"
-                                     + " blank (null/empty).");
+                                 .isEqualTo(format("Failed to resolve custom type reference on InventoryEntryDraft"
+                                     + " with SKU:'1000'. Reason: %s", BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
                              return null;
                          }).toCompletableFuture().join();
     }

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -287,8 +287,8 @@ public class InventoryReferenceResolverTest {
                                  .isExactlyInstanceOf(ReferenceResolutionException.class);
                              assertThat(exception.getCause().getMessage())
                                  .isEqualTo("Failed to resolve custom type reference on InventoryEntryDraft"
-                                         + " with SKU:'1000'. Reason: Reference 'id' field value is blank"
-                                         + " (null/empty).");
+                                     + " with SKU:'1000'. Reason: The value of 'id' field of the Resource Identifier is"
+                                     + " blank (null/empty).");
                              return null;
                          }).toCompletableFuture().join();
     }

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
@@ -27,8 +27,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -140,9 +142,8 @@ public class PriceReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on PriceDraft"
-                + " with country:'DE' and value: 'EUR 10'. Reason: The value of 'id' field of the Resource Identifier"
-                + " is blank (null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on PriceDraft"
+                + " with country:'DE' and value: 'EUR 10'. Reason: %s", BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -160,9 +161,8 @@ public class PriceReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve custom type reference on PriceDraft"
-                + " with country:'DE' and value: 'EUR 10'. Reason: The value of 'id' field of the Resource Identifier"
-                + " is blank (null/empty).");
+            .hasMessage(format("Failed to resolve custom type reference on PriceDraft"
+                + " with country:'DE' and value: 'EUR 10'. Reason: %s", BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
@@ -141,8 +141,8 @@ public class PriceReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on PriceDraft"
-                + " with country:'DE' and value: 'EUR 10'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + " with country:'DE' and value: 'EUR 10'. Reason: The value of 'id' field of the Resource Identifier"
+                + " is blank (null/empty).");
     }
 
     @Test
@@ -161,8 +161,8 @@ public class PriceReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve custom type reference on PriceDraft"
-                + " with country:'DE' and value: 'EUR 10'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + " with country:'DE' and value: 'EUR 10'. Reason: The value of 'id' field of the Resource Identifier"
+                + " is blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
@@ -286,8 +286,8 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'category' on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field value is blank "
-                + "(null/empty).");
+                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
+                + " Identifier is blank (null/empty).");
     }
 
     @Test
@@ -309,8 +309,8 @@ public class CategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'category' on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field value is blank "
-                + "(null/empty).");
+                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
+                + " Identifier is blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import static com.commercetools.sync.categories.CategorySyncMockUtils.getMockCategory;
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
 import static com.commercetools.sync.commons.MockUtils.mockCategoryService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithRandomProductTypeUuid;
@@ -35,6 +36,7 @@ import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProduc
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductTypeService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockStateService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockTaxCategoryService;
+import static java.lang.String.format;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -285,9 +287,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'category' on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
-                + " Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'category' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -308,9 +309,8 @@ public class CategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'category' on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
-                + " Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'category' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithProductTypeRef;
@@ -28,6 +29,7 @@ import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProduc
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductTypeService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockStateService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockTaxCategoryService;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -130,9 +132,8 @@ public class ProductTypeReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve product type reference on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
-                + " Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve product type reference on ProductDraft"
+                + " with key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -144,9 +145,8 @@ public class ProductTypeReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve product type reference on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
-                + " Identifier is blank (null/empty).");
+            .hasMessage(format("Failed to resolve product type reference on ProductDraft"
+                + " with key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
@@ -131,8 +131,8 @@ public class ProductTypeReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve product type reference on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
+                + " Identifier is blank (null/empty).");
     }
 
     @Test
@@ -145,8 +145,8 @@ public class ProductTypeReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve product type reference on ProductDraft"
-                + " with key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + " with key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource"
+                + " Identifier is blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
@@ -142,8 +142,8 @@ public class StateReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'state' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier"
+                + " is blank (null/empty).");
     }
 
     @Test
@@ -157,8 +157,8 @@ public class StateReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'state' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
+                + " blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithRandomProductTypeUuid;
@@ -27,6 +28,7 @@ import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProduc
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductTypeService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockStateService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockTaxCategoryService;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -141,9 +143,8 @@ public class StateReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'state' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier"
-                + " is blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'state' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -156,9 +157,8 @@ public class StateReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'state' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
-                + " blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'state' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
@@ -142,8 +142,8 @@ public class TaxCategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'tax-category' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
+                + " blank (null/empty).");
     }
 
     @Test
@@ -157,8 +157,8 @@ public class TaxCategoryReferenceResolverTest {
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
             .hasMessage("Failed to resolve reference 'tax-category' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: Reference 'id' field"
-                + " value is blank (null/empty).");
+                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
+                + " blank (null/empty).");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockChannelService;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getBuilderWithRandomProductTypeUuid;
@@ -27,6 +28,7 @@ import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProduc
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockProductTypeService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockStateService;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getMockTaxCategoryService;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -141,9 +143,8 @@ public class TaxCategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'tax-category' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
-                + " blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'tax-category' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test
@@ -156,9 +157,8 @@ public class TaxCategoryReferenceResolverTest {
             .hasFailed()
             .hasFailedWithThrowableThat()
             .isExactlyInstanceOf(ReferenceResolutionException.class)
-            .hasMessage("Failed to resolve reference 'tax-category' on ProductDraft with "
-                + "key:'" + productBuilder.getKey() + "'. Reason: The value of 'id' field of the Resource Identifier is"
-                + " blank (null/empty).");
+            .hasMessage(format("Failed to resolve reference 'tax-category' on ProductDraft with "
+                + "key:'%s'. Reason: %s", productBuilder.getKey(), BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.commercetools.sync.products.ProductSyncMockUtils.getChannelMock;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getPriceMockWithChannelReference;
@@ -37,6 +36,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -346,8 +346,8 @@ public class ProductReferenceReplacementUtilsTest {
         final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
-        assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryId);
+
+        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(categoryReferences);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -366,8 +366,8 @@ public class ProductReferenceReplacementUtilsTest {
         final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
-        assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryId);
+
+        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(categoryReferences);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -391,12 +391,13 @@ public class ProductReferenceReplacementUtilsTest {
         final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
-        assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryKey);
+
+        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(
+            singleton(Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey)));
+
         assertThat(categoryOrderHintsWithKeys).isNotNull();
-        assertThat(categoryOrderHintsWithKeys.getAsMap()).hasSize(1);
-        assertThat(categoryOrderHintsWithKeys.get(categoryKey))
-            .isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints().getAsMap().get(category.getId()));
+        assertThat(categoryOrderHintsWithKeys.getAsMap()).containsOnly(entry(categoryKey,
+            product.getMasterData().getStaged().getCategoryOrderHints().getAsMap().get(category.getId())));
     }
 
     @Test
@@ -415,8 +416,9 @@ public class ProductReferenceReplacementUtilsTest {
         final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
-        assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryKey);
+
+        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(
+            singleton(Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey)));
         assertThat(categoryOrderHintsWithKeys).isNull();
     }
 
@@ -450,18 +452,14 @@ public class ProductReferenceReplacementUtilsTest {
         final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
-        assertThat(categoryReferencesWithKeys).hasSize(2);
 
-        final List<String> referenceIds = categoryReferencesWithKeys.stream().map(ResourceIdentifier::getId)
-                                                                    .collect(Collectors.toList());
-
-        assertThat(referenceIds).contains(categoryKey1);
-        assertThat(referenceIds).contains(categoryKey2);
+        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(asList(
+            Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey1),
+            Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey2)));
 
         assertThat(categoryOrderHintsWithKeys).isNotNull();
-        assertThat(categoryOrderHintsWithKeys.getAsMap()).hasSize(1);
-        assertThat(categoryOrderHintsWithKeys.get(categoryKey1))
-            .isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints().getAsMap().get(category1.getId()));
+        assertThat(categoryOrderHintsWithKeys.getAsMap()).containsOnly(entry(categoryKey1,
+            product.getMasterData().getStaged().getCategoryOrderHints().getAsMap().get(category1.getId())));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -99,11 +99,13 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getProductType)
                                                      .extracting(ResourceIdentifier::getId)
-                                                     .containsExactly(productType.getId(), productType.getKey(), productType.getKey());
+                                                     .containsExactly(productType.getId(), productType.getKey(),
+                                                         productType.getKey());
 
         assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getTaxCategory)
                                                      .extracting(ResourceIdentifier::getId)
-                                                     .containsExactly(taxCategory.getKey(), taxCategory.getId(), taxCategory.getKey());
+                                                     .containsExactly(taxCategory.getKey(), taxCategory.getId(),
+                                                         taxCategory.getKey());
 
         assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getState)
                                                      .extracting(ResourceIdentifier::getId)

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -343,10 +343,11 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.get(0).getId()).isEqualTo(categoryId);
+        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryId);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -362,10 +363,11 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.get(0).getId()).isEqualTo(categoryId);
+        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryId);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -386,10 +388,11 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.get(0).getId()).isEqualTo(categoryKey);
+        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryKey);
         assertThat(categoryOrderHintsWithKeys).isNotNull();
         assertThat(categoryOrderHintsWithKeys.getAsMap()).hasSize(1);
         assertThat(categoryOrderHintsWithKeys.get(categoryKey))
@@ -409,10 +412,11 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).hasSize(1);
-        assertThat(categoryReferencesWithKeys.get(0).getId()).isEqualTo(categoryKey);
+        assertThat(categoryReferencesWithKeys.iterator().next().getId()).isEqualTo(categoryKey);
         assertThat(categoryOrderHintsWithKeys).isNull();
     }
 
@@ -443,11 +447,12 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).hasSize(2);
 
-        final List<String> referenceIds = categoryReferencesWithKeys.stream().map(Reference::getId)
+        final List<String> referenceIds = categoryReferencesWithKeys.stream().map(ResourceIdentifier::getId)
                                                                     .collect(Collectors.toList());
 
         assertThat(referenceIds).contains(categoryKey1);
@@ -468,7 +473,8 @@ public class ProductReferenceReplacementUtilsTest {
 
         assertThat(categoryReferencePair).isNotNull();
 
-        final List<Reference<Category>> categoryReferencesWithKeys = categoryReferencePair.getCategoryReferences();
+        final Set<ResourceIdentifier<Category>> categoryReferencesWithKeys =
+            categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
         assertThat(categoryReferencesWithKeys).isEmpty();
         assertThat(categoryOrderHintsWithKeys).isNull();

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -8,11 +8,13 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.CategoryOrderHints;
 import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductCatalogData;
 import io.sphere.sdk.products.ProductData;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.states.State;
@@ -95,20 +97,17 @@ public class ProductReferenceReplacementUtilsTest {
         final List<ProductDraft> productDraftsWithKeysOnReferences = ProductReferenceReplacementUtils
             .replaceProductsReferenceIdsWithKeys(products);
 
-        assertThat(productDraftsWithKeysOnReferences).hasSize(3);
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getProductType)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(productType.getId(), productType.getKey(), productType.getKey());
 
-        assertThat(productDraftsWithKeysOnReferences.get(0).getProductType().getId()).isEqualTo(productType.getId());
-        assertThat(productDraftsWithKeysOnReferences.get(0).getTaxCategory().getId()).isEqualTo(taxCategory.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(0).getState().getId()).isEqualTo(state.getKey());
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getTaxCategory)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(taxCategory.getKey(), taxCategory.getId(), taxCategory.getKey());
 
-        assertThat(productDraftsWithKeysOnReferences.get(1).getProductType().getId()).isEqualTo(productType.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(1).getTaxCategory().getId()).isEqualTo(taxCategory.getId());
-        assertThat(productDraftsWithKeysOnReferences.get(1).getState().getId()).isEqualTo(state.getKey());
-
-        assertThat(productDraftsWithKeysOnReferences.get(2).getProductType().getId()).isEqualTo(productType.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(2).getTaxCategory().getId()).isEqualTo(taxCategory.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(2).getState().getId()).isEqualTo(state.getId());
-
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getState)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(state.getKey(), state.getKey(), state.getId());
     }
 
     @Test
@@ -161,27 +160,27 @@ public class ProductReferenceReplacementUtilsTest {
         final List<ProductDraft> productDraftsWithKeysOnReferences = ProductReferenceReplacementUtils
             .replaceProductsReferenceIdsWithKeys(products);
 
-        assertThat(productDraftsWithKeysOnReferences).hasSize(2);
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getProductType)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(productType.getId(), productType.getKey());
 
-        assertThat(productDraftsWithKeysOnReferences.get(0).getProductType().getId()).isEqualTo(productType.getId());
-        assertThat(productDraftsWithKeysOnReferences.get(0).getTaxCategory().getId()).isEqualTo(taxCategory.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(0).getState().getId()).isEqualTo(state.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(0).getMasterVariant().getPrices().get(0).getChannel().getId())
-            .isEqualTo(channel.getKey());
+        assertThat(productDraftsWithKeysOnReferences).flatExtracting(ProductDraft::getCategories)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(category.getKey());
 
-        final Set<ResourceIdentifier<Category>> categoryResourceIdentifiers =
-            productDraftsWithKeysOnReferences.get(0).getCategories();
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getTaxCategory)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(taxCategory.getKey(), taxCategory.getId());
 
-        assertThat(categoryResourceIdentifiers).hasSize(1);
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getState)
+                                                     .extracting(ResourceIdentifier::getId)
+                                                     .containsExactly(state.getKey(), state.getKey());
 
-        assertThat(categoryResourceIdentifiers)
-            .containsOnlyElementsOf(singletonList(Category.referenceOfId(category.getKey())));
-
-        assertThat(productDraftsWithKeysOnReferences.get(1).getProductType().getId()).isEqualTo(productType.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(1).getTaxCategory().getId()).isEqualTo(taxCategory.getId());
-        assertThat(productDraftsWithKeysOnReferences.get(1).getState().getId()).isEqualTo(state.getKey());
-        assertThat(productDraftsWithKeysOnReferences.get(1).getMasterVariant().getPrices().get(0).getChannel().getId())
-            .isEqualTo(channel.getKey());
+        assertThat(productDraftsWithKeysOnReferences).extracting(ProductDraft::getMasterVariant)
+                                                     .flatExtracting(ProductVariantDraft::getPrices)
+                                                     .extracting(PriceDraft::getChannel)
+                                                     .extracting(Reference::getId)
+                                                     .containsExactly(channel.getKey(), channel.getKey());
     }
 
     @Test
@@ -347,7 +346,8 @@ public class ProductReferenceReplacementUtilsTest {
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
-        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(categoryReferences);
+        assertThat(categoryReferencesWithKeys).extracting(ResourceIdentifier::getId)
+                                              .containsExactlyInAnyOrder(categoryId);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -367,7 +367,8 @@ public class ProductReferenceReplacementUtilsTest {
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
-        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(categoryReferences);
+        assertThat(categoryReferencesWithKeys).extracting(ResourceIdentifier::getId)
+                                              .containsExactlyInAnyOrder(categoryId);
         assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getMasterData().getStaged().getCategoryOrderHints());
     }
 
@@ -417,8 +418,8 @@ public class ProductReferenceReplacementUtilsTest {
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
-        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(
-            singleton(Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey)));
+        assertThat(categoryReferencesWithKeys).extracting(ResourceIdentifier::getId)
+                                              .containsExactlyInAnyOrder(categoryKey);
         assertThat(categoryOrderHintsWithKeys).isNull();
     }
 
@@ -453,9 +454,9 @@ public class ProductReferenceReplacementUtilsTest {
             categoryReferencePair.getCategoryResourceIdentifiers();
         final CategoryOrderHints categoryOrderHintsWithKeys = categoryReferencePair.getCategoryOrderHints();
 
-        assertThat(categoryReferencesWithKeys).containsExactlyInAnyOrderElementsOf(asList(
-            Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey1),
-            Reference.ofResourceTypeIdAndId(Category.referenceTypeId(), categoryKey2)));
+
+        assertThat(categoryReferencesWithKeys).extracting(ResourceIdentifier::getId)
+                                              .containsExactlyInAnyOrder(categoryKey1, categoryKey2);
 
         assertThat(categoryOrderHintsWithKeys).isNotNull();
         assertThat(categoryOrderHintsWithKeys.getAsMap()).containsOnly(entry(categoryKey1,


### PR DESCRIPTION
#### Summary
This PR addresses updating the JVM SDK to version [1.29.0](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-771e2d81321cde33fec338d366924359R2) and addresses all the breaking changes resulting from this update:
Breaking changes are:
1. `CategoryDraft.parent` field now takes a `ResourceIdentifier<Category>` instead of `Reference<Category>`.
2. The `ProductDraft.categories` field now takes a `Set<ResourceIdentifier<Category>>` instead of 
`List<Reference<Category>>`
3. Deprecated method: `PagedQueryResult#of`


#### Hints for Review
1. `getParentCategoryKey` now gets it directly from the id field. Before, it is used to attempt to get it from the expansion in the category reference. But now, since it is a resource identifier and not a reference, so this step is now [omitted](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-7af94039b5018756bcec77f6203a1609).
2. Change of an [error message wording](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-30fa4801fa858d263119fb1fee97f608R70)
3. [`CategoryReferencePair`](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-f6c488c8250e241bdc3cf00bc96421bf) has now also changed to return set of `categoryResourceIdentifiers` instead of list of references.
4. Introduced the new [`ResourceIndentifierUtils#toResourceIdentifierIfNotNull`](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-7bd8478ddb8c79365c1dc721120d0ca4) | [unit tests](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-22a865a05fa998824ce961fe29ded487)
5. Mock [`PagedQueryResult`](https://github.com/commercetools/commercetools-sync-java/pull/267/files#diff-cc4443b639138096e8d3a02b41c582e2R43) instead of using the now deprecated `PagedQueryResult#of` method. 

#### Relevant Issues
#262 

#### Todo

- Tests
    - [x] Unit 
- [x] Documentation
- [x] Add Release Notes entry.
