### PR TITLE
286 product type attributes enum actions

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/exceptions/DifferentTypeException.java
+++ b/src/main/java/com/commercetools/sync/commons/exceptions/DifferentTypeException.java
@@ -1,0 +1,17 @@
+package com.commercetools.sync.commons.exceptions;
+
+import javax.annotation.Nonnull;
+
+public class DifferentTypeException extends RuntimeException {
+    public DifferentTypeException(@Nonnull final String message) {
+        super(message);
+    }
+
+    public DifferentTypeException(@Nonnull final Throwable cause) {
+        super(cause);
+    }
+
+    public DifferentTypeException(@Nonnull final String message, @Nonnull final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -97,8 +97,7 @@ public final class AttributeDefinitionUpdateActionUtils {
         @Nonnull final AttributeDefinition attributeDefinitionA,
         @Nonnull final AttributeDefinitionDraft attributeDefinitionB) {
 
-        return attributeDefinitionA.getAttributeType().getClass()
-                == attributeDefinitionB.getAttributeType().getClass();
+        return attributeDefinitionA.getAttributeType().getClass() == attributeDefinitionB.getAttributeType().getClass();
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -1,9 +1,13 @@
 package com.commercetools.sync.producttypes.utils;
 
+import com.commercetools.sync.commons.exceptions.DifferentTypeException;
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
+import io.sphere.sdk.products.attributes.EnumAttributeType;
+import io.sphere.sdk.products.attributes.LocalizedEnumAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeDefinitionLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
@@ -17,7 +21,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateLocalizedEnumActionUtils.buildLocalizedEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdatePlainEnumActionUtils.buildEnumValuesUpdateActions;
 import static java.util.stream.Collectors.toList;
+import static java.lang.String.format;
 
 
 public final class AttributeDefinitionUpdateActionUtils {
@@ -29,24 +36,91 @@ public final class AttributeDefinitionUpdateActionUtils {
      *
      * @param oldAttributeDefinition        the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft   the attribute definition draft where we get the new fields.
+     *
      * @return A list with the update actions or an empty list if the attribute definition fields are identical.
      *
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
         @Nonnull final AttributeDefinition oldAttributeDefinition,
-        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
+        @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft)
+        throws DuplicateKeyException, DifferentTypeException {
 
-        return Stream.of(
+        final List<UpdateAction<ProductType>> updateActions = Stream.of(
             buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
             buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
             buildChangeIsSearchableUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
             buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
             buildChangeAttributeConstraintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft)
         )
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(toList());
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList());
+
+        if (haveSameAttributeType(oldAttributeDefinition, newAttributeDefinitionDraft)) {
+            if (isPlainEnumAttribute(oldAttributeDefinition)) {
+                updateActions.addAll(buildEnumValuesUpdateActions(
+                    oldAttributeDefinition.getName(),
+                    ((EnumAttributeType) oldAttributeDefinition.getAttributeType()).getValues(),
+                    ((EnumAttributeType) newAttributeDefinitionDraft.getAttributeType()).getValues()
+                ));
+            } else if (isLocalizedEnumAttribute(oldAttributeDefinition)) {
+                updateActions.addAll(buildLocalizedEnumValuesUpdateActions(
+                    oldAttributeDefinition.getName(),
+                    ((LocalizedEnumAttributeType) oldAttributeDefinition.getAttributeType()).getValues(),
+                    ((LocalizedEnumAttributeType) newAttributeDefinitionDraft.getAttributeType()).getValues()
+                ));
+            }
+        } else {
+            throw new DifferentTypeException(format("The attribute type of the attribute definitions are different. "
+                + "Attribute name: '%s'. Old attribute type: '%s', new attribute type: '%s'. "
+                + "Attribute type has to remain the same for the same attribute name.",
+            oldAttributeDefinition.getName(),
+            oldAttributeDefinition.getAttributeType().getClass().getName(),
+            newAttributeDefinitionDraft.getAttributeType().getClass().getName()));
+        }
+
+
+        return updateActions;
+    }
+
+    /**
+     * Compares the attribute types of the {@code attributeDefinitionA} and the {@code attributeDefinitionB} and
+     * returns true if both attribute definitions have the same attribute type, false otherwise.
+     *
+     * @param attributeDefinitionA the first attribute definition to compare.
+     * @param attributeDefinitionB the second attribute definition to compare.
+     *
+     * @return true if both attribute definitions have the same attribute type, false otherwise.
+     */
+    private static final boolean haveSameAttributeType(
+        @Nonnull final AttributeDefinition attributeDefinitionA,
+        @Nonnull final AttributeDefinitionDraft attributeDefinitionB) {
+
+        return attributeDefinitionA.getAttributeType().getClass()
+                == attributeDefinitionB.getAttributeType().getClass();
+    }
+
+    /**
+     * Indicates if the attribute definition is a plain enum value or not.
+     *
+     * @param attributeDefiniton the attribute definition.
+     *
+     * @return true if the attribute definition is a plain enum value, false otherwise.
+     */
+    private static final boolean isPlainEnumAttribute(@Nonnull final AttributeDefinition attributeDefiniton) {
+        return attributeDefiniton.getAttributeType().getClass() == EnumAttributeType.class;
+    }
+
+    /**
+     * Indicates if the attribute definition is a localized enum value or not.
+     *
+     * @param attributeDefiniton the attribute definition.
+     *
+     * @return true if the attribute definition is a localized enum value, false otherwise.
+     */
+    private static final boolean isLocalizedEnumAttribute(@Nonnull final AttributeDefinition attributeDefiniton) {
+        return attributeDefiniton.getAttributeType().getClass() == LocalizedEnumAttributeType.class;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/producttypes/utils/LocalizedEnumUpdateActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/LocalizedEnumUpdateActionsUtils.java
@@ -19,22 +19,22 @@ public final class LocalizedEnumUpdateActionsUtils {
      * list of {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both {@link LocalizedEnumValue} have
      * identical fields then no update action is needed and hence an empty {@link List} is returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose localized enum values belong to.
-     * @param oldEnumValue              the localized enum value which should be updated.
-     * @param newEnumValue              the localized enum value where we get the new fields.
-     *
-     * @return                          A list with the update actions or an empty list if the localized enum values are
-     *                                  identical.
+     * @param attributeDefinitionName the attribute definition name whose localized enum values belong to.
+     * @param oldEnumValue            the localized enum value which should be updated.
+     * @param newEnumValue            the localized enum value where we get the new fields.
+     * @return A list with the update actions or an empty list if the localized enum values are
+     *         identical.
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
-            @Nonnull final String attributeDefinitionName,
-            @Nonnull final LocalizedEnumValue oldEnumValue,
-            @Nonnull final LocalizedEnumValue newEnumValue) {
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final LocalizedEnumValue oldEnumValue,
+        @Nonnull final LocalizedEnumValue newEnumValue) {
 
-        return Stream.of(
-            buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
-        )
+        return Stream
+            .of(
+                buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
+            )
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(toList());
@@ -46,12 +46,11 @@ public final class LocalizedEnumUpdateActionsUtils {
      * {@link UpdateAction}. If both, old and new {@link LocalizedEnumValue} have the same {@code label} values,
      * then no update action is needed and empty optional will be returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose localized enum values belong to.
-     * @param oldEnumValue              the old localized enum value.
-     * @param newEnumValue              the new localized enum value which contains the new description.
-     *
-     * @return                          optional containing update action or empty optional if labels
-     *                                  are identical.
+     * @param attributeDefinitionName the attribute definition name whose localized enum values belong to.
+     * @param oldEnumValue            the old localized enum value.
+     * @param newEnumValue            the new localized enum value which contains the new description.
+     * @return optional containing update action or empty optional if labels
+     *         are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeLabelAction(
@@ -63,5 +62,6 @@ public final class LocalizedEnumUpdateActionsUtils {
             () -> ChangeLocalizedEnumValueLabel.of(attributeDefinitionName, newEnumValue));
     }
 
-    private LocalizedEnumUpdateActionsUtils() {}
+    private LocalizedEnumUpdateActionsUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/LocalizedEnumUpdateActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/LocalizedEnumUpdateActionsUtils.java
@@ -1,0 +1,67 @@
+package com.commercetools.sync.producttypes.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedEnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static java.util.stream.Collectors.toList;
+
+public final class LocalizedEnumUpdateActionsUtils {
+    /**
+     * Compares all the fields of an old {@link LocalizedEnumValue} and a new {@link LocalizedEnumValue} and returns a
+     * list of {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both {@link LocalizedEnumValue} have
+     * identical fields then no update action is needed and hence an empty {@link List} is returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose localized enum values belong to.
+     * @param oldEnumValue              the localized enum value which should be updated.
+     * @param newEnumValue              the localized enum value where we get the new fields.
+     *
+     * @return                          A list with the update actions or an empty list if the localized enum values are
+     *                                  identical.
+     */
+    @Nonnull
+    public static List<UpdateAction<ProductType>> buildActions(
+            @Nonnull final String attributeDefinitionName,
+            @Nonnull final LocalizedEnumValue oldEnumValue,
+            @Nonnull final LocalizedEnumValue newEnumValue) {
+
+        return Stream.of(
+            buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
+        )
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList());
+    }
+
+    /**
+     * Compares the {@code label} values of an old {@link LocalizedEnumValue} and a new {@link LocalizedEnumValue}
+     * and returns an {@link Optional} of update action, which would contain the {@code "changeLabel"}
+     * {@link UpdateAction}. If both, old and new {@link LocalizedEnumValue} have the same {@code label} values,
+     * then no update action is needed and empty optional will be returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose localized enum values belong to.
+     * @param oldEnumValue              the old localized enum value.
+     * @param newEnumValue              the new localized enum value which contains the new description.
+     *
+     * @return                          optional containing update action or empty optional if labels
+     *                                  are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeLabelAction(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final LocalizedEnumValue oldEnumValue,
+        @Nonnull final LocalizedEnumValue newEnumValue) {
+
+        return buildUpdateAction(oldEnumValue.getLabel(), newEnumValue.getLabel(),
+            () -> ChangeLocalizedEnumValueLabel.of(attributeDefinitionName, newEnumValue));
+    }
+
+    private LocalizedEnumUpdateActionsUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/producttypes/utils/PlainEnumUpdateActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/PlainEnumUpdateActionsUtils.java
@@ -1,0 +1,67 @@
+package com.commercetools.sync.producttypes.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static java.util.stream.Collectors.toList;
+
+public final class PlainEnumUpdateActionsUtils {
+    /**
+     * Compares all the fields of an old {@link EnumValue} and a new {@link EnumValue} and returns a list of
+     * {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both {@link EnumValue} have identical fields,
+     * then no update action is needed and hence an empty {@link List} is returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose plain enum values belong to.
+     * @param oldEnumValue              the enum value which should be updated.
+     * @param newEnumValue              the enum value where we get the new fields.
+     *
+     * @return                          A list with the update actions or an empty list if the enum values are
+     *                                  identical.
+     */
+    @Nonnull
+    public static List<UpdateAction<ProductType>> buildActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final EnumValue oldEnumValue,
+        @Nonnull final EnumValue newEnumValue) {
+
+        return Stream.of(
+            buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
+        )
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(toList());
+    }
+
+    /**
+     * Compares the {@code label} values of an old {@link EnumValue} and a new {@link EnumValue}
+     * and returns an {@link Optional} of update action, which would contain the {@code "changeLabel"}
+     * {@link UpdateAction}. If both, old and new {@link EnumValue} have the same {@code label} values,
+     * then no update action is needed and empty optional will be returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose plain enum values belong to.
+     * @param oldEnumValue              the old plain enum value.
+     * @param newEnumValue              the new plain enum value which contains the new description.
+     *
+     * @return                          optional containing update action or empty optional if labels
+     *                                  are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ProductType>> buildChangeLabelAction(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final EnumValue oldEnumValue,
+        @Nonnull final EnumValue newEnumValue) {
+
+        return buildUpdateAction(oldEnumValue.getLabel(), newEnumValue.getLabel(),
+            () -> ChangePlainEnumValueLabel.of(attributeDefinitionName, newEnumValue));
+    }
+
+    private PlainEnumUpdateActionsUtils() { }
+}

--- a/src/main/java/com/commercetools/sync/producttypes/utils/PlainEnumUpdateActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/PlainEnumUpdateActionsUtils.java
@@ -19,12 +19,11 @@ public final class PlainEnumUpdateActionsUtils {
      * {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both {@link EnumValue} have identical fields,
      * then no update action is needed and hence an empty {@link List} is returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose plain enum values belong to.
-     * @param oldEnumValue              the enum value which should be updated.
-     * @param newEnumValue              the enum value where we get the new fields.
-     *
-     * @return                          A list with the update actions or an empty list if the enum values are
-     *                                  identical.
+     * @param attributeDefinitionName the attribute definition name whose plain enum values belong to.
+     * @param oldEnumValue            the enum value which should be updated.
+     * @param newEnumValue            the enum value where we get the new fields.
+     * @return A list with the update actions or an empty list if the enum values are
+     *         identical.
      */
     @Nonnull
     public static List<UpdateAction<ProductType>> buildActions(
@@ -32,12 +31,13 @@ public final class PlainEnumUpdateActionsUtils {
         @Nonnull final EnumValue oldEnumValue,
         @Nonnull final EnumValue newEnumValue) {
 
-        return Stream.of(
-            buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
-        )
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(toList());
+        return Stream
+            .of(
+                buildChangeLabelAction(attributeDefinitionName, oldEnumValue, newEnumValue)
+            )
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toList());
     }
 
     /**
@@ -46,12 +46,11 @@ public final class PlainEnumUpdateActionsUtils {
      * {@link UpdateAction}. If both, old and new {@link EnumValue} have the same {@code label} values,
      * then no update action is needed and empty optional will be returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose plain enum values belong to.
-     * @param oldEnumValue              the old plain enum value.
-     * @param newEnumValue              the new plain enum value which contains the new description.
-     *
-     * @return                          optional containing update action or empty optional if labels
-     *                                  are identical.
+     * @param attributeDefinitionName the attribute definition name whose plain enum values belong to.
+     * @param oldEnumValue            the old plain enum value.
+     * @param newEnumValue            the new plain enum value which contains the new description.
+     * @return optional containing update action or empty optional if labels
+     *         are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ProductType>> buildChangeLabelAction(
@@ -63,5 +62,6 @@ public final class PlainEnumUpdateActionsUtils {
             () -> ChangePlainEnumValueLabel.of(attributeDefinitionName, newEnumValue));
     }
 
-    private PlainEnumUpdateActionsUtils() { }
+    private PlainEnumUpdateActionsUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
@@ -27,7 +27,6 @@ public final class ProductTypeUpdateActionUtils {
      *
      * @param oldProductType the product type that should be updated.
      * @param newProductType the product type draft which contains the new name.
-
      * @return optional containing update action or empty optional if names are identical.
      */
     @Nonnull
@@ -47,7 +46,6 @@ public final class ProductTypeUpdateActionUtils {
      *
      * @param oldProductType the product type that should be updated.
      * @param newProductType the product type draft which contains the new description.
-     *
      * @return optional containing update action or empty optional if descriptions are identical.
      */
     @Nonnull
@@ -66,11 +64,11 @@ public final class ProductTypeUpdateActionUtils {
      * {@link List} is returned. In case, the new product type draft has a list of attributes in which a duplicate name
      * exists, the error callback is triggered and an empty list is returned.
      *
-     * @param oldProductType    the product type which should be updated.
-     * @param newProductType    the product type draft where we get the key.
-     * @param syncOptions       responsible for supplying the sync options to the sync utility method.
-     *                          It is used for triggering the error callback within the utility, in case of
-     *                          errors.
+     * @param oldProductType the product type which should be updated.
+     * @param newProductType the product type draft where we get the key.
+     * @param syncOptions    responsible for supplying the sync options to the sync utility method.
+     *                       It is used for triggering the error callback within the utility, in case of
+     *                       errors.
      * @return A list with the update actions or an empty list if the attributes are identical.
      */
     @Nonnull
@@ -92,5 +90,6 @@ public final class ProductTypeUpdateActionUtils {
         }
     }
 
-    private ProductTypeUpdateActionUtils() { }
+    private ProductTypeUpdateActionUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtils.java
@@ -95,8 +95,11 @@ public final class ProductTypeUpdateActionUtils {
      * {@link List} is returned. In case, the new product type draft has a list of attributes in which a duplicate name
      * exists, the error callback is triggered and an empty list is returned.
      *
-     * @param oldProductType the product type which should be updated.
-     * @param newProductType the product type draft where we get the key.
+     * @param oldProductType    the product type which should be updated.
+     * @param newProductType    the product type draft where we get the key.
+     * @param syncOptions       responsible for supplying the sync options to the sync utility method.
+     *                          It is used for triggering the error callback within the utility, in case of
+     *                          errors.
      * @return A list with the update actions or an empty list if the attributes are identical.
      */
     @Nonnull
@@ -107,8 +110,9 @@ public final class ProductTypeUpdateActionUtils {
 
         try {
             return buildAttributeDefinitionsUpdateActions(
-                    oldProductType.getAttributes(),
-                    newProductType.getAttributes());
+                oldProductType.getAttributes(),
+                newProductType.getAttributes()
+            );
         } catch (final BuildUpdateActionException exception) {
             syncOptions.applyErrorCallback(format("Failed to build update actions for the attributes definitions "
                     + "of the product type with the key '%s'. Reason: %s", oldProductType.getKey(), exception),

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
@@ -43,9 +43,8 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * <p>If the list of new {@link AttributeDefinitionDraft}s is {@code null}, then remove actions are built for
      * every existing attribute definition in the {@code oldAttributeDefinitions} list.
      *
-     * @param oldAttributeDefinitions                       the old list of attribute definitions.
-     * @param newAttributeDefinitionsDrafts                 the new list of attribute definitions drafts.
-     *
+     * @param oldAttributeDefinitions       the old list of attribute definitions.
+     * @param newAttributeDefinitionsDrafts the new list of attribute definitions drafts.
      * @return a list of attribute definitions update actions if the list of attribute definitions is not identical.
      *         Otherwise, if the attribute definitions are identical, an empty list is returned.
      * @throws BuildUpdateActionException in case there are attribute definitions drafts with duplicate names.
@@ -77,9 +76,8 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * update actions on attribute definitions (e.g. changeAttributeName, changeAttributeLabel, etc..) for the required
      * resource.
      *
-     * @param oldAttributeDefinitions                       the old list of attribute definitions.
-     * @param newAttributeDefinitionsDrafts                 the new list of attribute definitions drafts.
-     *
+     * @param oldAttributeDefinitions       the old list of attribute definitions.
+     * @param newAttributeDefinitionsDrafts the new list of attribute definitions drafts.
      * @return a list of attribute definitions update actions if the list of attribute definitions is not identical.
      *         Otherwise, if the attribute definitions are identical, an empty list is returned.
      * @throws BuildUpdateActionException in case there are attribute definitions drafts with duplicate names.
@@ -104,8 +102,8 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
                 toMap(AttributeDefinitionDraft::getName, attributeDefinitionDraft -> attributeDefinitionDraft,
                     (attributeDefinitionDraftA, attributeDefinitionDraftB) -> {
                         throw new DuplicateNameException(format("Attribute definitions drafts have duplicated names. "
-                            + "Duplicated attribute definition name: '%s'. "
-                            + "Attribute definitions names are expected to be unique inside their product type.",
+                                + "Duplicated attribute definition name: '%s'. "
+                                + "Attribute definitions names are expected to be unique inside their product type.",
                             attributeDefinitionDraftA.getName()));
                     }
                 ));
@@ -148,15 +146,14 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * Otherwise, if the attribute definition still exists in the new draft, then compare the attribute definition
      * fields (name, label, etc..), and add the computed actions to the list of update actions.
      *
-     * @param oldAttributeDefinitions                       the list of old {@link AttributeDefinition}s.
-     * @param removedAttributeDefinitionNames               a set containing names of removed attribute definitions.
-     * @param newAttributeDefinitionDraftsNameMap           a map of names to attribute definition drafts of the new
-     *                                                      list of attribute definition drafts.
-     *
+     * @param oldAttributeDefinitions             the list of old {@link AttributeDefinition}s.
+     * @param removedAttributeDefinitionNames     a set containing names of removed attribute definitions.
+     * @param newAttributeDefinitionDraftsNameMap a map of names to attribute definition drafts of the new
+     *                                            list of attribute definition drafts.
      * @return a list of attribute definition update actions if there are attribute definitions that are not existing
-     *      in the new draft. If the attribute definition still exists in the new draft, then compare the attribute
-     *      definition fields (name, label, etc..), and add the computed actions to the list of update actions.
-     *      Otherwise, if the attribute definitions are identical, an empty optional is returned.
+     *         in the new draft. If the attribute definition still exists in the new draft, then compare the attribute
+     *         definition fields (name, label, etc..), and add the computed actions to the list of update actions.
+     *         Otherwise, if the attribute definitions are identical, an empty optional is returned.
      */
     @Nonnull
     private static List<UpdateAction<ProductType>> buildRemoveAttributeDefinitionOrAttributeDefinitionUpdateActions(
@@ -189,9 +186,8 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * {@link AttributeDefinitionDraft}s. If there is a change in order, then a change attribute definition order
      * (with the new order) is built. If there are no changes in order an empty optional is returned.
      *
-     * @param oldAttributeDefinitions                       the list of old {@link AttributeDefinition}s
-     * @param newAttributeDefinitionDrafts                  the list of new {@link AttributeDefinitionDraft}s
-
+     * @param oldAttributeDefinitions      the list of old {@link AttributeDefinition}s
+     * @param newAttributeDefinitionDrafts the list of new {@link AttributeDefinitionDraft}s
      * @return a list of attribute definition update actions if the the order of attribute definitions is not
      *         identical. Otherwise, if the attribute definitions order is identical, an empty optional is returned.
      */
@@ -223,7 +219,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
             .collect(toList());
 
         final List<String> allNames = Stream.concat(existingNames.stream(), notExistingNames.stream())
-            .collect(toList());
+                                            .collect(toList());
 
         return buildUpdateAction(
             allNames,
@@ -240,9 +236,9 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
      * Otherwise, if there are no new attribute definitions, then an empty list
      * is returned.
      *
-     * @param newAttributeDefinitionDrafts                  the list of new {@link AttributeDefinitionDraft}s.
-     * @param oldAttributeDefinitionNameMap                 a map of names to AttributeDefinition of the old list
-     *                                                      of attribute definition.
+     * @param newAttributeDefinitionDrafts  the list of new {@link AttributeDefinitionDraft}s.
+     * @param oldAttributeDefinitionNameMap a map of names to AttributeDefinition of the old list
+     *                                      of attribute definition.
      * @return a list of attribute definition update actions if there are new attribute definition that should be added.
      *         Otherwise, if the attribute definitions are identical, an empty optional is returned.
      */
@@ -258,12 +254,13 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
             .stream()
             .filter(attributeDefinitionDraft ->
                 !oldAttributeDefinitionNameMap
-                .containsKey(attributeDefinitionDraft.getName())
+                    .containsKey(attributeDefinitionDraft.getName())
             )
             .map(AttributeDefinitionCustomBuilder::of)
             .map(AddAttributeDefinition::of)
             .collect(Collectors.toList());
     }
 
-    private ProductTypeUpdateAttributeDefinitionActionUtils() { }
+    private ProductTypeUpdateAttributeDefinitionActionUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateEnumActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateEnumActionsUtils.java
@@ -29,11 +29,10 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * Given a list of enum values, gets a map where the keys are the enum value key, and the values
      * are the enum instances.
      *
-     * @param enumValues                the list of enum values.
-     * @param <T>                       the enum type of the elements of the list.
-     *
-     * @return                          a map with the enum value key as a key of the map, and the
-     *                                  enum value as a value of the map.
+     * @param enumValues the list of enum values.
+     * @param <T>        the enum type of the elements of the list.
+     * @return a map with the enum value key as a key of the map, and the
+     *         enum value as a value of the map.
      */
     @Nonnull
     public static <T extends WithKey> Map<String, T> getEnumValuesKeyMap(@Nonnull final List<T> enumValues) {
@@ -46,13 +45,11 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * Given a list of new {@link EnumValue}s, gets a map where the keys are the enum value key, and the values
      * are the enum instances.
      *
-     * @param attributeDefinitionName   the attribute definition name whose the enum values belong to.
-     * @param enumValues                the list of enum values.
-     * @param <T>                       the enum type of the elements of the list.
-     *
-     * @return                          a map with the enum value key as a key of the map, and the enum
-     *                                  value as a value of the map.
-     *
+     * @param attributeDefinitionName the attribute definition name whose the enum values belong to.
+     * @param enumValues              the list of enum values.
+     * @param <T>                     the enum type of the elements of the list.
+     * @return a map with the enum value key as a key of the map, and the enum
+     *         value as a value of the map.
      * @throws DuplicateKeyException in case there are enum values with duplicate keys.
      */
     @Nonnull
@@ -64,8 +61,8 @@ public final class ProductTypeUpdateEnumActionsUtils {
             toMap(WithKey::getKey, enumValue -> enumValue,
                 (enumValueA, enumValueB) -> {
                     throw new DuplicateKeyException(format("Enum Values have duplicated keys. "
-                        + "Attribute definition name: '%s', Duplicated enum value: '%s'. "
-                        + "Enum Values are expected to be unique inside their attribute definition.",
+                            + "Attribute definition name: '%s', Duplicated enum value: '%s'. "
+                            + "Enum Values are expected to be unique inside their attribute definition.",
                         attributeDefinitionName, enumValueA.getKey()));
                 }
             ));
@@ -76,14 +73,13 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * If there are, then "remove" enum values update actions are built.
      * Otherwise, if there are no old enum values, then an empty list is returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
-     * @param oldEnumValues             the list of old enum values.
-     * @param newEnumValues             the list of new enum values.
-     * @param <T>                       the enum type of the elements of the list.
-     *
-     * @return                          a list of enum values update actions if there are old enum value
-     *                                  that should be removed.
-     *                                  Otherwise, if the enum values are identical, an empty optional is returned.
+     * @param attributeDefinitionName the attribute definition name whose enum values belong to.
+     * @param oldEnumValues           the list of old enum values.
+     * @param newEnumValues           the list of new enum values.
+     * @param <T>                     the enum type of the elements of the list.
+     * @return a list of enum values update actions if there are old enum value
+     *         that should be removed.
+     *         Otherwise, if the enum values are identical, an empty optional is returned.
      */
     @Nonnull
     public static <T extends WithKey> Optional<UpdateAction<ProductType>> buildRemoveEnumValuesUpdateActions(
@@ -95,8 +91,8 @@ public final class ProductTypeUpdateEnumActionsUtils {
 
         if (newEnumValues != null && !newEnumValues.isEmpty()) {
             final Map<String, T> newEnumValuesKeyMap = getEnumValuesKeyMapWithKeyValidation(
-                    attributeDefinitionName,
-                    newEnumValues
+                attributeDefinitionName,
+                newEnumValues
             );
 
             keysToRemove = oldEnumValues
@@ -123,16 +119,13 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * then a change of enum values order (with the new order) is built. If there are no changes in order an empty
      * optional is returned.
      *
-     * @param attributeDefinitionName    the attribute definition name whose enum values belong to.
-     * @param oldEnumValues              the list of old enum values.
-     * @param newEnumValues              the list of new enum values.
-     * @param changeOrderEnumCallback    the function that is called to apply the change in the order.
-     * @param <T>                        the enum type of the elements to change the order for.
-     *
-     * @return                           an optional update action if the the order of the enum values is not
-     *                                   identical.
-     *                                   Otherwise, if the enum values order is identical, an empty optional is
-     *                                   returned.
+     * @param attributeDefinitionName the attribute definition name whose enum values belong to.
+     * @param oldEnumValues           the list of old enum values.
+     * @param newEnumValues           the list of new enum values.
+     * @param changeOrderEnumCallback the function that is called to apply the change in the order.
+     * @param <T>                     the enum type of the elements to change the order for.
+     * @return an optional update action if the the order of the enum values is not identical.
+     *         Otherwise, if the enum values order is identical, an empty optional is returned.
      */
     @Nonnull
     public static <T extends WithKey> Optional<UpdateAction<ProductType>> buildChangeEnumValuesOrderUpdateAction(
@@ -158,7 +151,7 @@ public final class ProductTypeUpdateEnumActionsUtils {
             .collect(Collectors.toList());
 
         final List<String> allKeys = Stream.concat(existingKeys.stream(), notExistingKeys.stream())
-            .collect(Collectors.toList());
+                                           .collect(Collectors.toList());
 
 
         return buildUpdateAction(
@@ -173,15 +166,13 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * If there are, then "add" enum values update actions are built.
      * Otherwise, if there are no new enum values, then an empty list is returned.
      *
-     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
-     * @param oldEnumValues             the list of olf enum values.
-     * @param newEnumValues             the list of new enum values.
-     * @param addEnumCallback           the function that is called in order to add the new enum instance
-     * @param <T>                       the enum type of the element to add.
-     *
-     * @return                          a list of enum values update actions if there are new enum value
-     *                                  that should be added.
-     *                                  Otherwise, if the enum values are identical, an empty optional is returned.
+     * @param attributeDefinitionName the attribute definition name whose enum values belong to.
+     * @param oldEnumValues           the list of olf enum values.
+     * @param newEnumValues           the list of new enum values.
+     * @param addEnumCallback         the function that is called in order to add the new enum instance
+     * @param <T>                     the enum type of the element to add.
+     * @return a list of enum values update actions if there are new enum value that should be added.
+     *         Otherwise, if the enum values are identical, an empty optional is returned.
      */
     @Nonnull
     public static <T extends WithKey> List<UpdateAction<ProductType>> buildAddEnumValuesUpdateActions(
@@ -204,19 +195,16 @@ public final class ProductTypeUpdateEnumActionsUtils {
      * If there are, then compare the enum value fields, and add the computed actions to the list of
      * update actions.
      *
-     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
-     * @param oldEnumValues             the list of old enum values.
-     * @param newEnumValues             the list of new enum values.
-     * @param matchingEnumCallback      the function that is called to get the update action resulting from comparing
-     *                                  the enum value fields one by one.
-     * @param <T>                       the enum type of the elements of the list.
-     *
-     * @return                          a list of enum update actions if there are enum values that are
-     *                                  existing in the map of new enum values. If the enum value still
-     *                                  exists, then compare the enum value fields (label), and add the computed
-     *                                  actions to the list of update actions.
-     *                                  Otherwise, if the enum values are identical, an empty optional is
-     *                                  returned.
+     * @param attributeDefinitionName the attribute definition name whose enum values belong to.
+     * @param oldEnumValues           the list of old enum values.
+     * @param newEnumValues           the list of new enum values.
+     * @param matchingEnumCallback    the function that is called to get the update action resulting from comparing
+     *                                the enum value fields one by one.
+     * @param <T>                     the enum type of the elements of the list.
+     * @return a list of enum update actions if there are enum values that are existing in the map of new enum values.
+     *         If the enum value still exists, then compare the enum value fields (label), and add the computed
+     *         actions to the list of update actions.
+     *         Otherwise, if the enum values are identical, an empty optional is returned.
      */
     @Nonnull
     public static <T extends WithKey> List<UpdateAction<ProductType>> buildMatchingEnumValuesUpdateActions(
@@ -226,8 +214,8 @@ public final class ProductTypeUpdateEnumActionsUtils {
         @Nonnull final TriFunction<String, T, T, List<UpdateAction<ProductType>>> matchingEnumCallback) {
 
         final Map<String, T> newEnumValuesKeyMap = getEnumValuesKeyMapWithKeyValidation(
-                attributeDefinitionName,
-                newEnumValues
+            attributeDefinitionName,
+            newEnumValues
         );
 
         return oldEnumValues
@@ -243,5 +231,6 @@ public final class ProductTypeUpdateEnumActionsUtils {
             .collect(Collectors.toList());
     }
 
-    private ProductTypeUpdateEnumActionsUtils() { }
+    private ProductTypeUpdateEnumActionsUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateEnumActionsUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateEnumActionsUtils.java
@@ -1,0 +1,247 @@
+package com.commercetools.sync.producttypes.utils;
+
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.models.WithKey;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.List;
+import java.util.Optional;
+import java.util.Collection;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toMap;
+
+public final class ProductTypeUpdateEnumActionsUtils {
+    /**
+     * Given a list of enum values, gets a map where the keys are the enum value key, and the values
+     * are the enum instances.
+     *
+     * @param enumValues                the list of enum values.
+     * @param <T>                       the enum type of the elements of the list.
+     *
+     * @return                          a map with the enum value key as a key of the map, and the
+     *                                  enum value as a value of the map.
+     */
+    @Nonnull
+    public static <T extends WithKey> Map<String, T> getEnumValuesKeyMap(@Nonnull final List<T> enumValues) {
+        return enumValues
+            .stream()
+            .collect(toMap(WithKey::getKey, enumValue -> enumValue));
+    }
+
+    /**
+     * Given a list of new {@link EnumValue}s, gets a map where the keys are the enum value key, and the values
+     * are the enum instances.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose the enum values belong to.
+     * @param enumValues                the list of enum values.
+     * @param <T>                       the enum type of the elements of the list.
+     *
+     * @return                          a map with the enum value key as a key of the map, and the enum
+     *                                  value as a value of the map.
+     *
+     * @throws DuplicateKeyException in case there are enum values with duplicate keys.
+     */
+    @Nonnull
+    public static <T extends WithKey> Map<String, T> getEnumValuesKeyMapWithKeyValidation(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<T> enumValues) throws DuplicateKeyException {
+
+        return enumValues.stream().collect(
+            toMap(WithKey::getKey, enumValue -> enumValue,
+                (enumValueA, enumValueB) -> {
+                    throw new DuplicateKeyException(format("Enum Values have duplicated keys. "
+                        + "Attribute definition name: '%s', Duplicated enum value: '%s'. "
+                        + "Enum Values are expected to be unique inside their attribute definition.",
+                        attributeDefinitionName, enumValueA.getKey()));
+                }
+            ));
+    }
+
+    /**
+     * Checks if there are any old enum values which are not existing in the {@code newEnumValues}.
+     * If there are, then "remove" enum values update actions are built.
+     * Otherwise, if there are no old enum values, then an empty list is returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
+     * @param oldEnumValues             the list of old enum values.
+     * @param newEnumValues             the list of new enum values.
+     * @param <T>                       the enum type of the elements of the list.
+     *
+     * @return                          a list of enum values update actions if there are old enum value
+     *                                  that should be removed.
+     *                                  Otherwise, if the enum values are identical, an empty optional is returned.
+     */
+    @Nonnull
+    public static <T extends WithKey> Optional<UpdateAction<ProductType>> buildRemoveEnumValuesUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<T> oldEnumValues,
+        @Nullable final List<T> newEnumValues) {
+
+        final List<String> keysToRemove;
+
+        if (newEnumValues != null && !newEnumValues.isEmpty()) {
+            final Map<String, T> newEnumValuesKeyMap = getEnumValuesKeyMapWithKeyValidation(
+                    attributeDefinitionName,
+                    newEnumValues
+            );
+
+            keysToRemove = oldEnumValues
+                .stream()
+                .map(WithKey::getKey)
+                .filter(oldEnumValueKey -> !newEnumValuesKeyMap.containsKey(oldEnumValueKey))
+                .collect(Collectors.toList());
+        } else {
+            keysToRemove = oldEnumValues
+                .stream()
+                .map(WithKey::getKey)
+                .collect(Collectors.toList());
+        }
+
+        if (!keysToRemove.isEmpty()) {
+            return ofNullable(RemoveEnumValues.of(attributeDefinitionName, keysToRemove));
+        } else {
+            return empty();
+        }
+    }
+
+    /**
+     * Compares the order of a list of old enum values and a list of new enum values. If there is a change in order,
+     * then a change of enum values order (with the new order) is built. If there are no changes in order an empty
+     * optional is returned.
+     *
+     * @param attributeDefinitionName    the attribute definition name whose enum values belong to.
+     * @param oldEnumValues              the list of old enum values.
+     * @param newEnumValues              the list of new enum values.
+     * @param changeOrderEnumCallback    the function that is called to apply the change in the order.
+     * @param <T>                        the enum type of the elements to change the order for.
+     *
+     * @return                           an optional update action if the the order of the enum values is not
+     *                                   identical.
+     *                                   Otherwise, if the enum values order is identical, an empty optional is
+     *                                   returned.
+     */
+    @Nonnull
+    public static <T extends WithKey> Optional<UpdateAction<ProductType>> buildChangeEnumValuesOrderUpdateAction(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<T> oldEnumValues,
+        @Nonnull final List<T> newEnumValues,
+        @Nonnull final BiFunction<String, List<T>, UpdateAction<ProductType>> changeOrderEnumCallback) {
+
+        final List<String> newKeys = newEnumValues
+            .stream()
+            .map(WithKey::getKey)
+            .collect(Collectors.toList());
+
+        final List<String> existingKeys = oldEnumValues
+            .stream()
+            .map(WithKey::getKey)
+            .filter(newKeys::contains)
+            .collect(Collectors.toList());
+
+        final List<String> notExistingKeys = newKeys
+            .stream()
+            .filter(newKey -> !existingKeys.contains(newKey))
+            .collect(Collectors.toList());
+
+        final List<String> allKeys = Stream.concat(existingKeys.stream(), notExistingKeys.stream())
+            .collect(Collectors.toList());
+
+
+        return buildUpdateAction(
+            allKeys,
+            newKeys,
+            () -> changeOrderEnumCallback.apply(attributeDefinitionName, newEnumValues)
+        );
+    }
+
+    /**
+     * Checks if there are any new enum values which are not existing in the {@code oldEnumValues}.
+     * If there are, then "add" enum values update actions are built.
+     * Otherwise, if there are no new enum values, then an empty list is returned.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
+     * @param oldEnumValues             the list of olf enum values.
+     * @param newEnumValues             the list of new enum values.
+     * @param addEnumCallback           the function that is called in order to add the new enum instance
+     * @param <T>                       the enum type of the element to add.
+     *
+     * @return                          a list of enum values update actions if there are new enum value
+     *                                  that should be added.
+     *                                  Otherwise, if the enum values are identical, an empty optional is returned.
+     */
+    @Nonnull
+    public static <T extends WithKey> List<UpdateAction<ProductType>> buildAddEnumValuesUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<T> oldEnumValues,
+        @Nonnull final List<T> newEnumValues,
+        @Nonnull final BiFunction<String, T, UpdateAction<ProductType>> addEnumCallback) {
+
+        final Map<String, T> oldEnumValuesKeyMap = getEnumValuesKeyMap(oldEnumValues);
+
+        return newEnumValues
+            .stream()
+            .filter(newEnumValue -> !oldEnumValuesKeyMap.containsKey(newEnumValue.getKey()))
+            .map(newEnumValue -> addEnumCallback.apply(attributeDefinitionName, newEnumValue))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if there are any enum values which are existing in the {@code newEnumValues}.
+     * If there are, then compare the enum value fields, and add the computed actions to the list of
+     * update actions.
+     *
+     * @param attributeDefinitionName   the attribute definition name whose enum values belong to.
+     * @param oldEnumValues             the list of old enum values.
+     * @param newEnumValues             the list of new enum values.
+     * @param matchingEnumCallback      the function that is called to get the update action resulting from comparing
+     *                                  the enum value fields one by one.
+     * @param <T>                       the enum type of the elements of the list.
+     *
+     * @return                          a list of enum update actions if there are enum values that are
+     *                                  existing in the map of new enum values. If the enum value still
+     *                                  exists, then compare the enum value fields (label), and add the computed
+     *                                  actions to the list of update actions.
+     *                                  Otherwise, if the enum values are identical, an empty optional is
+     *                                  returned.
+     */
+    @Nonnull
+    public static <T extends WithKey> List<UpdateAction<ProductType>> buildMatchingEnumValuesUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<T> oldEnumValues,
+        @Nonnull final List<T> newEnumValues,
+        @Nonnull final TriFunction<String, T, T, List<UpdateAction<ProductType>>> matchingEnumCallback) {
+
+        final Map<String, T> newEnumValuesKeyMap = getEnumValuesKeyMapWithKeyValidation(
+                attributeDefinitionName,
+                newEnumValues
+        );
+
+        return oldEnumValues
+            .stream()
+            .map(oldEnumValue ->
+                ofNullable(newEnumValuesKeyMap.get(oldEnumValue.getKey())).map(newEnumValue ->
+                    matchingEnumCallback.apply(attributeDefinitionName, oldEnumValue, newEnumValue)
+                )
+            )
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+    }
+
+    private ProductTypeUpdateEnumActionsUtils() { }
+}

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateLocalizedEnumActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateLocalizedEnumActionUtils.java
@@ -31,13 +31,11 @@ public final class ProductTypeUpdateLocalizedEnumActionUtils {
      * <p>If the list of new {@link LocalizedEnumValue}s is {@code null}, then remove actions are built for
      * every existing localized enum value in the {@code oldEnumValues} list.
      *
-     * @param attributeDefinitionName   the attribute name whose localized enum values are going to be synced.
-     * @param oldEnumValues             the old list of localized enum values.
-     * @param newEnumValues             the new list of localized enum values.
-     *
+     * @param attributeDefinitionName the attribute name whose localized enum values are going to be synced.
+     * @param oldEnumValues           the old list of localized enum values.
+     * @param newEnumValues           the new list of localized enum values.
      * @return a list of localized enum values update actions if the list of localized enum values is not identical.
      *         Otherwise, if the localized enum values are identical, an empty list is returned.
-     *
      * @throws DuplicateKeyException in case there are localized enum values with duplicate keys.
      */
     @Nonnull
@@ -71,13 +69,11 @@ public final class ProductTypeUpdateLocalizedEnumActionUtils {
      * for building the required update actions (AddEnumValue, RemoveEnumValue, ChangeEnumValueOrder and 1-1
      * update actions on localized enum values (e.g. changeLabel) for the required resource.
      *
-     * @param attributeDefinitionName   the attribute name whose localized enum values are going to be synced.
-     * @param oldEnumValues             the old list of localized enum values.
-     * @param newEnumValues             the new list of localized enum values.
-     *
+     * @param attributeDefinitionName the attribute name whose localized enum values are going to be synced.
+     * @param oldEnumValues           the old list of localized enum values.
+     * @param newEnumValues           the new list of localized enum values.
      * @return a list of localized enum values update actions if the list of localized enum values is not identical.
      *         Otherwise, if the localized enum values are identical, an empty list is returned.
-     *
      * @throws DuplicateKeyException in case there are localized enum values with duplicate keys.
      */
     @Nonnull
@@ -132,5 +128,6 @@ public final class ProductTypeUpdateLocalizedEnumActionUtils {
         ).collect(Collectors.toList());
     }
 
-    private ProductTypeUpdateLocalizedEnumActionUtils() { }
+    private ProductTypeUpdateLocalizedEnumActionUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateLocalizedEnumActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateLocalizedEnumActionUtils.java
@@ -1,0 +1,136 @@
+package com.commercetools.sync.producttypes.utils;
+
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedEnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.AddLocalizedEnumValue;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueOrder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildRemoveEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildMatchingEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildAddEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildChangeEnumValuesOrderUpdateAction;
+import static java.util.Collections.emptyList;
+
+public final class ProductTypeUpdateLocalizedEnumActionUtils {
+    /**
+     * Compares a list of old {@link LocalizedEnumValue}s with a list of new {@link LocalizedEnumValue}s for a given
+     * attribute definition.
+     * The method serves as a generic implementation for localized enum values syncing. The method takes in functions
+     * for building the required update actions (AddLocalizedEnumValue, RemoveEnumValue, ChangeLocalizedEnumValueOrder
+     * and 1-1 update actions on localized enum values (e.g. changeLabel) for the required resource.
+     *
+     * <p>If the list of new {@link LocalizedEnumValue}s is {@code null}, then remove actions are built for
+     * every existing localized enum value in the {@code oldEnumValues} list.
+     *
+     * @param attributeDefinitionName   the attribute name whose localized enum values are going to be synced.
+     * @param oldEnumValues             the old list of localized enum values.
+     * @param newEnumValues             the new list of localized enum values.
+     *
+     * @return a list of localized enum values update actions if the list of localized enum values is not identical.
+     *         Otherwise, if the localized enum values are identical, an empty list is returned.
+     *
+     * @throws DuplicateKeyException in case there are localized enum values with duplicate keys.
+     */
+    @Nonnull
+    public static List<UpdateAction<ProductType>> buildLocalizedEnumValuesUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<LocalizedEnumValue> oldEnumValues,
+        @Nullable final List<LocalizedEnumValue> newEnumValues)
+        throws DuplicateKeyException {
+
+        if (newEnumValues != null && !newEnumValues.isEmpty()) {
+            return buildUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues
+            );
+        } else {
+            return buildRemoveEnumValuesUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues
+            )
+                .map(Collections::singletonList)
+                .orElse(emptyList());
+        }
+    }
+
+    /**
+     * Compares a list of old {@link LocalizedEnumValue}s with a list of new {@link LocalizedEnumValue}s for a given
+     * attribute definition.
+     * The method serves as a generic implementation for localized enum values syncing. The method takes in functions
+     * for building the required update actions (AddEnumValue, RemoveEnumValue, ChangeEnumValueOrder and 1-1
+     * update actions on localized enum values (e.g. changeLabel) for the required resource.
+     *
+     * @param attributeDefinitionName   the attribute name whose localized enum values are going to be synced.
+     * @param oldEnumValues             the old list of localized enum values.
+     * @param newEnumValues             the new list of localized enum values.
+     *
+     * @return a list of localized enum values update actions if the list of localized enum values is not identical.
+     *         Otherwise, if the localized enum values are identical, an empty list is returned.
+     *
+     * @throws DuplicateKeyException in case there are localized enum values with duplicate keys.
+     */
+    @Nonnull
+    private static List<UpdateAction<ProductType>> buildUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<LocalizedEnumValue> oldEnumValues,
+        @Nonnull final List<LocalizedEnumValue> newEnumValues)
+        throws DuplicateKeyException {
+
+        final List<UpdateAction<ProductType>> removeEnumValuesUpdateActions = buildRemoveEnumValuesUpdateActions(
+            attributeDefinitionName,
+            oldEnumValues,
+            newEnumValues
+        )
+            .map(Collections::singletonList)
+            .orElse(emptyList());
+
+        final List<UpdateAction<ProductType>> matchingEnumValuesUpdateActions =
+            buildMatchingEnumValuesUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues,
+                LocalizedEnumUpdateActionsUtils::buildActions
+            );
+
+        final List<UpdateAction<ProductType>> addEnumValuesUpdateActions = buildAddEnumValuesUpdateActions(
+            attributeDefinitionName,
+            oldEnumValues,
+            newEnumValues,
+            AddLocalizedEnumValue::of
+        );
+
+        final List<UpdateAction<ProductType>> changeEnumValuesOrderUpdateActions =
+            buildChangeEnumValuesOrderUpdateAction(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues,
+                ChangeLocalizedEnumValueOrder::of
+            )
+                .map(Collections::singletonList)
+                .orElse(emptyList());
+
+        return Stream.concat(
+            Stream.concat(
+                removeEnumValuesUpdateActions.stream(),
+                matchingEnumValuesUpdateActions.stream()
+            ),
+            Stream.concat(
+                addEnumValuesUpdateActions.stream(),
+                changeEnumValuesOrderUpdateActions.stream()
+            )
+        ).collect(Collectors.toList());
+    }
+
+    private ProductTypeUpdateLocalizedEnumActionUtils() { }
+}

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdatePlainEnumActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdatePlainEnumActionUtils.java
@@ -31,13 +31,11 @@ public final class ProductTypeUpdatePlainEnumActionUtils {
      * <p>If the list of new {@link EnumValue}s is {@code null}, then remove actions are built for
      * every existing plain enum value in the {@code oldEnumValues} list.
      *
-     * @param attributeDefinitionName   the attribute name whose plain enum values are going to be synced.
-     * @param oldEnumValues             the old list of plain enum values.
-     * @param newEnumValues             the new list of plain enum values.
-     *
+     * @param attributeDefinitionName the attribute name whose plain enum values are going to be synced.
+     * @param oldEnumValues           the old list of plain enum values.
+     * @param newEnumValues           the new list of plain enum values.
      * @return a list of plain enum values update actions if the list of plain enum values is not identical.
      *         Otherwise, if the plain enum values are identical, an empty list is returned.
-     *
      * @throws DuplicateKeyException in case there are plain enum values with duplicate keys.
      */
     @Nonnull
@@ -65,7 +63,6 @@ public final class ProductTypeUpdatePlainEnumActionUtils {
     }
 
 
-
     /**
      * Compares a list of old {@link EnumValue}s with a list of new {@link EnumValue}s for a given attribute
      * definition.
@@ -73,13 +70,11 @@ public final class ProductTypeUpdatePlainEnumActionUtils {
      * for building the required update actions (AddEnumValue, RemoveEnumValue, ChangeEnumValueOrder and 1-1
      * update actions on plain enum values (e.g. changeLabel) for the required resource.
      *
-     * @param attributeDefinitionName   the attribute name whose plain enum values are going to be synced.
-     * @param oldEnumValues             the old list of plain enum values.
-     * @param newEnumValues             the new list of plain enum values.
-     *
+     * @param attributeDefinitionName the attribute name whose plain enum values are going to be synced.
+     * @param oldEnumValues           the old list of plain enum values.
+     * @param newEnumValues           the new list of plain enum values.
      * @return a list of plain enum values update actions if the list of plain enum values is not identical.
      *         Otherwise, if the plain enum values are identical, an empty list is returned.
-     *
      * @throws DuplicateKeyException in case there are plain enum values with duplicate keys.
      */
     @Nonnull
@@ -119,8 +114,8 @@ public final class ProductTypeUpdatePlainEnumActionUtils {
                 newEnumValues,
                 ChangeEnumValueOrder::of
             )
-            .map(Collections::singletonList)
-            .orElse(emptyList());
+                .map(Collections::singletonList)
+                .orElse(emptyList());
 
         return Stream.concat(
             Stream.concat(
@@ -136,5 +131,6 @@ public final class ProductTypeUpdatePlainEnumActionUtils {
     }
 
 
-    private ProductTypeUpdatePlainEnumActionUtils() { }
+    private ProductTypeUpdatePlainEnumActionUtils() {
+    }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdatePlainEnumActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdatePlainEnumActionUtils.java
@@ -1,0 +1,140 @@
+package com.commercetools.sync.producttypes.utils;
+
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.AddEnumValue;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeEnumValueOrder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildRemoveEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildMatchingEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildAddEnumValuesUpdateActions;
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateEnumActionsUtils.buildChangeEnumValuesOrderUpdateAction;
+import static java.util.Collections.emptyList;
+
+public final class ProductTypeUpdatePlainEnumActionUtils {
+    /**
+     * Compares a list of old {@link EnumValue}s with a list of new {@link EnumValue}s for a given
+     * attribute definition.
+     * The method serves as a generic implementation for plain enum values syncing. The method takes in functions
+     * for building the required update actions (AddEnumValue, RemoveEnumValue, ChangeEnumValueOrder
+     * and 1-1 update actions on plain enum values (e.g. changeLabel) for the required resource.
+     *
+     * <p>If the list of new {@link EnumValue}s is {@code null}, then remove actions are built for
+     * every existing plain enum value in the {@code oldEnumValues} list.
+     *
+     * @param attributeDefinitionName   the attribute name whose plain enum values are going to be synced.
+     * @param oldEnumValues             the old list of plain enum values.
+     * @param newEnumValues             the new list of plain enum values.
+     *
+     * @return a list of plain enum values update actions if the list of plain enum values is not identical.
+     *         Otherwise, if the plain enum values are identical, an empty list is returned.
+     *
+     * @throws DuplicateKeyException in case there are plain enum values with duplicate keys.
+     */
+    @Nonnull
+    public static List<UpdateAction<ProductType>> buildEnumValuesUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<EnumValue> oldEnumValues,
+        @Nullable final List<EnumValue> newEnumValues)
+        throws DuplicateKeyException {
+
+        if (newEnumValues != null && !newEnumValues.isEmpty()) {
+            return buildUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues
+            );
+        } else {
+            return buildRemoveEnumValuesUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues
+            )
+                .map(Collections::singletonList)
+                .orElse(emptyList());
+        }
+    }
+
+
+
+    /**
+     * Compares a list of old {@link EnumValue}s with a list of new {@link EnumValue}s for a given attribute
+     * definition.
+     * The method serves as a generic implementation for plain enum values syncing. The method takes in functions
+     * for building the required update actions (AddEnumValue, RemoveEnumValue, ChangeEnumValueOrder and 1-1
+     * update actions on plain enum values (e.g. changeLabel) for the required resource.
+     *
+     * @param attributeDefinitionName   the attribute name whose plain enum values are going to be synced.
+     * @param oldEnumValues             the old list of plain enum values.
+     * @param newEnumValues             the new list of plain enum values.
+     *
+     * @return a list of plain enum values update actions if the list of plain enum values is not identical.
+     *         Otherwise, if the plain enum values are identical, an empty list is returned.
+     *
+     * @throws DuplicateKeyException in case there are plain enum values with duplicate keys.
+     */
+    @Nonnull
+    private static List<UpdateAction<ProductType>> buildUpdateActions(
+        @Nonnull final String attributeDefinitionName,
+        @Nonnull final List<EnumValue> oldEnumValues,
+        @Nonnull final List<EnumValue> newEnumValues)
+        throws DuplicateKeyException {
+
+        final List<UpdateAction<ProductType>> removeEnumValuesUpdateActions = buildRemoveEnumValuesUpdateActions(
+            attributeDefinitionName,
+            oldEnumValues,
+            newEnumValues
+        )
+            .map(Collections::singletonList)
+            .orElse(emptyList());
+
+        final List<UpdateAction<ProductType>> matchingEnumValuesUpdateActions =
+            buildMatchingEnumValuesUpdateActions(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues,
+                PlainEnumUpdateActionsUtils::buildActions
+            );
+
+        final List<UpdateAction<ProductType>> addEnumValuesUpdateActions = buildAddEnumValuesUpdateActions(
+            attributeDefinitionName,
+            oldEnumValues,
+            newEnumValues,
+            AddEnumValue::of
+        );
+
+        final List<UpdateAction<ProductType>> changeEnumValuesOrderUpdateActions =
+            buildChangeEnumValuesOrderUpdateAction(
+                attributeDefinitionName,
+                oldEnumValues,
+                newEnumValues,
+                ChangeEnumValueOrder::of
+            )
+            .map(Collections::singletonList)
+            .orElse(emptyList());
+
+        return Stream.concat(
+            Stream.concat(
+                removeEnumValuesUpdateActions.stream(),
+                matchingEnumValuesUpdateActions.stream()
+            ),
+            Stream.concat(
+                addEnumValuesUpdateActions.stream(),
+                changeEnumValuesOrderUpdateActions.stream()
+            )
+
+        ).collect(Collectors.toList());
+    }
+
+
+    private ProductTypeUpdatePlainEnumActionUtils() { }
+}

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DifferentTypeExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DifferentTypeExceptionTest.java
@@ -12,8 +12,8 @@ public class DifferentTypeExceptionTest {
         assertThatThrownBy(() -> {
             throw new DifferentTypeException(message);
         }).isExactlyInstanceOf(DifferentTypeException.class)
-            .hasNoCause()
-            .hasMessage(message);
+          .hasNoCause()
+          .hasMessage(message);
     }
 
     @Test
@@ -24,8 +24,8 @@ public class DifferentTypeExceptionTest {
         assertThatThrownBy(() -> {
             throw new DifferentTypeException(message, cause);
         }).isExactlyInstanceOf(DifferentTypeException.class)
-            .hasCause(cause)
-            .hasMessage(message);
+          .hasCause(cause)
+          .hasMessage(message);
     }
 
     @Test
@@ -35,8 +35,8 @@ public class DifferentTypeExceptionTest {
         assertThatThrownBy(() -> {
             throw new DifferentTypeException(cause);
         }).isExactlyInstanceOf(DifferentTypeException.class)
-            .hasCause(cause)
-            .hasMessage(cause.toString());
+          .hasCause(cause)
+          .hasMessage(cause.toString());
 
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DifferentTypeExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DifferentTypeExceptionTest.java
@@ -1,0 +1,42 @@
+package com.commercetools.sync.commons.exceptions;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DifferentTypeExceptionTest {
+    @Test
+    public void differentTypeException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+        final String message = "foo";
+
+        assertThatThrownBy(() -> {
+            throw new DifferentTypeException(message);
+        }).isExactlyInstanceOf(DifferentTypeException.class)
+            .hasNoCause()
+            .hasMessage(message);
+    }
+
+    @Test
+    public void differentTypeException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+        final String message = "foo";
+        final IllegalArgumentException cause = new IllegalArgumentException();
+
+        assertThatThrownBy(() -> {
+            throw new DifferentTypeException(message, cause);
+        }).isExactlyInstanceOf(DifferentTypeException.class)
+            .hasCause(cause)
+            .hasMessage(message);
+    }
+
+    @Test
+    public void differentTypeException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+        final IllegalArgumentException cause = new IllegalArgumentException();
+
+        assertThatThrownBy(() -> {
+            throw new DifferentTypeException(cause);
+        }).isExactlyInstanceOf(DifferentTypeException.class)
+            .hasCause(cause)
+            .hasMessage(cause.toString());
+
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -1,16 +1,25 @@
 package com.commercetools.sync.producttypes.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.models.LocalizedEnumValue;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.TextInputHint;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
 import io.sphere.sdk.products.attributes.AttributeConstraint;
+import io.sphere.sdk.products.attributes.EnumAttributeType;
+import io.sphere.sdk.products.attributes.LocalizedEnumAttributeType;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraftBuilder;
 import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.AddEnumValue;
+import io.sphere.sdk.producttypes.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeDefinitionLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
 import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeIsSearchable;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeInputHint;
@@ -18,13 +27,17 @@ import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeConstrai
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
+import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildActions;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeLabelUpdateAction;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildSetInputTipUpdateAction;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeIsSearchableUpdateAction;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeInputHintUpdateAction;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeAttributeConstraintUpdateAction;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeDefinitionUpdateActionUtilsTest {
@@ -34,6 +47,11 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     private static AttributeDefinitionDraft newDifferent;
     private static AttributeDefinitionDraft newNullValues;
 
+    private static final EnumValue ENUM_VALUE_A = EnumValue.of("a", "label_a");
+    private static final EnumValue ENUM_VALUE_B = EnumValue.of("b", "label_b");
+
+    private static final LocalizedEnumValue LOCALIZED_ENUM_VALUE_A = LocalizedEnumValue.of("a", ofEnglish("label_a"));
+    private static final LocalizedEnumValue LOCALIZED_ENUM_VALUE_B = LocalizedEnumValue.of("b", ofEnglish("label_b"));
 
     /**
      * Initialises test data.
@@ -200,4 +218,223 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             newNullValues.getAttributeConstraint())
         );
     }
+
+    @Test
+    public void buildActions_WithNewDifferentValues_ShouldReturnAction() {
+        final List<UpdateAction<ProductType>> result = buildActions(old, newDifferent);
+
+        assertThat(result).containsExactlyInAnyOrder(
+            ChangeAttributeDefinitionLabel.of(old.getName(), newDifferent.getLabel()),
+            SetInputTip.of(old.getName(), newDifferent.getInputTip()),
+            ChangeAttributeConstraint.of(old.getName(), newDifferent.getAttributeConstraint()),
+            ChangeInputHint.of(oldNullValues.getName(), newDifferent.getInputHint()),
+            ChangeIsSearchable.of(old.getName(), newDifferent.isSearchable())
+        );
+    }
+
+    @Test
+    public void buildActions_WithSameValues_ShouldReturnEmpty() {
+        final List<UpdateAction<ProductType>> result = buildActions(old, newSame);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                EnumAttributeType.of(ENUM_VALUE_A, ENUM_VALUE_B),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactly(AddEnumValue.of("attributeName1", ENUM_VALUE_B));
+    }
+
+    @Test
+    public void buildActions_WithoutOldPlainEnum_ShouldReturnRemoveEnumValueAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                EnumAttributeType.of(Collections.emptyList()),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactly(RemoveEnumValues.of("attributeName1", "a"));
+    }
+
+    @Test
+    public void buildActions_WitDifferentPlainEnumValueLabel_ShouldReturnChangeEnumValueLabelAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+        final EnumValue enumValueDiffLabel = EnumValue.of("a", "label_a_different");
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                EnumAttributeType.of(enumValueDiffLabel),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactly(ChangePlainEnumValueLabel.of("attributeName1", enumValueDiffLabel));
+    }
+
+    @Test
+    public void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of(
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A)
+            )
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A, LOCALIZED_ENUM_VALUE_B),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactly(AddLocalizedEnumValue.of("attributeName1", LOCALIZED_ENUM_VALUE_B));
+    }
+
+    @Test
+    public void buildActions_WithoutOldLocalizedEnum_ShouldReturnRemoveLocalizedEnumValueAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of(
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                LocalizedEnumAttributeType.of(Collections.emptyList()),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactly(RemoveEnumValues.of("attributeName1", "a"));
+    }
+
+    @Test
+    public void buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", LocalizedString.ofEnglish("label1"),
+                LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+        final LocalizedEnumValue localizedEnumValueDiffLabel = LocalizedEnumValue.of("a", ofEnglish("label_a_diff"));
+
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(
+                LocalizedEnumAttributeType.of(localizedEnumValueDiffLabel),
+                "attributeName1",
+                LocalizedString.ofEnglish("label1"),
+                false
+            )
+            .attributeConstraint(AttributeConstraint.NONE)
+            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result)
+            .containsExactly(ChangeLocalizedEnumValueLabel.of("attributeName1", localizedEnumValueDiffLabel));
+    }
+
+
 }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/LocalizedEnumValueUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/LocalizedEnumValueUpdateActionUtilsTest.java
@@ -1,0 +1,41 @@
+package com.commercetools.sync.producttypes.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedEnumValue;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static com.commercetools.sync.producttypes.utils.LocalizedEnumUpdateActionsUtils.buildChangeLabelAction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalizedEnumValueUpdateActionUtilsTest {
+    private static LocalizedEnumValue old = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label1"));
+    private static LocalizedEnumValue newSame = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label1"));
+    private static LocalizedEnumValue newDifferent = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label2"));
+
+    @Test
+    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
+            "attribute_definition_name_1",
+            old,
+            newDifferent
+        );
+
+        assertThat(result).contains(ChangeLocalizedEnumValueLabel.of("attribute_definition_name_1", newDifferent));
+    }
+
+    @Test
+    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
+            "attribute_definition_name_1",
+            old,
+            newSame
+        );
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/PlainEnumValueUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/PlainEnumValueUpdateActionUtilsTest.java
@@ -1,0 +1,52 @@
+package com.commercetools.sync.producttypes.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static com.commercetools.sync.producttypes.utils.PlainEnumUpdateActionsUtils.buildChangeLabelAction;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlainEnumValueUpdateActionUtilsTest {
+    private static EnumValue old;
+    private static EnumValue newSame;
+    private static EnumValue newDifferent;
+
+    /**
+     * Initialises test data.
+     */
+    @BeforeClass
+    public static void setup() {
+        old = EnumValue.of("key1", "label1");
+        newSame = EnumValue.of("key1", "label1");
+        newDifferent = EnumValue.of("key1", "label2");
+    }
+
+    @Test
+    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
+            "attribute_definition_name_1",
+            old,
+            newDifferent
+        );
+
+        assertThat(result).containsInstanceOf(ChangePlainEnumValueLabel.class);
+        assertThat(result).contains(ChangePlainEnumValueLabel.of("attribute_definition_name_1", newDifferent));
+    }
+
+    @Test
+    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
+            "attribute_definition_name_1",
+            old,
+            newSame
+        );
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -400,7 +400,8 @@ public class BuildAttributeDefinitionUpdateActionsTest {
 
         final List<String> errorMessages = new ArrayList<>();
         final List<Throwable> exceptions = new ArrayList<>();
-        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder.of(mock(SphereClient.class))
+        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
+            .of(mock(SphereClient.class))
             .errorCallback((errorMessage, exception) -> {
                 errorMessages.add(errorMessage);
                 exceptions.add(exception);

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.producttypes.utils.producttuypeactionutils;
 
 import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.commons.exceptions.DifferentTypeException;
 import com.commercetools.sync.commons.exceptions.DuplicateNameException;
 import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
 import com.commercetools.sync.producttypes.ProductTypeSyncOptionsBuilder;
@@ -53,6 +54,8 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         RES_ROOT + "product-type-with-attribute-definitions-adbc.json";
     private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_CBD =
         RES_ROOT + "product-type-with-attribute-definitions-cbd.json";
+    private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ABC_WITH_DIFFERENT_TYPE =
+        RES_ROOT + "product-type-with-attribute-definitions-abc-with-different-type.json";
 
 
     private static final ProductTypeSyncOptions SYNC_OPTIONS = ProductTypeSyncOptionsBuilder
@@ -96,6 +99,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     public void buildAttributesUpdateActions_WithNullNewAttributesAndNoOldAttributes_ShouldNotBuildActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes()).thenReturn(emptyList());
+        when(oldProductType.getKey()).thenReturn("product_type_key_1");
 
         final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(
             oldProductType,
@@ -110,6 +114,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     public void buildAttributesUpdateActions_WithNewAttributesAndNoOldAttributes_ShouldBuild3AddActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes()).thenReturn(emptyList());
+        when(oldProductType.getKey()).thenReturn("product_type_key_1");
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
             PRODUCT_TYPE_WITH_ATTRIBUTES_ABC,
@@ -382,5 +387,41 @@ public class BuildAttributeDefinitionUpdateActionsTest {
                     )
                 )
         );
+    }
+
+    @Test
+    public void buildAttributesUpdateActions_WithDifferentAttributeType_ShouldNotBuildActionsAndTriggerErrorCb() {
+        final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+        final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
+            PRODUCT_TYPE_WITH_ATTRIBUTES_ABC_WITH_DIFFERENT_TYPE,
+            ProductTypeDraft.class
+        );
+
+        final List<String> errorMessages = new ArrayList<>();
+        final List<Throwable> exceptions = new ArrayList<>();
+        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((errorMessage, exception) -> {
+                errorMessages.add(errorMessage);
+                exceptions.add(exception);
+            })
+            .build();
+
+        final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(
+            oldProductType,
+            newProductTypeDraft,
+            syncOptions
+        );
+
+        assertThat(updateActions).isEmpty();
+        assertThat(errorMessages).hasSize(1);
+        assertThat(errorMessages.get(0)).matches("Failed to build update actions for the attributes definitions of the "
+            + "product type with the key 'key'. Reason: .*DifferentTypeException: The attribute type of the "
+            + "attribute definitions are different. Attribute name: 'a'. Old attribute type: "
+            + "'.*StringAttributeType', new attribute type: '.*LocalizedStringAttributeType'. Attribute type has "
+            + "to remain the same for the same attribute name.");
+        assertThat(exceptions).hasSize(1);
+        assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+        assertThat(exceptions.get(0).getCause()).isExactlyInstanceOf(DifferentTypeException.class);
     }
 }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -38,18 +38,18 @@ public class BuildLocalizedEnumUpdateActionsTest {
     private static final List<LocalizedEnumValue> ENUM_VALUES_CAB = asList(ENUM_VALUE_C, ENUM_VALUE_A, ENUM_VALUE_B);
     private static final List<LocalizedEnumValue> ENUM_VALUES_CB = asList(ENUM_VALUE_C, ENUM_VALUE_B);
     private static final List<LocalizedEnumValue> ENUM_VALUES_ACBD = asList(
-            ENUM_VALUE_A,
-            ENUM_VALUE_C,
-            ENUM_VALUE_B,
-            ENUM_VALUE_D
+        ENUM_VALUE_A,
+        ENUM_VALUE_C,
+        ENUM_VALUE_B,
+        ENUM_VALUE_D
     );
     private static final List<LocalizedEnumValue> ENUM_VALUES_ADBC = asList(
-            ENUM_VALUE_A,
-            ENUM_VALUE_D,
-            ENUM_VALUE_B,
-            ENUM_VALUE_C
+        ENUM_VALUE_A,
+        ENUM_VALUE_D,
+        ENUM_VALUE_B,
+        ENUM_VALUE_C
     );
-    private static final List<LocalizedEnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C,ENUM_VALUE_B, ENUM_VALUE_D);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C, ENUM_VALUE_B, ENUM_VALUE_D);
 
     @Test
     public void buildLocalizedEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
@@ -210,9 +210,9 @@ public class BuildLocalizedEnumUpdateActionsTest {
     @Test
     public void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
-                "attribute_definition_name_1",
-                ENUM_VALUES_ABC,
-                ENUM_VALUES_ACBD
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ACBD
         );
 
         assertThat(updateActions).containsExactly(

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -1,0 +1,266 @@
+package com.commercetools.sync.producttypes.utils.producttuypeactionutils;
+
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedEnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
+import io.sphere.sdk.producttypes.commands.updateactions.AddLocalizedEnumValue;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateLocalizedEnumActionUtils.buildLocalizedEnumValuesUpdateActions;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+
+public class BuildLocalizedEnumUpdateActionsTest {
+    private static final LocalizedEnumValue ENUM_VALUE_A = LocalizedEnumValue.of("a", ofEnglish("label_a"));
+    private static final LocalizedEnumValue ENUM_VALUE_B = LocalizedEnumValue.of("b", ofEnglish("label_b"));
+    private static final LocalizedEnumValue ENUM_VALUE_C = LocalizedEnumValue.of("c", ofEnglish("label_c"));
+    private static final LocalizedEnumValue ENUM_VALUE_D = LocalizedEnumValue.of("d", ofEnglish("label_d"));
+
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ABC = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_C);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_AB = asList(ENUM_VALUE_A, ENUM_VALUE_B);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ABB = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_B);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ABD = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_D);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ABCD = asList(
+        ENUM_VALUE_A,
+        ENUM_VALUE_B,
+        ENUM_VALUE_C,
+        ENUM_VALUE_D
+    );
+    private static final List<LocalizedEnumValue> ENUM_VALUES_CAB = asList(ENUM_VALUE_C, ENUM_VALUE_A, ENUM_VALUE_B);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_CB = asList(ENUM_VALUE_C, ENUM_VALUE_B);
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ACBD = asList(
+            ENUM_VALUE_A,
+            ENUM_VALUE_C,
+            ENUM_VALUE_B,
+            ENUM_VALUE_D
+    );
+    private static final List<LocalizedEnumValue> ENUM_VALUES_ADBC = asList(
+            ENUM_VALUE_A,
+            ENUM_VALUE_D,
+            ENUM_VALUE_B,
+            ENUM_VALUE_C
+    );
+    private static final List<LocalizedEnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C,ENUM_VALUE_B, ENUM_VALUE_D);
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            null
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            Collections.emptyList()
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOlEnumValues_ShouldNotBuildActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            Collections.emptyList(),
+            ENUM_VALUES_ABC
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_A),
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_B),
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_C)
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABC
+        );
+
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
+        expectedException.expect(DuplicateKeyException.class);
+        expectedException.expectMessage("Enum Values have duplicated keys. Attribute definition name: "
+            + "'attribute_definition_name_1', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
+            + "their attribute definition.");
+
+        buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABB
+        );
+    }
+
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_AB
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("c"))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABCD
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D)
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABD
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("c")),
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D)
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CAB
+        );
+
+        assertThat(updateActions).containsExactly(
+            ChangeLocalizedEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_A,
+                ENUM_VALUE_B
+            ))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CB
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a")),
+            ChangeLocalizedEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_B
+            ))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+                "attribute_definition_name_1",
+                ENUM_VALUES_ABC,
+                ENUM_VALUES_ACBD
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeLocalizedEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_A,
+                ENUM_VALUE_C,
+                ENUM_VALUE_B,
+                ENUM_VALUE_D
+            ))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ADBC
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeLocalizedEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_A,
+                ENUM_VALUE_D,
+                ENUM_VALUE_B,
+                ENUM_VALUE_C
+            ))
+        );
+    }
+
+    @Test
+    public void buildLocalizedEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CBD
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a")),
+            AddLocalizedEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeLocalizedEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_B,
+                ENUM_VALUE_D
+            ))
+        );
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildPlainEnumUpdateActionsTest.java
@@ -1,0 +1,266 @@
+package com.commercetools.sync.producttypes.utils.producttuypeactionutils;
+
+import com.commercetools.sync.commons.exceptions.DuplicateKeyException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.updateactions.AddEnumValue;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeEnumValueOrder;
+import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.commercetools.sync.producttypes.utils.ProductTypeUpdatePlainEnumActionUtils.buildEnumValuesUpdateActions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.Arrays.asList;
+
+public class BuildPlainEnumUpdateActionsTest {
+
+    private static final EnumValue ENUM_VALUE_A = EnumValue.of("a", "label_a");
+    private static final EnumValue ENUM_VALUE_B = EnumValue.of("b", "label_b");
+    private static final EnumValue ENUM_VALUE_C = EnumValue.of("c", "label_c");
+    private static final EnumValue ENUM_VALUE_D = EnumValue.of("d", "label_d");
+
+    private static final List<EnumValue> ENUM_VALUES_ABC = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_C);
+    private static final List<EnumValue> ENUM_VALUES_AB = asList(ENUM_VALUE_A, ENUM_VALUE_B);
+    private static final List<EnumValue> ENUM_VALUES_ABB = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_B);
+    private static final List<EnumValue> ENUM_VALUES_ABD = asList(ENUM_VALUE_A, ENUM_VALUE_B, ENUM_VALUE_D);
+    private static final List<EnumValue> ENUM_VALUES_ABCD = asList(
+        ENUM_VALUE_A,
+        ENUM_VALUE_B,
+        ENUM_VALUE_C,
+        ENUM_VALUE_D
+    );
+    private static final List<EnumValue> ENUM_VALUES_CAB = asList(ENUM_VALUE_C, ENUM_VALUE_A, ENUM_VALUE_B);
+    private static final List<EnumValue> ENUM_VALUES_CB = asList(ENUM_VALUE_C, ENUM_VALUE_B);
+    private static final List<EnumValue> ENUM_VALUES_ACBD = asList(
+        ENUM_VALUE_A,
+        ENUM_VALUE_C,
+        ENUM_VALUE_B,
+        ENUM_VALUE_D
+    );
+    private static final List<EnumValue> ENUM_VALUES_ADBC = asList(
+        ENUM_VALUE_A,
+        ENUM_VALUE_D,
+        ENUM_VALUE_B,
+        ENUM_VALUE_C
+    );
+    private static final List<EnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C,ENUM_VALUE_B, ENUM_VALUE_D);
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            null
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            Collections.emptyList()
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a", "b", "c"))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOlEnumValues_ShouldNotBuildActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            Collections.emptyList(),
+            ENUM_VALUES_ABC
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_A),
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_B),
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_C)
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABC
+        );
+
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
+        expectedException.expect(DuplicateKeyException.class);
+        expectedException.expectMessage("Enum Values have duplicated keys. Attribute definition name: "
+            + "'attribute_definition_name_1', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
+            + "their attribute definition.");
+
+        buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABB
+        );
+    }
+
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_AB
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("c"))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABCD
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D)
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABD
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("c")),
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D)
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CAB
+        );
+
+        assertThat(updateActions).containsExactly(
+            ChangeEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_A,
+                ENUM_VALUE_B
+            ))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CB
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a")),
+            ChangeEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_B
+            ))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ACBD
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_A,
+                ENUM_VALUE_C,
+                ENUM_VALUE_B,
+                ENUM_VALUE_D
+            ))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ADBC
+        );
+
+        assertThat(updateActions).containsExactly(
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_A,
+                ENUM_VALUE_D,
+                ENUM_VALUE_B,
+                ENUM_VALUE_C
+            ))
+        );
+    }
+
+    @Test
+    public void buildPlainEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
+        final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
+            "attribute_definition_name_1",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_CBD
+        );
+
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("attribute_definition_name_1", asList("a")),
+            AddEnumValue.of("attribute_definition_name_1", ENUM_VALUE_D),
+            ChangeEnumValueOrder.of("attribute_definition_name_1", asList(
+                ENUM_VALUE_C,
+                ENUM_VALUE_B,
+                ENUM_VALUE_D
+            ))
+        );
+    }
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttuypeactionutils/BuildPlainEnumUpdateActionsTest.java
@@ -49,7 +49,7 @@ public class BuildPlainEnumUpdateActionsTest {
         ENUM_VALUE_B,
         ENUM_VALUE_C
     );
