### PR TITLE
apply empty completableUtil

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CompletableFutureUtils.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -156,6 +157,17 @@ public final class CompletableFutureUtils {
         @Nonnull final Collector<CompletableFuture<T>, ?, S> collector) {
         return values.filter(Objects::nonNull)
                      .map(CompletionStage::toCompletableFuture).collect(collector);
+    }
+
+    private static final CompletableFuture<Optional<?>> EMPTY = CompletableFuture.completedFuture(Optional.empty());
+
+    /**
+     * @return empty {@link CompletableFuture} elements of type {@code <T>}.
+     */
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static <T> CompletableFuture<T> emptyOptionalCompletedFuture() {
+        return (CompletableFuture<T>)EMPTY;
     }
 
     private CompletableFutureUtils() {

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -24,6 +24,7 @@ import com.commercetools.sync.services.impl.TypeServiceImpl;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import javax.annotation.Nonnull;
@@ -252,7 +253,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                                              final String productKey = oldProduct.getKey();
                                              handleError(format(UPDATE_FAILED, productKey, sphereException),
                                                  sphereException);
-                                             return CompletableFuture.completedFuture(Optional.empty());
+                                             return CompletableFutureUtils.emptyOptionalCompletedFuture();
                                          });
                                  } else {
                                      statistics.incrementUpdated();

--- a/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/VariantReferenceResolver.java
@@ -3,6 +3,7 @@ package com.commercetools.sync.products.helpers;
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
 import com.commercetools.sync.commons.helpers.AssetReferenceResolver;
 import com.commercetools.sync.commons.helpers.BaseReferenceResolver;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.services.ChannelService;
 import com.commercetools.sync.services.CustomerGroupService;
@@ -188,7 +189,7 @@ public final class VariantReferenceResolver extends BaseReferenceResolver<Produc
         final JsonNode idField = referenceValue.get(REFERENCE_ID_FIELD);
         return idField != null
             ? productService.getIdFromCacheOrFetch(idField.asText())
-            : CompletableFuture.completedFuture(Optional.empty());
+            : CompletableFutureUtils.emptyOptionalCompletedFuture();
     }
 
     @Nonnull

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.services.impl;
 
 import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import io.sphere.sdk.commands.DraftBasedCreateCommand;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.commands.UpdateCommand;
@@ -56,7 +57,7 @@ class BaseService<U extends Resource<U>, V> {
         @Nonnull final Function<V, DraftBasedCreateCommand<U, V>> createCommandFunction) {
         if (isBlank(draftKey)) {
             syncOptions.applyErrorCallback(format(CREATE_FAILED, draftKey, "Draft key is blank!"));
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         } else {
             final BiFunction<U, Throwable, Optional<U>> responseHandler =
                 (createdResource, sphereException) ->
@@ -67,7 +68,7 @@ class BaseService<U extends Resource<U>, V> {
                                              .execute(createCommandFunction.apply(mappedDraft))
                                              .handle(responseHandler)
                               )
-                              .orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()));
+                              .orElseGet(() -> CompletableFutureUtils.emptyOptionalCompletedFuture());
         }
     }
 

--- a/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.commercetools.sync.services.impl;
 
 
 import com.commercetools.sync.categories.CategorySyncOptions;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.services.CategoryService;
 import io.sphere.sdk.categories.Category;
