### PR TITLE
313 set of enums

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -34,6 +34,10 @@
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.0/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.0)
 
+- 🎉 **Features** (2)
+    - **ProductType Sync** - Added support for syncing changes to an attribute with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
+    - **Type Sync** - Added support for syncing changes to field with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
+
 - 🐞 **Bug Fixes** (2)
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -34,8 +34,8 @@
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.0)
 
 - 🎉 **Features** (2)
-    - **ProductType Sync** - Added support for syncing changes to an attribute with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
-    - **Type Sync** - Added support for syncing changes to field with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
+    - **ProductType Sync** - Added support for syncing changes to an `AttributeDefinition` with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
+    - **Type Sync** - Added support for syncing changes to a `FieldDefinition` with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
 
 - 🐞 **Bug Fixes** (2)
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -38,7 +38,7 @@
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
     - **ProductType Sync** - `ProductTypeSyncUtils#buildActions`, `ProductTypeUpdateActionUtils#buildAttributesUpdateActions`  
-    treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
+    now treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
     as (`true`, `SingleLine` and `None` respectivley) if they are not passed/`null`. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
 
 !-->

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -100,4 +100,3 @@ More examples of those utils for different fields can be found [here](https://gi
 
 ## Caveats    
 1. Syncing product types with an attribute of type [NestedType](https://docs.commercetools.com/http-api-projects-productTypes.html#nestedtype) is not supported yet.
-2. Currently the sync would handle changes to Enum or LocalizedEnum Types but not [Set](https://docs.commercetools.com/http-api-projects-types.html#settype) of either. [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)

--- a/docs/usage/TYPE_SYNC.md
+++ b/docs/usage/TYPE_SYNC.md
@@ -98,4 +98,3 @@ More examples of those utils for different types can be found [here](https://git
 1. Updating the label of enum values and localized enum values of field definition is not supported yet. [#339](https://github.com/commercetools/commercetools-sync-java/issues/339)
 2. Removing the enum values and localized enum values from the field definition is not supported yet. [#339](https://github.com/commercetools/commercetools-sync-java/issues/339)
 3. Updating the input hint of a field definition is not supported yet. [#339](https://github.com/commercetools/commercetools-sync-java/issues/339)
-4. Currently the sync would handle changes to Enum or LocalizedEnum Types but not [Set](https://docs.commercetools.com/http-api-projects-types.html#settype) of either. [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -20,6 +20,7 @@ import io.sphere.sdk.products.attributes.AttributeDefinitionDraftDsl;
 import io.sphere.sdk.products.attributes.EnumAttributeType;
 import io.sphere.sdk.products.attributes.LocalizedEnumAttributeType;
 import io.sphere.sdk.products.attributes.MoneyAttributeType;
+import io.sphere.sdk.products.attributes.SetAttributeType;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -769,7 +771,6 @@ public class ProductTypeSyncIT {
         return spyClient;
     }
 
-
     @Test
     public void sync_WithSeveralBatches_ShouldReturnProperStatistics() {
         // Default batch size is 50 (check ProductTypeSyncOptionsBuilder) so we have 2 batches of 50
@@ -794,6 +795,89 @@ public class ProductTypeSyncIT {
             .toCompletableFuture().join();
 
         assertThat(productTypeSyncStatistics).hasValues(100, 100, 0, 0);
+    }
+
+    @Test
+    public void sync_WithSetOfEnumsAndSetOfLenumsChanges_ShouldUpdateProductType() {
+        // preparation
+        final AttributeDefinitionDraft withSetOfEnumsOld = AttributeDefinitionDraftBuilder
+            .of(
+                SetAttributeType.of(EnumAttributeType.of(emptyList())),
+                "foo",
+                ofEnglish("foo"),
+                false
+            )
+            .build();
+
+        final AttributeDefinitionDraft withSetOfSetOfLEnumsOld = AttributeDefinitionDraftBuilder
+            .of(
+                SetAttributeType.of(
+                    LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))),
+                "bar",
+                ofEnglish("bar"),
+                false
+            )
+            .build();
+
+        final ProductTypeDraft oldDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
+            "withSetofEnums",
+            "withSetofEnums",
+            "withSetofEnums",
+            asList(withSetOfEnumsOld, withSetOfSetOfLEnumsOld)
+        );
+
+
+        CTP_TARGET_CLIENT.execute(ProductTypeCreateCommand.of(oldDraft)).toCompletableFuture().join();
+
+
+        final AttributeDefinitionDraft withSetOfEnumsNew = AttributeDefinitionDraftBuilder
+            .of(
+                SetAttributeType.of(EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar")))),
+                "foo",
+                ofEnglish("foo"),
+                false
+            )
+            .build();
+
+        final AttributeDefinitionDraft withSetOfSetOfLEnumsNew = AttributeDefinitionDraftBuilder
+            .of(
+                SetAttributeType.of(
+                    LocalizedEnumAttributeType.of(
+                        singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar").plus(Locale.GERMAN, "bar"))))),
+                "bar",
+                ofEnglish("bar"),
+                false
+            )
+            .build();
+
+
+        final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
+            "withSetOfEnums",
+            "withSetOfEnums",
+            "withSetOfEnums",
+            asList(withSetOfEnumsNew, withSetOfSetOfLEnumsNew)
+        );
+
+        final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder
+            .of(CTP_TARGET_CLIENT)
+            .build();
+
+        final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
+
+        // tests
+        final ProductTypeSyncStatistics productTypeSyncStatistics = productTypeSync
+            .sync(singletonList(newProductTypeDraft))
+            .toCompletableFuture().join();
+
+        // assertions
+        assertThat(productTypeSyncStatistics).hasValues(1, 0, 1, 0);
+
+        final Optional<ProductType> oldProductTypeAfter = getProductTypeByKey(CTP_TARGET_CLIENT, "withSetOfEnums");
+
+        assertThat(oldProductTypeAfter).hasValueSatisfying(productType ->
+            assertAttributesAreEqual(productType.getAttributes(),
+                asList(withSetOfEnumsNew, withSetOfSetOfLEnumsNew)
+            ));
     }
 
     private static void assertAttributesAreEqual(@Nonnull final List<AttributeDefinition> attributes,

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -802,7 +801,13 @@ public class ProductTypeSyncIT {
         // preparation
         final AttributeDefinitionDraft withSetOfEnumsOld = AttributeDefinitionDraftBuilder
             .of(
-                SetAttributeType.of(EnumAttributeType.of(emptyList())),
+                SetAttributeType.of(EnumAttributeType.of(
+                    asList(
+                        EnumValue.of("d", "d"),
+                        EnumValue.of("b", "newB"),
+                        EnumValue.of("a", "a"),
+                        EnumValue.of("c", "c")
+                    ))),
                 "foo",
                 ofEnglish("foo"),
                 false
@@ -812,7 +817,13 @@ public class ProductTypeSyncIT {
         final AttributeDefinitionDraft withSetOfSetOfLEnumsOld = AttributeDefinitionDraftBuilder
             .of(
                 SetAttributeType.of(
-                    LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))),
+                    LocalizedEnumAttributeType.of(
+                        asList(
+                            LocalizedEnumValue.of("d", ofEnglish("d")),
+                            LocalizedEnumValue.of("b", ofEnglish("newB")),
+                            LocalizedEnumValue.of("a", ofEnglish("a")),
+                            LocalizedEnumValue.of("c", ofEnglish("c"))
+                        ))),
                 "bar",
                 ofEnglish("bar"),
                 false
@@ -832,7 +843,12 @@ public class ProductTypeSyncIT {
 
         final AttributeDefinitionDraft withSetOfEnumsNew = AttributeDefinitionDraftBuilder
             .of(
-                SetAttributeType.of(EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar")))),
+                SetAttributeType.of(EnumAttributeType.of(
+                    asList(
+                        EnumValue.of("a", "a"),
+                        EnumValue.of("b", "b"),
+                        EnumValue.of("c", "c")
+                    ))),
                 "foo",
                 ofEnglish("foo"),
                 false
@@ -843,7 +859,11 @@ public class ProductTypeSyncIT {
             .of(
                 SetAttributeType.of(
                     LocalizedEnumAttributeType.of(
-                        singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar").plus(Locale.GERMAN, "bar"))))),
+                        asList(
+                            LocalizedEnumValue.of("a", ofEnglish("a")),
+                            LocalizedEnumValue.of("b", ofEnglish("newB")),
+                            LocalizedEnumValue.of("c", ofEnglish("c"))
+                        ))),
                 "bar",
                 ofEnglish("bar"),
                 false

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -820,9 +820,9 @@ public class ProductTypeSyncIT {
             .build();
 
         final ProductTypeDraft oldDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
-            "withSetofEnums",
-            "withSetofEnums",
-            "withSetofEnums",
+            "withSetOfEnums",
+            "withSetOfEnums",
+            "withSetOfEnums",
             asList(withSetOfEnumsOld, withSetOfSetOfLEnumsOld)
         );
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/types/TypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/types/TypeSyncIT.java
@@ -59,7 +59,6 @@ import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static io.sphere.sdk.utils.CompletableFutureUtils.exceptionallyCompletedFuture;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -753,14 +752,23 @@ public class TypeSyncIT {
         //preparation
         final FieldDefinition withSetOfEnumsOld = FieldDefinition.of(
             SetFieldType.of(
-                EnumFieldType.of(emptyList())),
+                EnumFieldType.of(
+                    asList(
+                        EnumValue.of("b", "b"),
+                        EnumValue.of("a", "a")
+
+                    ))),
             "foo",
             ofEnglish("foo"),
             false);
 
         final FieldDefinition withSetOfSetOfLEnumsOld = FieldDefinition.of(
             SetFieldType.of(
-                LocalizedEnumFieldType.of(emptyList())),
+                LocalizedEnumFieldType.of(
+                    asList(
+                        LocalizedEnumValue.of("b", ofEnglish("b")),
+                        LocalizedEnumValue.of("a", ofEnglish("a"))
+                    ))),
             "bar",
             ofEnglish("bar"),
             false);
@@ -775,14 +783,24 @@ public class TypeSyncIT {
 
         final FieldDefinition withSetOfEnumsNew = FieldDefinition.of(
             SetFieldType.of(
-                EnumFieldType.of(singletonList(EnumValue.of("foo", "bar")))),
+                EnumFieldType.of(
+                    asList(
+                        EnumValue.of("a", "a"),
+                        EnumValue.of("b", "b"),
+                        EnumValue.of("c", "c")
+                    ))),
             "foo",
             ofEnglish("foo"),
             false);
 
         final FieldDefinition withSetOfSetOfLEnumsNew = FieldDefinition.of(
             SetFieldType.of(LocalizedEnumFieldType.of(
-                singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))), "bar", ofEnglish("bar"), false);
+                asList(
+                    LocalizedEnumValue.of("a", ofEnglish("a")),
+                    LocalizedEnumValue.of("b", ofEnglish("b")),
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                )
+            )), "bar", ofEnglish("bar"), false);
 
         final TypeDraft newTypeDraft = TypeDraftBuilder.of("withSetOfEnums", ofEnglish("withSetOfEnums"),
             ResourceTypeIdsSetBuilder.of().addCategories().build())

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -65,31 +65,34 @@ final class AttributeDefinitionUpdateActionUtils {
     }
 
     /**
-     * Compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of an {@link AttributeDefinition} and
-     * an {@link AttributeDefinitionDraft} and returns a list of {@link UpdateAction}&lt;{@link ProductType}&gt; as a
-     * result. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have identical
-     * enum values, then no update action is needed and hence an empty {@link List} is returned.
+     * Checks if both the supplied {@code oldAttributeDefinition} and {@code newAttributeDefinitionDraft} have an
+     * {@link AttributeType} that is either an {@link EnumAttributeType} or a {@link LocalizedEnumAttributeType} or
+     * a {@link SetAttributeType} with a subtype that is either an {@link EnumAttributeType} or a
+     * {@link LocalizedEnumAttributeType}.
      *
-     * <p> On CTP, enum update actions can only update a enum type attribute definition or a Set of
-     * enum type attribute definition. Therefore, this method will update build enum update actions of the types
-     * supplied are of the same type and are either of enum attribute type or LocalizedEnum attribute type or set of
-     * either.</p>
+     * The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
+     * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} attribute types and returns a list of
+     * {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both the {@link AttributeDefinition} and the
+     * {@link AttributeDefinitionDraft} have identical enum values, then no update action is needed and hence an empty
+     * {@link List} is returned.
+     *
+     * <P>Note: This method expects the supplied {@link AttributeDefinition} and the {@link AttributeDefinitionDraft}
+     *  to have the same {@link AttributeType}. Otherwise, the behaviour is not guaranteed.</P>
      *
      * @param oldAttributeDefinition      the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new fields.
      * @return A list with the update actions or an empty list if the attribute definition enums are identical.
+     *
+     * @throws DuplicateKeyException in case there are enum values with duplicate keys.
      */
     @Nonnull
     static List<UpdateAction<ProductType>> buildEnumUpdateActions(
         @Nonnull final AttributeDefinition oldAttributeDefinition,
         @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
 
-
         final AttributeType oldAttributeType = oldAttributeDefinition.getAttributeType();
         final AttributeType newAttributeType = newAttributeDefinitionDraft.getAttributeType();
 
-
-        // Check if the attribute type is of type Enum or Set (of set of set..) of Enums
         return getEnumAttributeType(oldAttributeType)
             .map(oldEnumAttributeType ->
                 getEnumAttributeType(newAttributeType)
@@ -100,7 +103,7 @@ final class AttributeDefinitionUpdateActionUtils {
                     )
                     .orElseGet(Collections::emptyList)
             )
-            .orElseGet(() -> // Check if the attributeType is a LocalizedEnums or Set (of set..) of LocalizedEnums
+            .orElseGet(() ->
                 getLocalizedEnumAttributeType(oldAttributeType)
                     .map(oldLocalizedEnumAttributeType ->
                         getLocalizedEnumAttributeType(newAttributeType)
@@ -118,12 +121,14 @@ final class AttributeDefinitionUpdateActionUtils {
     }
 
     /**
-     * Indicates if the attribute type is a enum value or a set of enum value.
+     * Returns an optional containing the attribute type if is an {@link EnumAttributeType} or if the
+     * {@link AttributeType} is a {@link SetAttributeType} with an {@link EnumAttributeType} as a subtype, it returns
+     * this subtype in the optional. Otherwise, an empty optional.
      *
      * @param attributeType the attribute type.
-     * @return an optional containing the enum attribute type if the attribute type is a enum
-     *         attribute type or if is a set of enum attribute type, then it returns an optional containing
-     *         the enum attribute type under the set type.
+     * @return an optional containing the attribute type if is an {@link EnumAttributeType} or if the
+     *         {@link AttributeType} is a {@link SetAttributeType} with an {@link EnumAttributeType} as a subtype, it
+     *         returns this subtype in the optional. Otherwise, an empty optional.
      */
     private static Optional<EnumAttributeType> getEnumAttributeType(
         @Nonnull final AttributeType attributeType) {
@@ -145,12 +150,14 @@ final class AttributeDefinitionUpdateActionUtils {
     }
 
     /**
-     * Indicates if the attribute type is a localized enum value or a set of localized enum value.
+     * Returns an optional containing the attribute type if is an {@link LocalizedEnumAttributeType} or if the
+     * {@link AttributeType} is a {@link SetAttributeType} with an {@link LocalizedEnumAttributeType} as a subtype, it
+     * returns this subtype in the optional. Otherwise, an empty optional.
      *
      * @param attributeType the attribute type.
-     * @return an optional containing the localized enum attribute type if the attribute type is a localized enum
-     *         attribute type or if is a set of localized enum attribute type, then it returns an optional containing
-     *         the localized enum attribute type under the set type.
+     * @return an optional containing the attribute type if is an {@link LocalizedEnumAttributeType} or if the
+     *         {@link AttributeType} is a {@link SetAttributeType} with an {@link LocalizedEnumAttributeType} as a
+     *         subtype, it returns this subtype in the optional. Otherwise, an empty optional.
      */
     private static Optional<LocalizedEnumAttributeType> getLocalizedEnumAttributeType(
         @Nonnull final AttributeType attributeType) {

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -70,8 +70,10 @@ final class AttributeDefinitionUpdateActionUtils {
      * result. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have identical
      * enum values, then no update action is needed and hence an empty {@link List} is returned.
      *
-     * <p> Note: This method assumes that both types are identical and either of Enum attribute type or
-     * LocalizedEnum type or set of either or set of set of (etc..) of either. Otherwise, an empty list is returned.</p>
+     * <p> On CTP, enum update actions can only update a enum type attribute definition or a Set of
+     * enum type attribute definition. Therefore, this method will update build enum update actions of the types
+     * supplied are of the same type and are either of enum attribute type or LocalizedEnum attribute type or set of
+     * either.</p>
      *
      * @param oldAttributeDefinition      the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new fields.
@@ -116,10 +118,12 @@ final class AttributeDefinitionUpdateActionUtils {
     }
 
     /**
-     * Indicates if the attribute type is a plain enum value or a set of plain enum value.
+     * Indicates if the attribute type is a enum value or a set of enum value.
      *
      * @param attributeType the attribute type.
-     * @return true if the attribute type is a plain enum value or a set of it, false otherwise.
+     * @return an optional containing the enum attribute type if the attribute type is a enum
+     *         attribute type or if is a set of enum attribute type, then it returns an optional containing
+     *         the enum attribute type under the set type.
      */
     private static Optional<EnumAttributeType> getEnumAttributeType(
         @Nonnull final AttributeType attributeType) {
@@ -129,10 +133,12 @@ final class AttributeDefinitionUpdateActionUtils {
         }
 
         if (attributeType instanceof SetAttributeType) {
+            final SetAttributeType setFieldType = (SetAttributeType) attributeType;
+            final AttributeType subType = setFieldType.getElementType();
 
-            final SetAttributeType setAttributeType = (SetAttributeType) attributeType;
-            final AttributeType subType = setAttributeType.getElementType();
-            return getEnumAttributeType(subType);
+            if (subType instanceof EnumAttributeType) {
+                return Optional.of((EnumAttributeType) subType);
+            }
         }
 
         return Optional.empty();
@@ -142,7 +148,9 @@ final class AttributeDefinitionUpdateActionUtils {
      * Indicates if the attribute type is a localized enum value or a set of localized enum value.
      *
      * @param attributeType the attribute type.
-     * @return true if the attribute type is a localized enum value or a set of it, false otherwise.
+     * @return an optional containing the localized enum attribute type if the attribute type is a localized enum
+     *         attribute type or if is a set of localized enum attribute type, then it returns an optional containing
+     *         the localized enum attribute type under the set type.
      */
     private static Optional<LocalizedEnumAttributeType> getLocalizedEnumAttributeType(
         @Nonnull final AttributeType attributeType) {
@@ -152,9 +160,12 @@ final class AttributeDefinitionUpdateActionUtils {
         }
 
         if (attributeType instanceof SetAttributeType) {
-            final SetAttributeType setAttributeType = (SetAttributeType) attributeType;
-            final AttributeType subType = setAttributeType.getElementType();
-            return getLocalizedEnumAttributeType(subType);
+            final SetAttributeType setFieldType = (SetAttributeType) attributeType;
+            final AttributeType subType = setFieldType.getElementType();
+
+            if (subType instanceof LocalizedEnumAttributeType) {
+                return Optional.of((LocalizedEnumAttributeType) subType);
+            }
         }
 
         return Optional.empty();

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -70,14 +70,14 @@ final class AttributeDefinitionUpdateActionUtils {
      * a {@link SetAttributeType} with a subtype that is either an {@link EnumAttributeType} or a
      * {@link LocalizedEnumAttributeType}.
      *
-     * The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
+     * <p>The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
      * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} attribute types and returns a list of
      * {@link UpdateAction}&lt;{@link ProductType}&gt; as a result. If both the {@link AttributeDefinition} and the
      * {@link AttributeDefinitionDraft} have identical enum values, then no update action is needed and hence an empty
-     * {@link List} is returned.
+     * {@link List} is returned.</p>
      *
-     * <P>Note: This method expects the supplied {@link AttributeDefinition} and the {@link AttributeDefinitionDraft}
-     *  to have the same {@link AttributeType}. Otherwise, the behaviour is not guaranteed.</P>
+     * <p>Note: This method expects the supplied {@link AttributeDefinition} and the {@link AttributeDefinitionDraft}
+     *  to have the same {@link AttributeType}. Otherwise, the behaviour is not guaranteed.</p>
      *
      * @param oldAttributeDefinition      the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new fields.

--- a/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -70,8 +70,8 @@ final class AttributeDefinitionUpdateActionUtils {
      * result. If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have identical
      * enum values, then no update action is needed and hence an empty {@link List} is returned.
      *
-     * <p>Note: This method assumes that both types are identical and either of EnumAttributeType or
-     * LocalizedEnumType or set of either or set of set of (etc..) of either. Otherwise, an empty list is returned.</p>
+     * <p> Note: This method assumes that both types are identical and either of Enum attribute type or
+     * LocalizedEnum type or set of either or set of set of (etc..) of either. Otherwise, an empty list is returned.</p>
      *
      * @param oldAttributeDefinition      the attribute definition which should be updated.
      * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new fields.

--- a/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
@@ -59,14 +59,14 @@ final class FieldDefinitionUpdateActionUtils {
      * a {@link SetFieldType} with a subtype that is either an {@link EnumFieldType} or a
      * {@link LocalizedEnumFieldType}.
      *
-     * The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
+     * <p>The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
      * {@link FieldType} and the {@link FieldDefinition} types and returns a list of
      * {@link UpdateAction}&lt;{@link Type}&gt; as a result. If both the {@code oldFieldDefinition} and
      * {@code newFieldDefinition} have identical enum values, then no update action is needed and hence an empty
-     * {@link List} is returned.
+     * {@link List} is returned.</p>
      *
-     * <P>Note: This method expects the supplied {@code oldFieldDefinition} and {@code newFieldDefinition}
-     *  to have the same {@link FieldType}. Otherwise, the behaviour is not guaranteed.</P>
+     * <p>Note: This method expects the supplied {@code oldFieldDefinition} and {@code newFieldDefinition}
+     *  to have the same {@link FieldType}. Otherwise, the behaviour is not guaranteed.</p>
      *
      * @param oldFieldDefinition      the field definition which should be updated.
      * @param newFieldDefinition the new field definition draft where we get the new fields.

--- a/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
@@ -58,9 +58,9 @@ final class FieldDefinitionUpdateActionUtils {
      * a list of {@link UpdateAction}&lt;{@link Type}&gt; as a result. If both {@link FieldDefinition}s have identical
      * enum values, then no update action is needed and hence an empty {@link List} is returned.
      *
-     * <p> Note: This method assumes that both types are identical and either of Enum field type or
-     * LocalizedEnum field type or set of either or set of set of (etc..) of either. Otherwise, an empty list is
-     * returned.</p>
+     * <p> On CTP, enum update actions can only update a enum type field definition or a Set of
+     * enum type field definition. Therefore, this method will update build enum update actions of the types supplied
+     * are of the same type and are either of Enum field type or LocalizedEnum field type or set of either.</p>
      *
      * @param oldFieldDefinition the old field definition which should be updated.
      * @param newFieldDefinition the new field definition where we get the new fields.
@@ -109,7 +109,9 @@ final class FieldDefinitionUpdateActionUtils {
      * Indicates if the field type is a plain enum value or a set of plain enum value.
      *
      * @param fieldType the field type.
-     * @return true if the field type is a plain enum value or a set of it, false otherwise.
+     * @return an optional containing the enum field type if the field type is an enum field type
+     *          or if it is a set of enum field type, then it returns an optional containing the localized enum field
+     *          type under the set type.
      */
     private static Optional<EnumFieldType> getEnumFieldType(
         @Nonnull final FieldType fieldType) {
@@ -122,7 +124,10 @@ final class FieldDefinitionUpdateActionUtils {
 
             final SetFieldType setFieldType = (SetFieldType) fieldType;
             final FieldType subType = setFieldType.getElementType();
-            return getEnumFieldType(subType);
+
+            if (subType instanceof EnumFieldType) {
+                return Optional.of((EnumFieldType) subType);
+            }
         }
 
         return Optional.empty();
@@ -132,7 +137,9 @@ final class FieldDefinitionUpdateActionUtils {
      * Indicates if the field type is a localized enum value or a set of localized enum value.
      *
      * @param fieldType the field type.
-     * @return true if the field type is a localized enum value or a set of it, false otherwise.
+     * @return an optional containing the localized enum field type if the field type is a localized enum field type
+     *          or if is a set of localized enum field type, then it returns an optional containing the localized enum
+     *          field type under the set type.
      */
     private static Optional<LocalizedEnumFieldType> getLocalizedEnumFieldType(
         @Nonnull final FieldType fieldType) {
@@ -142,10 +149,12 @@ final class FieldDefinitionUpdateActionUtils {
         }
 
         if (fieldType instanceof SetFieldType) {
-
             final SetFieldType setFieldType = (SetFieldType) fieldType;
             final FieldType subType = setFieldType.getElementType();
-            return getLocalizedEnumFieldType(subType);
+
+            if (subType instanceof LocalizedEnumFieldType) {
+                return Optional.of((LocalizedEnumFieldType) subType);
+            }
         }
 
         return Optional.empty();

--- a/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
@@ -110,12 +110,12 @@ final class FieldDefinitionUpdateActionUtils {
     }
 
     /**
-     * Returns an optional containing the attribute type if is an {@link EnumFieldType} or if the
+     * Returns an optional containing the field type if is an {@link EnumFieldType} or if the
      * {@link FieldType} is a {@link SetFieldType} with an {@link EnumFieldType} as a subtype, it returns
      * this subtype in the optional. Otherwise, an empty optional.
      *
-     * @param fieldType the attribute type.
-     * @return an optional containing the attribute type if is an {@link EnumFieldType} or if the
+     * @param fieldType the field type.
+     * @return an optional containing the field type if is an {@link EnumFieldType} or if the
      *         {@link FieldType} is a {@link SetFieldType} with an {@link EnumFieldType} as a subtype, it
      *         returns this subtype in the optional. Otherwise, an empty optional.
      */
@@ -140,12 +140,12 @@ final class FieldDefinitionUpdateActionUtils {
     }
 
     /**
-     * Returns an optional containing the attribute type if is an {@link LocalizedEnumFieldType} or if the
+     * Returns an optional containing the field type if is an {@link LocalizedEnumFieldType} or if the
      * {@link FieldType} is a {@link SetFieldType} with an {@link LocalizedEnumFieldType} as a subtype, it
      * returns this subtype in the optional. Otherwise, an empty optional.
      *
-     * @param fieldType the attribute type.
-     * @return an optional containing the attribute type if is an {@link LocalizedEnumFieldType} or if the
+     * @param fieldType the field type.
+     * @return an optional containing the field type if is an {@link LocalizedEnumFieldType} or if the
      *         {@link FieldType} is a {@link SetFieldType} with an {@link LocalizedEnumFieldType} as a
      *         subtype, it returns this subtype in the optional. Otherwise, an empty optional.
      */

--- a/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtils.java
@@ -54,19 +54,25 @@ final class FieldDefinitionUpdateActionUtils {
     }
 
     /**
-     * Compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of {@link FieldDefinition}s and returns
-     * a list of {@link UpdateAction}&lt;{@link Type}&gt; as a result. If both {@link FieldDefinition}s have identical
-     * enum values, then no update action is needed and hence an empty {@link List} is returned.
+     * Checks if both the supplied {@code oldFieldDefinition} and {@code newFieldDefinition} have an
+     * {@link FieldType} that is either an {@link EnumFieldType} or a {@link LocalizedEnumFieldType} or
+     * a {@link SetFieldType} with a subtype that is either an {@link EnumFieldType} or a
+     * {@link LocalizedEnumFieldType}.
      *
-     * <p> On CTP, enum update actions can only update a enum type field definition or a Set of
-     * enum type field definition. Therefore, this method will update build enum update actions of the types supplied
-     * are of the same type and are either of Enum field type or LocalizedEnum field type or set of either.</p>
+     * The method compares all the {@link EnumValue} and {@link LocalizedEnumValue} values of the
+     * {@link FieldType} and the {@link FieldDefinition} types and returns a list of
+     * {@link UpdateAction}&lt;{@link Type}&gt; as a result. If both the {@code oldFieldDefinition} and
+     * {@code newFieldDefinition} have identical enum values, then no update action is needed and hence an empty
+     * {@link List} is returned.
      *
-     * @param oldFieldDefinition the old field definition which should be updated.
-     * @param newFieldDefinition the new field definition where we get the new fields.
+     * <P>Note: This method expects the supplied {@code oldFieldDefinition} and {@code newFieldDefinition}
+     *  to have the same {@link FieldType}. Otherwise, the behaviour is not guaranteed.</P>
+     *
+     * @param oldFieldDefinition      the field definition which should be updated.
+     * @param newFieldDefinition the new field definition draft where we get the new fields.
      * @return A list with the update actions or an empty list if the field definition enums are identical.
      *
-     * @throws DuplicateKeyException in case there are localized enum values with duplicate keys.
+     * @throws DuplicateKeyException in case there are enum values with duplicate keys.
      */
     @Nonnull
     static List<UpdateAction<Type>> buildEnumUpdateActions(
@@ -76,8 +82,6 @@ final class FieldDefinitionUpdateActionUtils {
         final FieldType oldFieldDefinitionType = oldFieldDefinition.getType();
         final FieldType newFieldDefinitionType = newFieldDefinition.getType();
 
-
-        // Check if the fieldType is of type Enum or Set (of set of set..) of Enums
         return getEnumFieldType(oldFieldDefinitionType)
             .map(oldEnumFieldType ->
                 getEnumFieldType(newFieldDefinitionType)
@@ -88,7 +92,7 @@ final class FieldDefinitionUpdateActionUtils {
                     )
                     .orElseGet(Collections::emptyList)
             )
-            .orElseGet(() -> // Check if the fieldType is a LocalizedEnums or Set (of set..) of LocalizedEnums
+            .orElseGet(() ->
                 getLocalizedEnumFieldType(oldFieldDefinitionType)
                     .map(oldLocalizedEnumFieldType ->
                         getLocalizedEnumFieldType(newFieldDefinitionType)
@@ -106,12 +110,14 @@ final class FieldDefinitionUpdateActionUtils {
     }
 
     /**
-     * Indicates if the field type is a plain enum value or a set of plain enum value.
+     * Returns an optional containing the attribute type if is an {@link EnumFieldType} or if the
+     * {@link FieldType} is a {@link SetFieldType} with an {@link EnumFieldType} as a subtype, it returns
+     * this subtype in the optional. Otherwise, an empty optional.
      *
-     * @param fieldType the field type.
-     * @return an optional containing the enum field type if the field type is an enum field type
-     *          or if it is a set of enum field type, then it returns an optional containing the localized enum field
-     *          type under the set type.
+     * @param fieldType the attribute type.
+     * @return an optional containing the attribute type if is an {@link EnumFieldType} or if the
+     *         {@link FieldType} is a {@link SetFieldType} with an {@link EnumFieldType} as a subtype, it
+     *         returns this subtype in the optional. Otherwise, an empty optional.
      */
     private static Optional<EnumFieldType> getEnumFieldType(
         @Nonnull final FieldType fieldType) {
@@ -134,12 +140,14 @@ final class FieldDefinitionUpdateActionUtils {
     }
 
     /**
-     * Indicates if the field type is a localized enum value or a set of localized enum value.
+     * Returns an optional containing the attribute type if is an {@link LocalizedEnumFieldType} or if the
+     * {@link FieldType} is a {@link SetFieldType} with an {@link LocalizedEnumFieldType} as a subtype, it
+     * returns this subtype in the optional. Otherwise, an empty optional.
      *
-     * @param fieldType the field type.
-     * @return an optional containing the localized enum field type if the field type is a localized enum field type
-     *          or if is a set of localized enum field type, then it returns an optional containing the localized enum
-     *          field type under the set type.
+     * @param fieldType the attribute type.
+     * @return an optional containing the attribute type if is an {@link LocalizedEnumFieldType} or if the
+     *         {@link FieldType} is a {@link SetFieldType} with an {@link LocalizedEnumFieldType} as a
+     *         subtype, it returns this subtype in the optional. Otherwise, an empty optional.
      */
     private static Optional<LocalizedEnumFieldType> getLocalizedEnumFieldType(
         @Nonnull final FieldType fieldType) {

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -534,7 +534,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     @Test
     public void buildActions_WithSetOfSetOfStringAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-            .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(StringAttributeType.of()))
+            .of("attributeName1", ofEnglish("label1"),
+                SetAttributeType.of(SetAttributeType.of(StringAttributeType.of())))
             .build();
 
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -539,7 +539,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             .build();
 
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(SetAttributeType.of(StringAttributeType.of())), "attributeName1", ofEnglish("label2"), false)
+            .of(SetAttributeType.of(SetAttributeType.of(StringAttributeType.of())),
+                "attributeName1", ofEnglish("label2"), false)
             .build();
 
         final List<UpdateAction<ProductType>> result =
@@ -666,8 +667,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             )
             .build();
 
-
-        final List<UpdateAction<ProductType>> result = buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+        final List<UpdateAction<ProductType>> result =
+            buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
 
         assertThat(result).containsExactly(RemoveEnumValues.of("attributeName1", "a"));
     }
@@ -689,8 +690,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             )
             .build();
 
-
-        final List<UpdateAction<ProductType>> result = buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+        final List<UpdateAction<ProductType>> result =
+            buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
 
         assertThat(result).containsExactly(ChangePlainEnumValueLabel.of("attributeName1", enumValueDiffLabel));
     }
@@ -715,8 +716,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             )
             .build();
 
-
-        final List<UpdateAction<ProductType>> result = buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+        final List<UpdateAction<ProductType>> result =
+            buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
 
         assertThat(result).containsExactly(AddLocalizedEnumValue.of("attributeName1", LOCALIZED_ENUM_VALUE_B));
     }
@@ -740,8 +741,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             )
             .build();
 
-
-        final List<UpdateAction<ProductType>> result = buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+        final List<UpdateAction<ProductType>> result =
+            buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
 
         assertThat(result).containsExactly(RemoveEnumValues.of("attributeName1", "a"));
     }
@@ -764,7 +765,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
             )
             .build();
 
-        final List<UpdateAction<ProductType>> result = buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+        final List<UpdateAction<ProductType>> result =
+            buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
 
         assertThat(result)
             .containsExactly(ChangeLocalizedEnumValueLabel.of("attributeName1", localizedEnumValueDiffLabel));

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -589,26 +589,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfSetOfEnumAttributeTypes_ShouldBuildEnumActions() {
-        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-            .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(SetAttributeType.of(
-                EnumAttributeType.of(emptyList()))))
-            .build();
-
-        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(SetAttributeType.of(
-                EnumAttributeType.of(singletonList(ENUM_VALUE_A)))),
-                "attributeName1", ofEnglish("label1"), false)
-            .build();
-
-        final List<UpdateAction<ProductType>> result =
-            buildActions(attributeDefinition, attributeDefinitionDraft);
-
-        assertThat(result).containsExactly(
-            AddEnumValue.of("attributeName1", ENUM_VALUE_A));
-    }
-
-    @Test
     public void buildActions_WithSameSetOfLEnumAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(
@@ -637,26 +617,6 @@ public class AttributeDefinitionUpdateActionUtilsTest {
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(SetAttributeType.of(
                 LocalizedEnumAttributeType.of(singletonList(LOCALIZED_ENUM_VALUE_A))),
-                "attributeName1", ofEnglish("label1"), false)
-            .build();
-
-        final List<UpdateAction<ProductType>> result =
-            buildActions(attributeDefinition, attributeDefinitionDraft);
-
-        assertThat(result).containsExactly(
-            AddLocalizedEnumValue.of("attributeName1", LOCALIZED_ENUM_VALUE_A));
-    }
-
-    @Test
-    public void buildActions_WithChangedSetOfSetOfLocalizedEnumAttributeTypes_ShouldBuildEnumActions() {
-        final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-            .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(SetAttributeType.of(
-                LocalizedEnumAttributeType.of(emptyList()))))
-            .build();
-
-        final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(SetAttributeType.of(
-                LocalizedEnumAttributeType.of(singletonList(LOCALIZED_ENUM_VALUE_A)))),
                 "attributeName1", ofEnglish("label1"), false)
             .build();
 

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -626,7 +626,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar"))));
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(newSetOfEnumType), "a", ofEnglish("new_label"), true)
+            .of(newSetOfEnumType, "a", ofEnglish("new_label"), true)
             .build();
         final ProductTypeDraft productTypeDraft = ProductTypeDraftBuilder
             .of("foo", "name", "desc", singletonList(newDefinition))
@@ -634,36 +634,6 @@ public class BuildAttributeDefinitionUpdateActionsTest {
 
 
         final SetAttributeType oldSetOfEnumType = SetAttributeType.of(EnumAttributeType.of(emptyList()));
-        final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
-            .of("a", ofEnglish("new_label"), oldSetOfEnumType)
-            .build();
-        final ProductType productType = mock(ProductType.class);
-        when(productType.getAttributes()).thenReturn(singletonList(oldDefinition));
-
-        // test
-        final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(productType,
-            productTypeDraft, SYNC_OPTIONS);
-
-        // assertion
-        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
-    }
-
-    @Test
-    public void buildAttributesUpdateActions_WithSetOfSetOfEnumsChanges_ShouldBuildCorrectActions() {
-        // preparation
-        final SetAttributeType newSetOfEnumType = SetAttributeType.of(SetAttributeType.of(
-            EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar")))));
-
-        final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(newSetOfEnumType), "a", ofEnglish("new_label"), true)
-            .build();
-        final ProductTypeDraft productTypeDraft = ProductTypeDraftBuilder
-            .of("foo", "name", "desc", singletonList(newDefinition))
-            .build();
-
-
-        final SetAttributeType oldSetOfEnumType = SetAttributeType.of(
-            SetAttributeType.of(EnumAttributeType.of(emptyList())));
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("a", ofEnglish("new_label"), oldSetOfEnumType)
             .build();
@@ -714,45 +684,14 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(newSetOfLenumType), "a", ofEnglish("new_label"), true)
+            .of(newSetOfLenumType, "a", ofEnglish("new_label"), true)
             .build();
         final ProductTypeDraft productTypeDraft = ProductTypeDraftBuilder
             .of("foo", "name", "desc", singletonList(newDefinition))
             .build();
 
-        final SetAttributeType oldSetOfLenumType = SetAttributeType.of(SetAttributeType.of(
-            LocalizedEnumAttributeType.of(emptyList())));
-
-        final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
-            .of("a", ofEnglish("new_label"), oldSetOfLenumType)
-            .build();
-        final ProductType productType = mock(ProductType.class);
-        when(productType.getAttributes()).thenReturn(singletonList(oldDefinition));
-
-        // test
-        final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(productType,
-            productTypeDraft, SYNC_OPTIONS);
-
-        // assertion
-        assertThat(updateActions)
-            .containsExactly(AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))));
-    }
-
-    @Test
-    public void buildAttributesUpdateActions_WithSetOfSetOfLEnumsChanges_ShouldBuildCorrectActions() {
-        // preparation
-        final SetAttributeType newSetOfLenumType = SetAttributeType.of(SetAttributeType.of(
-            LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))));
-
-        final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(newSetOfLenumType), "a", ofEnglish("new_label"), true)
-            .build();
-        final ProductTypeDraft productTypeDraft = ProductTypeDraftBuilder
-            .of("foo", "name", "desc", singletonList(newDefinition))
-            .build();
-
-        final SetAttributeType oldSetOfLenumType = SetAttributeType.of(SetAttributeType.of(SetAttributeType.of(
-            LocalizedEnumAttributeType.of(emptyList()))));
+        final SetAttributeType oldSetOfLenumType = SetAttributeType.of(
+            LocalizedEnumAttributeType.of(emptyList()));
 
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("a", ofEnglish("new_label"), oldSetOfLenumType)
@@ -806,14 +745,14 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
-            .of(SetAttributeType.of(newSetOfLenumType), "a", ofEnglish("new_label"), true)
+            .of(newSetOfLenumType, "a", ofEnglish("new_label"), true)
             .build();
         final ProductTypeDraft productTypeDraft = ProductTypeDraftBuilder
             .of("foo", "name", "desc", singletonList(newDefinition))
             .build();
 
-        final SetAttributeType oldSetOfLenumType = SetAttributeType.of(SetAttributeType.of(
-            LocalizedEnumAttributeType.of(emptyList())));
+        final SetAttributeType oldSetOfLenumType = SetAttributeType.of(
+            LocalizedEnumAttributeType.of(emptyList()));
 
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("a", ofEnglish("old_label"), oldSetOfLenumType)

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -739,7 +739,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
+    public void buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefLabelChange_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfLenumType = SetAttributeType.of(
             LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -831,5 +831,4 @@ public class BuildAttributeDefinitionUpdateActionsTest {
                 AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))),
                 ChangeAttributeDefinitionLabel.of("a", ofEnglish("new_label")));
     }
-
 }

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -29,9 +29,14 @@ import io.sphere.sdk.producttypes.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeConstraint;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeDefinitionLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeOrder;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeInputHint;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeIsSearchable;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueOrder;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveAttributeDefinition;
+import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -623,7 +628,12 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     public void buildAttributesUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfEnumType = SetAttributeType.of(
-            EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar"))));
+            EnumAttributeType.of(
+                asList(
+                    EnumValue.of("a", "a"),
+                    EnumValue.of("b", "newB"),
+                    EnumValue.of("c", "c")
+                )));
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
             .of(newSetOfEnumType, "a", ofEnglish("new_label"), true)
@@ -633,7 +643,13 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             .build();
 
 
-        final SetAttributeType oldSetOfEnumType = SetAttributeType.of(EnumAttributeType.of(emptyList()));
+        final SetAttributeType oldSetOfEnumType = SetAttributeType.of(
+            EnumAttributeType.of(
+                asList(
+                    EnumValue.of("d", "d"),
+                    EnumValue.of("b", "b"),
+                    EnumValue.of("a", "a")
+                )));
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("a", ofEnglish("new_label"), oldSetOfEnumType)
             .build();
@@ -645,7 +661,15 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             productTypeDraft, SYNC_OPTIONS);
 
         // assertion
-        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
+        assertThat(updateActions).containsExactly(
+            RemoveEnumValues.of("a", "d"),
+            ChangePlainEnumValueLabel.of("a", EnumValue.of("b", "newB")),
+            AddEnumValue.of("a", EnumValue.of("c", "c")),
+            ChangeEnumValueOrder.of("a", asList(
+                EnumValue.of("a", "a"),
+                EnumValue.of("b", "newB"),
+                EnumValue.of("c", "c")
+            )));
     }
 
     @Test
@@ -742,7 +766,13 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     public void buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefLabelChange_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfLenumType = SetAttributeType.of(
-            LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
+            LocalizedEnumAttributeType.of(
+                asList(
+                    LocalizedEnumValue.of("a", ofEnglish("a")),
+                    LocalizedEnumValue.of("b", ofEnglish("newB")),
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                    )
+            ));
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
             .of(newSetOfLenumType, "a", ofEnglish("new_label"), true)
@@ -752,7 +782,13 @@ public class BuildAttributeDefinitionUpdateActionsTest {
             .build();
 
         final SetAttributeType oldSetOfLenumType = SetAttributeType.of(
-            LocalizedEnumAttributeType.of(emptyList()));
+            LocalizedEnumAttributeType.of(
+                asList(
+                    LocalizedEnumValue.of("d", ofEnglish("d")),
+                    LocalizedEnumValue.of("b", ofEnglish("b")),
+                    LocalizedEnumValue.of("a", ofEnglish("a"))
+                )
+            ));
 
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("a", ofEnglish("old_label"), oldSetOfLenumType)
@@ -761,13 +797,20 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         when(productType.getAttributes()).thenReturn(singletonList(oldDefinition));
 
         // test
-        final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(productType,
-            productTypeDraft, SYNC_OPTIONS);
+        final List<UpdateAction<ProductType>> updateActions =
+            buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
 
         // assertion
         assertThat(updateActions)
             .containsExactlyInAnyOrder(
-                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))),
+                RemoveEnumValues.ofLocalizedEnumValue("a", LocalizedEnumValue.of("d", ofEnglish("d"))),
+                ChangeLocalizedEnumValueLabel.of("a", LocalizedEnumValue.of("b", ofEnglish("newB"))),
+                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("c", ofEnglish("c"))),
+                ChangeLocalizedEnumValueOrder.of("a", asList(
+                    LocalizedEnumValue.of("a", ofEnglish("a")),
+                    LocalizedEnumValue.of("b", ofEnglish("newB")),
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                )),
                 ChangeAttributeDefinitionLabel.of("a", ofEnglish("new_label")));
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
@@ -22,8 +22,10 @@ import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.types.commands.updateactions.AddFieldDefinition;
 import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
+import io.sphere.sdk.types.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionLabel;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionOrder;
+import io.sphere.sdk.types.commands.updateactions.ChangeLocalizedEnumValueOrder;
 import io.sphere.sdk.types.commands.updateactions.RemoveFieldDefinition;
 import org.junit.Test;
 
@@ -551,7 +553,13 @@ public class BuildFieldDefinitionUpdateActionsTest {
         // preparation
         final FieldDefinition newDefinition = FieldDefinition
             .of(SetFieldType.of(
-                EnumFieldType.of(singletonList(EnumValue.of("foo", "bar")))), "a", ofEnglish("new_label"), true);
+                EnumFieldType.of(
+                    asList(
+                        EnumValue.of("a", "a"),
+                        EnumValue.of("b", "b"),
+                        EnumValue.of("c", "c")
+                    )
+                )), "a", ofEnglish("new_label"), true);
 
         final TypeDraft typeDraft = TypeDraftBuilder
             .of("foo", ofEnglish("name"), emptySet())
@@ -560,7 +568,10 @@ public class BuildFieldDefinitionUpdateActionsTest {
 
         final FieldDefinition oldDefinition = FieldDefinition
             .of(SetFieldType.of(
-                EnumFieldType.of(emptyList())), "a", ofEnglish("new_label"), true);
+                EnumFieldType.of(asList(
+                    EnumValue.of("b", "b"),
+                    EnumValue.of("a", "a")
+                ))), "a", ofEnglish("new_label"), true);
 
         final Type type = mock(Type.class);
         when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
@@ -570,7 +581,10 @@ public class BuildFieldDefinitionUpdateActionsTest {
             typeDraft, SYNC_OPTIONS);
 
         // assertion
-        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
+        assertThat(updateActions).containsExactly(
+            AddEnumValue.of("a", EnumValue.of("c", "c")),
+            ChangeEnumValueOrder.of("a", asList("a", "b", "c"))
+        );
 
     }
 
@@ -604,7 +618,14 @@ public class BuildFieldDefinitionUpdateActionsTest {
     public void buildFieldsUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(
-            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
+            LocalizedEnumFieldType.of(
+                asList(
+                    LocalizedEnumValue.of("a", ofEnglish("a")),
+                    LocalizedEnumValue.of("b", ofEnglish("b")),
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                )
+            )
+        );
 
         final FieldDefinition newDefinition = FieldDefinition
             .of(newSetFieldType, "a", ofEnglish("new_label"), true);
@@ -614,7 +635,12 @@ public class BuildFieldDefinitionUpdateActionsTest {
             .fieldDefinitions(singletonList(newDefinition))
             .build();
 
-        final SetFieldType oldSetFieldType = SetFieldType.of(LocalizedEnumFieldType.of(emptyList()));
+        final SetFieldType oldSetFieldType = SetFieldType.of(
+            LocalizedEnumFieldType.of(
+                asList(
+                    LocalizedEnumValue.of("b", ofEnglish("b")),
+                    LocalizedEnumValue.of("a", ofEnglish("a"))
+                )));
         final FieldDefinition oldDefinition = FieldDefinition
             .of(oldSetFieldType, "a", ofEnglish("new_label"), true);
 
@@ -627,7 +653,9 @@ public class BuildFieldDefinitionUpdateActionsTest {
 
         // assertion
         assertThat(updateActions)
-            .containsExactly(AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))));
+            .containsExactly(
+                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("c", ofEnglish("c"))),
+                ChangeLocalizedEnumValueOrder.of("a", asList("a", "b", "c")));
     }
 
     @Test
