### PR TITLE
101 price integration test

### DIFF
--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -31,10 +31,10 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.calculateDiff;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannels;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypes;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteInventoryEntries;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteSupplyChannels;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,14 +45,14 @@ public class InventorySyncBenchmark {
     public void setup() {
         deleteInventoryEntries(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
-        deleteSupplyChannels(CTP_TARGET_CLIENT);
+        deleteChannels(CTP_TARGET_CLIENT);
     }
 
     @AfterClass
     public static void tearDown() {
         deleteInventoryEntries(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
-        deleteSupplyChannels(CTP_TARGET_CLIENT);
+        deleteChannels(CTP_TARGET_CLIENT);
     }
 
     @Test

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ChannelITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ChannelITUtils.java
@@ -1,0 +1,56 @@
+package com.commercetools.sync.integration.commons.utils;
+
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.channels.ChannelDraft;
+import io.sphere.sdk.channels.ChannelDraftBuilder;
+import io.sphere.sdk.channels.commands.ChannelCreateCommand;
+import io.sphere.sdk.channels.commands.ChannelDeleteCommand;
+import io.sphere.sdk.channels.queries.ChannelQuery;
+import io.sphere.sdk.client.SphereClient;
+
+import javax.annotation.Nonnull;
+
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+
+public final class ChannelITUtils {
+    /**
+     * Deletes all Channels from CTP projects defined by the {@code CTP_SOURCE_CLIENT} and
+     * {@code CTP_TARGET_CLIENT}.
+     */
+    public static void deleteChannelsFromTargetAndSource() {
+        deleteChannels(CTP_TARGET_CLIENT);
+        deleteChannels(CTP_SOURCE_CLIENT);
+    }
+
+    /**
+     * Deletes all Channels from the CTP project defined by the {@code ctpClient}.
+     *
+     * @param ctpClient defines the CTP project to delete the Channels from.
+     */
+    public static void deleteChannels(@Nonnull final SphereClient ctpClient) {
+        queryAndExecute(ctpClient, ChannelQuery.of(), ChannelDeleteCommand::of);
+    }
+
+    /**
+     * Creates a {@link Channel} in the CTP project defined by the {@code ctpClient} in a blocking fashion.
+     *
+     * @param ctpClient defines the CTP project to create the Channels in.
+     * @param name      the name of the channel to create.
+     * @param key       the key of the channel to create.
+     * @return the created Channel.
+     */
+    public static Channel createChannel(@Nonnull final SphereClient ctpClient, @Nonnull final String name,
+                                        @Nonnull final String key) {
+        final ChannelDraft channelDraft = ChannelDraftBuilder.of(name)
+                                                             .key(key)
+                                                             .build();
+
+        return executeBlocking(ctpClient.execute(ChannelCreateCommand.of(channelDraft)));
+    }
+
+    private ChannelITUtils() {
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CustomerGroupITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CustomerGroupITUtils.java
@@ -1,0 +1,56 @@
+package com.commercetools.sync.integration.commons.utils;
+
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.customergroups.CustomerGroupDraft;
+import io.sphere.sdk.customergroups.CustomerGroupDraftBuilder;
+import io.sphere.sdk.customergroups.commands.CustomerGroupCreateCommand;
+import io.sphere.sdk.customergroups.commands.CustomerGroupDeleteCommand;
+import io.sphere.sdk.customergroups.queries.CustomerGroupQuery;
+
+import javax.annotation.Nonnull;
+
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+
+public final class CustomerGroupITUtils {
+    /**
+     * Deletes all CustomerGroup from CTP projects defined by the {@code CTP_SOURCE_CLIENT} and
+     * {@code CTP_TARGET_CLIENT}.
+     */
+    public static void deleteCustomerGroupsFromTargetAndSource() {
+        deleteCustomerGroups(CTP_TARGET_CLIENT);
+        deleteCustomerGroups(CTP_SOURCE_CLIENT);
+    }
+
+    /**
+     * Deletes all CustomerGroups from the CTP project defined by the {@code ctpClient}.
+     *
+     * @param ctpClient defines the CTP project to delete the CustomerGroups from.
+     */
+    public static void deleteCustomerGroups(@Nonnull final SphereClient ctpClient) {
+        queryAndExecute(ctpClient, CustomerGroupQuery.of(), CustomerGroupDeleteCommand::of);
+    }
+
+    /**
+     * Creates a {@link CustomerGroup} in the CTP project defined by the {@code ctpClient} in a blocking fashion.
+     *
+     * @param ctpClient defines the CTP project to create the CustomerGroup in.
+     * @param name      the name of the CustomerGroup to create.
+     * @param key       the key of the CustomerGroup to create.
+     * @return the created CustomerGroup.
+     */
+    public static CustomerGroup createCustomerGroup(@Nonnull final SphereClient ctpClient, @Nonnull final String name,
+                                                    @Nonnull final String key) {
+        final CustomerGroupDraft customerGroupDraft = CustomerGroupDraftBuilder.of(name)
+                                                                               .key(key)
+                                                                               .build();
+
+        return executeBlocking(ctpClient.execute(CustomerGroupCreateCommand.of(customerGroupDraft)));
+    }
+
+    private CustomerGroupITUtils() {
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -11,6 +11,7 @@ import io.sphere.sdk.models.AssetDraftBuilder;
 import io.sphere.sdk.models.AssetSourceBuilder;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Resource;
+import io.sphere.sdk.products.PriceDraft;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
 import io.sphere.sdk.queries.PagedResult;
@@ -30,6 +31,7 @@ import io.sphere.sdk.types.queries.TypeQuery;
 import io.sphere.sdk.types.queries.TypeQueryBuilder;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -323,12 +325,30 @@ public final class ITUtils {
      *         the supplied {@code assetDrafts}.
      */
     public static ProductVariantDraft createVariantDraft(@Nonnull final String variantKeyAndSku,
-                                                         @Nonnull final List<AssetDraft> assetDrafts) {
+                                                         @Nullable final List<AssetDraft> assetDrafts) {
+
+        return createVariantDraft(variantKeyAndSku, assetDrafts, null);
+    }
+
+    /**
+     * Creates a {@link ProductVariantDraft} draft key and sku of the value supplied {@code variantKeyAndSku} and with
+     * the supplied {@code assetDrafts} and {@code priceDrafts}
+     *
+     * @param variantKeyAndSku the value of the key and sku of the created draft.
+     * @param assetDrafts the assets to assign to the created draft.
+     * @param priceDrafts the prices to assign to the created draft.
+     * @return a {@link ProductVariantDraft} draft key and sku of the value supplied {@code variantKeyAndSku} and with
+     *         the supplied {@code assetDrafts} and {@code priceDrafts}.
+     */
+    public static ProductVariantDraft createVariantDraft(@Nonnull final String variantKeyAndSku,
+                                                         @Nullable final List<AssetDraft> assetDrafts,
+                                                         @Nullable final List<PriceDraft> priceDrafts) {
 
         return ProductVariantDraftBuilder.of()
                                          .key(variantKeyAndSku)
                                          .sku(variantKeyAndSku)
                                          .assets(assetDrafts)
+                                         .prices(priceDrafts)
                                          .build();
     }
 

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -317,21 +317,6 @@ public final class ITUtils {
 
     /**
      * Creates a {@link ProductVariantDraft} draft key and sku of the value supplied {@code variantKeyAndSku} and with
-     * the supplied {@code assetDrafts}.
-     *
-     * @param variantKeyAndSku the value of the key and sku of the created draft.
-     * @param assetDrafts the assets to assign to the created draft.
-     * @return a {@link ProductVariantDraft} draft key and sku of the value supplied {@code variantKeyAndSku} and with
-     *         the supplied {@code assetDrafts}.
-     */
-    public static ProductVariantDraft createVariantDraft(@Nonnull final String variantKeyAndSku,
-                                                         @Nullable final List<AssetDraft> assetDrafts) {
-
-        return createVariantDraft(variantKeyAndSku, assetDrafts, null);
-    }
-
-    /**
-     * Creates a {@link ProductVariantDraft} draft key and sku of the value supplied {@code variantKeyAndSku} and with
      * the supplied {@code assetDrafts} and {@code priceDrafts}
      *
      * @param variantKeyAndSku the value of the key and sku of the created draft.

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -27,13 +27,13 @@ import java.util.Locale;
 import java.util.concurrent.CompletionStage;
 
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.deleteAllCategories;
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannels;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.createTypeIfNotAlreadyExisting;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypes;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndCompose;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.deleteProductTypes;
 import static com.commercetools.sync.integration.commons.utils.StateITUtils.deleteStates;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.deleteTaxCategories;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteSupplyChannels;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -49,7 +49,7 @@ public final class ProductITUtils {
         deleteProductTypes(ctpClient);
         deleteAllCategories(ctpClient);
         deleteTypes(ctpClient);
-        deleteSupplyChannels(ctpClient);
+        deleteChannels(ctpClient);
         deleteStates(ctpClient, StateType.PRODUCT_STATE);
         deleteTaxCategories(ctpClient);
     }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionStage;
 
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.deleteAllCategories;
 import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannels;
+import static com.commercetools.sync.integration.commons.utils.CustomerGroupITUtils.deleteCustomerGroups;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.createTypeIfNotAlreadyExisting;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypes;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndCompose;
@@ -52,6 +53,7 @@ public final class ProductITUtils {
         deleteChannels(ctpClient);
         deleteStates(ctpClient, StateType.PRODUCT_STATE);
         deleteTaxCategories(ctpClient);
+        deleteCustomerGroups(ctpClient);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -206,4 +206,7 @@ public final class ProductITUtils {
         return createTypeIfNotAlreadyExisting(
             typeKey, locale, name, ResourceTypeIdsSetBuilder.of().addPrices(), ctpClient);
     }
+
+    private ProductITUtils() {
+    }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
@@ -152,7 +152,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft draftToCreateOnSourceProject = ProductDraftBuilder
             .of(sourceProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInSource"),
-                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProduct))
+                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProduct, null))
             .key("existingProductInSource")
             .build();
         CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnSourceProject)).toCompletableFuture().join();
@@ -198,7 +198,7 @@ public class ProductSyncWithAssetsIT {
         final String productKey = "same-product";
         final ProductDraft draftToCreateOnTargetProject = ProductDraftBuilder
             .of(targetProductType.toReference(), ofEnglish("draftName"), ofEnglish("existingProductInTarget"),
-                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProductOnTargetProject))
+                createVariantDraft("masterVariant", assetDraftsToCreateOnExistingProductOnTargetProject, null))
             .key(productKey)
             .build();
         CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnTargetProject)).toCompletableFuture().join();
@@ -206,7 +206,7 @@ public class ProductSyncWithAssetsIT {
         final ProductDraft draftToCreateOnSourceProject = ProductDraftBuilder
             .of(sourceProductType.toReference(), draftToCreateOnTargetProject.getName(),
                 draftToCreateOnTargetProject.getSlug(), createVariantDraft("masterVariant",
-                    assetDraftsToCreateOnExistingProductOnSourceProject))
+                    assetDraftsToCreateOnExistingProductOnSourceProject, null))
             .key(productKey)
             .build();
         CTP_SOURCE_CLIENT.execute(ProductCreateCommand.of(draftToCreateOnSourceProject)).toCompletableFuture().join();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -105,7 +105,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft productDraft = ProductDraftBuilder
             .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
-                createVariantDraft("v1", assetDraftsToCreateOnExistingProduct))
+                createVariantDraft("v1", assetDraftsToCreateOnExistingProduct, null))
             .key("existingProduct")
             .build();
 
@@ -151,7 +151,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft productDraft = ProductDraftBuilder
             .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
-                createVariantDraft("masterVariant", assetDrafts))
+                createVariantDraft("masterVariant", assetDrafts, null))
             .key("draftKey")
             .build();
 
@@ -181,7 +181,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft productDraft = ProductDraftBuilder
             .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
-                createVariantDraft("masterVariant", assetDrafts))
+                createVariantDraft("masterVariant", assetDrafts, null))
             .key("draftKey")
             .build();
 
@@ -225,7 +225,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft productDraft = ProductDraftBuilder
             .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("existingSlug"),
-                createVariantDraft("v1", assetDrafts))
+                createVariantDraft("v1", assetDrafts, null))
             .key(product.getKey())
             .build();
 
@@ -277,7 +277,7 @@ public class ProductSyncWithAssetsIT {
 
         final ProductDraft productDraft = ProductDraftBuilder
             .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("existingSlug"),
-                createVariantDraft("v1", assetDrafts))
+                createVariantDraft("v1", assetDrafts, null))
             .key(product.getKey())
             .build();
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -1,0 +1,630 @@
+package com.commercetools.sync.integration.externalsource.products;
+
+import com.commercetools.sync.commons.utils.TriFunction;
+import com.commercetools.sync.internals.helpers.PriceCompositeId;
+import com.commercetools.sync.products.ProductSync;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.products.helpers.ProductSyncStatistics;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductDraftBuilder;
+import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.ProductProjectionType;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.products.commands.updateactions.AddPrice;
+import io.sphere.sdk.products.commands.updateactions.ChangePrice;
+import io.sphere.sdk.products.commands.updateactions.RemovePrice;
+import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomField;
+import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomType;
+import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.types.Type;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.commons.utils.CollectionUtils.collectionToMap;
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.createChannel;
+import static com.commercetools.sync.integration.commons.utils.CustomerGroupITUtils.createCustomerGroup;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.LOCALISED_STRING_CUSTOM_FIELD_NAME;
+import static com.commercetools.sync.integration.commons.utils.ITUtils.createVariantDraft;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.createPricesCustomType;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_02_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_EUR_03_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_222_EUR_CUST1;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_22_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_DE_333_USD_CUST1;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_FR_777_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_FR_888_EUR_01_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_FR_999_EUR_03_06;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_123_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_321_EUR_04_06;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_777_EUR_01_04;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_NE_777_EUR_05_07;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_111_GBP;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_111_GBP_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_111_GBP_02_03;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_333_GBP_03_05;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_UK_999_GBP;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_US_111_USD;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.DRAFT_US_666_USD_CUST2_01_02;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.byMonth;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.createCustomFieldsJsonMap;
+import static com.commercetools.sync.products.utils.productvariantupdateactionutils.prices.PriceDraftFixtures.getPriceDraft;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static com.neovisionaries.i18n.CountryCode.DE;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.EUR;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.USD;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductSyncWithPricesIT {
+    private static ProductType productType;
+    private static Type customType1;
+    private static Type customType2;
+    private static Channel channel1;
+    private static Channel channel2;
+    private static CustomerGroup cust1;
+    private static CustomerGroup cust2;
+    private Product product;
+    private ProductSync productSync;
+    private List<String> errorCallBackMessages;
+    private List<String> warningCallBackMessages;
+    private List<Throwable> errorCallBackExceptions;
+    private List<UpdateAction<Product>> updateActionsFromSync;
+
+    /**
+     * Delete all product related test data from the target project. Then creates for the target CTP project a product
+     * type and an asset custom type.
+     */
+    @BeforeClass
+    public static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+
+        customType1 = createPricesCustomType("customType1", Locale.ENGLISH,
+            "customType1", CTP_TARGET_CLIENT);
+
+        customType2 = createPricesCustomType("customType2", Locale.ENGLISH,
+            "customType2", CTP_TARGET_CLIENT);
+
+        cust1 = createCustomerGroup(CTP_TARGET_CLIENT, "cust1", "cust1");
+        cust2 = createCustomerGroup(CTP_TARGET_CLIENT, "cust2", "cust2");
+
+        channel1 = createChannel(CTP_TARGET_CLIENT, "channel1", "channel1");
+        channel2 = createChannel(CTP_TARGET_CLIENT, "channel2", "channel2");
+
+        productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    }
+
+    /**
+     * Deletes Products and Types from the target CTP project, then it populates target CTP project with product test
+     * data.
+     */
+    @Before
+    public void setupTest() {
+        clearSyncTestCollections();
+        deleteAllProducts(CTP_TARGET_CLIENT);
+        productSync = new ProductSync(buildSyncOptions());
+    }
+
+    private void clearSyncTestCollections() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+        updateActionsFromSync = new ArrayList<>();
+    }
+
+    private ProductSyncOptions buildSyncOptions() {
+        final BiConsumer<String, Throwable> errorCallBack = (errorMessage, exception) -> {
+            errorCallBackMessages.add(errorMessage);
+            errorCallBackExceptions.add(exception);
+        };
+        final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);
+
+        final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
+            actionsCallBack = (updateActions, newDraft, oldProduct) -> {
+                updateActionsFromSync.addAll(updateActions);
+                return updateActions;
+            };
+
+        return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                        .errorCallback(errorCallBack)
+                                        .warningCallback(warningCallBack)
+                                        .beforeUpdateCallback(actionsCallBack)
+                                        .build();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    @Test
+    public void sync_withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+        // Preparation
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                createVariantDraft("v1", null, null))
+            .key("existingProduct")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
+                createVariantDraft("masterVariant", null, null))
+            .key("draftKey")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 1, 0, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).isEmpty();
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertThat(productProjection.getMasterVariant().getPrices()).isEmpty();
+    }
+
+    @Test
+    public void sync_withAllMatchingPrices_ShouldNotBuildActions() {
+        // Preparation
+        final List<PriceDraft> oldPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_USD);
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, oldPrices))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, oldPrices))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 0, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).isEmpty();
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), oldPrices);
+    }
+
+    @Test
+    public void withNonEmptyNewPricesButEmptyExistingPrices_ShouldAddAllNewPrices() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_02_03,
+            DRAFT_DE_111_USD,
+            DRAFT_UK_111_GBP);
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, null))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, newPrices))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        final Integer masterVariantId = product.getMasterData().getStaged().getMasterVariant().getId();
+        assertThat(updateActionsFromSync).containsExactlyInAnyOrder(
+            AddPrice.ofVariantId(masterVariantId, DRAFT_US_111_USD, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_02_03, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_USD, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_UK_111_GBP, true));
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), newPrices);
+    }
+
+    @Test
+    public void withNonEmptyNewWithDuplicatesPricesButEmptyExistingPrices_ShouldNotSyncPrices() {
+        // Preparation
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_02_03,
+            DRAFT_DE_111_USD,
+            DRAFT_UK_111_GBP);
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, null))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, newPrices))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+
+        assertThat(errorCallBackExceptions).hasSize(1)
+                                           .extracting(Throwable::getMessage)
+                                           .extracting(String::toLowerCase)
+                                           .hasOnlyOneElementSatisfying(msg ->
+                                               assertThat(msg).contains("duplicate price scope"));
+        assertThat(errorCallBackMessages).hasSize(1)
+                                         .extracting(String::toLowerCase)
+                                         .hasOnlyOneElementSatisfying(msg ->
+                                             assertThat(msg).contains("duplicate price scope"));
+        assertThat(warningCallBackMessages).isEmpty();
+
+        final Integer masterVariantId = product.getMasterData().getStaged().getMasterVariant().getId();
+        assertThat(updateActionsFromSync).containsExactlyInAnyOrder(
+            AddPrice.ofVariantId(masterVariantId, DRAFT_US_111_USD, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_US_111_USD, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_01_02, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_02_03, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_USD, true),
+            AddPrice.ofVariantId(masterVariantId, DRAFT_UK_111_GBP, true));
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), emptyList());
+    }
+
+    @Test
+    public void sync_withNullNewPrices_ShouldRemoveAllPrices() {
+        // Preparation
+        final List<PriceDraft> oldPrices = asList(
+            DRAFT_US_111_USD,
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_02_03,
+            DRAFT_DE_111_USD,
+            DRAFT_UK_111_GBP);
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, oldPrices))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, null))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+
+
+        final RemovePrice[] expectedActions = product.getMasterData().getStaged().getMasterVariant().getPrices()
+                                                     .stream()
+                                                     .map(Price::getId)
+                                                     .map(id -> RemovePrice.of(id, true))
+                                                     .toArray(RemovePrice[]::new);
+        assertThat(updateActionsFromSync).containsExactlyInAnyOrder(expectedActions);
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), emptyList());
+    }
+
+    @Test
+    public void sync_withSomeChangedMatchingPrices_ShouldAddAndRemovePrices() {
+        // Preparation
+        final List<PriceDraft> oldPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_UK_111_GBP,
+            DRAFT_DE_111_EUR_03_04,
+            DRAFT_DE_111_EUR_01_02);
+
+        final PriceDraft draft_de_eur_222_cust1 = getPriceDraft(BigDecimal.valueOf(222), EUR,
+            DE, cust1.getId(), null, null, null, null);
+
+        final PriceDraft draft_de_usd_333_cust1 = getPriceDraft(BigDecimal.valueOf(333), USD,
+            DE, cust1.getId(), null, null, null, null);
+
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_UK_111_GBP,
+            draft_de_eur_222_cust1,
+            draft_de_usd_333_cust1);
+
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, oldPrices))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, newPrices))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+
+        final Integer masterVariantId = product.getMasterData().getStaged().getMasterVariant().getId();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof RemovePrice)
+                                         .hasSize(2);
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof AddPrice)
+                                         .hasSize(2)
+                                         .containsExactlyInAnyOrder(
+                                             AddPrice.ofVariantId(masterVariantId, draft_de_eur_222_cust1, true),
+                                             AddPrice.ofVariantId(masterVariantId, draft_de_usd_333_cust1, true));
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), newPrices);
+    }
+
+    @Test
+    public void withMixedCasesOfPriceMatches_ShouldBuildActions() {
+        // Preparation
+        final ObjectNode lTextWithEnDe = JsonNodeFactory.instance.objectNode()
+                                                                 .put("de", "rot")
+                                                                 .put("en", "red");
+        final ObjectNode lTextWithEnDeIt = lTextWithEnDe.put("it", "rosso");
+        final CustomFieldsDraft customType1WithEnDe = CustomFieldsDraft.ofTypeIdAndJson("customType1",
+            createCustomFieldsJsonMap(LOCALISED_STRING_CUSTOM_FIELD_NAME, lTextWithEnDe));
+
+        final PriceDraft draft_de_eur_100_01_02_channel1_ct1_de_en = getPriceDraft(BigDecimal.valueOf(100), EUR,
+            DE, null, byMonth(1), byMonth(2), "channel1", customType1WithEnDe);
+
+        final PriceDraft draft_de_eur_100_01_02_channel2_ct1_de_en = getPriceDraft(BigDecimal.valueOf(100), EUR,
+            DE, null, byMonth(1), byMonth(2), "channel2", customType1WithEnDe);
+
+        final List<PriceDraft> newPrices = asList(
+            DRAFT_DE_111_EUR,
+            DRAFT_DE_222_EUR_CUST1,
+            DRAFT_DE_111_EUR_01_02,
+            DRAFT_DE_111_EUR_03_04,
+            draft_de_eur_100_01_02_channel1_ct1_de_en,
+            draft_de_eur_100_01_02_channel2_ct1_de_en,
+            DRAFT_DE_333_USD_CUST1,
+            DRAFT_DE_22_USD,
+            DRAFT_UK_111_GBP_01_02,
+            DRAFT_UK_999_GBP,
+            DRAFT_US_666_USD_CUST2_01_02,
+            DRAFT_FR_888_EUR_01_03,
+            DRAFT_FR_999_EUR_03_06,
+            DRAFT_NE_777_EUR_01_04,
+            DRAFT_NE_777_EUR_05_07);
+
+
+        final CustomFieldsDraft customType2ByIdWithEnDeIt = CustomFieldsDraft
+            .ofTypeIdAndJson(ProductSyncWithPricesIT.customType1.getId(),
+                createCustomFieldsJsonMap(LOCALISED_STRING_CUSTOM_FIELD_NAME, lTextWithEnDeIt));
+
+        final PriceDraft draft_de_eur_222_01_02_channel1_ct1_de_en_it = getPriceDraft(BigDecimal.valueOf(222), EUR,
+            DE, null, byMonth(1), byMonth(2), channel1.getId(), customType2ByIdWithEnDeIt);
+
+        final CustomFieldsDraft customType2ByIdWithEnDe = CustomFieldsDraft.ofTypeIdAndJson(customType2.getId(),
+            createCustomFieldsJsonMap(LOCALISED_STRING_CUSTOM_FIELD_NAME, lTextWithEnDe));
+
+        final PriceDraft draft_de_eur_222_01_02_channel2_ct2_de_en = getPriceDraft(BigDecimal.valueOf(222), EUR,
+            DE, null, byMonth(1), byMonth(2), channel2.getId(),
+            customType2ByIdWithEnDe);
+
+        final PriceDraft draft_de_eur_345_cust2 = getPriceDraft(BigDecimal.valueOf(345), EUR,
+            DE, cust2.getId(), null, null, null, null);
+
+        final List<PriceDraft> oldPrices = asList(
+            DRAFT_DE_111_EUR,
+            draft_de_eur_345_cust2,
+            draft_de_eur_222_01_02_channel1_ct1_de_en_it,
+            draft_de_eur_222_01_02_channel2_ct2_de_en,
+            DRAFT_DE_22_USD,
+            DRAFT_UK_111_GBP_01_02,
+            DRAFT_UK_111_GBP_02_03,
+            DRAFT_UK_333_GBP_03_05,
+            DRAFT_FR_777_EUR_01_04,
+            DRAFT_NE_123_EUR_01_04,
+            DRAFT_NE_321_EUR_04_06
+        );
+
+
+        final ProductDraft existingProductDraft = ProductDraftBuilder
+            .of(productType.toReference(), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, oldPrices))
+            .key("bar")
+            .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
+
+        final ProductDraft newProductDraft = ProductDraftBuilder
+            .of(referenceOfId(productType.getKey()), ofEnglish("foo"), ofEnglish("bar"),
+                createVariantDraft("foo", null, newPrices))
+            .key("bar")
+            .build();
+
+
+        // test
+        final ProductSyncStatistics syncStatistics =
+            executeBlocking(productSync.sync(singletonList(newProductDraft)));
+
+        // assertion
+        assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+
+        final Integer masterVariantId = product.getMasterData().getStaged().getMasterVariant().getId();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof RemovePrice)
+                                         .hasSize(5);
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof ChangePrice)
+                                         .hasSize(3);
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof SetProductPriceCustomType)
+                                         .hasSize(1);
+        assertThat(updateActionsFromSync).filteredOn(action -> action instanceof SetProductPriceCustomField)
+                                         .hasSize(1);
+        assertThat(updateActionsFromSync)
+            .filteredOn(action -> action instanceof AddPrice)
+            .hasSize(9)
+            .containsExactlyInAnyOrder(
+                AddPrice.ofVariantId(masterVariantId, DRAFT_DE_222_EUR_CUST1, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_01_02, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_DE_111_EUR_03_04, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_DE_333_USD_CUST1, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_UK_999_GBP, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_US_666_USD_CUST2_01_02, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_FR_888_EUR_01_03, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_FR_999_EUR_03_06, true),
+                AddPrice.ofVariantId(masterVariantId, DRAFT_NE_777_EUR_05_07, true));
+
+        final ProductProjection productProjection = CTP_TARGET_CLIENT
+            .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))
+            .toCompletableFuture().join();
+
+        assertThat(productProjection).isNotNull();
+        assertPricesAreEqual(productProjection.getMasterVariant().getPrices(), newPrices);
+    }
+
+    /**
+     * Asserts that a list of {@link Asset} and a list of {@link AssetDraft} have the same ordering of prices (prices
+     * are matched by key). It asserts that the matching assets have the same name, description, custom fields, tags,
+     * and asset sources.
+     *
+     * <p>TODO: This should be refactored into Asset asserts helpers. GITHUB ISSUE#261
+     *
+     * @param prices      the list of prices to compare to the list of price drafts.
+     * @param priceDrafts the list of price drafts to compare to the list of prices.
+     */
+    public static void assertPricesAreEqual(@Nonnull final List<Price> prices,
+                                            @Nonnull final List<PriceDraft> priceDrafts) {
+
+        final Map<PriceCompositeId, Price> priceMap = collectionToMap(prices, PriceCompositeId::of);
+        final PriceCompositeId[] priceCompositeIds = priceDrafts.stream()
+                                                                .map(PriceCompositeId::of)
+                                                                .toArray(PriceCompositeId[]::new);
+
+        assertThat(priceMap).containsOnlyKeys(priceCompositeIds);
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -109,8 +109,8 @@ public class ProductSyncWithPricesIT {
     private List<UpdateAction<Product>> updateActionsFromSync;
 
     /**
-     * Delete all product related test data from the target project. Then creates for the target CTP project a product
-     * type and an asset custom type.
+     * Delete all product related test data from the target project. Then creates price custom types, customer groups,
+     * channels and a product type for the target CTP project.
      */
     @BeforeClass
     public static void setup() {
@@ -132,8 +132,7 @@ public class ProductSyncWithPricesIT {
     }
 
     /**
-     * Deletes Products from the target CTP project, then it populates target CTP project with product test
-     * data.
+     * Deletes Products from the target CTP project.
      */
     @Before
     public void setupTest() {

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -132,7 +132,7 @@ public class ProductSyncWithPricesIT {
     }
 
     /**
-     * Deletes Products and Types from the target CTP project, then it populates target CTP project with product test
+     * Deletes Products from the target CTP project, then it populates target CTP project with product test
      * data.
      */
     @Before

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -479,7 +479,8 @@ public class ProductSyncWithPricesIT {
                                          .hasSize(2)
                                          .containsExactlyInAnyOrder(
                                              AddPrice.ofVariantId(masterVariantId, price1WithCustomerGroupWithId, true),
-                                             AddPrice.ofVariantId(masterVariantId, price2WithCustomerGroupWithId, true));
+                                             AddPrice.ofVariantId(masterVariantId, price2WithCustomerGroupWithId,
+                                                 true));
 
         final ProductProjection productProjection = CTP_TARGET_CLIENT
             .execute(ProductProjectionByKeyGet.of(newProductDraft.getKey(), ProductProjectionType.STAGED))

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -175,7 +175,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void sync_withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+    public void sync_withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildUpdateActions() {
         // Preparation
         final ProductDraft existingProductDraft = ProductDraftBuilder
             .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
@@ -186,9 +186,9 @@ public class ProductSyncWithPricesIT {
         product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(existingProductDraft)));
 
         final ProductDraft newProductDraft = ProductDraftBuilder
-            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("slug"),
-                createVariantDraft("masterVariant", null, null))
-            .key("draftKey")
+            .of(referenceOfId(productType.getKey()), ofEnglish("draftName"), ofEnglish("existingSlug"),
+                createVariantDraft("v1", null, null))
+            .key("existingProduct")
             .build();
 
 
@@ -197,7 +197,7 @@ public class ProductSyncWithPricesIT {
             executeBlocking(productSync.sync(singletonList(newProductDraft)));
 
         // assertion
-        assertThat(syncStatistics).hasValues(1, 1, 0, 0);
+        assertThat(syncStatistics).hasValues(1, 0, 0, 0);
         assertThat(errorCallBackExceptions).isEmpty();
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -117,7 +117,7 @@ public class ProductReferenceReplacementUtilsIT {
 
         final ProductDraft parentProductDraft = ProductDraftBuilder
             .of(productType.toReference(), ofEnglish("parentProduct"), ofEnglish("parentProduct"),
-                createVariantDraft("parent", emptyList()))
+                createVariantDraft("parent", emptyList(), null))
             .key("parentProduct")
             .build();
 

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
@@ -33,6 +33,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
@@ -46,7 +47,6 @@ import static com.commercetools.sync.integration.inventories.utils.InventoryITUt
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SKU_2;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SUPPLY_CHANNEL_KEY_1;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SUPPLY_CHANNEL_KEY_2;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteInventoryEntriesFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.getChannelByKey;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.getInventoryEntryBySkuAndSupplyChannel;

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventoryUpdateActionUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventoryUpdateActionUtilsIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildPrimaryResourceCustomUpdateActions;
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.CUSTOM_FIELD_NAME;
@@ -33,7 +34,6 @@ import static com.commercetools.sync.integration.inventories.utils.InventoryITUt
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.RESTOCKABLE_IN_DAYS_1;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.RESTOCKABLE_IN_DAYS_2;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SKU_1;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteInventoryEntriesFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.getInventoryEntryBySkuAndSupplyChannel;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.populateTargetProject;

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
@@ -25,8 +25,6 @@ import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.TypeCreateCommand;
-import io.sphere.sdk.types.queries.TypeQuery;
-import io.sphere.sdk.types.queries.TypeQueryBuilder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -204,18 +202,5 @@ public class InventoryITUtils {
         final ChannelQuery channelQuery = ChannelQueryBuilder.of().plusPredicates(channelQueryModel ->
             channelQueryModel.key().is(channelKey)).build();
         return sphereClient.execute(channelQuery).toCompletableFuture().join().head();
-    }
-
-    /**
-     * Tries to fetch type of key {@code typeKey} using {@code sphereClient}.
-     *
-     * @param sphereClient sphere client used to execute requests
-     * @param typeKey key of requested type
-     * @return {@link Optional} which may contain type of key {@code typeKey}
-     */
-    public static Optional<Type> getTypeByKey(@Nonnull final SphereClient sphereClient, @Nonnull final String typeKey) {
-        final TypeQuery typeQuery = TypeQueryBuilder.of().plusPredicates(typeQueryModel ->
-            typeQueryModel.key().is(typeKey)).build();
-        return sphereClient.execute(typeQuery).toCompletableFuture().join().head();
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/utils/InventoryITUtils.java
@@ -6,7 +6,6 @@ import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.channels.ChannelDraft;
 import io.sphere.sdk.channels.ChannelRole;
 import io.sphere.sdk.channels.commands.ChannelCreateCommand;
-import io.sphere.sdk.channels.commands.ChannelDeleteCommand;
 import io.sphere.sdk.channels.queries.ChannelQuery;
 import io.sphere.sdk.channels.queries.ChannelQueryBuilder;
 import io.sphere.sdk.client.SphereClient;
@@ -74,29 +73,12 @@ public class InventoryITUtils {
     }
 
     /**
-     * Deletes all channels from CTP project, represented by the supplied {@code ctpClient}.
-     *
-     * @param ctpClient represents the CTP project the channels will be deleted from.
-     */
-    public static void deleteSupplyChannels(@Nonnull final SphereClient ctpClient) {
-        queryAndExecute(ctpClient, ChannelQuery.of(), ChannelDeleteCommand::of);
-    }
-
-    /**
      * Deletes all inventory entries from CTP projects defined by {@code CTP_SOURCE_CLIENT} and
      * {@code CTP_TARGET_CLIENT}.
      */
     public static void deleteInventoryEntriesFromTargetAndSource() {
         deleteInventoryEntries(CTP_SOURCE_CLIENT);
         deleteInventoryEntries(CTP_TARGET_CLIENT);
-    }
-
-    /**
-     * Deletes all channels from CTP projects defined by {@code CTP_SOURCE_CLIENT} and {@code CTP_TARGET_CLIENT}.
-     */
-    public static void deleteChannelsFromTargetAndSource() {
-        deleteSupplyChannels(CTP_SOURCE_CLIENT);
-        deleteSupplyChannels(CTP_TARGET_CLIENT);
     }
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/services/ChannelServiceIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/ChannelServiceIT.java
@@ -17,9 +17,9 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Optional;
 
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteInventoryEntriesFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.populateTargetProject;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/integration-test/java/com/commercetools/sync/integration/services/InventoryServiceIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/InventoryServiceIT.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTypesFromTargetAndSource;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.EXPECTED_DELIVERY_1;
@@ -28,7 +29,6 @@ import static com.commercetools.sync.integration.inventories.utils.InventoryITUt
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.RESTOCKABLE_IN_DAYS_2;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SKU_1;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.SKU_2;
-import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteChannelsFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.deleteInventoryEntriesFromTargetAndSource;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.getInventoryEntryBySkuAndSupplyChannel;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.populateTargetProject;

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
@@ -330,7 +330,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
 
         final List<Price> oldPrices = asList(
             DE_111_EUR,
-            UK_333_GBP_02_05,
+            UK_333_GBP_03_05,
             US_555_USD_CUST2_01_02,
             FR_777_EUR_01_04,
             NE_123_EUR_01_04,
@@ -345,7 +345,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
         // Assertion
         assertThat(updateActions).containsExactlyInAnyOrder(
             RemovePrice.of(DE_111_EUR.getId(), true),
-            RemovePrice.of(UK_333_GBP_02_05.getId(), true),
+            RemovePrice.of(UK_333_GBP_03_05.getId(), true),
             RemovePrice.of(US_555_USD_CUST2_01_02.getId(), true),
             RemovePrice.of(FR_777_EUR_01_04.getId(), true),
             RemovePrice.of(NE_321_EUR_04_06.getId(), true),
@@ -468,7 +468,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
             DE_22_USD,
             UK_111_GBP_01_02,
             UK_111_GBP_02_03,
-            UK_333_GBP_02_05,
+            UK_333_GBP_03_05,
             FR_777_EUR_01_04,
             NE_123_EUR_01_04,
             NE_321_EUR_04_06
@@ -483,7 +483,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
         assertThat(updateActions).containsExactlyInAnyOrder(
             RemovePrice.of(DE_345_EUR_CUST2.getId(), true),
             RemovePrice.of(UK_111_GBP_02_03.getId(), true),
-            RemovePrice.of(UK_333_GBP_02_05.getId(), true),
+            RemovePrice.of(UK_333_GBP_03_05.getId(), true),
             RemovePrice.of(FR_777_EUR_01_04.getId(), true),
             RemovePrice.of(NE_321_EUR_04_06.getId(), true),
             ChangePrice.of(DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY,

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -230,7 +230,7 @@ public final class PriceDraftFixtures {
     }
 
     @Nonnull
-    private static Map<String, JsonNode> createCustomFieldsJsonMap(@Nonnull final String fieldName,
+    public static Map<String, JsonNode> createCustomFieldsJsonMap(@Nonnull final String fieldName,
                                                                    @Nonnull final JsonNode fieldValue) {
         final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
         customFieldsJsons.put(fieldName, fieldValue);
@@ -239,7 +239,7 @@ public final class PriceDraftFixtures {
 
 
     @Nonnull
-    private static PriceDraft getPriceDraft(@Nonnull final BigDecimal value,
+    public static PriceDraft getPriceDraft(@Nonnull final BigDecimal value,
                                             @Nonnull final CurrencyUnit currencyUnits,
                                             @Nullable final CountryCode countryCode,
                                             @Nullable final String customerGroupId,

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -226,7 +226,7 @@ public final class PriceDraftFixtures {
 
     @Nonnull
     public static ZonedDateTime byMonth(final int month) {
-        return ZonedDateTime.of(2018, month, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        return ZonedDateTime.of(2018, month, 1, 0, 0, 0, 0, ZoneId.of("Z"));
     }
 
     @Nonnull

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -143,6 +143,12 @@ public final class PriceDraftFixtures {
     public static final PriceDraft DRAFT_UK_111_GBP_01_02 = getPriceDraft(BigDecimal.valueOf(111), GBP, UK, null,
         byMonth(1), byMonth(2), null, null);
 
+    public static final PriceDraft DRAFT_UK_111_GBP_02_03 = getPriceDraft(BigDecimal.valueOf(111), GBP, UK, null,
+        byMonth(2), byMonth(3), null, null);
+
+    public static final PriceDraft DRAFT_UK_333_GBP_03_05 = getPriceDraft(BigDecimal.valueOf(333), GBP, UK, null,
+        byMonth(3), byMonth(5), null, null);
+
     public static final PriceDraft DRAFT_UK_333_GBP_01_04 = getPriceDraft(BigDecimal.valueOf(333), GBP, UK, null,
         byMonth(1), byMonth(4), null, null);
 
@@ -161,6 +167,9 @@ public final class PriceDraftFixtures {
     public static final PriceDraft DRAFT_FR_888_EUR_01_03 = getPriceDraft(BigDecimal.valueOf(888), EUR, FR, null,
         byMonth(1), byMonth(3), null, null);
 
+    public static final PriceDraft DRAFT_FR_777_EUR_01_04 = getPriceDraft(BigDecimal.valueOf(777), EUR, FR, null,
+        byMonth(1), byMonth(4), null, null);
+
     public static final PriceDraft DRAFT_FR_999_EUR_03_06 = getPriceDraft(BigDecimal.valueOf(999), EUR, FR, null,
         byMonth(3), byMonth(6), null, null);
 
@@ -169,6 +178,12 @@ public final class PriceDraftFixtures {
 
     public static final PriceDraft DRAFT_NE_777_EUR_05_07 = getPriceDraft(BigDecimal.valueOf(777), EUR, NE, null,
         byMonth(5), byMonth(7), null, null);
+
+    public static final PriceDraft DRAFT_NE_123_EUR_01_04 = getPriceDraft(BigDecimal.valueOf(123), EUR, NE, null,
+        byMonth(1), byMonth(4), null, null);
+
+    public static final PriceDraft DRAFT_NE_321_EUR_04_06 = getPriceDraft(BigDecimal.valueOf(321), EUR, NE, null,
+        byMonth(4), byMonth(6), null, null);
 
     public static final PriceDraft DRAFT_NE_777_CUST1_CHANNEL1_EUR_05_07 = getPriceDraft(BigDecimal.valueOf(777), EUR,
         NE, "cust1",

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -231,7 +231,7 @@ public final class PriceDraftFixtures {
 
     @Nonnull
     public static Map<String, JsonNode> createCustomFieldsJsonMap(@Nonnull final String fieldName,
-                                                                   @Nonnull final JsonNode fieldValue) {
+                                                                  @Nonnull final JsonNode fieldValue) {
         final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
         customFieldsJsons.put(fieldName, fieldValue);
         return customFieldsJsons;
@@ -240,13 +240,13 @@ public final class PriceDraftFixtures {
 
     @Nonnull
     public static PriceDraft getPriceDraft(@Nonnull final BigDecimal value,
-                                            @Nonnull final CurrencyUnit currencyUnits,
-                                            @Nullable final CountryCode countryCode,
-                                            @Nullable final String customerGroupId,
-                                            @Nullable final ZonedDateTime validFrom,
-                                            @Nullable final ZonedDateTime validUntil,
-                                            @Nullable final String channelId,
-                                            @Nullable final CustomFieldsDraft customFieldsDraft) {
+                                           @Nonnull final CurrencyUnit currencyUnits,
+                                           @Nullable final CountryCode countryCode,
+                                           @Nullable final String customerGroupId,
+                                           @Nullable final ZonedDateTime validFrom,
+                                           @Nullable final ZonedDateTime validUntil,
+                                           @Nullable final String channelId,
+                                           @Nullable final CustomFieldsDraft customFieldsDraft) {
 
         return PriceDraftBuilder.of(Price.of(value, currencyUnits))
                                 .country(countryCode)

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceDraftFixtures.java
@@ -143,12 +143,6 @@ public final class PriceDraftFixtures {
     public static final PriceDraft DRAFT_UK_111_GBP_01_02 = getPriceDraft(BigDecimal.valueOf(111), GBP, UK, null,
         byMonth(1), byMonth(2), null, null);
 
-    public static final PriceDraft DRAFT_UK_111_GBP_02_03 = getPriceDraft(BigDecimal.valueOf(111), GBP, UK, null,
-        byMonth(2), byMonth(3), null, null);
-
-    public static final PriceDraft DRAFT_UK_333_GBP_03_05 = getPriceDraft(BigDecimal.valueOf(333), GBP, UK, null,
-        byMonth(3), byMonth(5), null, null);
-
     public static final PriceDraft DRAFT_UK_333_GBP_01_04 = getPriceDraft(BigDecimal.valueOf(333), GBP, UK, null,
         byMonth(1), byMonth(4), null, null);
 
@@ -167,9 +161,6 @@ public final class PriceDraftFixtures {
     public static final PriceDraft DRAFT_FR_888_EUR_01_03 = getPriceDraft(BigDecimal.valueOf(888), EUR, FR, null,
         byMonth(1), byMonth(3), null, null);
 
-    public static final PriceDraft DRAFT_FR_777_EUR_01_04 = getPriceDraft(BigDecimal.valueOf(777), EUR, FR, null,
-        byMonth(1), byMonth(4), null, null);
-
     public static final PriceDraft DRAFT_FR_999_EUR_03_06 = getPriceDraft(BigDecimal.valueOf(999), EUR, FR, null,
         byMonth(3), byMonth(6), null, null);
 
@@ -178,12 +169,6 @@ public final class PriceDraftFixtures {
 
     public static final PriceDraft DRAFT_NE_777_EUR_05_07 = getPriceDraft(BigDecimal.valueOf(777), EUR, NE, null,
         byMonth(5), byMonth(7), null, null);
-
-    public static final PriceDraft DRAFT_NE_123_EUR_01_04 = getPriceDraft(BigDecimal.valueOf(123), EUR, NE, null,
-        byMonth(1), byMonth(4), null, null);
-
-    public static final PriceDraft DRAFT_NE_321_EUR_04_06 = getPriceDraft(BigDecimal.valueOf(321), EUR, NE, null,
-        byMonth(4), byMonth(6), null, null);
 
     public static final PriceDraft DRAFT_NE_777_CUST1_CHANNEL1_EUR_05_07 = getPriceDraft(BigDecimal.valueOf(777), EUR,
         NE, "cust1",

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceFixtures.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/PriceFixtures.java
@@ -134,8 +134,8 @@ public final class PriceFixtures {
     public static final Price UK_111_GBP_02_03 = getPrice(BigDecimal.valueOf(111), GBP, UK,
         null, byMonth(2), byMonth(3), null, null);
 
-    public static final Price UK_333_GBP_02_05 = getPrice(BigDecimal.valueOf(333), GBP, UK,
-        null, byMonth(2), byMonth(5), null, null);
+    public static final Price UK_333_GBP_03_05 = getPrice(BigDecimal.valueOf(333), GBP, UK,
+        null, byMonth(3), byMonth(5), null, null);
 
     public static final Price US_555_USD_CUST2_01_02 = getPrice(BigDecimal.valueOf(555), USD, US,
         "cust2", byMonth(1), byMonth(2), null, null);


### PR DESCRIPTION
#### Summary
This PR mainly addresses adding integration tests for the price sync. They are mainly in the file: [ProductSyncWithPricesIT](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-3e806d8e50cc0a32edd77abfe11bb3f3)

#### Relevant Issues
#101 #297 

#### Todo

- Tests
    - [x] Integration

#### Hints for Review about other changes in the PR
1. Introduce [ChannelITUtils](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-38ed40e407227b2fea9f57ccff9aed04)

2. Remove redundant methods [InventoryITUtils#deleteSupplyChannels, InventoryITUtils#deleteChannelsFromTargetAndSource and InventoryITUtils#getTypeByKey.](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-700d7be0d0bce91a2c4b75468817737c).

3. [Also cleanup customer groups on product sync integration test data clean up](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-b898f087a7928e68de64a4ecd9db2c66R56)

4. [Add private empty constructor for ProductITUtils](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-b898f087a7928e68de64a4ecd9db2c66R210)

5. Add new util method in ITUtil for creating a variant draft with prices [ITUtils#createVariantDraft](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-1d8a8cea016d4c60e4d2fba61d10445c)

6. [Fix validity date of one of the old prices in the test cases](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-9b8bf3d35c4c6defe605666223313241R471) since it was already overlapping.

7. [Use Z zoneId instead of systemDefault](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-f0f12735dfb19bd279f0f9ba277a6353R229)

8. Make the utils [`createCustomFieldsJsonMap`](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-f0f12735dfb19bd279f0f9ba277a6353R233) and [`getPriceDraft`](https://github.com/commercetools/commercetools-sync-java/pull/298/files#diff-f0f12735dfb19bd279f0f9ba277a6353R242) `public` to be used in the `ProductSyncWithPricesIT`.