### PR TITLE
Fix release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
-      script: ./gradlew clean setLibraryVersion build
+      script: ./gradlew clean setLibraryVersion build --debug --stacktrace
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -19,8 +19,7 @@ gitPublish {
 
     // what to keep in the existing branch (include=keep)
     preserve {
-        include 'v/**'
-        include 'benchmarks/**'
+        include 'v/**', 'benchmarks/**'
         exclude 'v/test**' // always remove documentation of test releases
     }
 

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -7,10 +7,12 @@ gitPublish {
 
     branch = 'gh-pages'
 
-    // what to publish, this is a standard CopySpec
+    // Copies the output of the 'javadoc' task into the path value passed to the 'into' method.
+    // More about it:
+    // https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html#from-java.lang.Object-groovy.lang.Closure-
+    // https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-
     contents {
-        from 'src/pages'
-        from(javadoc) {
+        from (javadoc) {
             into "v/$rootProject.version"
         }
     }

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -5,8 +5,6 @@ gitPublish {
     //    https://github.com/ajoberstar/grgit#usage
     // 2) to use GH token `repoUri` must have an https (not git or ssh) protocol
 
-    // The .toString() is temporarily used for this issue: https://github.com/ajoberstar/gradle-git-publish/issues/50
-    repoUri = scmHttpsUrl.toString()
     branch = 'gh-pages'
 
     // what to publish, this is a standard CopySpec


### PR DESCRIPTION
Add ` --debug --stacktrace` for the gradle build command to investigate the error on publishing the Javadocs after releasing.