@@ -662,7 +690,12 @@ public class BuildFieldDefinitionUpdateActionsTest {
     public void buildFieldsUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(
-            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
+            LocalizedEnumFieldType.of(
+                asList(
+                    LocalizedEnumValue.of("a", ofEnglish("a")),
+                    LocalizedEnumValue.of("b", ofEnglish("newB")),
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                )));
 
         final FieldDefinition newDefinition = FieldDefinition
             .of(newSetFieldType, "a", ofEnglish("new_label"), true);
@@ -672,7 +705,13 @@ public class BuildFieldDefinitionUpdateActionsTest {
             .fieldDefinitions(singletonList(newDefinition))
             .build();
 
-        final SetFieldType oldSetFieldType = SetFieldType.of((LocalizedEnumFieldType.of(emptyList())));
+        final SetFieldType oldSetFieldType = SetFieldType.of(
+            LocalizedEnumFieldType.of(
+                asList(
+                    LocalizedEnumValue.of("b", ofEnglish("b")),
+                    LocalizedEnumValue.of("a", ofEnglish("a"))
+                )
+            ));
         final FieldDefinition oldDefinition = FieldDefinition
             .of(oldSetFieldType, "a", ofEnglish("old_label"), true);
 
@@ -686,7 +725,9 @@ public class BuildFieldDefinitionUpdateActionsTest {
         // assertion
         assertThat(updateActions)
             .containsExactlyInAnyOrder(
-                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))),
-                ChangeFieldDefinitionLabel.of("a", ofEnglish("new_label")));
+                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("c", ofEnglish("c"))),
+                ChangeLocalizedEnumValueOrder.of("a", asList("a", "b", "c")),
+                ChangeFieldDefinitionLabel.of("a", ofEnglish("new_label"))
+            );
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
@@ -6,15 +6,22 @@ import com.commercetools.sync.types.TypeSyncOptions;
 import com.commercetools.sync.types.TypeSyncOptionsBuilder;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.EnumValue;
