### PR TITLE
325 producttypes concurrency modification

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -45,11 +45,14 @@
     - **Commons** - Moved documentation of sync options to a separate [doc](/docs/usage/SYNC_OPTIONS.md).
     - **Commons** - Added a the earliest compatible version of the commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a prerequisite for using the library.
 
-- 🛠️ **Enhancements** (11)
-    - **ProductType Sync** - Added `ProductTypeSyncBenchmark` to benchmark the product type sync, to be able to compare the performance of the sync with the future releases. [#301](https://github.com/commercetools/commercetools-sync-java/issues/301)
+- 🛠️ **Enhancements** (16)
+    - **ProductType Sync** - Added concurrnency modification exception handeling. [#325](https://github.com/commercetools/commercetools-sync-java/issues/325)
+    - **Commons** - `ProductSyncUtils#buildActions`, `CategorySyncUtils#buildActions`, `InventorySyncUtils#buildActions` and `ProductTypeSyncUtils#buildActions` now don't apply the `beforeUpdateCallback` implicitly. 
+        If you want you can apply it explicitly on the result. [#302](https://github.com/commercetools/commercetools-sync-java/issues/302)
     - **Product Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)
     - **Category Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)
     - **Inventory Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)
+    - **ProductType Sync** - Added `ProductTypeSyncBenchmark` to benchmark the product type sync, to be able to compare the performance of the sync with the future releases. [#301](https://github.com/commercetools/commercetools-sync-java/issues/301)
     - **Commons** - Bumped commercetools-jvm-sdk to version [1.37.0](http://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/ReleaseNotes.html#v1_37_0).
     - **Commons** - Bumped `mockito` to 2.23.4.
     - **Commons** - Bumped `com.adarshr.test-logger` to 1.6.0.
@@ -60,9 +63,6 @@
     - **Commons** - Bumped `com.adarshr.test-logger` to 1.6.0.
     - **Commons** - Bumped `org.ajoberstar.grgit` to 3.0.0.
     - **Commons** - Bumped gradle to version [gradle-5.0](https://docs.gradle.org/5.0/release-notes.html)
-    - **Commons** - `ProductSyncUtils#buildActions`, `CategorySyncUtils#buildActions`, `InventorySyncUtils#buildActions` and `ProductTypeSyncUtils#buildActions` now don't apply the `beforeUpdateCallback` implicitly. 
-    If you want you can apply it explicitly on the result. [#302](https://github.com/commercetools/commercetools-sync-java/issues/302)
-    
 
 - 🚧 **Breaking Changes** (11) 
     - **Product Sync** - `allowUuid` option is now removed. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166) 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -46,7 +46,7 @@
     - **Commons** - Added a the earliest compatible version of the commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a prerequisite for using the library.
 
 - 🛠️ **Enhancements** (16)
-    - **ProductType Sync** - Added concurrnency modification exception handeling. [#325](https://github.com/commercetools/commercetools-sync-java/issues/325)
+    - **ProductType Sync** - Added concurrency modification exception handeling. [#325](https://github.com/commercetools/commercetools-sync-java/issues/325)
     - **Commons** - `ProductSyncUtils#buildActions`, `CategorySyncUtils#buildActions`, `InventorySyncUtils#buildActions` and `ProductTypeSyncUtils#buildActions` now don't apply the `beforeUpdateCallback` implicitly. 
         If you want you can apply it explicitly on the result. [#302](https://github.com/commercetools/commercetools-sync-java/issues/302)
     - **Product Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -46,7 +46,7 @@
     - **Commons** - Added a the earliest compatible version of the commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a prerequisite for using the library.
 
 - 🛠️ **Enhancements** (16)
-    - **ProductType Sync** - Added concurrency modification exception handeling. [#325](https://github.com/commercetools/commercetools-sync-java/issues/325)
+    - **ProductType Sync** - Added concurrency modification exception handling. [#325](https://github.com/commercetools/commercetools-sync-java/issues/325)
     - **Commons** - `ProductSyncUtils#buildActions`, `CategorySyncUtils#buildActions`, `InventorySyncUtils#buildActions` and `ProductTypeSyncUtils#buildActions` now don't apply the `beforeUpdateCallback` implicitly. 
         If you want you can apply it explicitly on the result. [#302](https://github.com/commercetools/commercetools-sync-java/issues/302)
     - **Product Sync** - Reference keys are not validated if they are in UUID format anymore. [#166](https://github.com/commercetools/commercetools-sync-java/issues/166)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -592,7 +592,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewCategoryWithSuccess() {
+    public void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewProductTypeWithSuccess() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdate();
 
@@ -697,7 +697,7 @@ public class ProductTypeSyncIT {
 
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         when(spyClient.execute(any(ProductTypeQuery.class)))
-            .thenCallRealMethod() // Call real fetch on fetching matching categories
+            .thenCallRealMethod() // Call real fetch on fetching matching product types
             .thenReturn(exceptionallyCompletedFuture(new BadGatewayException()));
 
         final ProductTypeUpdateCommand anyProductTypeUpdate = any(ProductTypeUpdateCommand.class);
@@ -760,7 +760,7 @@ public class ProductTypeSyncIT {
         final ProductTypeQuery anyProductTypeQuery = any(ProductTypeQuery.class);
 
         when(spyClient.execute(anyProductTypeQuery))
-            .thenCallRealMethod() // Call real fetch on fetching matching categories
+            .thenCallRealMethod() // Call real fetch on fetching matching product types
             .thenReturn(CompletableFuture.completedFuture(PagedQueryResult.empty()));
 
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -471,7 +471,7 @@ public class ProductTypeSyncIT {
         assertThat(errorMessages)
             .hasSize(1)
             .hasOnlyOneElementSatisfying(message ->
-                assertThat(message).contains("Failed to update product type of key: 'key_1'.")
+                assertThat(message).contains("Failed to update product type with key: 'key_1'.")
             );
 
         assertThat(exceptions)
@@ -518,7 +518,7 @@ public class ProductTypeSyncIT {
         assertThat(errorMessages)
             .hasSize(1)
             .hasOnlyOneElementSatisfying(message ->
-                assertThat(message).contains("Failed to update product type of key: 'key_1'.")
+                assertThat(message).contains("Failed to update product type with key: 'key_1'.")
             );
 
         assertThat(exceptions)
@@ -577,7 +577,7 @@ public class ProductTypeSyncIT {
         assertThat(errorMessages)
             .hasSize(1)
             .hasOnlyOneElementSatisfying(message ->
-                assertThat(message).contains("Failed to update product type of key: 'key_1'.")
+                assertThat(message).contains("Failed to update product type with key: 'key_1'.")
             );
 
         assertThat(exceptions)

--- a/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
+++ b/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -32,9 +33,10 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  * This class syncs product type drafts with the corresponding product types in the CTP project.
  */
 public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncStatistics, ProductTypeSyncOptions> {
-    private static final String CTP_PRODUCT_TYPE_FETCH_FAILED = "Failed to fetch existing product types of keys '%s'.";
-    private static final String CTP_PRODUCT_TYPE_UPDATE_FAILED = "Failed to update product type of key '%s'.";
-    private static final String CTP_PRODUCT_TYPE_CREATE_FAILED = "Failed to create product type of key '%s'.";
+    private static final String CTP_PRODUCT_TYPE_FETCH_FAILED = "Failed to fetch existing product types with keys:"
+        + " '%s'.";
+    private static final String CTP_PRODUCT_TYPE_UPDATE_FAILED = "Failed to update product type with key: '%s'."
+        + " Reason: %s";
     private static final String PRODUCT_TYPE_DRAFT_HAS_NO_KEY = "Failed to process product type draft without key.";
     private static final String PRODUCT_TYPE_DRAFT_IS_NULL = "Failed to process null product type draft.";
 
@@ -191,7 +193,7 @@ public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncS
                 final ProductType oldProductType = oldProductTypeMap.get(newProductType.getKey());
 
                 return ofNullable(oldProductType)
-                    .map(productType -> updateProductType(oldProductType, newProductType))
+                    .map(productType -> buildActionsAndUpdate(oldProductType, newProductType))
                     .orElseGet(() -> applyCallbackAndCreate(newProductType));
             })
             .map(CompletionStage::toCompletableFuture)
@@ -206,22 +208,40 @@ public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncS
      * @return a {@link CompletionStage} which contains an empty result after execution of the create.
      */
     @Nonnull
-    private CompletionStage<Void> applyCallbackAndCreate(
+    private CompletionStage<Optional<ProductType>> applyCallbackAndCreate(
         @Nonnull final ProductTypeDraft productTypeDraft) {
 
         return syncOptions
             .applyBeforeCreateCallBack(productTypeDraft)
             .map(draft -> productTypeService
                 .createProductType(draft)
-                .thenAccept(productTypeOptional -> {
+                .thenApply(productTypeOptional -> {
                     if (productTypeOptional.isPresent()) {
                         statistics.incrementCreated();
                     } else {
                         statistics.incrementFailed();
                     }
+                    return productTypeOptional;
                 })
             )
-            .orElse(CompletableFuture.completedFuture(null));
+            .orElse(CompletableFuture.completedFuture(Optional.empty()));
+    }
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
+    private CompletionStage<Optional<ProductType>> buildActionsAndUpdate(
+        @Nonnull final ProductType oldProductType,
+        @Nonnull final ProductTypeDraft newProductType) {
+
+        final List<UpdateAction<ProductType>> updateActions = buildActions(oldProductType, newProductType, syncOptions);
+
+        final List<UpdateAction<ProductType>> updateActionsAfterCallback =
+            syncOptions.applyBeforeUpdateCallBack(updateActions, newProductType, oldProductType);
+
+        if (!updateActionsAfterCallback.isEmpty()) {
+            return updateProductType(oldProductType, newProductType, updateActionsAfterCallback);
+        }
+
+        return completedFuture(null);
     }
 
     /**
@@ -238,29 +258,61 @@ public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncS
      * @param newProductType draft containing data that could differ from data in {@code oldProductType}.
      * @return a {@link CompletionStage} which contains an empty result after execution of the update.
      */
-    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
-    private CompletionStage<Void> updateProductType(@Nonnull final ProductType oldProductType,
-                                                    @Nonnull final ProductTypeDraft newProductType) {
+    private CompletionStage<Optional<ProductType>> updateProductType(@Nonnull final ProductType oldProductType,
+                                                                     @Nonnull final ProductTypeDraft newProductType,
+                                                                     @Nonnull final List<UpdateAction<ProductType>> updateActions) {
 
-        final List<UpdateAction<ProductType>> updateActions = buildActions(oldProductType, newProductType, syncOptions);
+        return productTypeService
+            .updateProductType(oldProductType, updateActions)
+            .handle(ImmutablePair::new)
+            .thenCompose(updateResponse -> {
+                final ProductType updatedProductType = updateResponse.getKey();
+                final Throwable sphereException = updateResponse.getValue();
+                if (sphereException != null) {
+                    return executeSupplierIfConcurrentModificationException(
+                        sphereException,
+                        () -> fetchAndUpdate(oldProductType, newProductType),
+                        () -> {
+                            final String errorMessage =
+                                format(CTP_PRODUCT_TYPE_UPDATE_FAILED, newProductType.getKey(),
+                                    sphereException.getMessage());
+                            handleError(errorMessage, sphereException, 1);
+                            return CompletableFuture.completedFuture(Optional.empty());
+                        });
+                } else {
+                    statistics.incrementUpdated();
+                    return CompletableFuture.completedFuture(Optional.of(updatedProductType));
+                }
+            });
+    }
 
-        final List<UpdateAction<ProductType>> updateActionsAfterCallback = syncOptions.applyBeforeUpdateCallBack(
-            updateActions,
-            newProductType,
-            oldProductType
-        );
+    private CompletionStage<Optional<ProductType>> fetchAndUpdate(@Nonnull final ProductType oldProductType,
+                                                                  @Nonnull final ProductTypeDraft newProductType) {
+        final String key = oldProductType.getKey();
+        return productTypeService
+            .fetchProductType(key)
+            .handle(ImmutablePair::new)
+            .thenCompose(fetchResponse -> {
+                final Optional<ProductType> fetchedProductTypeOptional = fetchResponse.getKey();
+                final Throwable exception = fetchResponse.getValue();
 
-        if (!updateActionsAfterCallback.isEmpty()) {
-            return productTypeService.updateProductType(oldProductType, updateActionsAfterCallback)
-                    .thenAccept(updatedProductType -> statistics.incrementUpdated())
-                    .exceptionally(exception -> {
-                        final String errorMessage = format(CTP_PRODUCT_TYPE_UPDATE_FAILED, newProductType.getKey());
-                        handleError(errorMessage, exception, 1);
+                if (exception != null) {
+                    final String errorMessage = format(CTP_PRODUCT_TYPE_UPDATE_FAILED, key,
+                        "Failed to fetch from CTP while retrying after concurrency modification.");
+                    handleError(errorMessage, exception, 1);
+                    return CompletableFuture.completedFuture(null);
+                }
 
-                        return null;
+                return fetchedProductTypeOptional
+                    .map(fetchedProductType -> buildActionsAndUpdate(fetchedProductType, newProductType))
+                    .orElseGet(() -> {
+                        final String errorMessage =
+                            format(CTP_PRODUCT_TYPE_UPDATE_FAILED, key,
+                                "Not found when attempting to fetch while retrying "
+                                    + "after concurrency modification.");
+                        handleError(errorMessage, null, 1);
+                        return CompletableFuture.completedFuture(null);
                     });
-        }
-
-        return completedFuture(null);
+            });
     }
 }

--- a/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
+++ b/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
@@ -295,7 +295,7 @@ public class ProductTypeSync extends BaseSync<ProductTypeDraft, ProductTypeSyncS
     private CompletionStage<Optional<ProductType>> fetchAndUpdate(
         @Nonnull final ProductType oldProductType,
         @Nonnull final ProductTypeDraft newProductType) {
-        
+
         final String key = oldProductType.getKey();
         return productTypeService
             .fetchProductType(key)

--- a/src/main/java/com/commercetools/sync/services/CategoryService.java
+++ b/src/main/java/com/commercetools/sync/services/CategoryService.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletionStage;
 public interface CategoryService {
 
     /**
-     * If not already done once before, it fetches all the category keys from the CTP project defined in a potentially
+     * If not already done once before, it fetches all the category keys from the CTP project defined in an
      * injected {@link io.sphere.sdk.client.SphereClient} and stores a mapping for every category to id in {@link Map}
      * and returns this cached map.
      *
@@ -28,7 +28,7 @@ public interface CategoryService {
 
     /**
      * Given a {@link Set} of category keys, this method fetches a set of all the categories, matching this given set of
-     * keys in the CTP project, defined in a potentially injected {@link io.sphere.sdk.client.SphereClient}. A mapping
+     * keys in the CTP project, defined in an injected {@link io.sphere.sdk.client.SphereClient}. A mapping
      * of the key to the id of the fetched categories is persisted in an in-memory map.
      *
      * @param categoryKeys set of category keys to fetch matching categories by.

--- a/src/main/java/com/commercetools/sync/services/ProductService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductService.java
@@ -34,7 +34,7 @@ public interface ProductService {
 
     /**
      * Filters out the keys which are already cached and fetches only the not-cached product keys from the CTP project
-     * defined in a potentially injected {@link SphereClient} and stores a mapping for every product to id in
+     * defined in an injected {@link SphereClient} and stores a mapping for every product to id in
      * the cached map of keys -&gt; ids and returns this cached map.
      *
      * <p>Note: If all the supplied keys are already cached, the cached map is returned right away with no request to
@@ -50,7 +50,7 @@ public interface ProductService {
 
     /**
      * Given a {@link Set} of product keys, this method fetches a set of all the products, matching this given set of
-     * keys in the CTP project, defined in a potentially injected {@link SphereClient}. A mapping of the key to the id
+     * keys in the CTP project, defined in an injected {@link SphereClient}. A mapping of the key to the id
      * of the fetched products is persisted in an in-memory map.
      *
      * @param productKeys set of product keys to fetch matching products by.

--- a/src/main/java/com/commercetools/sync/services/ProductTypeService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductTypeService.java
@@ -1,11 +1,13 @@
 package com.commercetools.sync.services;
 
 import com.commercetools.sync.products.AttributeMetaData;
+import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,4 +107,16 @@ public interface ProductTypeService {
     @Nonnull
     CompletionStage<ProductType> updateProductType(@Nonnull final ProductType productType,
                                                    @Nonnull final List<UpdateAction<ProductType>> updateActions);
+
+    /**
+     * Given a productType key, this method fetches a productType that matches this given key in the CTP project defined
+     * in a potentially injected {@link SphereClient}. If there is no matching productType an empty {@link Optional}
+     * will be returned in the returned future.
+     *
+     * @param key the key of the category to fetch.
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
+     *         {@link Optional} that contains the matching {@link ProductType} if exists, otherwise empty.
+     */
+    @Nonnull
+    CompletionStage<Optional<ProductType>> fetchProductType(@Nullable final String key);
 }

--- a/src/main/java/com/commercetools/sync/services/ProductTypeService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductTypeService.java
@@ -59,7 +59,7 @@ public interface ProductTypeService {
 
     /**
      * Given a {@link Set} of ProductType keys, this method fetches a set of all the ProductTypes, matching this given
-     * set of keys in the CTP project, defined in a potentially injected {@link io.sphere.sdk.client.SphereClient}. A
+     * set of keys in the CTP project, defined in an injected {@link io.sphere.sdk.client.SphereClient}. A
      * mapping of the key to the id of the fetched ProductType is persisted in an in-memory map.
      *
      * @param keys set of ProductType keys to fetch matching ProductTypes by.
@@ -110,7 +110,7 @@ public interface ProductTypeService {
 
     /**
      * Given a productType key, this method fetches a productType that matches this given key in the CTP project defined
-     * in a potentially injected {@link SphereClient}. If there is no matching productType an empty {@link Optional}
+     * in an injected {@link SphereClient}. If there is no matching productType an empty {@link Optional}
      * will be returned in the returned future.
      *
      * @param key the key of the category to fetch.

--- a/src/main/java/com/commercetools/sync/services/ProductTypeService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductTypeService.java
@@ -113,7 +113,7 @@ public interface ProductTypeService {
      * in an injected {@link SphereClient}. If there is no matching productType an empty {@link Optional}
      * will be returned in the returned future.
      *
-     * @param key the key of the category to fetch.
+     * @param key the key of the product type to fetch.
      * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
      *         {@link Optional} that contains the matching {@link ProductType} if exists, otherwise empty.
      */

--- a/src/test/java/com/commercetools/sync/services/impl/ProductTypeServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/ProductTypeServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.commercetools.sync.services.impl;
+
+import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
+import com.commercetools.sync.producttypes.ProductTypeSyncOptionsBuilder;
+import com.commercetools.sync.services.ProductTypeService;
+import io.sphere.sdk.client.BadGatewayException;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
+import io.sphere.sdk.utils.CompletableFutureUtils;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProductTypeServiceImplTest {
+
+    @Test
+    public void fetchProductType_WithEmptyKey_ShouldNotFetchCategory() {
+        // preparation
+        final SphereClient sphereClient = mock(SphereClient.class);
+        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
+            .of(sphereClient)
+            .build();
+        final ProductTypeService productTypeService = new ProductTypeServiceImpl(syncOptions);
+
+        // test
+        final CompletionStage<Optional<ProductType>> result = productTypeService.fetchProductType("");
+
+        // assertions
+        assertThat(result).isCompletedWithValue(Optional.empty());
+        verify(sphereClient, never()).execute(any());
+    }
+
+    @Test
+    public void fetchProductType_WithNullKey_ShouldNotFetchCategory() {
+        // preparation
+        final SphereClient sphereClient = mock(SphereClient.class);
+        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
+            .of(sphereClient)
+            .build();
+        final ProductTypeService productTypeService = new ProductTypeServiceImpl(syncOptions);
+
+        // test
+        final CompletionStage<Optional<ProductType>> result = productTypeService.fetchProductType(null);
+
+        // assertions
+        assertThat(result).isCompletedWithValue(Optional.empty());
+        verify(sphereClient, never()).execute(any());
+    }
+
+    @Test
+    public void fetchProductType_WithBadGateWayException_ShouldCompleteExceptionally() {
+        // preparation
+        final SphereClient sphereClient = mock(SphereClient.class);
+        when(sphereClient.execute(any(ProductTypeQuery.class)))
+            .thenReturn(CompletableFutureUtils.exceptionallyCompletedFuture(new BadGatewayException()));
+
+
+        final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
+            .of(sphereClient)
+            .build();
+        final ProductTypeService productTypeService = new ProductTypeServiceImpl(syncOptions);
+
+        // test
+        final CompletionStage<Optional<ProductType>> result = productTypeService.fetchProductType("foo");
+
+        // assertions
+        assertThat(result).hasFailedWithThrowableThat().isExactlyInstanceOf(BadGatewayException.class);
+    }
+
+}


### PR DESCRIPTION
#### Summary
This PR mainly addresses adding handeling of concurrency modification exception for productTypes sync.

#### Relevant Issues
#325 

#### Todo
- Add unit tests for caching on fetch.

- Tests
    - [x] Unit 
    - [x] Integration
- [x] Documentation
- [x] Add Release Notes entry.

