### PR TITLE
Bump dependencies

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -63,6 +63,10 @@
 empty optionals in a supplied list (with a varargs variation) returning a list of the contents of the non-empty 
 optionals. [#255](https://github.com/commercetools/commercetools-sync-java/issues/255)
 
+**Enhancements** (2)
+- **Commons** - Bumped commercetools-jvm-sdk to version [1.35.0](http://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/ReleaseNotes.html#v1_35_0).
+- **Commons** - Bumped `mockito` to 2.23.0.
+
 **Changes** (3)
 - **Product Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)
 - **Category Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,5 +1,5 @@
 ext{
-    commercetoolsJvmSdkVersion = '1.33.0'
+    commercetoolsJvmSdkVersion = '1.35.0'
     mockitoVersion = '2.22.0'
     jupiterApiVersion = '5.3.1'
     assertjVersion = '3.11.1'

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,6 +1,6 @@
 ext{
     commercetoolsJvmSdkVersion = '1.35.0'
-    mockitoVersion = '2.22.0'
+    mockitoVersion = '2.23.0'
     jupiterApiVersion = '5.3.1'
     assertjVersion = '3.11.1'
     checkstyleVersion = '8.10.1'

--- a/src/main/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtils.java
@@ -121,7 +121,7 @@ public final class CategoryUpdateActionUtils {
             // are null, then the supplier will not be called at all. The remaining cases all involve the newParent
             // being not null.
             return buildUpdateAction(oldParent,
-                newParent, () -> ChangeParent.of(Category.referenceOfId(newParent.getId())));
+                newParent, () -> ChangeParent.of(ResourceIdentifier.ofId(newParent.getId())));
         }
     }
 

--- a/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilder.java
+++ b/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilder.java
@@ -20,27 +20,21 @@ public final class AttributeDefinitionCustomBuilder {
      * @return The attribute definition with the same fields as the  attribute definition draft.
      */
     public static AttributeDefinition of(@Nonnull final AttributeDefinitionDraft attributeDefinitionDraft) {
-        // Bug in the commercetools JVM SDK. AddAttributeDefinition should expect an AttributeDefinitionDraft rather
-        // than AttributeDefinition. That's why we use AttributeDefinitionCustomBuilder
-        // TODO It will be fixed in https://github.com/commercetools/commercetools-jvm-sdk/issues/1786
-        return AttributeDefinitionBuilder.of(
-            attributeDefinitionDraft.getName(),
-            attributeDefinitionDraft.getLabel(),
-            attributeDefinitionDraft.getAttributeType()
-        )
-        .isRequired(attributeDefinitionDraft.isRequired())
-        .attributeConstraint(Optional.ofNullable(
-            attributeDefinitionDraft.getAttributeConstraint())
-            .orElse(AttributeConstraint.NONE) // Default value is NONE according to commercetools API
-        )
-        .inputTip(attributeDefinitionDraft.getInputTip())
-        .inputHint(Optional.ofNullable(
-            attributeDefinitionDraft.getInputHint())
-            .orElse(TextInputHint.SINGLE_LINE) // Default value is SINGLE_LINE according to commercetools API
-        )
-        .isSearchable(attributeDefinitionDraft.isSearchable())
-        .build();
-
+        return AttributeDefinitionBuilder
+            .of(
+                attributeDefinitionDraft.getName(),
+                attributeDefinitionDraft.getLabel(),
+                attributeDefinitionDraft.getAttributeType())
+            .isRequired(attributeDefinitionDraft.isRequired())
+            .attributeConstraint(Optional
+                .ofNullable(attributeDefinitionDraft.getAttributeConstraint())
+                .orElse(AttributeConstraint.NONE)) // Default value is NONE according to commercetools API
+            .inputTip(attributeDefinitionDraft.getInputTip())
+            .inputHint(Optional
+                .ofNullable(attributeDefinitionDraft.getInputHint())
+                .orElse(TextInputHint.SINGLE_LINE)) // Default value is SINGLE_LINE according to commercetools API
+            .isSearchable(attributeDefinitionDraft.isSearchable())
+            .build();
     }
 
     private AttributeDefinitionCustomBuilder() { }

--- a/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateAttributeDefinitionActionUtils.java
@@ -168,8 +168,7 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
                             } else {
                                 return Arrays.asList(
                                     RemoveAttributeDefinition.of(oldAttributeDefinitionName),
-                                    AddAttributeDefinition
-                                        .of(AttributeDefinitionCustomBuilder.of(attributeDefinitionDraft))
+                                    AddAttributeDefinition.of(attributeDefinitionDraft)
                                 );
                             }
                         } else {
@@ -263,17 +262,11 @@ public final class ProductTypeUpdateAttributeDefinitionActionUtils {
     private static List<UpdateAction<ProductType>> buildAddAttributeDefinitionUpdateActions(
         @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionDrafts,
         @Nonnull final Map<String, AttributeDefinition> oldAttributeDefinitionNameMap) {
-
-        // Bug in the commercetools JVM SDK. AddAttributeDefinition should expect an AttributeDefinitionDraft rather
-        // than AttributeDefinition. That's why we use AttributeDefinitionCustomBuilder
-        // TODO It will be fixed in https://github.com/commercetools/commercetools-jvm-sdk/issues/1786
         return newAttributeDefinitionDrafts
             .stream()
-            .filter(attributeDefinitionDraft ->
-                !oldAttributeDefinitionNameMap
-                    .containsKey(attributeDefinitionDraft.getName())
+            .filter(attributeDefinitionDraft -> !oldAttributeDefinitionNameMap
+                .containsKey(attributeDefinitionDraft.getName())
             )
-            .map(AttributeDefinitionCustomBuilder::of)
             .map(AddAttributeDefinition::of)
             .collect(Collectors.toList());
     }

--- a/src/test/java/com/commercetools/sync/categories/utils/CategorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategorySyncUtilsTest.java
@@ -23,6 +23,7 @@ import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.models.AssetDraftBuilder;
 import io.sphere.sdk.models.AssetSourceBuilder;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.ResourceIdentifier;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -127,7 +128,7 @@ public class CategorySyncUtilsTest {
             ChangeSlug.of(LocalizedString.of(LOCALE, "differentSlug")),
             SetExternalId.of("differentExternalId"),
             SetDescription.of(LocalizedString.of(LOCALE, "differentDescription")),
-            ChangeParent.of(Category.referenceOfId("differentParentId")),
+            ChangeParent.of(ResourceIdentifier.ofId("differentParentId")),
             ChangeOrderHint.of("differentOrderHint"),
             SetMetaTitle.of(LocalizedString.of(LOCALE, "differentMetaTitle")),
             SetMetaDescription.of(LocalizedString.of(LOCALE, "differentMetaDescription")),
@@ -173,7 +174,7 @@ public class CategorySyncUtilsTest {
             SetMetaDescription.of(LocalizedString.of(LOCALE, "differentMetaDescription")),
             SetMetaTitle.of(LocalizedString.of(LOCALE, "differentMetaTitle")),
             ChangeOrderHint.of("differentOrderHint"),
-            ChangeParent.of(Category.referenceOfId("differentParentId")),
+            ChangeParent.of(ResourceIdentifier.ofId("differentParentId")),
             SetDescription.of(LocalizedString.of(LOCALE, "differentDescription")),
             SetExternalId.of("differentExternalId"),
             ChangeSlug.of(LocalizedString.of(LOCALE, "differentSlug")),

--- a/src/test/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtilsTest.java
@@ -17,6 +17,7 @@ import io.sphere.sdk.categories.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.ResourceIdentifier;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -190,7 +191,7 @@ public class CategoryUpdateActionUtilsTest {
     @Test
     public void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
-        when(newCategoryDraft.getParent()).thenReturn(Category.referenceOfId("2"));
+        when(newCategoryDraft.getParent()).thenReturn(Category.referenceOfId("2").toResourceIdentifier());
 
         final UpdateAction<Category> changeParentUpdateAction =
             buildChangeParentUpdateAction(MOCK_OLD_CATEGORY, newCategoryDraft, CATEGORY_SYNC_OPTIONS).orElse(null);
@@ -198,7 +199,7 @@ public class CategoryUpdateActionUtilsTest {
         assertThat(changeParentUpdateAction).isNotNull();
         assertThat(changeParentUpdateAction.getAction()).isEqualTo("changeParent");
         assertThat(((ChangeParent) changeParentUpdateAction).getParent())
-            .isEqualTo(Category.referenceOfId("2"));
+            .isEqualTo(ResourceIdentifier.ofId("2"));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -8,6 +8,8 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
+import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
+import io.sphere.sdk.products.attributes.AttributeDefinitionDraftBuilder;
 import io.sphere.sdk.products.attributes.LocalizedStringAttributeType;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
@@ -131,14 +133,13 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             SYNC_OPTIONS
         );
 
-        // Bug in the commercetools JVM SDK. AddAttributeDefinition should expect an AttributeDefinitionDraft rather
-        // than AttributeDefinition.
-        // TODO It will be fixed in https://github.com/commercetools/commercetools-jvm-sdk/issues/1786
-        assertThat(updateActions).containsExactly(
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_A),
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_B),
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_C)
-        );
+        assertThat(updateActions).hasSize(3);
+        assertThat(updateActions).allSatisfy(action -> {
+            assertThat(action).isExactlyInstanceOf(AddAttributeDefinition.class);
+            final AddAttributeDefinition addAttributeDefinition = (AddAttributeDefinition) action;
+            final AttributeDefinitionDraft attribute = addAttributeDefinition.getAttribute();
+            assertThat(newProductTypeDraft.getAttributes()).contains(attribute);
+        });
     }
 
     @Test
@@ -231,7 +232,11 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         );
 
         assertThat(updateActions).containsExactly(
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_D)
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                .of(ATTRIBUTE_DEFINITION_D.getAttributeType(), ATTRIBUTE_DEFINITION_D.getName(),
+                    ATTRIBUTE_DEFINITION_D.getLabel(), ATTRIBUTE_DEFINITION_D.isRequired())
+                .isSearchable(true)
+                .build())
         );
     }
 
