### PR TITLE
Return 0 if there is no previous avg benchmarks.

### DIFF
--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -153,8 +153,9 @@ public class BenchmarkUtils {
                                                   .get(benchmark)
                                                   .get(AVERAGE))
             .map(latestAverageNode -> average - latestAverageNode.asDouble())
-            // if there is no latest version - the current average is the diff.
-            .orElse(average);
+            // if there is no latest version (meaning this is the first benchmark for this module)
+            // then return a 0 diff.
+            .orElse(0.0);
     }
 
     private static Optional<String> getLatestVersionName(@Nonnull final JsonNode originalRoot,


### PR DESCRIPTION
#### Summary
In the benchmarks it fails, if this is the first time a benchmark for a new module (first time) is added, since the difference between the current time and the previous one, could easily exceed the threshold. So if it's the first time a module is benchmarked we make the diff as least as possible `0.0` so we have a first avg.