-    private static final List<EnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C,ENUM_VALUE_B, ENUM_VALUE_D);
+    private static final List<EnumValue> ENUM_VALUES_CBD = asList(ENUM_VALUE_C, ENUM_VALUE_B, ENUM_VALUE_D);
 
     @Test
     public void buildPlainEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {

--- a/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-abc-with-different-type.json
+++ b/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-abc-with-different-type.json
@@ -1,0 +1,40 @@
+{
+  "name": "name",
+  "key": "key",
+  "description": "description",
+  "attributes": [
+    {
+      "type": {
+        "name": "ltext"
+      },
+      "name": "a",
+      "label": {
+        "en": "label_en"
+      },
+      "isRequired": false,
+      "isSearchable": true
+    },
+    {
+      "type": {
+        "name": "text"
+      },
+      "name": "b",
+      "label": {
+        "en": "label_en"
+      },
+      "isRequired": false,
+      "isSearchable": true
+    },
+    {
+      "type": {
+        "name": "text"
+      },
+      "name": "c",
+      "label": {
+        "en": "label_en"
+      },
+      "isRequired": false,
+      "isSearchable": true
+    }
+  ]
+}


### PR DESCRIPTION
#### Summary
This PR adds the attribute definition update actions for plain enum values and localized enum values

#### Description
- `AttributeDefinitionUpdateActionUtils` 
   - Add PlainEnumValue to attribute definition update action
   - Change order of PlainEnumValue update action
   - Remove PlainEnumValues from attribute definition update action
   - Change plain enum value label update action
   - Add LocalizedEnumValue to attribute definition update action
   - Change order of LocalizedEnumValue update action
   - Remove LocalizedEnumValues from attribute definition update action
   - Change localized enum value label update action

#### Todo

- Tests
    - [X] Unit 