+import io.sphere.sdk.models.LocalizedEnumValue;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.TextInputHint;
+import io.sphere.sdk.types.EnumFieldType;
 import io.sphere.sdk.types.FieldDefinition;
 import io.sphere.sdk.types.LocalizedEnumFieldType;
 import io.sphere.sdk.types.ResourceTypeIdsSetBuilder;
+import io.sphere.sdk.types.SetFieldType;
+import io.sphere.sdk.types.StringFieldType;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
+import io.sphere.sdk.types.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.types.commands.updateactions.AddFieldDefinition;
+import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionLabel;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionOrder;
 import io.sphere.sdk.types.commands.updateactions.RemoveFieldDefinition;
@@ -26,6 +33,7 @@ import java.util.List;
 import static com.commercetools.sync.types.utils.FieldDefinitionFixtures.*;
 import static com.commercetools.sync.types.utils.TypeUpdateActionUtils.buildFieldDefinitionsUpdateActions;
 import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -36,8 +44,8 @@ import static org.mockito.Mockito.when;
 
 public class BuildFieldDefinitionUpdateActionsTest {
     private static final String TYPE_KEY = "key";
-    private static final LocalizedString TYPE_NAME = LocalizedString.ofEnglish("name");
-    private static final LocalizedString TYPE_DESCRIPTION = LocalizedString.ofEnglish("description");
+    private static final LocalizedString TYPE_NAME = ofEnglish("name");
+    private static final LocalizedString TYPE_DESCRIPTION = ofEnglish("description");
 
     private static final TypeDraft TYPE_DRAFT = TypeDraftBuilder.of(
             TYPE_KEY,
@@ -383,7 +391,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             LocalizedEnumFieldType.of(emptyList()),
             "field_1",
-            LocalizedString.ofEnglish("label1"),
+            ofEnglish("label1"),
             false,
             TextInputHint.SINGLE_LINE);
 
@@ -393,12 +401,12 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition newFieldDefinition = FieldDefinition.of(
             LocalizedEnumFieldType.of(emptyList()),
             "field_1",
-            LocalizedString.ofEnglish("label2"),
+            ofEnglish("label2"),
             false,
             TextInputHint.SINGLE_LINE);
 
         final TypeDraft typeDraft = TypeDraftBuilder
-            .of("key", LocalizedString.ofEnglish("label"), emptySet())
+            .of("key", ofEnglish("label"), emptySet())
             .fieldDefinitions(asList(null, newFieldDefinition))
             .build();
 
@@ -421,7 +429,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             LocalizedEnumFieldType.of(emptyList()),
             "field_1",
-            LocalizedString.ofEnglish("label1"),
+            ofEnglish("label1"),
             false,
             TextInputHint.SINGLE_LINE);
 
