### PR TITLE
357 add variant with asset

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
 - 🎉 **New Features** (2)
     - **Product Sync** - Added support for syncing assets of newly added variants. [#357](https://github.com/commercetools/commercetools-sync-java/issues/357).
     - **Product Sync** - `ProductSyncUtils#buildActions` and `ProductUpdateActionUtils#buildVariantsUpdateActions` now build `AddAsset` actions for every new asset on every new variant on the new `ProductDraft`. [#357](https://github.com/commercetools/commercetools-sync-java/issues/357).
+
 - 🐞 **Bug Fixes** (2)
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -33,6 +33,9 @@
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.0/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.0)
 
+- 🎉 **New Features** (2)
+    - **Product Sync** - Added support for syncing assets of newly added variants. [#357](https://github.com/commercetools/commercetools-sync-java/issues/357).
+    - **Product Sync** - `ProductSyncUtils#buildActions` and `ProductUpdateActionUtils#buildVariantsUpdateActions` now build `AddAsset` actions for every new asset on every new variant on the new `ProductDraft`. [#357](https://github.com/commercetools/commercetools-sync-java/issues/357).
 - 🐞 **Bug Fixes** (2)
     - **ProductType Sync** - Fixed a bug in the `productType` sync which would try to unset `isSearchable`, `inputHint` 
     and `attributeConstraint` values to `null` instead of their default values. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -306,6 +306,13 @@ public class ProductSyncWithAssetsIT {
                                                             .stream().collect(toMap(Asset::getKey, Asset::getId));
 
         assertThat(updateActionsFromSync).containsExactly(
+            AddVariant.of(null, null, "v2", true).withKey("v2"),
+            AddAsset.ofSku("v2", createAssetDraft("4", ofEnglish("4"), assetsCustomType.getId()))
+                    .withStaged(true),
+            AddAsset.ofSku("v2", createAssetDraft("3", ofEnglish("3"), assetsCustomType.getId(), customFieldsJsonMap))
+                    .withStaged(true),
+            AddAsset.ofSku("v2", createAssetDraft("2", ofEnglish("new name")))
+                    .withStaged(true),
             RemoveAsset.ofVariantIdWithKey(1, "1", true),
             ChangeAssetName.ofAssetKeyAndVariantId(1, "2", ofEnglish("new name"), true),
             SetAssetCustomType.ofVariantIdAndAssetKey(1, "2", null, true),
@@ -315,11 +322,7 @@ public class ProductSyncWithAssetsIT {
                 null, true),
             ChangeAssetOrder.ofVariantId(1, asList(assetsKeyToIdMap.get("3"), assetsKeyToIdMap.get("2")), true),
             AddAsset.ofVariantId(1, createAssetDraft("4", ofEnglish("4"), assetsCustomType.getId()))
-                    .withStaged(true).withPosition(0),
-            AddVariant.of(null, null, "v2").withKey("v2"),
-            AddAsset.ofSku("v2", createAssetDraft("4", ofEnglish("4"), assetsCustomType.getId())),
-            AddAsset.ofSku("v2", createAssetDraft("3", ofEnglish("4"), assetsCustomType.getId(), customFieldsJsonMap)),
-            AddAsset.ofSku("v2", createAssetDraft("2", ofEnglish("new name")))
+                    .withStaged(true).withPosition(0)
         );
 
         // Assert that assets got updated correctly

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -613,15 +613,13 @@ public final class ProductUpdateActionUtils {
 
         actions.add(addVariant);
 
-        final List<UpdateAction<Product>> addAssetActions = ofNullable(draft.getAssets())
+        ofNullable(draft.getAssets())
             .map(assetDrafts -> assetDrafts.stream()
                                            .map(assetDraft -> (UpdateAction<Product>)
-                                               AddAsset.ofSku(draft.getSku(), assetDraft)
-                                                       .withStaged(true))
+                                               AddAsset.ofSku(draft.getSku(), assetDraft).withStaged(true))
                                            .collect(toList()))
-            .orElse(emptyList());
+            .ifPresent(actions::addAll);
 
-        actions.addAll(addAssetActions);
         return actions;
     }
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -15,6 +15,7 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.ProductVariantDraft;
+import io.sphere.sdk.products.commands.updateactions.AddAsset;
 import io.sphere.sdk.products.commands.updateactions.AddToCategory;
 import io.sphere.sdk.products.commands.updateactions.AddVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
@@ -66,7 +67,6 @@ import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUt
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
@@ -415,7 +415,7 @@ public final class ProductUpdateActionUtils {
                     final List<UpdateAction<Product>> updateOrAddVariant = ofNullable(matchingOldVariant)
                         .map(oldVariant -> collectAllVariantUpdateActions(oldProduct, oldVariant, newProductVariant,
                             attributesMetaData, syncOptions))
-                        .orElseGet(() -> singletonList(buildAddVariantUpdateActionFromDraft(newProductVariant)));
+                        .orElseGet(() -> buildAddVariantUpdateActionFromDraft(newProductVariant));
                     updateActions.addAll(updateOrAddVariant);
                 }
             }
@@ -432,6 +432,7 @@ public final class ProductUpdateActionUtils {
             @Nonnull final ProductVariantDraft newProductVariant,
             @Nonnull final Map<String, AttributeMetaData> attributesMetaData,
             @Nonnull final ProductSyncOptions syncOptions) {
+
         final ArrayList<UpdateAction<Product>> updateActions = new ArrayList<>();
         final SyncFilter syncFilter = syncOptions.getSyncFilter();
 
@@ -584,7 +585,9 @@ public final class ProductUpdateActionUtils {
     }
 
     /**
-     * Factory method to create {@link AddVariant} action from {@link ProductVariantDraft} instance.
+     * Factory method to create {@link AddVariant} action from {@link ProductVariantDraft} instance. If the supplied
+     * {@link ProductVariantDraft} contains assets, this method will append an {@link AddAsset} action for each
+     * new asset.
      *
      * <p>The {@link AddVariant} will include:<ul>
      * <li>sku</li>
@@ -595,13 +598,31 @@ public final class ProductUpdateActionUtils {
      * </ul>
      *
      * @param draft {@link ProductVariantDraft} which to add.
-     * @return new {@link AddVariant} update action with properties from {@code draft}
+     * @return a list of actions which contains an {@link AddVariant} update action with properties from {@code draft},
+     *         and {@link AddAsset} actions for each asset in the new variant.
      */
     @Nonnull
-    static AddVariant buildAddVariantUpdateActionFromDraft(@Nonnull final ProductVariantDraft draft) {
-        return AddVariant.of(draft.getAttributes(), draft.getPrices(), draft.getSku(), true)
-                         .withKey(draft.getKey())
-                         .withImages(draft.getImages());
+    static List<UpdateAction<Product>> buildAddVariantUpdateActionFromDraft(@Nonnull final ProductVariantDraft draft) {
+
+        final ArrayList<UpdateAction<Product>> actions = new ArrayList<>();
+
+        final UpdateAction<Product> addVariant = AddVariant
+            .of(draft.getAttributes(), draft.getPrices(), draft.getSku(), true)
+            .withKey(draft.getKey())
+            .withImages(draft.getImages());
+
+        actions.add(addVariant);
+
+        final List<UpdateAction<Product>> addAssetActions = ofNullable(draft.getAssets())
+            .map(assetDrafts -> assetDrafts.stream()
+                                           .map(assetDraft -> (UpdateAction<Product>)
+                                               AddAsset.ofSku(draft.getSku(), assetDraft)
+                                                       .withStaged(true))
+                                           .collect(toList()))
+            .orElse(emptyList());
+
+        actions.addAll(addAssetActions);
+        return actions;
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -6,6 +6,9 @@ import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.SyncFilter;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.AssetDraft;
+import io.sphere.sdk.models.AssetDraftBuilder;
+import io.sphere.sdk.models.AssetSourceBuilder;
 import io.sphere.sdk.products.Image;
 import io.sphere.sdk.products.PriceDraft;
 import io.sphere.sdk.products.Product;
@@ -13,9 +16,9 @@ import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
-import io.sphere.sdk.products.ProductVariantDraftDsl;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
 import io.sphere.sdk.products.attributes.AttributeDraft;
+import io.sphere.sdk.products.commands.updateactions.AddAsset;
 import io.sphere.sdk.products.commands.updateactions.AddExternalImage;
 import io.sphere.sdk.products.commands.updateactions.AddVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
@@ -40,7 +43,11 @@ import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLA
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildAddVariantUpdateActionFromDraft;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeMasterVariantUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildVariantsUpdateActions;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -67,6 +74,7 @@ public class ProductUpdateActionUtilsTest {
 
     @Test
     public void buildVariantsUpdateActions_updatesVariants() {
+        // preparation
         final Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         final ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
 
@@ -88,13 +96,35 @@ public class ProductUpdateActionUtilsTest {
             .containsExactlyInAnyOrder(RemoveVariant.ofVariantId(2, true), RemoveVariant.ofVariantId(3, true));
 
         // check add actions
-        ProductVariantDraft draftMaster = productDraftNew.getMasterVariant();
-        ProductVariantDraft draft5 = productDraftNew.getVariants().get(1);
-        ProductVariantDraft draft6 = productDraftNew.getVariants().get(2);
+
+        final ProductVariantDraft draftMaster = productDraftNew.getMasterVariant();
+        final ProductVariantDraft draft5 = productDraftNew.getVariants().get(1);
+        final ProductVariantDraft draft6 = productDraftNew.getVariants().get(2);
+        final ProductVariantDraft draft7 = productDraftNew.getVariants().get(3);
+
         assertThat(updateActions).contains(
-            buildAddVariantUpdateActionFromDraft(draftMaster),
-            buildAddVariantUpdateActionFromDraft(draft5),
-            buildAddVariantUpdateActionFromDraft(draft6));
+            AddVariant.of(draftMaster.getAttributes(), draftMaster.getPrices(), draftMaster.getSku(), true)
+                      .withKey(draftMaster.getKey())
+                      .withImages(draftMaster.getImages()),
+            AddVariant.of(draft5.getAttributes(), draft5.getPrices(), draft5.getSku(), true)
+                      .withKey(draft5.getKey())
+                      .withImages(draft5.getImages()),
+            AddVariant.of(draft6.getAttributes(), draft6.getPrices(), draft6.getSku(), true)
+                      .withKey(draft6.getKey())
+                      .withImages(draft6.getImages()),
+            AddVariant.of(draft7.getAttributes(), draft7.getPrices(), draft7.getSku(), true)
+                      .withKey(draft7.getKey())
+                      .withImages(draft7.getImages()));
+
+        // Check add asset actions of new variants
+        assertThat(updateActions).containsAll(
+            draft7.getAssets()
+                  .stream()
+                  .map(assetDraft -> (UpdateAction<Product>) AddAsset
+                      .ofSku(draft7.getSku(), assetDraft)
+                      .withStaged(true))
+                  .collect(toList())
+        );
 
         // variant 4 sku change
         assertThat(updateActions).containsOnlyOnce(SetSku.of(4, "var-44-sku", true));
@@ -165,7 +195,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyOldMasterVariantKey() throws Exception {
+    public void buildVariantsUpdateActions_withEmptyOldMasterVariantKey() {
         assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITH_VARIANTS_MOVE_MASTER,
             BLANK_OLD_MASTER_VARIANT_KEY);
     }
@@ -254,23 +284,106 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddVariantUpdateActionFromDraft_returnsProperties() throws Exception {
-        List<AttributeDraft> attributeList = Collections.emptyList();
-        List<PriceDraft> priceList = Collections.emptyList();
-        List<Image> imageList = Collections.emptyList();
-        ProductVariantDraftDsl draft = ProductVariantDraftBuilder.of()
-                .attributes(attributeList)
-                .prices(priceList)
-                .sku("testSKU")
-                .key("testKey")
-                .images(imageList)
-                .build();
+    public void buildAddVariantUpdateActionFromDraft_WithAttribsPricesAndImages_ShouldBuildCorrectAddVariantAction() {
+        // preparation
+        final List<AttributeDraft> attributeList = Collections.emptyList();
+        final List<PriceDraft> priceList = Collections.emptyList();
+        final List<Image> imageList = Collections.emptyList();
+        final ProductVariantDraft draft = ProductVariantDraftBuilder.of()
+                                                                    .attributes(attributeList)
+                                                                    .prices(priceList)
+                                                                    .sku("testSKU")
+                                                                    .key("testKey")
+                                                                    .images(imageList)
+                                                                    .build();
 
-        AddVariant addVariant = buildAddVariantUpdateActionFromDraft(draft);
-        assertThat(addVariant.getAttributes()).isSameAs(attributeList);
-        assertThat(addVariant.getPrices()).isSameAs(priceList);
-        assertThat(addVariant.getSku()).isEqualTo("testSKU");
-        assertThat(addVariant.getKey()).isEqualTo("testKey");
-        assertThat(addVariant.getImages()).isSameAs(imageList);
+        // test
+        final List<UpdateAction<Product>> result = buildAddVariantUpdateActionFromDraft(draft);
+
+        // assertion
+        assertThat(result).hasOnlyOneElementSatisfying(action -> {
+            assertThat(action).isInstanceOf(AddVariant.class);
+            final AddVariant addVariant = (AddVariant) action;
+            assertThat(addVariant.getAttributes()).isSameAs(attributeList);
+            assertThat(addVariant.getPrices()).isSameAs(priceList);
+            assertThat(addVariant.getSku()).isEqualTo("testSKU");
+            assertThat(addVariant.getKey()).isEqualTo("testKey");
+            assertThat(addVariant.getImages()).isSameAs(imageList);
+        });
+    }
+
+    @Test
+    public void buildAddVariantUpdateActionFromDraft_WithNoAssets_BuildsNoAddAssets() {
+        // preparation
+        final ProductVariantDraft productVariantDraft = ProductVariantDraftBuilder.of()
+                                                                                  .sku("foo")
+                                                                                  .build();
+
+        // test
+        final List<UpdateAction<Product>> result = buildAddVariantUpdateActionFromDraft(productVariantDraft);
+
+        // assertion
+        assertThat(result).containsExactlyInAnyOrder(
+            AddVariant.of(null, null, "foo", true)
+        );
+    }
+
+    @Test
+    public void buildAddVariantUpdateActionFromDraft_WithOneAsset_BuildsOneAddAssetsAction() {
+        // preparation
+
+        final AssetDraft assetDraft = AssetDraftBuilder
+            .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
+            .build();
+
+        final ProductVariantDraft productVariantDraft = ProductVariantDraftBuilder.of()
+                                                                                  .sku("foo")
+                                                                                  .assets(singletonList(assetDraft))
+                                                                                  .build();
+
+        // test
+        final List<UpdateAction<Product>> result = buildAddVariantUpdateActionFromDraft(productVariantDraft);
+
+        // assertion
+        assertThat(result).containsExactlyInAnyOrder(
+            AddVariant.of(null, null, "foo", true),
+            AddAsset.ofSku("foo", assetDraft).withStaged(true)
+        );
+    }
+
+    @Test
+    public void buildAddVariantUpdateActionFromDraft_WithMultipleAsset_BuildsMultipleAddAssetsActions() {
+        // preparation
+        final AssetDraft assetDraft = AssetDraftBuilder
+            .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
+            .key("1")
+            .build();
+
+        final AssetDraft assetDraft1 = AssetDraftBuilder
+            .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
+            .key("2")
+            .build();
+
+        final AssetDraft assetDraft2 = AssetDraftBuilder
+            .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
+            .key("3")
+            .build();
+
+        final ProductVariantDraft productVariantDraft = ProductVariantDraftBuilder
+            .of()
+            .sku("foo")
+            .assets(asList(assetDraft, assetDraft1, assetDraft2))
+            .build();
+
+        // test
+        final List<UpdateAction<Product>> result = buildAddVariantUpdateActionFromDraft(productVariantDraft);
+
+        // assertion
+        assertThat(result).containsExactlyInAnyOrder(
+            AddVariant.of(null, null, "foo", true),
+            AddAsset.ofSku("foo", assetDraft).withStaged(true),
+            AddAsset.ofSku("foo", assetDraft1).withStaged(true),
+            AddAsset.ofSku("foo", assetDraft2).withStaged(true)
+        );
     }
 }

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -329,30 +329,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddVariantUpdateActionFromDraft_WithOneAsset_BuildsOneAddAssetsAction() {
-        // preparation
-
-        final AssetDraft assetDraft = AssetDraftBuilder
-            .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
-            .build();
-
-        final ProductVariantDraft productVariantDraft = ProductVariantDraftBuilder.of()
-                                                                                  .sku("foo")
-                                                                                  .assets(singletonList(assetDraft))
-                                                                                  .build();
-
-        // test
-        final List<UpdateAction<Product>> result = buildAddVariantUpdateActionFromDraft(productVariantDraft);
-
-        // assertion
-        assertThat(result).containsExactlyInAnyOrder(
-            AddVariant.of(null, null, "foo", true),
-            AddAsset.ofSku("foo", assetDraft).withStaged(true)
-        );
-    }
-
-    @Test
-    public void buildAddVariantUpdateActionFromDraft_WithMultipleAsset_BuildsMultipleAddAssetsActions() {
+    public void buildAddVariantUpdateActionFromDraft_WithMultipleAssets_BuildsMultipleAddAssetsActions() {
         // preparation
         final AssetDraft assetDraft = AssetDraftBuilder
             .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -333,7 +333,7 @@ public class ProductUpdateActionUtilsTest {
         // preparation
         final List<AssetDraft> assetDrafts = IntStream
             .range(1, 4)
-            .mapToObj(i-> AssetDraftBuilder
+            .mapToObj(i -> AssetDraftBuilder
                 .of(singletonList(AssetSourceBuilder.ofUri("foo").build()), ofEnglish("assetName"))
                 .key(i + "")
                 .build())

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_changeRemoveMasterVariant.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_changeRemoveMasterVariant.json
@@ -84,6 +84,55 @@
           "value": "ca. 1 x 1000 g"
         }
       ]
+    },
+    {
+      "key": "var-7-key",
+      "sku": "var-7-sku",
+      "prices": [
+      ],
+      "images": [
+        {
+          "url": "https://xxx.ggg/7.png"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        },
+        {
+          "name": "size",
+          "value": "ca. 1 x 1000 g"
+        }
+      ],
+      "assets": [
+        {
+          "id": "1",
+          "sources": [
+            {
+              "uri": "uri"
+            }
+          ],
+          "name": {
+            "en": "asset name"
+          },
+          "key": "a",
+          "tags": []
+        },
+        {
+          "id": "2",
+          "sources": [
+            {
+              "uri": "uri"
+            }
+          ],
+          "name": {
+            "en": "asset name"
+          },
+          "key": "b",
+          "tags": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
#### Summary
Added support for syncing assets of newly added variants.

Resolves issue #357  

#### Description
`ProductSyncUtils#buildActions` and `ProductUpdateActionUtils#buildVariantsUpdateActions` now build `AddAsset` actions for every new asset on every new variant on the new `ProductDraft`.
#### Relevant Issues
<!-- What are the relevant issues? Make sure there is an issue that this PR addresses here:
 https://github.com/commercetools/commercetools-sync-java/issues and add the number(s) here please.-->

#### Todo

- Tests
    - [x] Unit 
    - [x] Integration
- [x] Documentation
- [x] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

