### PR TITLE
Fix bintray publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.jfrog.bintray' version '1.8.0'
+    id 'com.jfrog.bintray' version '1.8.1'
     id 'org.ajoberstar.git-publish' version '1.0.1'
     id 'com.adarshr.test-logger' version '1.2.0'
     id 'org.ajoberstar.grgit' version '2.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.jfrog.bintray' version '1.8.1'
     id 'org.ajoberstar.git-publish' version '1.0.1'
-    id 'com.adarshr.test-logger' version '1.2.0'
+    id 'com.adarshr.test-logger' version '1.3.1'
     id 'org.ajoberstar.grgit' version '2.2.1'
 }
 


### PR DESCRIPTION
#### Summary
This PR addresses:

1. Fixing the [failed build](https://travis-ci.org/commercetools/commercetools-sync-java/jobs/398305021#L2146) due to a bug in the bintray gradle plugin (https://github.com/bintray/gradle-bintray-plugin/issues/242) which was fixed in new version '1.8.1'.

2. Boy-scout-change: update test-logger gradle plugin.