@@ -431,12 +439,12 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition newFieldDefinition = FieldDefinition.of(
             LocalizedEnumFieldType.of(emptyList()),
             null,
-            LocalizedString.ofEnglish("label2"),
+            ofEnglish("label2"),
             false,
             TextInputHint.SINGLE_LINE);
 
         final TypeDraft typeDraft = TypeDraftBuilder
-            .of("key", LocalizedString.ofEnglish("label"), emptySet())
+            .of("key", ofEnglish("label"), emptySet())
             .fieldDefinitions(asList(null, newFieldDefinition))
             .build();
 
@@ -460,7 +468,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             LocalizedEnumFieldType.of(emptyList()),
             "field_1",
-            LocalizedString.ofEnglish("label1"),
+            ofEnglish("label1"),
             false,
             TextInputHint.SINGLE_LINE);
 
@@ -470,12 +478,12 @@ public class BuildFieldDefinitionUpdateActionsTest {
         final FieldDefinition newFieldDefinition = FieldDefinition.of(
             null,
             "field_1",
-            LocalizedString.ofEnglish("label2"),
+            ofEnglish("label2"),
             false,
             TextInputHint.SINGLE_LINE);
 
         final TypeDraft typeDraft = TypeDraftBuilder
-            .of("key", LocalizedString.ofEnglish("label"), emptySet())
+            .of("key", ofEnglish("label"), emptySet())
             .fieldDefinitions(asList(null, newFieldDefinition))
             .build();
 
@@ -488,5 +496,257 @@ public class BuildFieldDefinitionUpdateActionsTest {
 
         // assertion
         assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfText_ShouldBuildActions() {
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(SetFieldType.of(StringFieldType.of()), "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(SetFieldType.of(StringFieldType.of()), "a", ofEnglish("old_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        assertThat(updateActions)
+            .containsExactly(ChangeFieldDefinitionLabel.of(newDefinition.getName(), newDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
+
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(SetFieldType.of(SetFieldType.of(StringFieldType.of())), "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(SetFieldType.of(SetFieldType.of(StringFieldType.of())), "a", ofEnglish("old_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        assertThat(updateActions)
+            .containsExactly(ChangeFieldDefinitionLabel.of(newDefinition.getName(), newDefinition.getLabel()));
+
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
+        // preparation
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(SetFieldType.of(
+                EnumFieldType.of(singletonList(EnumValue.of("foo", "bar")))), "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(SetFieldType.of(
+                EnumFieldType.of(emptyList())), "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
+
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfSetOfEnumsChanges_ShouldBuildCorrectActions() {
+        // preparation
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(SetFieldType.of(
+                SetFieldType.of(
+                    EnumFieldType.of(singletonList(EnumValue.of("foo", "bar"))))), "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(SetFieldType.of(
+                SetFieldType.of(
+                    EnumFieldType.of(emptyList()))), "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
+        // preparation
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(SetFieldType.of(EnumFieldType.of(emptyList())), "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(SetFieldType.of(
+                EnumFieldType.of(emptyList())), "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
+        // preparation
+        final SetFieldType newSetFieldType = SetFieldType.of(
+            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
+
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(newSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final SetFieldType oldSetFieldType = SetFieldType.of(LocalizedEnumFieldType.of(emptyList()));
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(oldSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions)
+            .containsExactly(AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))));
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfSetOfLEnumsChanges_ShouldBuildCorrectActions() {
+        // preparation
+        final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(
+            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))));
+
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(newSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final SetFieldType oldSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(oldSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions)
+            .containsExactly(AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))));
+    }
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfIdenticalLEnums_ShouldBuildNoActions() {
+        // preparation
+        final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
+
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(newSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final SetFieldType oldSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(oldSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions).isEmpty();
+    }
+
+
+    @Test
+    public void buildFieldsUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
+        // preparation
+        final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(
+            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))));
+
+        final FieldDefinition newDefinition = FieldDefinition
+            .of(newSetFieldType, "a", ofEnglish("new_label"), true);
+
+        final TypeDraft typeDraft = TypeDraftBuilder
+            .of("foo", ofEnglish("name"), emptySet())
+            .fieldDefinitions(singletonList(newDefinition))
+            .build();
+
+        final SetFieldType oldSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
+        final FieldDefinition oldDefinition = FieldDefinition
+            .of(oldSetFieldType, "a", ofEnglish("old_label"), true);
+
+        final Type type = mock(Type.class);
+        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
+
+        // test
+        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
+            typeDraft, SYNC_OPTIONS);
+
+        // assertion
+        assertThat(updateActions)
+            .containsExactlyInAnyOrder(
+                AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))),
+                ChangeFieldDefinitionLabel.of("a", ofEnglish("new_label")));
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
@@ -575,35 +575,6 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfSetOfEnumsChanges_ShouldBuildCorrectActions() {
-        // preparation
-        final FieldDefinition newDefinition = FieldDefinition
-            .of(SetFieldType.of(
-                SetFieldType.of(
-                    EnumFieldType.of(singletonList(EnumValue.of("foo", "bar"))))), "a", ofEnglish("new_label"), true);
-
-        final TypeDraft typeDraft = TypeDraftBuilder
-            .of("foo", ofEnglish("name"), emptySet())
-            .fieldDefinitions(singletonList(newDefinition))
-            .build();
-
-        final FieldDefinition oldDefinition = FieldDefinition
-            .of(SetFieldType.of(
-                SetFieldType.of(
-                    EnumFieldType.of(emptyList()))), "a", ofEnglish("new_label"), true);
-
-        final Type type = mock(Type.class);
-        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
-
-        // test
-        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
-            typeDraft, SYNC_OPTIONS);
-
-        // assertion
-        assertThat(updateActions).containsExactly(AddEnumValue.of("a", EnumValue.of("foo", "bar")));
-    }
-
-    @Test
     public void buildFieldsUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
         // preparation
         final FieldDefinition newDefinition = FieldDefinition
