### PR TITLE
286 product type attributes actions one to one

### DIFF
--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -164,4 +164,6 @@ public final class AttributeDefinitionUpdateActionUtils {
             )
         );
     }
+
+    private AttributeDefinitionUpdateActionUtils() { }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -27,26 +27,25 @@ public final class AttributeDefinitionUpdateActionUtils {
      * and the {@link AttributeDefinitionDraft} have identical fields, then no update action is needed and hence an
      * empty {@link List} is returned.
      *
-     * @param oldAttributeDefinition        the attribute definition which should be updated.
-     * @param newAttributeDefinitionDraft   the attribute definition draft where we get the new fields.
+     * @param oldAttributeDefinition      the attribute definition which should be updated.
+     * @param newAttributeDefinitionDraft the attribute definition draft where we get the new fields.
      * @return A list with the update actions or an empty list if the attribute definition fields are identical.
-     *
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
 
         return Stream.of(
-            buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
-            buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
-            buildChangeIsSearchableUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
-            buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
-            buildChangeAttributeConstraintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft)
+                buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+                buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+                buildChangeIsSearchableUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+                buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+                buildChangeAttributeConstraintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft)
         )
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(toList());
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toList());
     }
 
     /**
@@ -61,14 +60,12 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeLabelUpdateAction(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getLabel(), newAttributeDefinition.getLabel(),
-            () -> ChangeAttributeDefinitionLabel.of(
-                oldAttributeDefinition.getName(),
-                newAttributeDefinition.getLabel()
-            )
+            () -> ChangeAttributeDefinitionLabel.of(oldAttributeDefinition.getName(),
+                    newAttributeDefinition.getLabel())
         );
     }
 
@@ -84,14 +81,11 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildSetInputTipUpdateAction(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getInputTip(), newAttributeDefinition.getInputTip(),
-            () -> SetInputTip.of(
-                oldAttributeDefinition.getName(),
-                newAttributeDefinition.getInputTip()
-            )
+            () -> SetInputTip.of(oldAttributeDefinition.getName(), newAttributeDefinition.getInputTip())
         );
     }
 
@@ -107,14 +101,11 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeIsSearchableUpdateAction(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.isSearchable(), newAttributeDefinition.isSearchable(),
-            () -> ChangeIsSearchable.of(
-                oldAttributeDefinition.getName(),
-                newAttributeDefinition.isSearchable()
-            )
+            () -> ChangeIsSearchable.of(oldAttributeDefinition.getName(), newAttributeDefinition.isSearchable())
         );
     }
 
@@ -130,14 +121,11 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeInputHintUpdateAction(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getInputHint(), newAttributeDefinition.getInputHint(),
-            () -> ChangeInputHint.of(
-                oldAttributeDefinition.getName(),
-                newAttributeDefinition.getInputHint()
-            )
+            () -> ChangeInputHint.of(oldAttributeDefinition.getName(), newAttributeDefinition.getInputHint())
         );
     }
 
@@ -153,17 +141,16 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeAttributeConstraintUpdateAction(
-        @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+            @Nonnull final AttributeDefinition oldAttributeDefinition,
+            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getAttributeConstraint(),
-            newAttributeDefinition.getAttributeConstraint(),
-            () -> ChangeAttributeConstraint.of(
-                oldAttributeDefinition.getName(),
-                newAttributeDefinition.getAttributeConstraint()
-            )
+                newAttributeDefinition.getAttributeConstraint(),
+            () -> ChangeAttributeConstraint.of(oldAttributeDefinition.getName(),
+                    newAttributeDefinition.getAttributeConstraint())
         );
     }
 
-    private AttributeDefinitionUpdateActionUtils() { }
+    private AttributeDefinitionUpdateActionUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -2,13 +2,22 @@ package com.commercetools.sync.producttypes.utils;
 
 import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
 import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeDefinitionLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeIsSearchable;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeInputHint;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeConstraint;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
 
 
 public final class AttributeDefinitionUpdateActionUtils {
@@ -35,5 +44,121 @@ public final class AttributeDefinitionUpdateActionUtils {
         // TODO Add Attribute Definition Update Actions
 
         return Collections.emptyList();
+    }
+
+    /**
+     * Compares the {@link LocalizedString} labels of an {@link AttributeDefinition} and an
+     * {@link AttributeDefinitionDraft} and returns an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in
+     * an {@link Optional}. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the
+     * same label, then no update action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldAttributeDefinition the attribute definition which should be updated.
+     * @param newAttributeDefinition the attribute definition draft where we get the new label.
+     * @return A filled optional with the update action or an empty optional if the labels are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeLabelUpdateAction(
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+        return buildUpdateAction(oldAttributeDefinition.getLabel(), newAttributeDefinition.getLabel(),
+            () -> ChangeAttributeDefinitionLabel.of(
+                oldAttributeDefinition.getName(),
+                newAttributeDefinition.getLabel()
+            )
+        );
+    }
+
+    /**
+     * Compares the {@link LocalizedString} input tips of an {@link AttributeDefinition} and an
+     * {@link AttributeDefinitionDraft} and returns an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in
+     * an {@link Optional}. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the
+     * same input tip, then no update action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldAttributeDefinition the attribute definition which should be updated.
+     * @param newAttributeDefinition the attribute definition draft where we get the new input tip.
+     * @return A filled optional with the update action or an empty optional if the labels are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildSetInputTipUpdateAction(
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+        return buildUpdateAction(oldAttributeDefinition.getInputTip(), newAttributeDefinition.getInputTip(),
+            () -> SetInputTip.of(
+                oldAttributeDefinition.getName(),
+                newAttributeDefinition.getInputTip()
+            )
+        );
+    }
+
+    /**
+     * Compares the 'isSearchable' fields of an {@link AttributeDefinition} and an
+     * {@link AttributeDefinitionDraft} and returns an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in
+     * an {@link Optional}. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the
+     * same 'isSearchable' field, then no update action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldAttributeDefinition the attribute definition which should be updated.
+     * @param newAttributeDefinition the attribute definition draft where we get the new 'isSearchable' field.
+     * @return A filled optional with the update action or an empty optional if the 'isSearchable' fields are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeIsSearchableUpdateAction(
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+        return buildUpdateAction(oldAttributeDefinition.isSearchable(), newAttributeDefinition.isSearchable(),
+            () -> ChangeIsSearchable.of(
+                oldAttributeDefinition.getName(),
+                newAttributeDefinition.isSearchable()
+            )
+        );
+    }
+
+    /**
+     * Compares the input hints of an {@link AttributeDefinition} and an {@link AttributeDefinitionDraft} and returns
+     * an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in an {@link Optional}. If both the
+     * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the same input hints, then no update
+     * action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldAttributeDefinition the attribute definition which should be updated.
+     * @param newAttributeDefinition the attribute definition draft where we get the new input hint.
+     * @return A filled optional with the update action or an empty optional if the input hints are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeInputHintUpdateAction(
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+        return buildUpdateAction(oldAttributeDefinition.getInputHint(), newAttributeDefinition.getInputHint(),
+            () -> ChangeInputHint.of(
+                oldAttributeDefinition.getName(),
+                newAttributeDefinition.getInputHint()
+            )
+        );
+    }
+
+    /**
+     * Compares the attribute constraints of an {@link AttributeDefinition} and an {@link AttributeDefinitionDraft}
+     * and returns an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in an {@link Optional}. If both the
+     * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the same attribute constraints, then
+     * no update action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldAttributeDefinition the attribute definition which should be updated.
+     * @param newAttributeDefinition the attribute definition draft where we get the new attribute constraint.
+     * @return A filled optional with the update action or an empty optional if the attribute constraints are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeAttributeConstraintUpdateAction(
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+        return buildUpdateAction(oldAttributeDefinition.getAttributeConstraint(),
+            newAttributeDefinition.getAttributeConstraint(),
+            () -> ChangeAttributeConstraint.of(
+                oldAttributeDefinition.getName(),
+                newAttributeDefinition.getAttributeConstraint()
+            )
+        );
     }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -37,7 +37,6 @@ public final class AttributeDefinitionUpdateActionUtils {
         @Nonnull final AttributeDefinition oldAttributeDefinition,
         @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
 
-        // TODO Add Attribute Definition Update Actions
         return Stream.of(
             buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
             buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.producttypes.utils;
 
-import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
@@ -13,11 +12,12 @@ import io.sphere.sdk.producttypes.commands.updateactions.ChangeInputHint;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeConstraint;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static java.util.stream.Collectors.toList;
 
 
 public final class AttributeDefinitionUpdateActionUtils {
@@ -29,21 +29,25 @@ public final class AttributeDefinitionUpdateActionUtils {
      *
      * @param oldAttributeDefinition        the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft   the attribute definition draft where we get the new fields.
-     * @param syncOptions                   responsible for supplying the sync options to the sync utility method.
-     *                                      It is used for triggering the error callback within the utility, in case of
-     *                                      errors.
      * @return A list with the update actions or an empty list if the attribute definition fields are identical.
      *
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
         @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft,
-        @Nonnull final ProductTypeSyncOptions syncOptions) {
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
 
         // TODO Add Attribute Definition Update Actions
-
-        return Collections.emptyList();
+        return Stream.of(
+            buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeIsSearchableUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeAttributeConstraintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft)
+        )
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(toList());
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -33,19 +33,20 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
 
-        return Stream.of(
+        return Stream
+            .of(
                 buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
                 buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
                 buildChangeIsSearchableUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
                 buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
                 buildChangeAttributeConstraintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft)
-        )
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(toList());
+            )
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList());
     }
 
     /**
@@ -60,12 +61,12 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeLabelUpdateAction(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getLabel(), newAttributeDefinition.getLabel(),
             () -> ChangeAttributeDefinitionLabel.of(oldAttributeDefinition.getName(),
-                    newAttributeDefinition.getLabel())
+                newAttributeDefinition.getLabel())
         );
     }
 
@@ -81,8 +82,8 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildSetInputTipUpdateAction(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getInputTip(), newAttributeDefinition.getInputTip(),
             () -> SetInputTip.of(oldAttributeDefinition.getName(), newAttributeDefinition.getInputTip())
@@ -101,8 +102,8 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeIsSearchableUpdateAction(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.isSearchable(), newAttributeDefinition.isSearchable(),
             () -> ChangeIsSearchable.of(oldAttributeDefinition.getName(), newAttributeDefinition.isSearchable())
@@ -121,8 +122,8 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeInputHintUpdateAction(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getInputHint(), newAttributeDefinition.getInputHint(),
             () -> ChangeInputHint.of(oldAttributeDefinition.getName(), newAttributeDefinition.getInputHint())
@@ -141,13 +142,13 @@ public final class AttributeDefinitionUpdateActionUtils {
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeAttributeConstraintUpdateAction(
-            @Nonnull final AttributeDefinition oldAttributeDefinition,
-            @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+        @Nonnull final AttributeDefinition oldAttributeDefinition,
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
         return buildUpdateAction(oldAttributeDefinition.getAttributeConstraint(),
-                newAttributeDefinition.getAttributeConstraint(),
+            newAttributeDefinition.getAttributeConstraint(),
             () -> ChangeAttributeConstraint.of(oldAttributeDefinition.getName(),
-                    newAttributeDefinition.getAttributeConstraint())
+                newAttributeDefinition.getAttributeConstraint())
         );
     }
 

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
@@ -19,39 +19,24 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
 public final class ProductTypeUpdateActionUtils {
-    private static final String PRODUCT_TYPE_CHANGE_NAME_EMPTY_NAME = "Cannot unset 'name' field of product type with "
-        + "id '%s'.";
-    private static final String PRODUCT_TYPE_CHANGE_DESCRIPTION_EMPTY_DESCRIPTION = "Cannot unset 'description' field "
-        +   "of product type with id '%s'.";
-
     /**
      * Compares the {@code name} values of a {@link ProductType} and a {@link ProductTypeDraft}
      * and returns an {@link Optional} of update action, which would contain the {@code "changeName"}
      * {@link UpdateAction}. If both {@link ProductType} and {@link ProductTypeDraft} have the same
      * {@code name} values, then no update action is needed and empty optional will be returned.
      *
-     * <p>Note: If the name of the new {@link ProductTypeDraft} is null, an empty {@link Optional} is returned with no
-     * update actions and a custom callback function, if set on the supplied {@link ProductTypeSyncOptions}, is called.
-     *
      * @param oldProductType the product type that should be updated.
      * @param newProductType the product type draft which contains the new name.
-     * @param syncOptions    the sync syncOptions with which a custom callback function is called in case the parent
-     *                       is null.
+
      * @return optional containing update action or empty optional if names are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeNameAction(
         @Nonnull final ProductType oldProductType,
-        @Nonnull final ProductTypeDraft newProductType,
-        @Nonnull final ProductTypeSyncOptions syncOptions) {
+        @Nonnull final ProductTypeDraft newProductType) {
 
-        if (newProductType.getName() == null && oldProductType.getName() != null) {
-            syncOptions.applyWarningCallback(format(PRODUCT_TYPE_CHANGE_NAME_EMPTY_NAME, oldProductType.getId()));
-            return Optional.empty();
-        } else {
-            return buildUpdateAction(oldProductType.getName(), newProductType.getName(),
-                () -> ChangeName.of(newProductType.getName()));
-        }
+        return buildUpdateAction(oldProductType.getName(), newProductType.getName(),
+            () -> ChangeName.of(newProductType.getName()));
     }
 
     /**
@@ -60,32 +45,18 @@ public final class ProductTypeUpdateActionUtils {
      * {@link UpdateAction}. If both {@link ProductType} and {@link ProductTypeDraft} have the same
      * {@code description} values, then no update action is needed and empty optional will be returned.
      *
-     * <p>Note: If the description of the new {@link ProductTypeDraft} is null, an empty {@link Optional} is returned
-     * with no update actions and a custom callback function, if set on the supplied {@link ProductTypeSyncOptions},
-     * is called.
-     *
      * @param oldProductType the product type that should be updated.
      * @param newProductType the product type draft which contains the new description.
-     * @param syncOptions    the sync syncOptions with which a custom callback function is called in case the
-     *                       description is null.
+     *
      * @return optional containing update action or empty optional if descriptions are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeDescriptionAction(
         @Nonnull final ProductType oldProductType,
-        @Nonnull final ProductTypeDraft newProductType,
-        @Nonnull final ProductTypeSyncOptions syncOptions) {
+        @Nonnull final ProductTypeDraft newProductType) {
 
-        if (newProductType.getDescription() == null && oldProductType.getDescription() != null) {
-            syncOptions.applyWarningCallback(format(PRODUCT_TYPE_CHANGE_DESCRIPTION_EMPTY_DESCRIPTION,
-                oldProductType.getId()));
-            return Optional.empty();
-        } else {
-            return buildUpdateAction(oldProductType.getDescription(), newProductType.getDescription(),
-                () -> ChangeDescription.of(newProductType.getDescription()));
-        }
-
-
+        return buildUpdateAction(oldProductType.getDescription(), newProductType.getDescription(),
+            () -> ChangeDescription.of(newProductType.getDescription()));
     }
 
     /**
@@ -95,8 +66,11 @@ public final class ProductTypeUpdateActionUtils {
      * {@link List} is returned. In case, the new product type draft has a list of attributes in which a duplicate name
      * exists, the error callback is triggered and an empty list is returned.
      *
-     * @param oldProductType the product type which should be updated.
-     * @param newProductType the product type draft where we get the key.
+     * @param oldProductType    the product type which should be updated.
+     * @param newProductType    the product type draft where we get the key.
+     * @param syncOptions       responsible for supplying the sync options to the sync utility method. It is used for
+     *                          triggering the error callback within the utility, in case of errors.
+     *
      * @return A list with the update actions or an empty list if the attributes are identical.
      */
     @Nonnull

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
@@ -97,8 +97,6 @@ public final class ProductTypeUpdateActionUtils {
      *
      * @param oldProductType the product type which should be updated.
      * @param newProductType the product type draft where we get the key.
-     * @param syncOptions the sync options with which a custom callback function is called in case errors exists
-     *                    while building attributes update actions.
      * @return A list with the update actions or an empty list if the attributes are identical.
      */
     @Nonnull
@@ -110,8 +108,7 @@ public final class ProductTypeUpdateActionUtils {
         try {
             return buildAttributeDefinitionsUpdateActions(
                     oldProductType.getAttributes(),
-                    newProductType.getAttributes(),
-                    syncOptions);
+                    newProductType.getAttributes());
         } catch (final BuildUpdateActionException exception) {
             syncOptions.applyErrorCallback(format("Failed to build update actions for the attributes definitions "
                     + "of the product type with the key '%s'. Reason: %s", oldProductType.getKey(), exception),

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
@@ -2,7 +2,6 @@ package com.commercetools.sync.producttypes.utils;
 
 import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
 import com.commercetools.sync.commons.exceptions.DuplicateNameException;
-import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
 import com.commercetools.sync.producttypes.helpers.AttributeDefinitionCustomBuilder;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
@@ -44,8 +43,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      *
      * @param oldAttributeDefinitions                       the old list of attribute definitions.
      * @param newAttributeDefinitionsDrafts                 the new list of attribute definitions drafts.
-     * @param syncOptions                                   the sync options with which a custom callback function is
-     *                                                      called if warnings or errors.
+     *
      * @return a list of attribute definitions update actions if the list of attribute definitions is not identical.
      *         Otherwise, if the attribute definitions are identical, an empty list is returned.
      * @throws BuildUpdateActionException in case there are attribute definitions drafts with duplicate names.
@@ -53,15 +51,13 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
     @Nonnull
     public static List<UpdateAction<ProductType>> buildAttributeDefinitionsUpdateActions(
         @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
-        @Nullable final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts,
-        @Nonnull final ProductTypeSyncOptions syncOptions)
+        @Nullable final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts)
         throws BuildUpdateActionException {
 
         if (newAttributeDefinitionsDrafts != null) {
             return buildUpdateActions(
                 oldAttributeDefinitions,
-                newAttributeDefinitionsDrafts,
-                syncOptions
+                newAttributeDefinitionsDrafts
             );
         } else {
             return oldAttributeDefinitions
@@ -81,8 +77,6 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      *
      * @param oldAttributeDefinitions                       the old list of attribute definitions.
      * @param newAttributeDefinitionsDrafts                 the new list of attribute definitions drafts.
-     * @param syncOptions                                   the sync options with which a custom callback function is
-     *                                                      called if warnings or errors.
      *
      * @return a list of attribute definitions update actions if the list of attribute definitions is not identical.
      *         Otherwise, if the attribute definitions are identical, an empty list is returned.
@@ -91,8 +85,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
     @Nonnull
     private static List<UpdateAction<ProductType>> buildUpdateActions(
         @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
-        @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts,
-        @Nonnull final ProductTypeSyncOptions syncOptions)
+        @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts)
         throws BuildUpdateActionException {
 
         final HashSet<String> removedAttributesDefinitionsNames = new HashSet<>();
@@ -122,8 +115,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
             buildRemoveAttributeDefinitionOrAttributeDefinitionUpdateActions(
                 oldAttributeDefinitions,
                 removedAttributesDefinitionsNames,
-                newAttributesDefinitionsDraftsNameMap,
-                syncOptions
+                newAttributesDefinitionsDraftsNameMap
             );
 
         // Add before changing the order because commercetools API doesn't allow to add an attribute definition
@@ -156,8 +148,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * @param removedAttributeDefinitionNames               a set containing names of removed attribute definitions.
      * @param newAttributeDefinitionDraftsNameMap           a map of names to attribute definition drafts of the new
      *                                                      list of attribute definition drafts.
-     * @param syncOptions                                   the sync options with which a custom callback function is
-     *                                                      called if warnings or errors.
+     *
      * @return a list of attribute definition update actions if there are attribute definitions that are not existing
      *      in the new draft. If the attribute definition still exists in the new draft, then compare the attribute
      *      definition fields (name, label, etc..), and add the computed actions to the list of update actions.
@@ -167,8 +158,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
     private static List<UpdateAction<ProductType>> buildRemoveAttributeDefinitionOrAttributeDefinitionUpdateActions(
         @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
         @Nonnull final Set<String> removedAttributeDefinitionNames,
-        @Nonnull final Map<String, AttributeDefinitionDraft> newAttributeDefinitionDraftsNameMap,
-        @Nonnull final ProductTypeSyncOptions syncOptions) {
+        @Nonnull final Map<String, AttributeDefinitionDraft> newAttributeDefinitionDraftsNameMap) {
 
         return oldAttributeDefinitions
             .stream()
@@ -180,8 +170,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
                     .map(attributeDefinitionDraft ->
                         buildActions(
                             oldAttributeDefinition,
-                            attributeDefinitionDraft,
-                            syncOptions
+                            attributeDefinitionDraft
                         )
                     )
                     .orElseGet(() -> {

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
@@ -168,10 +168,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
                     newAttributeDefinitionDraftsNameMap.get(oldAttributeDefinitionName);
                 return ofNullable(matchingNewAttributeDefinitionDraft)
                     .map(attributeDefinitionDraft ->
-                        buildActions(
-                            oldAttributeDefinition,
-                            attributeDefinitionDraft
-                        )
+                        buildActions(oldAttributeDefinition, attributeDefinitionDraft)
                     )
                     .orElseGet(() -> {
                         removedAttributeDefinitionNames.add(oldAttributeDefinitionName);

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
@@ -12,8 +12,8 @@ public class DuplicateNameExceptionTest {
         assertThatThrownBy(() -> {
             throw new DuplicateNameException(message);
         }).isExactlyInstanceOf(DuplicateNameException.class)
-            .hasNoCause()
-            .hasMessage(message);
+          .hasNoCause()
+          .hasMessage(message);
     }
 
     @Test
@@ -24,8 +24,8 @@ public class DuplicateNameExceptionTest {
         assertThatThrownBy(() -> {
             throw new DuplicateNameException(message, cause);
         }).isExactlyInstanceOf(DuplicateNameException.class)
-            .hasCause(cause)
-            .hasMessage(message);
+          .hasCause(cause)
+          .hasMessage(message);
     }
 
     @Test
@@ -35,8 +35,8 @@ public class DuplicateNameExceptionTest {
         assertThatThrownBy(() -> {
             throw new DuplicateNameException(cause);
         }).isExactlyInstanceOf(DuplicateNameException.class)
-            .hasCause(cause)
-            .hasMessage(cause.toString());
+          .hasCause(cause)
+          .hasMessage(cause.toString());
 
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
@@ -1,0 +1,42 @@
+package com.commercetools.sync.commons.exceptions;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DuplicateNameExceptionTest {
+    @Test
+    public void duplicateNameException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+        final String message = "foo";
+
+        assertThatThrownBy(() -> {
+            throw new DuplicateNameException(message);
+        }).isExactlyInstanceOf(DuplicateNameException.class)
+            .hasNoCause()
+            .hasMessage(message);
+    }
+
+    @Test
+    public void duplicateNameException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+        final String message = "foo";
+        final IllegalArgumentException cause = new IllegalArgumentException();
+
+        assertThatThrownBy(() -> {
+            throw new DuplicateNameException(message, cause);
+        }).isExactlyInstanceOf(DuplicateNameException.class)
+            .hasCause(cause)
+            .hasMessage(message);
+    }
+
+    @Test
+    public void duplicateNameException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+        final IllegalArgumentException cause = new IllegalArgumentException();
+
+        assertThatThrownBy(() -> {
+            throw new DuplicateNameException(cause);
+        }).isExactlyInstanceOf(DuplicateNameException.class)
+            .hasCause(cause)
+            .hasMessage(cause.toString());
+
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -1,0 +1,214 @@
+package com.commercetools.sync.producttypes.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.TextInputHint;
+import io.sphere.sdk.products.attributes.AttributeDefinition;
+import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
+import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
+import io.sphere.sdk.products.attributes.AttributeConstraint;
+import io.sphere.sdk.products.attributes.StringAttributeType;
+import io.sphere.sdk.products.attributes.AttributeDefinitionDraftBuilder;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeDefinitionLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeIsSearchable;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeInputHint;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeConstraint;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeLabelUpdateAction;
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildSetInputTipUpdateAction;
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeIsSearchableUpdateAction;
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeInputHintUpdateAction;
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeAttributeConstraintUpdateAction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AttributeDefinitionUpdateActionUtilsTest {
+    private static AttributeDefinition old;
+    private static AttributeDefinition oldNullValues;
+    private static AttributeDefinitionDraft newSame;
+    private static AttributeDefinitionDraft newDifferent;
+    private static AttributeDefinitionDraft newNullValues;
+
+
+    /**
+     * Initialises test data.
+     */
+    @BeforeClass
+    public static void setup() {
+        old = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"), StringAttributeType.of())
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+        oldNullValues = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"), StringAttributeType.of())
+            .isRequired(false)
+            .attributeConstraint(null)
+            .inputTip(null)
+            .inputHint(null)
+            .isSearchable(false)
+            .build();
+
+        newSame = AttributeDefinitionDraftBuilder
+            .of(old)
+            .build();
+
+        newDifferent = AttributeDefinitionDraftBuilder
+            .of(StringAttributeType.of(), "attributeName1", LocalizedString.ofEnglish("label2"), true)
+            .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
+            .inputTip(LocalizedString.ofEnglish("inputTip2"))
+            .inputHint(TextInputHint.MULTI_LINE)
+            .isSearchable(true)
+            .build();
+
+        newNullValues = AttributeDefinitionDraftBuilder
+            .of(StringAttributeType.of(), "attributeName1", LocalizedString.ofEnglish("label2"), true)
+            .attributeConstraint(null)
+            .inputTip(null)
+            .inputHint(null)
+            .isSearchable(true)
+            .build();
+    }
+
+    @Test
+    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(old, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeAttributeDefinitionLabel.class);
+        assertThat(result).contains(ChangeAttributeDefinitionLabel.of(old.getName(), newDifferent.getLabel()));
+    }
+
+    @Test
+    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newDifferent);
+
+        assertThat(result).containsInstanceOf(SetInputTip.class);
+        assertThat(result).contains(SetInputTip.of(old.getName(), newDifferent.getInputTip()));
+    }
+
+    @Test
+    public void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(oldNullValues, newDifferent);
+
+        assertThat(result).containsInstanceOf(SetInputTip.class);
+        assertThat(result).contains(SetInputTip.of(oldNullValues.getName(), newDifferent.getInputTip()));
+    }
+
+    @Test
+    public void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newNullValues);
+
+        assertThat(result).containsInstanceOf(SetInputTip.class);
+        assertThat(result).contains(SetInputTip.of(old.getName(), newNullValues.getInputTip()));
+    }
+
+    @Test
+    public void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeIsSearchableUpdateAction(old, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeIsSearchable.class);
+        assertThat(result).contains(ChangeIsSearchable.of(old.getName(), newDifferent.isSearchable()));
+    }
+
+    @Test
+    public void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeIsSearchableUpdateAction(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeInputHint.class);
+        assertThat(result).contains(ChangeInputHint.of(old.getName(), newDifferent.getInputHint()));
+    }
+
+    @Test
+    public void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildChangeInputHintAction_WithSourceNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeInputHintUpdateAction(oldNullValues, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeInputHint.class);
+        assertThat(result).contains(ChangeInputHint.of(oldNullValues.getName(), newDifferent.getInputHint()));
+    }
+
+    @Test
+    public void buildChangeInputHintAction_WithTargetNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newNullValues);
+
+        assertThat(result).containsInstanceOf(ChangeInputHint.class);
+        assertThat(result).contains(ChangeInputHint.of(old.getName(), newNullValues.getInputHint()));
+    }
+
+    @Test
+    public void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(old, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
+        assertThat(result).contains(ChangeAttributeConstraint.of(old.getName(), newDifferent.getAttributeConstraint()));
+    }
+
+    @Test
+    public void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeAttributeConstraintUpdateAction(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildChangeAttributeConstraintAction_WithSourceNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(oldNullValues, newDifferent);
+
+        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
+        assertThat(result).contains(ChangeAttributeConstraint.of(
+            oldNullValues.getName(),
+            newDifferent.getAttributeConstraint())
+        );
+    }
+
+    @Test
+    public void buildChangeAttributeConstraintAction_WithTargetNullValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(old, newNullValues);
+
+        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
+        assertThat(result).contains(ChangeAttributeConstraint.of(
+            old.getName(),
+            newNullValues.getAttributeConstraint())
+        );
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -83,7 +83,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(old, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeAttributeDefinitionLabel.class);
         assertThat(result).contains(ChangeAttributeDefinitionLabel.of(old.getName(), newDifferent.getLabel()));
     }
 