@@ -94,7 +95,7 @@ public final class CategoryServiceImpl extends BaseService<Category, CategoryDra
     @Override
     public CompletionStage<Optional<Category>> fetchCategory(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
 
         return syncOptions.getCtpClient()

--- a/src/main/java/com/commercetools/sync/services/impl/CustomerGroupServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomerGroupServiceImpl.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.services.impl;
 
 import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.services.CustomerGroupService;
 import io.sphere.sdk.customergroups.CustomerGroup;
@@ -35,7 +36,7 @@ public final class CustomerGroupServiceImpl implements CustomerGroupService {
     @Override
     public CompletionStage<Optional<String>> fetchCachedCustomerGroupId(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.isEmpty()) {
             return fetchAndCache(key);

--- a/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.services.impl;
 
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.services.ProductService;
@@ -43,7 +44,7 @@ public class ProductServiceImpl extends BaseService<Product, ProductDraft> imple
     @Override
     public CompletionStage<Optional<String>> getIdFromCacheOrFetch(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.containsKey(key)) {
             return CompletableFuture.completedFuture(Optional.of(keyToIdCache.get(key)));
@@ -121,7 +122,7 @@ public class ProductServiceImpl extends BaseService<Product, ProductDraft> imple
     @Override
     public CompletionStage<Optional<Product>> fetchProduct(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
         final QueryPredicate<Product> queryPredicate = buildProductKeysQueryPredicate(singleton(key));
         return syncOptions.getCtpClient().execute(ProductQuery.of().withPredicates(queryPredicate))

--- a/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.services.impl;
 
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.services.StateService;
@@ -36,7 +37,7 @@ public class StateServiceImpl implements StateService {
     @Override
     public CompletionStage<Optional<String>> fetchCachedStateId(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.isEmpty()) {
             return fetchAndCache(key);

--- a/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.services.impl;
 
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.services.TaxCategoryService;
@@ -32,7 +33,7 @@ public class TaxCategoryServiceImpl implements TaxCategoryService {
     @Override
     public CompletionStage<Optional<String>> fetchCachedTaxCategoryId(@Nullable final String key) {
         if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return CompletableFutureUtils.emptyOptionalCompletedFuture();
         }
         if (keyToIdCache.isEmpty()) {
             return fetchAndCache(key);

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -3,6 +3,7 @@ package com.commercetools.sync.categories.helpers;
 import com.commercetools.sync.categories.CategorySyncOptions;
 import com.commercetools.sync.categories.CategorySyncOptionsBuilder;
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.services.CategoryService;
 import com.commercetools.sync.services.TypeService;
 import io.sphere.sdk.categories.Category;
@@ -137,7 +138,7 @@ public class CategoryReferenceResolverTest {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(categoryService.fetchCachedCategoryId(CACHED_CATEGORY_KEY))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         referenceResolver.resolveParentReference(categoryDraft)
                                  .thenApply(CategoryDraftBuilder::build)
@@ -169,7 +170,7 @@ public class CategoryReferenceResolverTest {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         referenceResolver.resolveCustomTypeReference(categoryDraft)
                                  .thenApply(CategoryDraftBuilder::build)

--- a/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.helpers;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.TypeService;
@@ -51,7 +52,7 @@ public class AssetReferenceResolverTest {
                                                                      .custom(customFieldsDraft);
 
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final AssetReferenceResolver assetReferenceResolver = new AssetReferenceResolver(syncOptions, typeService);
 

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.inventories;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.inventories.helpers.InventorySyncStatistics;
 import com.commercetools.sync.services.ChannelService;
 import com.commercetools.sync.services.InventoryService;
@@ -351,7 +352,7 @@ public class InventorySyncTest {
 
         final ChannelService channelService = getMockChannelService(getMockSupplyChannel(REF_3, KEY_3));
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft
             .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, Channel.referenceOfId(KEY_3));
@@ -375,7 +376,7 @@ public class InventorySyncTest {
 
         final ChannelService channelService = getMockChannelService(getMockSupplyChannel(REF_3, KEY_3));
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
         when(channelService.createAndCacheChannel(anyString())).thenReturn(failed(new SphereException()));
 
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -7,6 +7,7 @@ import com.commercetools.sync.inventories.InventorySyncOptions;
 import com.commercetools.sync.inventories.InventorySyncOptionsBuilder;
 import com.commercetools.sync.services.ChannelService;
 import com.commercetools.sync.services.TypeService;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.inventory.InventoryEntryDraft;
@@ -14,7 +15,6 @@ import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
-import io.sphere.sdk.utils.CompletableFutureUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,7 +63,7 @@ public class InventoryReferenceResolverTest {
     public void
         resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
@@ -92,7 +92,7 @@ public class InventoryReferenceResolverTest {
                                                                                           .ensureChannels(true)
                                                                                           .build();
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
@@ -116,7 +116,7 @@ public class InventoryReferenceResolverTest {
             .custom(CustomFieldsDraft.ofTypeIdAndJson(CUSTOM_TYPE_KEY, new HashMap<>()));
 
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFutureUtils.failed(new SphereException("bad request")));
+            .thenReturn(io.sphere.sdk.utils.CompletableFutureUtils.failed(new SphereException("bad request")));
 
         final InventoryReferenceResolver referenceResolver =
             new InventoryReferenceResolver(syncOptions, typeService, channelService);
@@ -133,7 +133,7 @@ public class InventoryReferenceResolverTest {
     @Test
     public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final InventoryEntryDraftBuilder draftBuilder = InventoryEntryDraftBuilder
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -21,9 +21,7 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.MockUtils.getMockTypeService;

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceCustomerGroupReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceCustomerGroupReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products.helpers;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.ChannelService;
@@ -80,7 +81,7 @@ public class PriceCustomerGroupReferenceResolverTest {
             .customerGroup(CustomerGroup.referenceOfId("nonExistentKey"));
 
         when(customerGroupService.fetchCachedCustomerGroupId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveCustomerGroupReference(priceBuilder).toCompletableFuture())
             .hasNotFailed()

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products.helpers;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.ChannelService;
@@ -72,7 +73,7 @@ public class PriceReferenceResolverTest {
             .custom(customFieldsDraft);
 
         when(typeService.fetchCachedTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final PriceReferenceResolver priceReferenceResolver =
             new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
@@ -171,7 +172,7 @@ public class PriceReferenceResolverTest {
     public void
         resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
@@ -204,7 +205,7 @@ public class PriceReferenceResolverTest {
                                                                                       .ensurePriceChannels(true)
                                                                                       .build();
         when(channelService.fetchCachedChannelId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))

--- a/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.products.helpers;
 
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.ChannelService;
@@ -283,7 +284,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void resolveAttributeReference_WithProductReferenceAttribute_ShouldResolveAttribute() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("typeId", "product");
@@ -410,7 +411,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void resolveAttributeReference_WithNonExistingProductReferenceSetAttribute_ShouldNotResolveReferences() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final ObjectNode productReference = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute =
@@ -435,7 +436,7 @@ public class VariantReferenceResolverTest { ;
         when(productService.getIdFromCacheOrFetch("existingKey"))
             .thenReturn(CompletableFuture.completedFuture(Optional.of("existingId")));
         when(productService.getIdFromCacheOrFetch("randomKey"))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final ObjectNode productReference1 = getProductReferenceWithId("existingKey");
         final ObjectNode productReference2 = getProductReferenceWithId("randomKey");
@@ -529,7 +530,7 @@ public class VariantReferenceResolverTest { ;
     @Test
     public void getResolvedIdFromKeyInReference_WithNonExistingProductReferenceAttribute_ShouldGetEmptyId() {
         when(productService.getIdFromCacheOrFetch(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         final ObjectNode attributeValue = getProductReferenceWithRandomId();
         final AttributeDraft attributeDraft = AttributeDraft.of("attributeName", attributeValue);

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products.helpers.productreferenceresolver;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.helpers.ProductReferenceResolver;
@@ -78,7 +79,7 @@ public class ProductTypeReferenceResolverTest {
             .key("dummyKey");
 
         when(productTypeService.fetchCachedProductTypeId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveProductTypeReference(productBuilder).toCompletableFuture())
             .hasNotFailed()

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products.helpers.productreferenceresolver;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.helpers.ProductReferenceResolver;
@@ -87,7 +88,7 @@ public class StateReferenceResolverTest {
             .key("dummyKey");
 
         when(stateService.fetchCachedStateId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveStateReference(productBuilder).toCompletableFuture())
             .hasNotFailed()

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products.helpers.productreferenceresolver;
 
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.commons.utils.CompletableFutureUtils;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.helpers.ProductReferenceResolver;
@@ -87,7 +88,7 @@ public class TaxCategoryReferenceResolverTest {
             .key("dummyKey");
 
         when(taxCategoryService.fetchCachedTaxCategoryId(anyString()))
-            .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+            .thenReturn(CompletableFutureUtils.emptyOptionalCompletedFuture());
 
         assertThat(referenceResolver.resolveTaxCategoryReference(productBuilder).toCompletableFuture())
             .hasNotFailed()


### PR DESCRIPTION
#### Summary
apply empty completable util

#### Description
change all CompletableFuture.completedFuture(Optional.empty()) to use util function instead

#### Relevant Issues
[issues 164](https://github.com/commercetools/commercetools-sync-java/issues/164)

#### Todo

- Tests
    - [ ] Unit 
    - [/ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
CompletableFuture.completedFuture(Optional.empty()) replace with emptyOptionalCompletedFuture() function