@@ -660,36 +631,6 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfSetOfLEnumsChanges_ShouldBuildCorrectActions() {
-        // preparation
-        final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(
-            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))));
-
-        final FieldDefinition newDefinition = FieldDefinition
-            .of(newSetFieldType, "a", ofEnglish("new_label"), true);
-
-        final TypeDraft typeDraft = TypeDraftBuilder
-            .of("foo", ofEnglish("name"), emptySet())
-            .fieldDefinitions(singletonList(newDefinition))
-            .build();
-
-        final SetFieldType oldSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
-        final FieldDefinition oldDefinition = FieldDefinition
-            .of(oldSetFieldType, "a", ofEnglish("new_label"), true);
-
-        final Type type = mock(Type.class);
-        when(type.getFieldDefinitions()).thenReturn(singletonList(oldDefinition));
-
-        // test
-        final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(type,
-            typeDraft, SYNC_OPTIONS);
-
-        // assertion
-        assertThat(updateActions)
-            .containsExactly(AddLocalizedEnumValue.of("a", LocalizedEnumValue.of("foo", ofEnglish("bar"))));
-    }
-
-    @Test
     public void buildFieldsUpdateActions_WithSetOfIdenticalLEnums_ShouldBuildNoActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
@@ -717,12 +658,11 @@ public class BuildFieldDefinitionUpdateActionsTest {
         assertThat(updateActions).isEmpty();
     }
 
