### PR TITLE
Fix release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
-      script: -Dbuild.version="test" gitPublishPush --debug --stacktrace
+      script: ./gradlew gitPublishPush --debug --stacktrace -Dbuild.version="test"
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
-      script: ./gradlew gitPublishPush --debug --stacktrace -Dbuild.version="test"
+      script: ./gradlew clean setLibraryVersion build
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
-      script: ./gradlew clean setLibraryVersion build --debug --stacktrace
+      script: -Dbuild.version="test" gitPublishPush --debug --stacktrace
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.jfrog.bintray' version '1.8.0'
-    id 'org.ajoberstar.git-publish' version '1.0.0'
+    id 'org.ajoberstar.git-publish' version '1.0.1'
     id 'com.adarshr.test-logger' version '1.2.0'
     id 'org.ajoberstar.grgit' version '2.2.1'
 }

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -5,7 +5,12 @@ gitPublish {
     //    https://github.com/ajoberstar/grgit#usage
     // 2) to use GH token `repoUri` must have an https (not git or ssh) protocol
 
+    // The .toString() is temporarily used for this issue: https://github.com/ajoberstar/gradle-git-publish/issues/50
+    repoUri = scmHttpsUrl.toString()
     branch = 'gh-pages'
+
+    println("###########GITPUBLISH:  IS TESTING THE GRGIT###########")
+    grgit.remote.list().each { println it }
 
     // Copies the output of the 'javadoc' task into the path value passed to the 'into' method.
     // More about it:
@@ -57,5 +62,10 @@ gitPublishReset {
         }
 
         validateVersion('Documentation publishing could be performed only with a valid release version')
+    }
+
+    doLast {
+        println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########")
+        grgit.remote.list().each { println it }
     }
 }

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -9,9 +9,6 @@ gitPublish {
     repoUri = scmHttpsUrl.toString()
     branch = 'gh-pages'
 
-    println("###########GITPUBLISH:  IS TESTING THE GRGIT###########")
-    grgit.remote.list().each { println it }
-
     // Copies the output of the 'javadoc' task into the path value passed to the 'into' method.
     // More about it:
     // https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html#from-java.lang.Object-groovy.lang.Closure-
@@ -42,9 +39,6 @@ gitPublishReset {
          interrupt the task if neither of them is set.
         */
 
-        println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########1")
-        grgit.remote.list().each { println it }
-
         final authProperty = 'org.ajoberstar.grgit.auth.username'
         if (!System.getProperty(authProperty)?.trim()) {
             def githubToken =
@@ -63,9 +57,6 @@ gitPublishReset {
             }
 
             System.setProperty(authProperty, githubToken)
-
-            println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########2")
-            grgit.remote.list().each { println it }
         }
 
         validateVersion('Documentation publishing could be performed only with a valid release version')

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -5,10 +5,7 @@ gitPublish {
     //    https://github.com/ajoberstar/grgit#usage
     // 2) to use GH token `repoUri` must have an https (not git or ssh) protocol
 
-    // The .toString() is temporarily used for this issue: https://github.com/ajoberstar/gradle-git-publish/issues/50
-    repoUri = scmHttpsUrl.toString()
     branch = 'gh-pages'
-
     // Copies the output of the 'javadoc' task into the path value passed to the 'into' method.
     // More about it:
     // https://docs.gradle.org/current/javadoc/org/gradle/api/file/CopySpec.html#from-java.lang.Object-groovy.lang.Closure-

--- a/gradle-scripts/javadocs-publish.gradle
+++ b/gradle-scripts/javadocs-publish.gradle
@@ -41,6 +41,10 @@ gitPublishReset {
              3) $GH_TOKEN
          interrupt the task if neither of them is set.
         */
+
+        println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########1")
+        grgit.remote.list().each { println it }
+
         final authProperty = 'org.ajoberstar.grgit.auth.username'
         if (!System.getProperty(authProperty)?.trim()) {
             def githubToken =
@@ -59,13 +63,11 @@ gitPublishReset {
             }
 
             System.setProperty(authProperty, githubToken)
+
+            println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########2")
+            grgit.remote.list().each { println it }
         }
 
         validateVersion('Documentation publishing could be performed only with a valid release version')
-    }
-
-    doLast {
-        println("######################GITPUBLISHRESET: IS TESTING THE GRGIT###########")
-        grgit.remote.list().each { println it }
     }
 }


### PR DESCRIPTION
#### Summary
This PR upgrades 'org.ajoberstar.git-publish' to version '1.0.1' due to a discovered problem with the previous version which was preventing the library from being pushed:https://github.com/ajoberstar/gradle-git-publish/issues/51