@@ -98,7 +97,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newDifferent);
 
-        assertThat(result).containsInstanceOf(SetInputTip.class);
         assertThat(result).contains(SetInputTip.of(old.getName(), newDifferent.getInputTip()));
     }
 
@@ -113,7 +111,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(oldNullValues, newDifferent);
 
-        assertThat(result).containsInstanceOf(SetInputTip.class);
         assertThat(result).contains(SetInputTip.of(oldNullValues.getName(), newDifferent.getInputTip()));
     }
 
@@ -121,7 +118,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newNullValues);
 
-        assertThat(result).containsInstanceOf(SetInputTip.class);
         assertThat(result).contains(SetInputTip.of(old.getName(), newNullValues.getInputTip()));
     }
 
@@ -129,7 +125,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeIsSearchableUpdateAction(old, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeIsSearchable.class);
         assertThat(result).contains(ChangeIsSearchable.of(old.getName(), newDifferent.isSearchable()));
     }
 
@@ -144,7 +139,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeInputHint.class);
         assertThat(result).contains(ChangeInputHint.of(old.getName(), newDifferent.getInputHint()));
     }
 
@@ -160,7 +154,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final Optional<UpdateAction<ProductType>> result =
             buildChangeInputHintUpdateAction(oldNullValues, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeInputHint.class);
         assertThat(result).contains(ChangeInputHint.of(oldNullValues.getName(), newDifferent.getInputHint()));
     }
 