-
     @Test
     public void buildFieldsUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
         // preparation
-        final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(
-            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar"))))));
+        final SetFieldType newSetFieldType = SetFieldType.of(
+            LocalizedEnumFieldType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
 
         final FieldDefinition newDefinition = FieldDefinition
             .of(newSetFieldType, "a", ofEnglish("new_label"), true);
@@ -732,7 +672,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
             .fieldDefinitions(singletonList(newDefinition))
             .build();
 
-        final SetFieldType oldSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
+        final SetFieldType oldSetFieldType = SetFieldType.of((LocalizedEnumFieldType.of(emptyList())));
         final FieldDefinition oldDefinition = FieldDefinition
             .of(oldSetFieldType, "a", ofEnglish("old_label"), true);
 

--- a/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
@@ -13,7 +13,9 @@ import io.sphere.sdk.types.StringFieldType;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
+import io.sphere.sdk.types.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionLabel;
+import io.sphere.sdk.types.commands.updateactions.ChangeLocalizedEnumValueOrder;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -215,17 +217,30 @@ public class FieldDefinitionUpdateActionUtilsTest {
 
     @Test
     public void buildActions_WithChangedSetOfEnumFieldTypes_ShouldBuildEnumActions() {
-        final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(EnumFieldType.of(emptyList())),
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(EnumFieldType.of(
+                asList(
+                    ENUM_VALUE_A,
+                    ENUM_VALUE_B
+                ))),
             "fieldName1", ofEnglish("label1"), false);
 
-        final FieldDefinition newFieldDefinition = FieldDefinition.of(SetFieldType.of(
-            EnumFieldType.of(singletonList(ENUM_VALUE_A))),
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(
+                EnumFieldType.of(
+                    asList(
+                        ENUM_VALUE_B,
+                        ENUM_VALUE_A,
+                        EnumValue.of("c", "c")
+                    ))),
             "fieldName1", ofEnglish("label1"), false);
 
         final List<UpdateAction<Type>> result =
             buildActions(oldFieldDefinition, newFieldDefinition);
 
-        assertThat(result).containsExactly(AddEnumValue.of("fieldName1", ENUM_VALUE_A));
+        assertThat(result).containsExactly(
+            AddEnumValue.of("fieldName1", EnumValue.of("c", "c")),
+            ChangeEnumValueOrder.of("fieldName1", asList("b", "a", "c")));
     }
 
     @Test
@@ -252,11 +267,20 @@ public class FieldDefinitionUpdateActionUtilsTest {
     public void buildActions_WithChangedSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
         // preparation
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(LocalizedEnumFieldType.of(emptyList())),
+            SetFieldType.of(LocalizedEnumFieldType.of(
+                asList(
+                    LOCALIZED_ENUM_VALUE_A,
+                    LOCALIZED_ENUM_VALUE_B
+                ))),
             "fieldName1", ofEnglish("label1"), false);
 
         final FieldDefinition newFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A))),
