### PR TITLE
334-The `syncBatches` method implementation moved to the `BaseSync` class.

### DIFF
--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -134,17 +134,6 @@ public class CategorySync extends BaseSync<CategoryDraft, CategorySyncStatistics
         return syncBatches(batches, CompletableFuture.completedFuture(statistics));
     }
 
-    @Override
-    protected CompletionStage<CategorySyncStatistics> syncBatches(@Nonnull final List<List<CategoryDraft>> batches,
-                                                                  @Nonnull final
-                                                                  CompletionStage<CategorySyncStatistics> result) {
-        if (batches.isEmpty()) {
-            return result;
-        }
-        final List<CategoryDraft> firstBatch = batches.remove(0);
-        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
-    }
-
     /**
      * Given a list of {@code CategoryDraft} that represent a batch of category drafts, this method for the first batch
      * only caches a list of all the categories in the CTP project in a cached map that representing each category's

--- a/src/main/java/com/commercetools/sync/commons/BaseSync.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSync.java
@@ -83,8 +83,14 @@ public abstract class BaseSync<T, U extends BaseSyncStatistics, V extends BaseSy
      *      {@link BaseSyncStatistics} representing the {@code statistics} of the sync process executed on the
      *      given list of batches.
      */
-    protected abstract CompletionStage<U> syncBatches(@Nonnull final List<List<T>> batches,
-                                                      @Nonnull final CompletionStage<U> result);
+    protected CompletionStage<U> syncBatches(@Nonnull final List<List<T>> batches,
+                                                      @Nonnull final CompletionStage<U> result) {
+        if (batches.isEmpty()) {
+            return result;
+        }
+        final List<T> firstBatch = batches.remove(0);
+        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
+    }
 
     protected abstract CompletionStage<U> processBatch(@Nonnull final List<T> batch);
 

--- a/src/main/java/com/commercetools/sync/inventories/InventorySync.java
+++ b/src/main/java/com/commercetools/sync/inventories/InventorySync.java
@@ -111,17 +111,6 @@ public final class InventorySync extends BaseSync<InventoryEntryDraft, Inventory
             });
     }
 
