### PR TITLE
354 fix null optional with defaults

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,10 +29,17 @@
 -->
 
 <!--
-### 1.1.0 -  Dec 10, 2018
-[Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M14...1.1.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.1.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.1.0)
+### 1.1.0 -  Dec 20, 2018
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.0.0...1.1.0) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.0/) | 
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.0)
+
+- 🐞 **Bug Fixes** (2)
+    - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
+    and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
+    - **ProductType Sync** - `ProductTypeSyncUtils#buildActions`, `ProductTypeUpdateActionUtils#buildAttributesUpdateActions`  
+    treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
+    as (`true`, `SingleLine` and `None` respectivley) if they are not passed/`null`. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
 
 !-->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -39,7 +39,7 @@
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
     - **ProductType Sync** - `ProductTypeSyncUtils#buildActions`, `ProductTypeUpdateActionUtils#buildAttributesUpdateActions`  
     now treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
-    as (`true`, `SingleLine` and `None` respectivley) if they are not passed/`null`. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
+    as (`true`, `SingleLine` and `None` respectivley) if they are `null` or not passed. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
 
 !-->
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -38,7 +38,7 @@
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
     - **ProductType Sync** - `ProductTypeSyncUtils#buildActions`, `ProductTypeUpdateActionUtils#buildAttributesUpdateActions`  
-    treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
+    now treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
     as (`true`, `SingleLine` and `None` respectivley) if they are not passed/`null`. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
 
 !-->

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.integration.commons.utils;
 
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.models.LocalizedString;
-import io.sphere.sdk.models.TextInputHint;
-import io.sphere.sdk.products.attributes.AttributeConstraint;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraftBuilder;
 import io.sphere.sdk.products.attributes.BooleanAttributeType;
@@ -50,10 +48,7 @@ public final class ProductTypeITUtils {
             LocalizedString.ofEnglish("attr_label_1"),
             true
         )
-        .attributeConstraint(AttributeConstraint.NONE)
         .inputTip(LocalizedString.ofEnglish("inputTip1"))
-        .inputHint(TextInputHint.SINGLE_LINE)
-        .isSearchable(false)
         .build();
 
     public static final AttributeDefinitionDraft ATTRIBUTE_DEFINITION_DRAFT_2 = AttributeDefinitionDraftBuilder
@@ -63,10 +58,7 @@ public final class ProductTypeITUtils {
             LocalizedString.ofEnglish("attr_label_2"),
             true
         )
-        .attributeConstraint(AttributeConstraint.NONE)
         .inputTip(LocalizedString.ofEnglish("inputTip2"))
-        .inputHint(TextInputHint.SINGLE_LINE)
-        .isSearchable(false)
         .build();
 
     public static final AttributeDefinitionDraft ATTRIBUTE_DEFINITION_DRAFT_3 = AttributeDefinitionDraftBuilder
@@ -76,10 +68,7 @@ public final class ProductTypeITUtils {
             LocalizedString.ofEnglish("attr_label_3"),
             true
         )
-        .attributeConstraint(AttributeConstraint.NONE)
         .inputTip(LocalizedString.ofEnglish("inputTip3"))
