### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 
 # Benchmarks
 benchmarks.json
+
+out

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
-      script: ./gradlew clean setLibraryVersion build
+      script: ./gradlew clean dependencyUpdates setLibraryVersion build
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.ajoberstar.git-publish' version '1.0.1'
     id 'com.adarshr.test-logger' version '1.3.1'
     id 'org.ajoberstar.grgit' version '2.2.1'
+    id "com.github.ben-manes.versions" version '0.20.0'
 }
 
 apply from: "$rootDir/gradle-scripts/plugins.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.jfrog.bintray' version '1.8.1'
+    id 'com.jfrog.bintray' version '1.8.3'
     id 'org.ajoberstar.git-publish' version '1.0.1'
     id 'com.adarshr.test-logger' version '1.3.1'
     id 'org.ajoberstar.grgit' version '2.2.1'

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,8 +1,8 @@
 ext{
-    commercetoolsJvmSdkVersion = '1.32.0'
-    mockitoVersion = '2.18.3'
+    commercetoolsJvmSdkVersion = '1.33.0'
+    mockitoVersion = '2.19.0'
     jUnitVersion = '4.12'
-    assertjVersion = '3.9.1'
+    assertjVersion = '3.10.0'
     checkstyleVersion = '8.10.1'
     pmdVersion = '5.8.1'
     jacocoVersion = '0.8.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Summary
1. Add `com.github.ben-manes.versions` to check for latest dependency updates.
2. Run the `dependencyUpdates` task in the CI build to show the latest dependencies:
````bash
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:1.3.1
 - com.commercetools.sdk.jvm.core:commercetools-convenience:1.33.0
 - com.commercetools.sdk.jvm.core:commercetools-java-client:1.33.0
 - com.commercetools.sdk.jvm.core:commercetools-models:1.33.0
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.20.0
 - com.google.code.findbugs:annotations:3.0.1
 - com.jfrog.bintray:com.jfrog.bintray.gradle.plugin:1.8.3
 - junit:junit:4.12
 - org.ajoberstar.git-publish:org.ajoberstar.git-publish.gradle.plugin:1.0.1
 - org.assertj:assertj-core:3.10.0
 - org.mockito:mockito-core:2.19.0

The following dependencies have later milestone versions:
 - org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin [2.2.1 -> 3.0.0-beta.1]

Gradle updates:
 - Gradle: [4.8.1 -> 4.9-rc-1]

Generated report file build/dependencyUpdates/report.txt
````
3. Update the following dependencies:
  - `com.jfrog.bintray`
  - assertJ
  - commercetools JVM SDK
  - mockito