+            SetFieldType.of(LocalizedEnumFieldType.of(
+                asList(
+                    LOCALIZED_ENUM_VALUE_B,
+                    LOCALIZED_ENUM_VALUE_A,
+                    LocalizedEnumValue.of("c", ofEnglish("c"))
+                ))),
             "fieldName1", ofEnglish("label1"), false);
 
         // test
@@ -264,6 +288,9 @@ public class FieldDefinitionUpdateActionUtilsTest {
             buildActions(oldFieldDefinition, newFieldDefinition);
 
         // assertion
-        assertThat(result).containsExactly(AddLocalizedEnumValue.of("fieldName1", LOCALIZED_ENUM_VALUE_A));
+        assertThat(result).containsExactly(
+            AddLocalizedEnumValue.of("fieldName1", LocalizedEnumValue.of("c", ofEnglish("c"))),
+            ChangeLocalizedEnumValueOrder.of("fieldName1", asList("b", "a", "c"))
+        );
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
@@ -229,22 +229,6 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfSetOfEnumFieldTypes_ShouldBuildEnumActions() {
-        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(SetFieldType.of(EnumFieldType.of(emptyList()))),
-            "fieldName1", ofEnglish("label1"), false);
-
-        final FieldDefinition newFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(SetFieldType.of(EnumFieldType.of(singletonList(ENUM_VALUE_A)))),
-            "fieldName1", ofEnglish("label1"), false);
-
-        final List<UpdateAction<Type>> result =
-            buildActions(oldFieldDefinition, newFieldDefinition);
-
-        assertThat(result).containsExactly(AddEnumValue.of("fieldName1", ENUM_VALUE_A));
-    }
-
-    @Test
     public void buildActions_WithSameSetOfLEnumFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         // preparation
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
@@ -273,25 +257,6 @@ public class FieldDefinitionUpdateActionUtilsTest {
 
         final FieldDefinition newFieldDefinition = FieldDefinition.of(
             SetFieldType.of(LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A))),
