### PR TITLE
WIP: 101 Add unit tests for ProductVariantUpdateActionUtils#buildProductVariantPricesUpdateActions

### DIFF
--- a/src/test/java/com/commercetools/sync/commons/MockUtils.java
+++ b/src/test/java/com/commercetools/sync/commons/MockUtils.java
@@ -44,6 +44,33 @@ public class MockUtils {
         return CustomFieldsDraft.ofTypeIdAndJson("StepCategoryTypeId", customFieldsJsons);
     }
 
+    /**
+     * Returns mock {@link CustomFields} instance. Executing {@link CustomFields#getType()} on returned instance will
+     * return {@link Reference} of given {@code typeId} with mock {@link Type} instance of {@code typeId} and {@code
+     * typeKey} (getters of key and id would return given values). Executing {@link CustomFields#getFieldsJsonMap()} on
+     * returned instance will return {@link Map} populated with given {@code fieldName} and {@code fieldValue}
+     *
+     * @param typeId custom type id
+     * @param fieldName custom field name
+     * @param fieldValue custom field value
+     * @return mock instance of {@link CustomFields}
+     */
+    public static CustomFields getMockCustomFields(final String typeId, final String fieldName,
+                                                   final JsonNode fieldValue) {
+        final CustomFields customFields = mock(CustomFields.class);
+        final Type type = mock(Type.class);
+        when(type.getId()).thenReturn(typeId);
+        when(customFields.getFieldsJsonMap()).thenReturn(mockFields(fieldName, fieldValue));
+        when(customFields.getType()).thenReturn(Type.referenceOfId(typeId).filled(type));
+        return customFields;
+    }
+
+    private static Map<String, JsonNode> mockFields(final String name, final JsonNode value) {
+        final HashMap<String, JsonNode> fields = new HashMap<>();
+        fields.put(name, value);
+        return fields;
+    }
+
     public static CategoryService mockCategoryService(@Nonnull final Set<Category> existingCategories,
                                                       @Nonnull final Set<Category> createdCategories) {
         final CategoryService mockCategoryService = mock(CategoryService.class);

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncMockUtils.java
@@ -2,20 +2,16 @@ package com.commercetools.sync.inventories;
 
 import com.commercetools.sync.services.ChannelService;
 import com.commercetools.sync.services.InventoryService;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.channels.ChannelRole;
 import io.sphere.sdk.inventory.InventoryEntry;
 import io.sphere.sdk.inventory.InventoryEntryDraft;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
-import io.sphere.sdk.types.CustomFieldsDraftBuilder;
-import io.sphere.sdk.types.Type;
 
 import javax.annotation.Nonnull;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -74,33 +70,7 @@ public class InventorySyncMockUtils {
         return inventoryEntry;
     }
 
-    /**
-     * Returns mock {@link CustomFields} instance. Executing {@link CustomFields#getType()} on returned instance will
-     * return {@link Reference} of given {@code typeId} with mock {@link Type} instance of {@code typeId} and {@code
-     * typeKey} (getters of key and id would return given values). Executing {@link CustomFields#getFieldsJsonMap()} on
-     * returned instance will return {@link Map} populated with given {@code fieldName} and {@code fieldValue}
-     *
-     * @param typeId custom type id
-     * @param fieldName custom field name
-     * @param fieldValue custom field value
-     * @return mock instance of {@link CustomFields}
-     */
-    public static CustomFields getMockCustomFields(final String typeId, final String fieldName,
-                                                   final Object fieldValue) {
-        final CustomFields customFields = mock(CustomFields.class);
-        final Type type = mock(Type.class);
-        when(type.getId()).thenReturn(typeId);
-        when(customFields.getFieldsJsonMap()).thenReturn(mockFields(fieldName, fieldValue));
-        when(customFields.getType()).thenReturn(Type.referenceOfId(typeId).filled(type));
-        return customFields;
-    }
 
-    private static Map<String, JsonNode> mockFields(final String name, final Object obj) {
-        return CustomFieldsDraftBuilder.ofTypeKey("123")
-                .addObject(name, obj)
-                .build()
-                .getFields();
-    }
 
     /**
      * Returns mock instance of {@link InventoryService}. Executing any method with any parameter on this instance

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventorySyncUtilsTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.inventories.utils;
 
 import com.commercetools.sync.inventories.InventorySyncOptionsBuilder;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
@@ -24,7 +25,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockCustomFields;
+import static com.commercetools.sync.commons.MockUtils.getMockCustomFields;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockInventoryEntry;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockSupplyChannel;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,8 +53,8 @@ public class InventorySyncUtilsTest {
     public void setup() {
         final Channel channel = getMockSupplyChannel("111", "key1");
         final Reference<Channel> reference = Channel.referenceOfId("111").filled(channel);
-        final CustomFields customFields =
-            getMockCustomFields(CUSTOM_TYPE_ID, CUSTOM_FIELD_1_NAME, CUSTOM_FIELD_1_VALUE);
+        final CustomFields customFields = getMockCustomFields(CUSTOM_TYPE_ID, CUSTOM_FIELD_1_NAME,
+            JsonNodeFactory.instance.textNode(CUSTOM_FIELD_1_VALUE));
 
         inventoryEntry = getMockInventoryEntry("123", 10L, 10, DATE_1, reference, null);
         inventoryEntryWithCustomField1 = getMockInventoryEntry("123", 10L, 10, DATE_1, reference, customFields);

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
@@ -1,0 +1,539 @@
+package com.commercetools.sync.products.utils.productvariantupdateactionutils.prices;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.commands.updateactions.AddPrice;
+import io.sphere.sdk.products.commands.updateactions.ChangePrice;
+import io.sphere.sdk.products.commands.updateactions.RemovePrice;
+import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomField;
+import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomType;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildProductVariantPricesUpdateActions;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_02_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_03_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_222_EUR_03_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_222_EUR_CUST1;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_22_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_333_USD_CUST1;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_FR_888_EUR_01_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_FR_999_EUR_03_06;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_777_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_777_EUR_05_07;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_111_GBP;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_111_GBP_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_22_USD_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_333_GBP_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_444_GBP_04_06;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_666_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_999_GBP;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_US_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_US_666_USD_CUST1_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_US_666_USD_CUST2_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_111_EUR;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_111_EUR_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_111_EUR_02_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_22_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_345_EUR_CUST2;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_567_EUR_CUST2;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.DE_666_EUR;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.FR_777_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.NE_123_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.NE_321_EUR_04_06;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_111_GBP_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_111_GBP_02_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_1_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDY;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_22_USD_CUSTOMTYPE2_CUSTOMFIELDX;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.UK_333_GBP_02_05;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.US_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceFixtures.US_555_USD_CUST2_01_02;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BuildProductVariantPricesUpdateActionsTest {
+
+    private static final ProductVariant oldProductVariant = mock(ProductVariant.class);
+    private static final ProductVariantDraft newProductVariant = mock(ProductVariantDraft.class);
+
+    @BeforeClass
+    public static void setup() {
+        when(oldProductVariant.getId()).thenReturn(101);
+    }
+
+    /**
+     * Case#1
+     */
+    @Test
+    public void withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+        // Preparation
+        when(oldProductVariant.getPrices()).thenReturn(emptyList());
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).isEmpty();
+    }
+
+    /**
+     * Case#1
+     */
+    @Test
+    public void withEmptyNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+        // Preparation
+        when(oldProductVariant.getPrices()).thenReturn(emptyList());
+        when(newProductVariant.getPrices()).thenReturn(emptyList());
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).isEmpty();
+    }
+
+    /**
+     * Case#2
+     */
+    @Test
+    public void withAllMatchingPrices_ShouldBuildNoActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_USD);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_USD,
+            DE_111_EUR,
+            DE_111_EUR_01_02,
+            US_111_USD);
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).isEmpty();
+    }
+
+    /**
+     * Case#3
+     */
+    @Test
+    public void withNonEmptyNewPricesButEmptyExistingPrices_ShouldBuildAddPriceActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_02_03,
+            DRAFT_DE_111_USD,
+            DRAFT_UK_111_GBP);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        when(oldProductVariant.getPrices()).thenReturn(emptyList());
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_US_111_USD, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_02_03, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_USD, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_111_GBP, true));
+    }
+
+
+    /**
+     * Case#4
+     */
+    @Test
+    public void withSomeNonChangedMatchingPricesAndNewPrices_ShouldBuildAddPriceActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_02_03,
+            DRAFT_DE_111_USD,
+            DRAFT_UK_111_GBP);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_EUR,
+            DE_111_EUR_01_02
+        );
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_02_03, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_USD, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_111_GBP, true));
+    }
+
+    /**
+     * Case#5: NULL
+     */
+    @Test
+    public void withNullNewPrices_ShouldBuildRemovePricesAction() {
+        // Preparation
+        when(newProductVariant.getPrices()).thenReturn(null);
+        final List<Price> prices = asList(
+            US_111_USD,
+            DE_111_EUR,
+            DE_111_EUR_01_02,
+            DE_111_USD);
+        when(oldProductVariant.getPrices()).thenReturn(prices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(US_111_USD.getId(), true),
+            RemovePrice.of(DE_111_USD.getId(), true),
+            RemovePrice.of(DE_111_EUR_01_02.getId(), true),
+            RemovePrice.of(DE_111_USD.getId(), true));
+    }
+
+    /**
+     * Case#5: EMPTY
+     */
+    @Test
+    public void withEmptyNewPrices_ShouldBuildRemovePricesAction() {
+        // Preparation
+        when(newProductVariant.getPrices()).thenReturn(emptyList());
+        final List<Price> prices = asList(
+            US_111_USD,
+            DE_111_EUR,
+            DE_111_EUR_01_02,
+            DE_111_USD);
+        when(oldProductVariant.getPrices()).thenReturn(prices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(US_111_USD.getId(), true),
+            RemovePrice.of(DE_111_USD.getId(), true),
+            RemovePrice.of(DE_111_EUR_01_02.getId(), true),
+            RemovePrice.of(DE_111_USD.getId(), true));
+    }
+
+    /**
+     * Case#6
+     */
+    @Test
+    public void withSomeNonChangedMatchingPricesAndNoNewPrices_ShouldBuildRemovePriceActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = singletonList(DRAFT_US_111_USD);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+        final List<Price> prices = asList(
+            US_111_USD,
+            DE_111_EUR,
+            DE_111_EUR_01_02,
+            DE_111_USD);
+        when(oldProductVariant.getPrices()).thenReturn(prices);
+
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(DE_111_EUR.getId(), true),
+            RemovePrice.of(DE_111_EUR_01_02.getId(), true),
+            RemovePrice.of(DE_111_USD.getId(), true));
+    }
+
+    /**
+     * Case#7
+     */
+    @Test
+    public void withNoMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_UK_111_GBP);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_USD,
+            DE_111_EUR_02_03,
+            US_111_USD);
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(DE_111_USD.getId(), true),
+            RemovePrice.of(DE_111_EUR_01_02.getId(), true),
+            RemovePrice.of(US_111_USD.getId(), true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_111_GBP, true));
+    }
+
+    /**
+     * Case#8
+     */
+    @Test
+    public void withSomeChangedMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_222_EUR_CUST1,
+            DRAFT_DE_333_USD_CUST1,
+            DRAFT_UK_111_GBP_01_02,
+            DRAFT_UK_111_GBP);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_EUR,
+            DE_345_EUR_CUST2,
+            DE_567_EUR_CUST2,
+            UK_111_GBP_02_03,
+            UK_111_GBP_01_02);
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(DE_345_EUR_CUST2.getId(), true),
+            RemovePrice.of(DE_567_EUR_CUST2.getId(), true),
+            RemovePrice.of(UK_111_GBP_02_03.getId(), true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_222_EUR_CUST1, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_333_USD_CUST1, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_111_GBP, true));
+    }
+
+    /**
+     * Case#9
+     */
+    @Test
+    public void withPricesWithOverlappingValidityDates_ShouldBuildRemoveAndAddPricesActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_222_EUR_03_04,
+            DRAFT_UK_333_GBP_01_04,
+            DRAFT_UK_444_GBP_04_06,
+            DRAFT_US_666_USD_CUST1_01_02,
+            DRAFT_FR_888_EUR_01_03,
+            DRAFT_FR_999_EUR_03_06,
+            DRAFT_NE_777_EUR_01_04,
+            DRAFT_NE_777_EUR_05_07);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_EUR,
+            UK_333_GBP_02_05,
+            US_555_USD_CUST2_01_02,
+            FR_777_EUR_01_04,
+            NE_123_EUR_01_04,
+            NE_321_EUR_04_06
+        );
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(DE_111_EUR.getId(), true),
+            RemovePrice.of(UK_333_GBP_02_05.getId(), true),
+            RemovePrice.of(US_555_USD_CUST2_01_02.getId(), true),
+            RemovePrice.of(FR_777_EUR_01_04.getId(), true),
+            RemovePrice.of(NE_321_EUR_04_06.getId(), true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_222_EUR_03_04, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_333_GBP_01_04, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_444_GBP_04_06, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_US_666_USD_CUST1_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_FR_888_EUR_01_03, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_FR_999_EUR_03_06, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_NE_777_EUR_05_07, true),
+            ChangePrice.of(NE_123_EUR_01_04, DRAFT_NE_777_EUR_01_04, true)
+        );
+    }
+
+
+    /**
+     * Case#10
+     */
+    @Test
+    public void withAllMatchingChangedPrices_ShouldBuildChangePriceActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_US_111_USD,
+            DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_UK_22_USD_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_UK_666_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_666_EUR,
+            DE_22_USD,
+            DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY,
+            DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX,
+            UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDY,
+            UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDY,
+            UK_22_USD_CUSTOMTYPE2_CUSTOMFIELDX,
+            UK_1_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX
+        );
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            ChangePrice.of(DE_666_EUR, DRAFT_DE_111_EUR, true),
+            ChangePrice.of(DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY,
+                DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX, true),
+            SetProductPriceCustomField.ofJson("foo",
+                DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields().get("foo"),
+                DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY.getId(), true),
+            ChangePrice.of(DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX,
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX, true),
+            SetProductPriceCustomType.ofTypeIdAndJson(
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getType().getId(),
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields(),
+                DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX.getId(), true),
+            SetProductPriceCustomField.ofJson("foo",
+                DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields().get("foo"),
+                UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDY.getId(), true),
+            SetProductPriceCustomType.ofTypeIdAndJson(
+                DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getType().getId(),
+                DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields(),
+                UK_22_USD_CUSTOMTYPE2_CUSTOMFIELDX.getId(), true),
+            ChangePrice.of(UK_1_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX,
+                DRAFT_UK_666_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX, true));
+    }
+
+    /**
+     * Case#11
+     */
+    @Test
+    public void withMixedCasesOfPriceMatches_ShouldBuildActions() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_222_EUR_CUST1,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_03_04,
+            DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX,
+            DRAFT_DE_333_USD_CUST1,
+            DRAFT_DE_22_USD,
+            DRAFT_UK_111_GBP_01_02,
+            DRAFT_UK_999_GBP,
+            DRAFT_US_666_USD_CUST2_01_02,
+            DRAFT_FR_888_EUR_01_03,
+            DRAFT_FR_999_EUR_03_06,
+            DRAFT_NE_777_EUR_01_04,
+            DRAFT_NE_777_EUR_05_07);
+        when(newProductVariant.getPrices()).thenReturn(newPrices);
+
+        final List<Price> oldPrices = asList(
+            DE_111_EUR,
+            DE_345_EUR_CUST2,
+            DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY,
+            DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX,
+            DE_22_USD,
+            UK_111_GBP_01_02,
+            UK_111_GBP_02_03,
+            UK_333_GBP_02_05,
+            FR_777_EUR_01_04,
+            NE_123_EUR_01_04,
+            NE_321_EUR_04_06
+        );
+        when(oldProductVariant.getPrices()).thenReturn(oldPrices);
+
+        // Test
+        final List<UpdateAction<Product>> updateActions =
+            buildProductVariantPricesUpdateActions(oldProductVariant, newProductVariant);
+
+        // Assertion
+        assertThat(updateActions).containsExactly(
+            RemovePrice.of(DE_345_EUR_CUST2.getId(), true),
+            RemovePrice.of(UK_111_GBP_02_03.getId(), true),
+            RemovePrice.of(UK_333_GBP_02_05.getId(), true),
+            RemovePrice.of(FR_777_EUR_01_04.getId(), true),
+            RemovePrice.of(NE_321_EUR_04_06.getId(), true),
+            ChangePrice.of(DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY,
+                DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX, true),
+            SetProductPriceCustomField.ofJson("foo",
+                DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields().get("foo"),
+                DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY.getId(), true),
+            ChangePrice.of(DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX,
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX, true),
+            SetProductPriceCustomType.ofTypeIdAndJson(
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getType().getId(),
+                DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX.getCustom().getFields(),
+                DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX.getId(), true),
+            ChangePrice.of(NE_123_EUR_01_04, DRAFT_NE_777_EUR_01_04, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_222_EUR_CUST1, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_111_EUR_03_04, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_DE_333_USD_CUST1, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_UK_999_GBP, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_US_666_USD_CUST2_01_02, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_FR_888_EUR_01_03, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_FR_999_EUR_03_06, true),
+            AddPrice.ofVariantId(oldProductVariant.getId(), DRAFT_NE_777_EUR_05_07, true)
+        );
+
+
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -1,0 +1,185 @@
+package com.commercetools.sync.products.utils.productvariantupdateactionutils.prices;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.PriceDraftBuilder;
+import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.utils.MoneyImpl;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.money.CurrencyUnit;
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.neovisionaries.i18n.CountryCode.DE;
+import static com.neovisionaries.i18n.CountryCode.FR;
+import static com.neovisionaries.i18n.CountryCode.UK;
+import static com.neovisionaries.i18n.CountryCode.US;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.EUR;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.USD;
+
+final class PriceDraftFixtures {
+    static final PriceDraft DRAFT_US_111_USD = getPriceDraft(BigDecimal.valueOf(111), USD, US,
+        null, null, null, null, null);
+
+    static final PriceDraft DRAFT_DE_111_EUR = getPriceDraft(BigDecimal.valueOf(111), EUR, DE,
+        null, null, null, null, null);
+
+    static final PriceDraft DRAFT_DE_111_EUR_01_02 = getPriceDraft(BigDecimal.valueOf(111), EUR, DE, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_DE_111_EUR_02_03 = getPriceDraft(BigDecimal.valueOf(111), EUR, DE, null,
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_DE_111_EUR_03_04 = getPriceDraft(BigDecimal.valueOf(111), EUR, DE, null,
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_DE_222_EUR_03_04 = getPriceDraft(BigDecimal.valueOf(222), EUR, DE, null,
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_DE_111_USD = getPriceDraft(BigDecimal.valueOf(111), USD, DE,
+        null, null, null, null, null);
+
+    static final CurrencyUnit GBP = MoneyImpl.createCurrencyByCode("GBP");
+
+    static final PriceDraft DRAFT_UK_111_GBP = getPriceDraft(BigDecimal.valueOf(111), GBP,
+        UK, null, null, null, null, null);
+
+    static final PriceDraft DRAFT_DE_222_EUR_CUST1 = getPriceDraft(BigDecimal.valueOf(222), EUR,
+        DE, "cust1", null, null, null, null);
+
+    static final PriceDraft DRAFT_DE_333_USD_CUST1 = getPriceDraft(BigDecimal.valueOf(333), USD,
+        DE, "cust1", null, null, null, null);
+
+    static final PriceDraft DRAFT_UK_111_GBP_01_02 = getPriceDraft(BigDecimal.valueOf(111), GBP, UK, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_UK_333_GBP_01_04 = getPriceDraft(BigDecimal.valueOf(333), GBP, UK, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_UK_444_GBP_04_06 = getPriceDraft(BigDecimal.valueOf(444), GBP, UK, null,
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 6, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_US_666_USD_CUST1_01_02 = getPriceDraft(BigDecimal.valueOf(666), USD, US,
+        "cust1",
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_US_666_USD_CUST2_01_02 = getPriceDraft(BigDecimal.valueOf(666), USD, US,
+        "cust2",
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_FR_888_EUR_01_03 = getPriceDraft(BigDecimal.valueOf(888), EUR, FR, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_FR_999_EUR_03_06 = getPriceDraft(BigDecimal.valueOf(999), EUR, FR, null,
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 6, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_NE_777_EUR_01_04 = getPriceDraft(BigDecimal.valueOf(777), EUR, FR, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_NE_777_EUR_05_07 = getPriceDraft(BigDecimal.valueOf(777), EUR, FR, null,
+        ZonedDateTime.of(2018, 5, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 7, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        null, null);
+
+    static final PriceDraft DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX =
+        getPriceDraft(BigDecimal.valueOf(111), EUR, DE, null,
+            ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+            "channel1", CustomFieldsDraft.ofTypeIdAndJson("customType1",
+                createCustomFieldsJsonMap("X", JsonNodeFactory.instance.textNode("X"))));
+
+    static final PriceDraft DRAFT_DE_100_EUR_01_02_CHANNEL2_CUSTOMTYPE1_CUSTOMFIELDX =
+        getPriceDraft(BigDecimal.valueOf(111), EUR, DE, null,
+            ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+            "channel2", CustomFieldsDraft.ofTypeIdAndJson("customType1",
+                createCustomFieldsJsonMap("X", JsonNodeFactory.instance.textNode("X"))));
+
+    static final PriceDraft DRAFT_UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDX =
+        getPriceDraft(BigDecimal.valueOf(22), GBP, UK, null, null, null, null,
+            CustomFieldsDraft.ofTypeIdAndJson("customType1",
+                createCustomFieldsJsonMap("foo", JsonNodeFactory.instance.textNode("X"))));
+
+    static final PriceDraft DRAFT_UK_22_USD_CUSTOMTYPE1_CUSTOMFIELDX =
+        getPriceDraft(BigDecimal.valueOf(22), GBP, UK, null, null, null, null,
+            CustomFieldsDraft.ofTypeIdAndJson("customType1",
+                createCustomFieldsJsonMap("foo", JsonNodeFactory.instance.textNode("X"))));
+
+    static final PriceDraft DRAFT_UK_666_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX =
+        getPriceDraft(BigDecimal.valueOf(666), GBP, UK, null, null, null, "channel1",
+            CustomFieldsDraft.ofTypeIdAndJson("customType1",
+                createCustomFieldsJsonMap("foo", JsonNodeFactory.instance.textNode("X"))));
+
+    static final PriceDraft DRAFT_DE_22_USD = getPriceDraft(BigDecimal.valueOf(22), USD, DE,
+        null, null, null, null, null);
+
+    static final PriceDraft DRAFT_UK_999_GBP = getPriceDraft(BigDecimal.valueOf(999), GBP,
+        UK, null, null, null, null, null);
+
+
+    @Nonnull
+    private static Map<String, JsonNode> createCustomFieldsJsonMap(@Nonnull final String fieldName,
+                                                                   @Nonnull final JsonNode fieldValue) {
+        final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
+        customFieldsJsons.put(fieldName, fieldValue);
+        return customFieldsJsons;
+    }
+
+
+    @Nonnull
+    private static PriceDraft getPriceDraft(@Nonnull final BigDecimal value,
+                                            @Nonnull final CurrencyUnit currencyUnits,
+                                            @Nonnull final CountryCode countryCode,
+                                            @Nullable final String customerGroupId,
+                                            @Nullable final ZonedDateTime validFrom,
+                                            @Nullable final ZonedDateTime validUntil,
+                                            @Nullable final String channelId,
+                                            @Nullable final CustomFieldsDraft customFieldsDraft) {
+
+        return PriceDraftBuilder.of(Price.of(value, currencyUnits))
+                                .country(countryCode)
+                                .customerGroup(CustomerGroup.referenceOfId(customerGroupId))
+                                .validFrom(validFrom)
+                                .validUntil(validUntil)
+                                .channel(Channel.referenceOfId(channelId))
+                                .custom(customFieldsDraft)
+                                .build();
+    }
+
+    private PriceDraftFixtures() {
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceFixtures.java
@@ -1,0 +1,139 @@
+package com.commercetools.sync.products.utils.productvariantupdateactionutils.prices;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceBuilder;
+import io.sphere.sdk.types.CustomFields;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.money.CurrencyUnit;
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import static com.commercetools.sync.commons.MockUtils.getMockCustomFields;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.GBP;
+import static com.neovisionaries.i18n.CountryCode.DE;
+import static com.neovisionaries.i18n.CountryCode.FR;
+import static com.neovisionaries.i18n.CountryCode.NE;
+import static com.neovisionaries.i18n.CountryCode.UK;
+import static com.neovisionaries.i18n.CountryCode.US;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.EUR;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.USD;
+
+final class PriceFixtures {
+
+    static final Price US_111_USD = getPrice(BigDecimal.valueOf(111), USD, US,
+        null, null, null, null, null);
+
+    static final Price DE_111_EUR = getPrice(BigDecimal.valueOf(111), EUR, DE, null, null, null, null, null);
+
+    static final Price DE_111_EUR_01_02 = getPrice(BigDecimal.valueOf(111), EUR,
+        DE, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price DE_111_EUR_02_03 = getPrice(BigDecimal.valueOf(111), EUR,
+        DE, null,
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price DE_111_USD = getPrice(BigDecimal.valueOf(111), USD, DE,
+        null, null, null, null, null);
+
+    static final Price DE_345_EUR_CUST2 = getPrice(BigDecimal.valueOf(345), EUR, DE, "cust2",
+        null, null, null, null);
+    static final Price DE_567_EUR_CUST2 = getPrice(BigDecimal.valueOf(567), EUR, DE, "cust2",
+        null, null, null, null);
+
+    static final Price UK_111_GBP_01_02 = getPrice(BigDecimal.valueOf(111), GBP, UK,
+        null, ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price UK_111_GBP_02_03 = getPrice(BigDecimal.valueOf(111), GBP, UK,
+        null, ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+
+    static final Price UK_333_GBP_02_05 = getPrice(BigDecimal.valueOf(333), GBP, UK,
+        null, ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 5, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price US_555_USD_CUST2_01_02 = getPrice(BigDecimal.valueOf(555), USD, US,
+        "cust2", ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price FR_777_EUR_01_04 = getPrice(BigDecimal.valueOf(777), EUR, FR,
+        null, ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price NE_123_EUR_01_04 = getPrice(BigDecimal.valueOf(123), EUR, NE,
+        null, ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price NE_321_EUR_04_06 = getPrice(BigDecimal.valueOf(321), EUR, NE,
+        null, ZonedDateTime.of(2018, 4, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 6, 1, 0, 0, 0, 0, ZoneId.systemDefault()), null, null);
+
+    static final Price DE_666_EUR = getPrice(BigDecimal.valueOf(666), EUR, DE, null, null, null, null, null);
+
+    static final Price DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY = getPrice(BigDecimal.valueOf(222),
+        EUR,
+        DE, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        "channel1", getMockCustomFields("1", "foo", JsonNodeFactory.instance.textNode("Y")));
+
+    static final Price DE_222_EUR_01_02_CHANNEL2_CUSTOMTYPE2_CUSTOMFIELDX = getPrice(BigDecimal.valueOf(222),
+        EUR,
+        DE, null,
+        ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        ZonedDateTime.of(2018, 2, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+        "channel2", getMockCustomFields("2", "foo", JsonNodeFactory.instance.textNode("X")));
+
+    static final Price UK_22_GBP_CUSTOMTYPE1_CUSTOMFIELDY = getPrice(BigDecimal.valueOf(22), GBP,
+        UK, null, null, null, null,
+        getMockCustomFields("1", "foo", JsonNodeFactory.instance.textNode("Y")));
+
+    static final Price UK_22_USD_CUSTOMTYPE2_CUSTOMFIELDX = getPrice(BigDecimal.valueOf(22), USD,
+        UK, null, null, null, null,
+        getMockCustomFields("2", "foo", JsonNodeFactory.instance.textNode("X")));
+
+    static final Price UK_1_GBP_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX = getPrice(BigDecimal.valueOf(1), GBP,
+        UK, null, null, null, "channel1",
+        getMockCustomFields("1", "foo", JsonNodeFactory.instance.textNode("X")));
+
+    static final Price DE_22_USD = getPrice(BigDecimal.valueOf(22), USD, DE,
+        null, null, null, null, null);
+
+
+    @Nonnull
+    private static Price getPrice(@Nonnull final BigDecimal value,
+                                  @Nonnull final CurrencyUnit currencyUnits,
+                                  @Nonnull final CountryCode countryCode,
+                                  @Nullable final String customerGroupId,
+                                  @Nullable final ZonedDateTime validFrom,
+                                  @Nullable final ZonedDateTime validUntil,
+                                  @Nullable final String channelId,
+                                  @Nullable final CustomFields customFields) {
+
+        return PriceBuilder.of(Price.of(value, currencyUnits))
+                           .id(UUID.randomUUID().toString())
+                           .customerGroup(CustomerGroup.referenceOfId(customerGroupId))
+                           .country(countryCode)
+                           .validFrom(validFrom)
+                           .validUntil(validUntil)
+                           .channel(Channel.referenceOfId(channelId))
+                           .custom(customFields)
+                           .build();
+    }
+
+
+    private PriceFixtures() {
+    }
+}


### PR DESCRIPTION
#### Summary
This PR addresses adding unit tests for `ProductVariantUpdateActionUtils#buildProductVariantPricesUpdateActions` . 


All the tests should be failing, since the logic is not yet implemented. 


#### Relevant Issues
#101 

#### Todo
- Tests
    - [ ] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
<!-- Where should the reviewer start? Most important files to review.-->