-        .inputHint(TextInputHint.SINGLE_LINE)
-        .isSearchable(false)
         .build();
 
 

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -16,8 +16,6 @@ import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.producttypes.queries.ProductTypeQueryBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -27,6 +25,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public final class ProductTypeITUtils {
     private static final String LOCALISED_STRING_ATTRIBUTE_NAME = "backgroundColor";
@@ -76,14 +75,14 @@ public final class ProductTypeITUtils {
         PRODUCT_TYPE_KEY_1,
         PRODUCT_TYPE_NAME_1,
         PRODUCT_TYPE_DESCRIPTION_1,
-        Arrays.asList(ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2)
+        asList(ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2)
     );
 
     public static final ProductTypeDraft productTypeDraft2 = ProductTypeDraft.ofAttributeDefinitionDrafts(
         PRODUCT_TYPE_KEY_2,
         PRODUCT_TYPE_NAME_2,
         PRODUCT_TYPE_DESCRIPTION_2,
-        Collections.singletonList(ATTRIBUTE_DEFINITION_DRAFT_1)
+        singletonList(ATTRIBUTE_DEFINITION_DRAFT_1)
     );
 
     /**

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -91,7 +91,6 @@ public class ProductTypeSyncIT {
     public void sync_WithUpdatedProductType_ShouldUpdateProductType() {
         // preparation
         final Optional<ProductType> oldProductTypeBefore = getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_1);
-        assertThat(oldProductTypeBefore).isNotEmpty();
 
 
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
@@ -267,10 +266,10 @@ public class ProductTypeSyncIT {
                 ofEnglish("attr_label_updated"),
                 true
             )
-            .attributeConstraint(AttributeConstraint.NONE)
+            .attributeConstraint(AttributeConstraint.COMBINATION_UNIQUE)
             .inputTip(ofEnglish("inputTip_updated"))
             .inputHint(TextInputHint.MULTI_LINE)
-            .isSearchable(true)
+            .isSearchable(false)
             .build();
 
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -91,9 +91,6 @@ public class ProductTypeSyncIT {
     @Test
     public void sync_WithUpdatedProductType_ShouldUpdateProductType() {
         // preparation
-        final Optional<ProductType> oldProductTypeBefore = getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_1);
-
-
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_1,
             PRODUCT_TYPE_NAME_2,

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -254,7 +254,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedProductType_WithUpdatedAttributeDefinition_ShouldUpdateProductTypeUpdatingAttribute() {
+    public void sync_WithUpdatedAttributeDefinition_ShouldUpdateProductTypeUpdatingAttribute() {
         // Updating ATTRIBUTE_DEFINITION_1 (name = "attr_name_1") changing the label, attribute constraint, input tip,
         // input hint, isSearchable fields.
         final AttributeDefinitionDraft attributeDefinitionDraftUpdated = AttributeDefinitionDraftBuilder
@@ -264,7 +264,7 @@ public class ProductTypeSyncIT {
                 ofEnglish("attr_label_updated"),
                 true
             )
-            .attributeConstraint(AttributeConstraint.COMBINATION_UNIQUE)
+            .attributeConstraint(AttributeConstraint.NONE)
             .inputTip(ofEnglish("inputTip_updated"))
             .inputHint(TextInputHint.MULTI_LINE)
             .isSearchable(false)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -60,6 +60,7 @@ import static io.sphere.sdk.utils.CompletableFutureUtils.exceptionallyCompletedF
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.emptyList;
 import static org.mockito.ArgumentMatchers.any;
@@ -807,13 +808,24 @@ public class ProductTypeSyncIT {
                      final AttributeDefinitionDraft attributeDraft = attributesDrafts.get(index);
 
                      assertThat(attribute.getName()).isEqualTo(attributeDraft.getName());
+
                      assertThat(attribute.getLabel()).isEqualTo(attributeDraft.getLabel());
+
                      assertThat(attribute.getAttributeType()).isEqualTo(attributeDraft.getAttributeType());
-                     assertThat(attribute.getInputHint()).isEqualTo(attributeDraft.getInputHint());
+
+                     assertThat(attribute.getInputHint())
+                         .isEqualTo(ofNullable(attributeDraft.getInputHint()).orElse(TextInputHint.SINGLE_LINE));
+
                      assertThat(attribute.getInputTip()).isEqualTo(attributeDraft.getInputTip());
+
                      assertThat(attribute.isRequired()).isEqualTo(attributeDraft.isRequired());
-                     assertThat(attribute.isSearchable()).isEqualTo(attributeDraft.isSearchable());
-                     assertThat(attribute.getAttributeConstraint()).isEqualTo(attributeDraft.getAttributeConstraint());
+
+                     assertThat(attribute.isSearchable())
+                         .isEqualTo(ofNullable(attributeDraft.isSearchable()).orElse(true));
+
+                     assertThat(attribute.getAttributeConstraint())
+                         .isEqualTo(ofNullable(attributeDraft.getAttributeConstraint())
+                             .orElse(AttributeConstraint.NONE));
 
                      if (attribute.getAttributeType().getClass() == EnumAttributeType.class) {
                          assertPlainEnumsValuesAreEqual(

--- a/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilder.java
+++ b/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilder.java
@@ -39,7 +39,7 @@ public final class AttributeDefinitionCustomBuilder {
                 .orElse(TextInputHint.SINGLE_LINE)) // Default value is SINGLE_LINE according to commercetools API
             .isSearchable(
                 ofNullable(attributeDefinitionDraft.isSearchable())
-                .orElse(false)) // Default value is false according to commercetools API
+                .orElse(true)) // Default value is true according to commercetools API
             .build();
     }
 

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -5,6 +5,8 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.EnumValue;
 import io.sphere.sdk.models.LocalizedEnumValue;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.TextInputHint;
+import io.sphere.sdk.products.attributes.AttributeConstraint;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
 import io.sphere.sdk.products.attributes.EnumAttributeType;
@@ -25,6 +27,7 @@ import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.b
 import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
 import static com.commercetools.sync.producttypes.utils.LocalizedEnumValueUpdateActionUtils.buildLocalizedEnumValuesUpdateActions;
 import static com.commercetools.sync.producttypes.utils.PlainEnumValueUpdateActionUtils.buildEnumValuesUpdateActions;
+import static java.util.Optional.ofNullable;
 
 /**
  * This class is only meant for the internal use of the commercetools-sync-java library.
@@ -160,6 +163,9 @@ final class AttributeDefinitionUpdateActionUtils {
      * an {@link Optional}. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the
      * same 'isSearchable' field, then no update action is needed and hence an empty {@link Optional} is returned.
      *
+     * <p>Note: A {@code null} {@code isSearchable} value in the {@link AttributeDefinitionDraft} is treated as a
+     * {@code true} value which is the default value of CTP.
+     *
      * @param oldAttributeDefinition the attribute definition which should be updated.
      * @param newAttributeDefinition the attribute definition draft where we get the new 'isSearchable' field.
      * @return A filled optional with the update action or an empty optional if the 'isSearchable' fields are identical.
@@ -169,8 +175,10 @@ final class AttributeDefinitionUpdateActionUtils {
         @Nonnull final AttributeDefinition oldAttributeDefinition,
         @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
-        return buildUpdateAction(oldAttributeDefinition.isSearchable(), newAttributeDefinition.isSearchable(),
-            () -> ChangeIsSearchable.of(oldAttributeDefinition.getName(), newAttributeDefinition.isSearchable())
+        final Boolean searchable = ofNullable(newAttributeDefinition.isSearchable()).orElse(true);
+
+        return buildUpdateAction(oldAttributeDefinition.isSearchable(), searchable,
+            () -> ChangeIsSearchable.of(oldAttributeDefinition.getName(), searchable)
         );
     }
 
@@ -179,6 +187,9 @@ final class AttributeDefinitionUpdateActionUtils {
      * an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in an {@link Optional}. If both the
      * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the same input hints, then no update
      * action is needed and hence an empty {@link Optional} is returned.
+     *
+     * <p>Note: A {@code null} {@code inputHint} value in the {@link AttributeDefinitionDraft} is treated as a
+     * {@code TextInputHint#SINGLE_LINE} value which is the default value of CTP.
      *
      * @param oldAttributeDefinition the attribute definition which should be updated.
      * @param newAttributeDefinition the attribute definition draft where we get the new input hint.
@@ -189,8 +200,11 @@ final class AttributeDefinitionUpdateActionUtils {
         @Nonnull final AttributeDefinition oldAttributeDefinition,
         @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
-        return buildUpdateAction(oldAttributeDefinition.getInputHint(), newAttributeDefinition.getInputHint(),
-            () -> ChangeInputHint.of(oldAttributeDefinition.getName(), newAttributeDefinition.getInputHint())
+        final TextInputHint inputHint = ofNullable(newAttributeDefinition.getInputHint())
+            .orElse(TextInputHint.SINGLE_LINE);
+
+        return buildUpdateAction(oldAttributeDefinition.getInputHint(), inputHint,
+            () -> ChangeInputHint.of(oldAttributeDefinition.getName(), inputHint)
         );
     }
 
@@ -199,6 +213,9 @@ final class AttributeDefinitionUpdateActionUtils {
      * and returns an {@link UpdateAction}&lt;{@link ProductType}&gt; as a result in an {@link Optional}. If both the
      * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have the same attribute constraints, then
      * no update action is needed and hence an empty {@link Optional} is returned.
+     *
+     * <p>Note: A {@code null} {@code AttributeConstraint} value in the {@link AttributeDefinitionDraft} is treated as a
+     * {@code AttributeConstraint#NONE} value which is the default value of CTP.
      *
      * @param oldAttributeDefinition the attribute definition which should be updated.
      * @param newAttributeDefinition the attribute definition draft where we get the new attribute constraint.
@@ -209,10 +226,13 @@ final class AttributeDefinitionUpdateActionUtils {
         @Nonnull final AttributeDefinition oldAttributeDefinition,
         @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
 
+        final AttributeConstraint attributeConstraint = ofNullable(newAttributeDefinition.getAttributeConstraint())
+            .orElse(AttributeConstraint.NONE);
+
         return buildUpdateAction(oldAttributeDefinition.getAttributeConstraint(),
-            newAttributeDefinition.getAttributeConstraint(),
+            attributeConstraint,
             () -> ChangeAttributeConstraint.of(oldAttributeDefinition.getName(),
-                newAttributeDefinition.getAttributeConstraint())
+                attributeConstraint)
         );
     }
 

--- a/src/test/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionCustomBuilderTest.java
@@ -135,7 +135,7 @@ public class AttributeDefinitionCustomBuilderTest {
     }
 
     @Test
-    public void of_withNullSearchable_ShouldCreateAttributeDefinitionWithFalseSearchable() {
+    public void of_withNullSearchable_ShouldCreateAttributeDefinitionWithTrueSearchable() {
         // preparation
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(MoneyAttributeType.of(), "foo", ofEnglish("bar"), true)
@@ -146,6 +146,6 @@ public class AttributeDefinitionCustomBuilderTest {
 
         // assertions
         assertThat(attributeDefinition).isNotNull();
-        assertThat(attributeDefinition.isSearchable()).isFalse();
+        assertThat(attributeDefinition.isSearchable()).isTrue();
     }
 }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -42,10 +42,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeDefinitionUpdateActionUtilsTest {
     private static AttributeDefinition old;
-    private static AttributeDefinition oldNullValues;
     private static AttributeDefinitionDraft newSame;
     private static AttributeDefinitionDraft newDifferent;
-    private static AttributeDefinitionDraft newNullValues;
 
     private static final EnumValue ENUM_VALUE_A = EnumValue.of("a", "label_a");
     private static final EnumValue ENUM_VALUE_B = EnumValue.of("b", "label_b");
@@ -67,15 +65,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .isSearchable(false)
             .build();
 
-        oldNullValues = AttributeDefinitionBuilder
-            .of("attributeName1", ofEnglish("label1"), StringAttributeType.of())
-            .isRequired(false)
-            .attributeConstraint(null)
-            .inputTip(null)
-            .inputHint(null)
-            .isSearchable(false)
-            .build();
-
         newSame = AttributeDefinitionDraftBuilder
             .of(old)
             .build();
@@ -85,14 +74,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
             .inputTip(ofEnglish("inputTip2"))
             .inputHint(TextInputHint.MULTI_LINE)
-            .isSearchable(true)
-            .build();
-
-        newNullValues = AttributeDefinitionDraftBuilder
-            .of(StringAttributeType.of(), "attributeName1", LocalizedString.ofEnglish("label2"), true)
-            .attributeConstraint(null)
-            .inputTip(null)
-            .inputHint(null)
             .isSearchable(true)
             .build();
     }
@@ -458,7 +439,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             ChangeAttributeDefinitionLabel.of(old.getName(), newDifferent.getLabel()),
             SetInputTip.of(old.getName(), newDifferent.getInputTip()),
             ChangeAttributeConstraint.of(old.getName(), newDifferent.getAttributeConstraint()),
-            ChangeInputHint.of(oldNullValues.getName(), newDifferent.getInputHint()),
+            ChangeInputHint.of(old.getName(), newDifferent.getInputHint()),
             ChangeIsSearchable.of(old.getName(), newDifferent.isSearchable())
         );
     }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -99,124 +99,355 @@ public class AttributeDefinitionUpdateActionUtilsTest {
 
     @Test
     public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(old, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .build();
 
-        assertThat(result).contains(ChangeAttributeDefinitionLabel.of(old.getName(), newDifferent.getLabel()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("y"), null)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(attributeDefinition, draft);
+
+        //assertion
+        assertThat(result).contains(ChangeAttributeDefinitionLabel.of(attributeDefinition.getName(), ofEnglish("x")));
     }
 
     @Test
     public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(old, newSame);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .build();
 
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeLabelUpdateAction(attributeDefinition, draft);
+
+        //assertion
         assertThat(result).isEmpty();
     }
 
     @Test
     public void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("foo"))
+            .build();
 
-        assertThat(result).contains(SetInputTip.of(old.getName(), newDifferent.getInputTip()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("bar"))
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+        //assertion
+        assertThat(result).contains(SetInputTip.of(attributeDefinition.getName(), ofEnglish("foo")));
     }
 
     @Test
     public void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newSame);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("foo"))
+            .build();
 
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("foo"))
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+        //assertion
         assertThat(result).isEmpty();
     }
 
     @Test
     public void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(oldNullValues, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputTip(null)
+            .build();
 
-        assertThat(result).contains(SetInputTip.of(oldNullValues.getName(), newDifferent.getInputTip()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("foo"))
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+        //assertion
+        assertThat(result).contains(SetInputTip.of(attributeDefinition.getName(), null));
     }
 
     @Test
     public void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(old, newNullValues);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputTip(ofEnglish("foo"))
+            .build();
 
-        assertThat(result).contains(SetInputTip.of(old.getName(), newNullValues.getInputTip()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputTip(null)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+        //assertion
+        assertThat(result).contains(SetInputTip.of(attributeDefinition.getName(), ofEnglish("foo")));
     }
 
     @Test
     public void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeIsSearchableUpdateAction(old, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .isSearchable(true)
+            .build();
 
-        assertThat(result).contains(ChangeIsSearchable.of(old.getName(), newDifferent.isSearchable()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .isSearchable(false)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeIsSearchable.of(attributeDefinition.getName(), true));
     }
 
     @Test
     public void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeIsSearchableUpdateAction(old, newSame);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .isSearchable(true)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .isSearchable(true)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldSetFieldToDefault() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .isSearchable(null)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .isSearchable(true)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeIsSearchable.of(attributeDefinition.getName(), false));
+    }
+
+    @Test
+    public void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotUpdateField() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .isSearchable(null)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .isSearchable(false)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
 
         assertThat(result).isEmpty();
     }
 
     @Test
     public void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.MULTI_LINE)
+            .build();
 
-        assertThat(result).contains(ChangeInputHint.of(old.getName(), newDifferent.getInputHint()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeInputHint.of(attributeDefinition.getName(), TextInputHint.MULTI_LINE));
     }
 
     @Test
     public void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newSame);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.MULTI_LINE)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.MULTI_LINE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(attributeDefinition, draft);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSourceNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result =
-            buildChangeInputHintUpdateAction(oldNullValues, newDifferent);
+    public void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldSetToDefault() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputHint(null)
+            .build();
 
-        assertThat(result).contains(ChangeInputHint.of(oldNullValues.getName(), newDifferent.getInputHint()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.MULTI_LINE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeInputHint.of(attributeDefinition.getName(), TextInputHint.SINGLE_LINE));
     }
 
     @Test
-    public void buildChangeInputHintAction_WithTargetNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(old, newNullValues);
+    public void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldSetToDefault() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .inputHint(null)
+            .build();
 
-        assertThat(result).contains(ChangeInputHint.of(old.getName(), newNullValues.getInputHint()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result = buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).isEmpty();
     }
 
     @Test
     public void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result =
-            buildChangeAttributeConstraintUpdateAction(old, newDifferent);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.COMBINATION_UNIQUE)
+            .build();
 
-        assertThat(result).contains(ChangeAttributeConstraint.of(old.getName(), newDifferent.getAttributeConstraint()));
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(
+            ChangeAttributeConstraint.of(attributeDefinition.getName(), AttributeConstraint.COMBINATION_UNIQUE));
     }
 
     @Test
     public void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional() {
-        final Optional<UpdateAction<ProductType>> result = buildChangeAttributeConstraintUpdateAction(old, newSame);
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.COMBINATION_UNIQUE)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.COMBINATION_UNIQUE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSourceNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result =
-            buildChangeAttributeConstraintUpdateAction(oldNullValues, newDifferent);
+    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndDefaultTarget_ShouldReturnAction() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .attributeConstraint(null)
+            .build();
 
-        assertThat(result).contains(ChangeAttributeConstraint.of(
-            oldNullValues.getName(),
-            newDifferent.getAttributeConstraint())
-        );
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.NONE)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithTargetNullValues_ShouldReturnAction() {
-        final Optional<UpdateAction<ProductType>> result =
-            buildChangeAttributeConstraintUpdateAction(old, newNullValues);
+    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldReturnAction() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .attributeConstraint(null)
+            .build();
 
-        assertThat(result).contains(ChangeAttributeConstraint.of(
-            old.getName(),
-            newNullValues.getAttributeConstraint())
-        );
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeAttributeConstraint.of(draft.getName(), AttributeConstraint.NONE));
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -235,27 +235,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldSetFieldToDefault() {
-        // Preparation
-        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
-            .of(null, "foo", ofEnglish("x"), null)
-            .isSearchable(null)
-            .build();
-
-        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-            .of("foo", ofEnglish("x"), null)
-            .isSearchable(true)
-            .build();
-
-        // test
-        final Optional<UpdateAction<ProductType>> result =
-            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
-
-        assertThat(result).contains(ChangeIsSearchable.of(attributeDefinition.getName(), false));
-    }
-
-    @Test
-    public void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotUpdateField() {
+    public void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -265,6 +245,26 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("foo", ofEnglish("x"), null)
             .isSearchable(false)
+            .build();
+
+        // test
+        final Optional<UpdateAction<ProductType>> result =
+            buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+        assertThat(result).contains(ChangeIsSearchable.of("foo", true));
+    }
+
+    @Test
+    public void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotBuildAction() {
+        // Preparation
+        final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
+            .of(null, "foo", ofEnglish("x"), null)
+            .isSearchable(null)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("foo", ofEnglish("x"), null)
+            .isSearchable(true)
             .build();
 
         // test
@@ -313,7 +313,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldSetToDefault() {
+    public void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -332,7 +332,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldSetToDefault() {
+    public void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldNotBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -351,7 +351,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldReturnAction() {
+    public void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -392,7 +392,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndDefaultTarget_ShouldReturnAction() {
+    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndDefaultTarget_ShouldNotBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -412,7 +412,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldReturnAction() {
+    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -429,6 +429,50 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
 
         assertThat(result).contains(ChangeAttributeConstraint.of(draft.getName(), AttributeConstraint.NONE));
+    }
+
+    @Test
+    public void buildActions_WithNullOptionalsAndDefaultValues_ShouldBuildNoActions() {
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(StringAttributeType.of(), "attributeName1", ofEnglish("label2"), true)
+            .attributeConstraint(null)
+            .inputHint(null)
+            .isSearchable(null)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", ofEnglish("label2"), StringAttributeType.of())
+            .isRequired(true)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void buildActions_WithNonDefaultValuesForOptionalFields_ShouldBuildActions() {
+        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
+            .of(StringAttributeType.of(), "attributeName1", ofEnglish("label2"), true)
+            .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
+            .inputHint(TextInputHint.MULTI_LINE)
+            .isSearchable(false)
+            .build();
+
+        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
+            .of("attributeName1", ofEnglish("label2"), StringAttributeType.of())
+            .isRequired(true)
+            .build();
+
+
+        final List<UpdateAction<ProductType>> result = buildActions(attributeDefinition, attributeDefinitionDraft);
+
+        assertThat(result).containsExactlyInAnyOrder(
+            ChangeAttributeConstraint.of("attributeName1", AttributeConstraint.SAME_FOR_ALL),
+            ChangeInputHint.of("attributeName1", TextInputHint.MULTI_LINE),
+            ChangeIsSearchable.of("attributeName1", false)
+        );
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -3,6 +3,7 @@ package com.commercetools.sync.producttypes.utils;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.EnumValue;
 import io.sphere.sdk.models.LocalizedEnumValue;
+import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.TextInputHint;
 import io.sphere.sdk.products.attributes.AttributeConstraint;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
@@ -37,7 +38,6 @@ import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdat
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildSetInputTipUpdateAction;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeDefinitionUpdateActionUtilsTest {
@@ -655,7 +655,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
-            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputTip(ofEnglish("inputTip1"))
             .inputHint(TextInputHint.SINGLE_LINE)
             .isSearchable(false)
             .build();

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -3,7 +3,6 @@ package com.commercetools.sync.producttypes.utils;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.EnumValue;
 import io.sphere.sdk.models.LocalizedEnumValue;
-import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.TextInputHint;
 import io.sphere.sdk.products.attributes.AttributeConstraint;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
@@ -27,7 +26,6 @@ import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +36,8 @@ import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdat
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildChangeLabelUpdateAction;
 import static com.commercetools.sync.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildSetInputTipUpdateAction;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeDefinitionUpdateActionUtilsTest {
@@ -59,16 +59,16 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     @BeforeClass
     public static void setup() {
         old = AttributeDefinitionBuilder
-            .of("attributeName1", LocalizedString.ofEnglish("label1"), StringAttributeType.of())
+            .of("attributeName1", ofEnglish("label1"), StringAttributeType.of())
             .isRequired(false)
             .attributeConstraint(AttributeConstraint.NONE)
-            .inputTip(LocalizedString.ofEnglish("inputTip1"))
+            .inputTip(ofEnglish("inputTip1"))
             .inputHint(TextInputHint.SINGLE_LINE)
             .isSearchable(false)
             .build();
 
         oldNullValues = AttributeDefinitionBuilder
-            .of("attributeName1", LocalizedString.ofEnglish("label1"), StringAttributeType.of())
+            .of("attributeName1", ofEnglish("label1"), StringAttributeType.of())
             .isRequired(false)
             .attributeConstraint(null)
             .inputTip(null)
@@ -81,9 +81,9 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .build();
 
         newDifferent = AttributeDefinitionDraftBuilder
-            .of(StringAttributeType.of(), "attributeName1", LocalizedString.ofEnglish("label2"), true)
+            .of(StringAttributeType.of(), "attributeName1", ofEnglish("label2"), true)
             .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
-            .inputTip(LocalizedString.ofEnglish("inputTip2"))
+            .inputTip(ofEnglish("inputTip2"))
             .inputHint(TextInputHint.MULTI_LINE)
             .isSearchable(true)
             .build();
@@ -255,7 +255,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .of(
                 EnumAttributeType.of(ENUM_VALUE_A, ENUM_VALUE_B),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
@@ -284,9 +284,9 @@ public class AttributeDefinitionUpdateActionUtilsTest {
 
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(
-                EnumAttributeType.of(Collections.emptyList()),
+                EnumAttributeType.of(emptyList()),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
@@ -318,7 +318,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .of(
                 EnumAttributeType.of(enumValueDiffLabel),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
@@ -338,7 +338,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of(
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A)
             )
             .isRequired(false)
@@ -353,7 +353,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .of(
                 LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A, LOCALIZED_ENUM_VALUE_B),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
@@ -373,7 +373,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of(
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A))
             .isRequired(false)
             .attributeConstraint(AttributeConstraint.NONE)
@@ -385,9 +385,9 @@ public class AttributeDefinitionUpdateActionUtilsTest {
 
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(
-                LocalizedEnumAttributeType.of(Collections.emptyList()),
+                LocalizedEnumAttributeType.of(emptyList()),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)
@@ -405,7 +405,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     @Test
     public void buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-            .of("attributeName1", LocalizedString.ofEnglish("label1"),
+            .of("attributeName1", ofEnglish("label1"),
                 LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A))
             .isRequired(false)
             .attributeConstraint(AttributeConstraint.NONE)
@@ -420,7 +420,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .of(
                 LocalizedEnumAttributeType.of(localizedEnumValueDiffLabel),
                 "attributeName1",
-                LocalizedString.ofEnglish("label1"),
+                ofEnglish("label1"),
                 false
             )
             .attributeConstraint(AttributeConstraint.NONE)

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -406,7 +406,11 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             AddAttributeDefinition.of(AttributeDefinitionDraftBuilder
                 .of(ATTRIBUTE_DEFINITION_D.getAttributeType(),
                     ATTRIBUTE_DEFINITION_D.getName(), ATTRIBUTE_DEFINITION_D.getLabel(),
-                    ATTRIBUTE_DEFINITION_D.isRequired()).isSearchable(true).build()),
+                    ATTRIBUTE_DEFINITION_D.isRequired())
+                .isSearchable(true)
+                .inputHint(TextInputHint.SINGLE_LINE)
+                .attributeConstraint(AttributeConstraint.NONE)
+                .build()),
             ChangeAttributeOrder
                 .of(asList(
                         ATTRIBUTE_DEFINITION_A,

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -50,7 +50,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOlEnumValues_ShouldNotBuildActions() {
+    public void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
@@ -50,7 +50,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOlEnumValues_ShouldNotBuildActions() {
+    public void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),

--- a/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-abc.json
+++ b/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-abc.json
@@ -12,7 +12,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     },
     {
       "type": {
@@ -23,7 +25,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     },
     {
       "type": {
@@ -34,7 +38,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     }
   ]
 }

--- a/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-acbd.json
+++ b/src/test/resources/com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/product-type-with-attribute-definitions-acbd.json
@@ -12,7 +12,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     },
     {
       "type": {
@@ -23,7 +25,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     },
     {
       "type": {
@@ -34,7 +38,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     },
     {
       "type": {
@@ -45,7 +51,9 @@
         "en": "label_en"
       },
       "isRequired": false,
-      "isSearchable": true
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "attributeConstraint": "None"
     }
   ]
 }


### PR DESCRIPTION
#### Summary
- Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint`     
    and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
- `ProductTypeSyncUtils#buildActions`, `ProductTypeUpdateActionUtils#buildAttributesUpdateActions`  
    now treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
    as (`true`, `SingleLine` and `None` respectivley) if they are not passed/`null`. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### Relevant Issues
#354

#### Todo

- Tests
    - [x] Unit 
    - [x] Integration
- [x] Documentation
- [x] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
Main implementation change is here: https://github.com/commercetools/commercetools-sync-java/pull/355/files#diff-bd7e426b8092e06cd744c507c132b93b