-            "fieldName1", ofEnglish("label1"), false);
-
-        // test
-        final List<UpdateAction<Type>> result =
-            buildActions(oldFieldDefinition, newFieldDefinition);
-
-        // assertion
-        assertThat(result).containsExactly(AddLocalizedEnumValue.of("fieldName1", LOCALIZED_ENUM_VALUE_A));
-    }
-
-    @Test
-    public void buildActions_WithChangedSetOfSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
-        // preparation
-        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList()))),
-            "fieldName1", ofEnglish("label1"), false);
-
-        final FieldDefinition newFieldDefinition = FieldDefinition.of(
-            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A)))),
             "fieldName1", ofEnglish("label1"), false);
 
         // test

--- a/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
@@ -8,6 +8,8 @@ import io.sphere.sdk.models.TextInputHint;
 import io.sphere.sdk.types.EnumFieldType;
 import io.sphere.sdk.types.FieldDefinition;
 import io.sphere.sdk.types.LocalizedEnumFieldType;
+import io.sphere.sdk.types.SetFieldType;
+import io.sphere.sdk.types.StringFieldType;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
@@ -105,7 +107,6 @@ public class FieldDefinitionUpdateActionUtilsTest {
         assertThat(result).containsExactly(AddEnumValue.of(FIELD_NAME_1, ENUM_VALUE_B));
     }
 
-
     @Test
     public void buildActions_WithoutOldPlainEnum_ShouldNotReturnAnyValueAction() {
 
@@ -128,7 +129,6 @@ public class FieldDefinitionUpdateActionUtilsTest {
 
         assertThat(result).isEmpty();
     }
-
 
     @Test
     public void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
@@ -153,4 +153,152 @@ public class FieldDefinitionUpdateActionUtilsTest {
         assertThat(result).containsExactly(AddLocalizedEnumValue.of(FIELD_NAME_1, LOCALIZED_ENUM_VALUE_B));
     }
 
+    @Test
+    public void buildActions_WithStringFieldTypesWithLabelChanges_ShouldBuildChangeLabelAction() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(StringFieldType.of(),"fieldName1",
+            ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(StringFieldType.of(),"fieldName1",
+            ofEnglish("label2"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(
+            ChangeFieldDefinitionLabel.of("fieldName1", newFieldDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildActions_WithSetOfStringFieldTypesWithDefinitionLabelChanges_ShouldBuildChangeLabelAction() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(StringFieldType.of()),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(SetFieldType.of(StringFieldType.of()),
+            "fieldName1", ofEnglish("label2"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(
+            ChangeFieldDefinitionLabel.of("fieldName1", newFieldDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildActions_WithSetOfSetOfStringFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(StringFieldType.of())), "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(StringFieldType.of())), "fieldName1", ofEnglish("label2"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(
+            ChangeFieldDefinitionLabel.of("fieldName1", newFieldDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildActions_WithSameSetOfEnumsFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(EnumFieldType.of(emptyList())),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(SetFieldType.of(EnumFieldType.of(emptyList())),
+            "fieldName1", ofEnglish("label2"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(
+            ChangeFieldDefinitionLabel.of("fieldName1", newFieldDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildActions_WithChangedSetOfEnumFieldTypes_ShouldBuildEnumActions() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(EnumFieldType.of(emptyList())),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(SetFieldType.of(
+            EnumFieldType.of(singletonList(ENUM_VALUE_A))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(AddEnumValue.of("fieldName1", ENUM_VALUE_A));
+    }
+
+    @Test
+    public void buildActions_WithChangedSetOfSetOfEnumFieldTypes_ShouldBuildEnumActions() {
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(EnumFieldType.of(emptyList()))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(EnumFieldType.of(singletonList(ENUM_VALUE_A)))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        assertThat(result).containsExactly(AddEnumValue.of("fieldName1", ENUM_VALUE_A));
+    }
+
+    @Test
+    public void buildActions_WithSameSetOfLEnumFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+        // preparation
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList()))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList()))),
+            "fieldName1", ofEnglish("label2"), false);
+
+        // test
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        // assertion
+        assertThat(result).containsExactly(ChangeFieldDefinitionLabel.of("fieldName1",
+            newFieldDefinition.getLabel()));
+    }
+
+    @Test
+    public void buildActions_WithChangedSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
+        // preparation
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(LocalizedEnumFieldType.of(emptyList())),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        // test
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        // assertion
+        assertThat(result).containsExactly(AddLocalizedEnumValue.of("fieldName1", LOCALIZED_ENUM_VALUE_A));
+    }
+
+    @Test
+    public void buildActions_WithChangedSetOfSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
+        // preparation
+        final FieldDefinition oldFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList()))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        final FieldDefinition newFieldDefinition = FieldDefinition.of(
+            SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A)))),
+            "fieldName1", ofEnglish("label1"), false);
+
+        // test
+        final List<UpdateAction<Type>> result =
+            buildActions(oldFieldDefinition, newFieldDefinition);
+
+        // assertion
+        assertThat(result).containsExactly(AddLocalizedEnumValue.of("fieldName1", LOCALIZED_ENUM_VALUE_A));
+    }
 }


### PR DESCRIPTION
#### Summary
- **ProductType Sync** - Added support for syncing changes to an attribute with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)
- **Type Sync** - Added support for syncing changes to field with a `SetType` of a subtype `LocalizableEnumType` or `EnumType` [#313](https://github.com/commercetools/commercetools-sync-java/issues/313)

#### Relevant Issues
#313  

#### Todo

- Tests
    - [x] Unit 
    - [x] Integration
- [x] Documentation
- [x] Add Release Notes entry.