@@ -168,7 +161,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     public void buildChangeInputHintAction_WithTargetNullValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newNullValues);
 
-        assertThat(result).containsInstanceOf(ChangeInputHint.class);
         assertThat(result).contains(ChangeInputHint.of(old.getName(), newNullValues.getInputHint()));
     }
 
@@ -177,7 +169,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final Optional<UpdateAction<ProductType>> result =
             buildChangeAttributeConstraintUpdateAction(old, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
         assertThat(result).contains(ChangeAttributeConstraint.of(old.getName(), newDifferent.getAttributeConstraint()));
     }
 
@@ -193,7 +184,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final Optional<UpdateAction<ProductType>> result =
             buildChangeAttributeConstraintUpdateAction(oldNullValues, newDifferent);
 
-        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
         assertThat(result).contains(ChangeAttributeConstraint.of(
             oldNullValues.getName(),
             newDifferent.getAttributeConstraint())
@@ -205,7 +195,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final Optional<UpdateAction<ProductType>> result =
             buildChangeAttributeConstraintUpdateAction(old, newNullValues);
 
-        assertThat(result).containsInstanceOf(ChangeAttributeConstraint.class);
         assertThat(result).contains(ChangeAttributeConstraint.of(
             old.getName(),
             newNullValues.getAttributeConstraint())

--- a/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
@@ -1,8 +1,5 @@
 package com.commercetools.sync.producttypes.utils;
 
-import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
-import com.commercetools.sync.producttypes.ProductTypeSyncOptionsBuilder;
-import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
@@ -20,25 +17,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.sphere.sdk.producttypes.ProductTypeDraft;
-import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeDescription;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public class ProductTypeUpdateActionUtilsTest {
-    private static final ProductTypeSyncOptions SYNC_OPTIONS = ProductTypeSyncOptionsBuilder
-        .of(mock(SphereClient.class)).build();
     private static ProductType old;
     private static ProductTypeDraft newSame;
     private static ProductTypeDraft newDifferent;
-    private static ProductTypeDraft newNullValues;
 
     /**
      * Initialises test data.
@@ -75,15 +66,12 @@ public class ProductTypeUpdateActionUtilsTest {
                 sameAttributeDefinitionDrafts
         );
 
-        newNullValues = ProductTypeDraftBuilder.of(null, null, null, null)
-                .build();
-
         // TODO For all product types the attribute definitions will change in future commits
     }
 
     @Test
     public void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newDifferent, SYNC_OPTIONS);
+        final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newDifferent);
 
         assertThat(result).containsInstanceOf(ChangeName.class);
         assertThat(result).contains(ChangeName.of(newDifferent.getName()));
@@ -91,34 +79,14 @@ public class ProductTypeUpdateActionUtilsTest {
 
     @Test
     public void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newSame, SYNC_OPTIONS);
+        final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildChangeNameAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
-        when(old.getId()).thenReturn("id1");
-
-        final ArrayList<Object> callBackResponse = new ArrayList<>();
-        final Consumer<String> updateActionWarningCallBack = callBackResponse::add;
-
-        final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(mock(SphereClient.class))
-            .warningCallback(updateActionWarningCallBack)
-            .build();
-
-        final Optional<UpdateAction<ProductType>> changeNameUpdateAction =
-            buildChangeNameAction(old, newNullValues, productTypeSyncOptions);
-
-        assertThat(changeNameUpdateAction).isNotPresent();
-        assertThat(callBackResponse).hasSize(1);
-        assertThat(callBackResponse.get(0)).isEqualTo("Cannot unset 'name' field of product type with id 'id1'.");
-    }
-
-    @Test
     public void buildChangeDescriptionAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newDifferent,
-            SYNC_OPTIONS);
+        final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newDifferent);
 
         assertThat(result).containsInstanceOf(ChangeDescription.class);
         assertThat(result).contains(ChangeDescription.of(newDifferent.getDescription()));
@@ -126,28 +94,8 @@ public class ProductTypeUpdateActionUtilsTest {
 
     @Test
     public void buildChangeDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newSame, SYNC_OPTIONS);
+        final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newSame);
 
         assertThat(result).isEmpty();
-    }
-
-    @Test
-    public void buildChangeNameDescription_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
-        when(old.getId()).thenReturn("id1");
-
-        final ArrayList<Object> callBackResponse = new ArrayList<>();
-        final Consumer<String> updateActionWarningCallBack = callBackResponse::add;
-
-        final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(mock(SphereClient.class))
-            .warningCallback(updateActionWarningCallBack)
-            .build();
-
-        final Optional<UpdateAction<ProductType>> changeDescriptionUpdateAction =
-            buildChangeDescriptionAction(old, newNullValues, productTypeSyncOptions);
-
-        assertThat(changeDescriptionUpdateAction).isNotPresent();
-        assertThat(callBackResponse).hasSize(1);
-        assertThat(callBackResponse.get(0)).isEqualTo("Cannot unset 'description' field of product type with id "
-            + "'id1'.");
     }
 }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtilsTest.java
@@ -1,0 +1,4 @@
+package com.commercetools.sync.producttypes.utils;
+
+public class ProductTypeUpdateAttributeDefinitionActionUtilsTest {
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtilsTest.java
@@ -1,4 +1,0 @@
-package com.commercetools.sync.producttypes.utils;
-
-public class ProductTypeUpdateAttributeDefinitionActionUtilsTest {
-}


### PR DESCRIPTION
#### Summary
This PR adds the product type attribute definition update actions for those attribute definitions that match by name.

#### Description
- `AttributeDefinitionUpdateActionUtils` 
   - Change Attribute Definition Label update action
   - Set Attribute Definition Input Tip update action
   - Change Attribute Definition isSearchable update action
   - Change Attribute Definition inputHint update action
   - Change Attribute Definition attribute contraint update action
   - Remove unnecessary null validations for required fields
   - Add DuplicateNameException unit test

#### Todo

- Tests
    - [X] Unit 