@@ -253,7 +258,11 @@ public class BuildAttributeDefinitionUpdateActionsTest {
 
         assertThat(updateActions).containsExactly(
             RemoveAttributeDefinition.of("c"),
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_D)
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                .of(ATTRIBUTE_DEFINITION_D.getAttributeType(), ATTRIBUTE_DEFINITION_D.getName(),
+                    ATTRIBUTE_DEFINITION_D.getLabel(), ATTRIBUTE_DEFINITION_D.isRequired())
+                .isSearchable(true)
+                .build())
         );
     }
 
@@ -325,7 +334,10 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         );
 
         assertThat(updateActions).containsExactly(
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_D),
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                .of(ATTRIBUTE_DEFINITION_D.getAttributeType(),
+                    ATTRIBUTE_DEFINITION_D.getName(), ATTRIBUTE_DEFINITION_D.getLabel(),
+                    ATTRIBUTE_DEFINITION_D.isRequired()).isSearchable(true).build()),
             ChangeAttributeOrder
                 .of(asList(
                         ATTRIBUTE_DEFINITION_A,
@@ -353,7 +365,12 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         );
 
         assertThat(updateActions).containsExactly(
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_D),
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                .of(ATTRIBUTE_DEFINITION_D.getAttributeType(),
+                    ATTRIBUTE_DEFINITION_D.getName(), ATTRIBUTE_DEFINITION_D.getLabel(),
+                    ATTRIBUTE_DEFINITION_D.isRequired())
+                .isSearchable(true)
+                .build()),
             ChangeAttributeOrder
                 .of(asList(
                         ATTRIBUTE_DEFINITION_A,
@@ -382,7 +399,11 @@ public class BuildAttributeDefinitionUpdateActionsTest {
 
         assertThat(updateActions).containsExactly(
             RemoveAttributeDefinition.of("a"),
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_D),
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                    .of(ATTRIBUTE_DEFINITION_D.getAttributeType(),
+                        ATTRIBUTE_DEFINITION_D.getName(), ATTRIBUTE_DEFINITION_D.getLabel(),
+                        ATTRIBUTE_DEFINITION_D.isRequired())
+                    .isSearchable(true).build()),
             ChangeAttributeOrder
                 .of(asList(
                         ATTRIBUTE_DEFINITION_C,
@@ -414,7 +435,12 @@ public class BuildAttributeDefinitionUpdateActionsTest {
 
         assertThat(updateActions).containsExactly(
             RemoveAttributeDefinition.of("a"),
-            AddAttributeDefinition.of(ATTRIBUTE_DEFINITION_A_LOCALIZED_TYPE)
+            AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
+                .of(ATTRIBUTE_DEFINITION_A_LOCALIZED_TYPE.getAttributeType(),
+                    ATTRIBUTE_DEFINITION_A_LOCALIZED_TYPE.getName(), ATTRIBUTE_DEFINITION_A_LOCALIZED_TYPE.getLabel(),
+                    ATTRIBUTE_DEFINITION_A_LOCALIZED_TYPE.isRequired())
+                .isSearchable(true)
+                .build())
         );
     }
 }


### PR DESCRIPTION
#### Summary
- Bump JVM SDK dependency to 1.35.0 (apply changes after dep bump)
- Bump mockito dependency to 2.23.0

#### Relevant Issues
https://github.com/commercetools/commercetools-jvm-sdk/issues/1786