-    @Override
-    protected CompletionStage<InventorySyncStatistics> syncBatches(
-        @Nonnull final List<List<InventoryEntryDraft>> batches,
-        @Nonnull final CompletionStage<InventorySyncStatistics> result) {
-        if (batches.isEmpty()) {
-            return result;
-        }
-        final List<InventoryEntryDraft> firstBatch = batches.remove(0);
-        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
-    }
-
     /**
      * Checks if a draft is valid for further processing. If so, then returns {@code true}. Otherwise handles an error
      * and returns {@code false}. A valid draft is a {@link InventoryEntryDraft} object that is not {@code null} and its

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -104,17 +104,6 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
     }
 
     @Override
-    protected CompletionStage<ProductSyncStatistics> syncBatches(@Nonnull final List<List<ProductDraft>> batches,
-                                                                 @Nonnull final CompletionStage<ProductSyncStatistics>
-                                                                     result) {
-        if (batches.isEmpty()) {
-            return result;
-        }
-        final List<ProductDraft> firstBatch = batches.remove(0);
-        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
-    }
-
-    @Override
     protected CompletionStage<ProductSyncStatistics> processBatch(@Nonnull final List<ProductDraft> batch) {
         productsToSync = new HashMap<>();
         draftsToCreate = new HashSet<>();

--- a/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
+++ b/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
@@ -71,19 +71,6 @@ public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncS
         return syncBatches(batches, CompletableFuture.completedFuture(statistics));
     }
 
-    @Override
-    protected CompletionStage<ProductTypeSyncStatistics> syncBatches(
-            @Nonnull final List<List<ProductTypeDraft>> batches,
-            @Nonnull final CompletionStage<ProductTypeSyncStatistics> result) {
-
-        if (batches.isEmpty()) {
-            return result;
-        }
-
-        final List<ProductTypeDraft> firstBatch = batches.remove(0);
-        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
-    }
-
     /**
      * This method first creates a new {@link Set} of valid {@link ProductTypeDraft} elements. For more on the rules of
      * validation, check: {@link ProductTypeSync#validateDraft(ProductTypeDraft)}. Using the resulting set of

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -3,6 +3,7 @@ package com.commercetools.sync.categories;
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
 import com.commercetools.sync.services.CategoryService;
+import com.commercetools.sync.services.TypeService;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.CategoryDraftBuilder;
@@ -11,6 +12,7 @@ import io.sphere.sdk.models.LocalizedString;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,6 +47,19 @@ public class CategorySyncTest {
     private CategorySyncOptions categorySyncOptions;
     private List<String> errorCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
+
+    // protected method access helper
+    private class CategorySyncTestie extends CategorySync {
+
+        public CategorySyncTestie(@Nonnull CategorySyncOptions syncOptions, @Nonnull TypeService typeService, @Nonnull CategoryService categoryService) {
+            super(syncOptions, typeService, categoryService);
+        }
+
+        @Override
+        protected CompletionStage<CategorySyncStatistics> syncBatches(@Nonnull List<List<CategoryDraft>> batches, @Nonnull CompletionStage<CategorySyncStatistics> result) {
+            return super.syncBatches(batches, result);
+        }
+    }
 
     /**
      * Initializes instances of  {@link CategorySyncOptions} and {@link CategorySync} which will be used by some
@@ -317,9 +333,9 @@ public class CategorySyncTest {
                                    .collect(Collectors.toList());
         final CategoryService mockCategoryService =
             mockCategoryService(emptySet(), new HashSet<>(mockedCreatedCategories));
-        final CategorySync categorySync = new CategorySync(categorySyncOptions, getMockTypeService(),
+        final CategorySyncTestie categorySync = new CategorySyncTestie(categorySyncOptions, getMockTypeService(),
             mockCategoryService);
-        final CategorySync syncSpy = spy(categorySync);
+        final CategorySyncTestie syncSpy = spy(categorySync);
 
         syncSpy.sync(categoryDrafts).toCompletableFuture().join();
 
@@ -342,9 +358,9 @@ public class CategorySyncTest {
                                    .collect(Collectors.toList());
         final CategoryService mockCategoryService =
             mockCategoryService(emptySet(), new HashSet<>(mockedCreatedCategories));
-        final CategorySync categorySync = new CategorySync(categorySyncOptions, getMockTypeService(),
+        final CategorySyncTestie categorySync = new CategorySyncTestie(categorySyncOptions, getMockTypeService(),
             mockCategoryService);
-        final CategorySync syncSpy = spy(categorySync);
+        final CategorySyncTestie syncSpy = spy(categorySync);
 
         syncSpy.sync(categoryDrafts).toCompletableFuture().join();
 

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -49,11 +49,11 @@ public class CategorySyncTest {
     private List<Throwable> errorCallBackExceptions;
 
     // protected method access helper
-    private static class CategorySyncTestie extends CategorySync {
+    private static class CategorySyncMock extends CategorySync {
 
-        CategorySyncTestie(@Nonnull final CategorySyncOptions syncOptions,
-                                  @Nonnull final TypeService typeService,
-                                  @Nonnull final CategoryService categoryService) {
+        CategorySyncMock(@Nonnull final CategorySyncOptions syncOptions,
+                         @Nonnull final TypeService typeService,
+                         @Nonnull final CategoryService categoryService) {
             super(syncOptions, typeService, categoryService);
         }
 
@@ -337,9 +337,9 @@ public class CategorySyncTest {
                                    .collect(Collectors.toList());
         final CategoryService mockCategoryService =
             mockCategoryService(emptySet(), new HashSet<>(mockedCreatedCategories));
-        final CategorySyncTestie categorySync = new CategorySyncTestie(categorySyncOptions, getMockTypeService(),
+        final CategorySyncMock categorySync = new CategorySyncMock(categorySyncOptions, getMockTypeService(),
             mockCategoryService);
-        final CategorySyncTestie syncSpy = spy(categorySync);
+        final CategorySyncMock syncSpy = spy(categorySync);
 
         syncSpy.sync(categoryDrafts).toCompletableFuture().join();
 
@@ -362,9 +362,9 @@ public class CategorySyncTest {
                                    .collect(Collectors.toList());
         final CategoryService mockCategoryService =
             mockCategoryService(emptySet(), new HashSet<>(mockedCreatedCategories));
-        final CategorySyncTestie categorySync = new CategorySyncTestie(categorySyncOptions, getMockTypeService(),
+        final CategorySyncMock categorySync = new CategorySyncMock(categorySyncOptions, getMockTypeService(),
             mockCategoryService);
-        final CategorySyncTestie syncSpy = spy(categorySync);
+        final CategorySyncMock syncSpy = spy(categorySync);
 
         syncSpy.sync(categoryDrafts).toCompletableFuture().join();
 

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -49,9 +49,9 @@ public class CategorySyncTest {
     private List<Throwable> errorCallBackExceptions;
 
     // protected method access helper
-    private class CategorySyncTestie extends CategorySync {
+    private static class CategorySyncTestie extends CategorySync {
 
-        public CategorySyncTestie(@Nonnull final CategorySyncOptions syncOptions,
+        CategorySyncTestie(@Nonnull final CategorySyncOptions syncOptions,
                                   @Nonnull final TypeService typeService,
                                   @Nonnull final CategoryService categoryService) {
             super(syncOptions, typeService, categoryService);

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -51,12 +51,16 @@ public class CategorySyncTest {
     // protected method access helper
     private class CategorySyncTestie extends CategorySync {
 
-        public CategorySyncTestie(@Nonnull CategorySyncOptions syncOptions, @Nonnull TypeService typeService, @Nonnull CategoryService categoryService) {
+        public CategorySyncTestie(@Nonnull final CategorySyncOptions syncOptions,
+                                  @Nonnull final TypeService typeService,
+                                  @Nonnull final CategoryService categoryService) {
             super(syncOptions, typeService, categoryService);
         }
 
         @Override
-        protected CompletionStage<CategorySyncStatistics> syncBatches(@Nonnull List<List<CategoryDraft>> batches, @Nonnull CompletionStage<CategorySyncStatistics> result) {
+        protected CompletionStage<CategorySyncStatistics> syncBatches(
+                @Nonnull final List<List<CategoryDraft>> batches,
+                @Nonnull final CompletionStage<CategorySyncStatistics> result) {
             return super.syncBatches(batches, result);
         }
     }


### PR DESCRIPTION
#### Summary
Corresponds to #334

> _**Note**_
> _Doesn't build on Travis because of [Pull Requests and Security Restrictions](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions)_