### PR TITLE
246 improve benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark
-      if: tag IS present
+      if: branch = master AND commit_message =~ /^(Merge pull request .*)/
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build
       script: ./gradlew clean dependencyUpdates setLibraryVersion build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,7 @@ before_install:
 install: true # skips travis' default installation step which executes gradle assemble.
 jobs:
   include:
-    - stage: benchmark#1
-      if: tag IS present
-      script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-    - stage: benchmark#2
-      if: tag IS present
-      script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-    - stage: benchmark#3
-      if: tag IS present
-      script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-    - stage: benchmark#4
-      if: tag IS present
-      script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-    - stage: benchmark#5
+    - stage: benchmark
       if: tag IS present
       script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
     - stage: full build

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -40,6 +40,9 @@
     now treat the values of the optional fields `isSearchable`, `inputHint` and `attributeConstraint` 
     as (`true`, `SingleLine` and `None` respectivley) if they are `null` or not passed. [#354](https://github.com/commercetools/commercetools-sync-java/issues/354)
 
+- 🛠️ **Enhancements** (1)
+    - **Commons** - Benchmarks are now run once on every merge to `master` with a lower number of resources for faster benchmarking. [#246](https://github.com/commercetools/commercetools-sync-java/issues/246)
+
 - 📋 **Documentation** (1)
     - *Commons* - Add link to documentation pages in README of the github repo.
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -41,7 +41,7 @@ public class BenchmarkUtils {
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
     static final int THRESHOLD = 120000; //120 seconds in milliseconds
-    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 10000;
+    static final int NUMBER_OF_RESOURCE_UNDER_TEST = 1000;
 
 
     static void saveNewResult(@Nonnull final String version,

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Spliterator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,15 +21,13 @@ import static java.util.Optional.ofNullable;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 
-public class BenchmarkUtils {
+class BenchmarkUtils {
     private static final String BENCHMARK_RESULTS_FILE_NAME = "benchmarks.json";
     private static final String BENCHMARK_RESULTS_FILE_DIR = ofNullable(System.getenv("CI_BUILD_DIR"))
         .map(path -> path + "/tmp_git_dir/benchmarks/").orElse("");
     private static final String BENCHMARK_RESULTS_FILE_PATH = BENCHMARK_RESULTS_FILE_DIR + BENCHMARK_RESULTS_FILE_NAME;
     private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
     private static final String EXECUTION_TIMES = "executionTimes";
-    private static final String AVERAGE = "average";
-    private static final String DIFF = "diff";
 
     static final String PRODUCT_SYNC = "productSync";
     static final String INVENTORY_SYNC = "inventorySync";
@@ -40,7 +37,6 @@ public class BenchmarkUtils {
     static final String CREATES_ONLY = "createsOnly";
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
-    static final int THRESHOLD = 120000; //120 seconds in milliseconds
     static final int NUMBER_OF_RESOURCE_UNDER_TEST = 1000;
 
 
@@ -79,14 +75,6 @@ public class BenchmarkUtils {
         results.add(JsonNodeFactory.instance.numberNode(newResult));
         benchmarkNode.set(EXECUTION_TIMES, JsonNodeFactory.instance.arrayNode().addAll(results));
 
-        // Compute new average and add to JSON Object
-        final double averageResult = calculateAvg(results);
-        benchmarkNode.set(AVERAGE, JsonNodeFactory.instance.numberNode(averageResult));
-
-        // Compute new diff from the last version.
-        final double diff = calculateDiff(rootNode, version, sync, benchmark, averageResult);
-        benchmarkNode.set(DIFF, JsonNodeFactory.instance.numberNode(diff));
-
         final JsonNode newSyncNode = syncNode.set(benchmark, benchmarkNode);
         final JsonNode newVersionNode = versionNode.set(sync, newSyncNode);
         final JsonNode newRoot = rootNode.set(version, newVersionNode);
@@ -101,10 +89,6 @@ public class BenchmarkUtils {
     @Nonnull
     private static <T> Stream<T> toStream(@Nonnull final Iterator<T> iterator) {
         return stream(spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
-    }
-
-    private static double calculateAvg(@Nonnull final List<JsonNode> results) {
-        return results.stream().mapToDouble(JsonNode::asLong).average().orElse(0);
     }
 
     private static ObjectNode createVersionNode(@Nonnull final ObjectNode rootNode, @Nonnull final String version) {
@@ -127,43 +111,10 @@ public class BenchmarkUtils {
                                                   @Nonnull final String benchmark) {
         final ObjectNode newBenchmarkNode = JsonNodeFactory.instance.objectNode();
         newBenchmarkNode.set(EXECUTION_TIMES, JsonNodeFactory.instance.arrayNode());
-        newBenchmarkNode.set(AVERAGE, JsonNodeFactory.instance.numberNode(0));
-        newBenchmarkNode.set(DIFF, JsonNodeFactory.instance.numberNode(0));
 
         syncNode.set(benchmark, newBenchmarkNode);
         return syncNode;
     }
-
-    static double calculateDiff(@Nonnull final String version,
-                                @Nonnull final String sync,
-                                @Nonnull final String benchmark,
-                                final double average) throws IOException {
-        final JsonNode rootNode = new ObjectMapper().readTree(getFileContent(BENCHMARK_RESULTS_FILE_PATH));
-        return calculateDiff(rootNode, version, sync, benchmark, average);
-    }
-
-    private static double calculateDiff(@Nonnull final JsonNode originalRoot,
-                                @Nonnull final String version,
-                                @Nonnull final String sync,
-                                @Nonnull final String benchmark,
-                                final double average) {
-        return getLatestVersionName(originalRoot, version)
-            .map(latestVersionName -> originalRoot.get(latestVersionName)
-                                                  .get(sync)
-                                                  .get(benchmark)
-                                                  .get(AVERAGE))
-            .map(latestAverageNode -> average - latestAverageNode.asDouble())
-            // if there is no latest version (meaning this is the first benchmark for this module)
-            // then return a 0 diff.
-            .orElse(0.0);
-    }
-
-    private static Optional<String> getLatestVersionName(@Nonnull final JsonNode originalRoot,
-                                                         @Nonnull final String currentVersionName) {
-        return toStream(originalRoot.fieldNames()).reduce((firstVersion, secondVersion) ->
-            !currentVersionName.equals(secondVersion) ? secondVersion : firstVersion);
-    }
-
 
     private static String getFileContent(@Nonnull final String path) throws IOException {
         final byte[] fileBytes = Files.readAllBytes(Paths.get(path));
@@ -172,5 +123,8 @@ public class BenchmarkUtils {
 
     private static void writeToFile(@Nonnull final String content, @Nonnull final String path) throws IOException {
         Files.write(Paths.get(path), content.getBytes(UTF8_CHARSET));
+    }
+
+    private BenchmarkUtils() {
     }
 }

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -21,6 +21,8 @@ class BenchmarkUtils {
     private static final String BENCHMARK_RESULTS_FILE_PATH = BENCHMARK_RESULTS_FILE_DIR + BENCHMARK_RESULTS_FILE_NAME;
     private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
     private static final String EXECUTION_TIME = "executionTime";
+    private static final String BRANCH_NAME = ofNullable(System.getenv("TRAVIS_COMMIT"))
+        .orElse("dev-local");
 
     static final String PRODUCT_SYNC = "productSync";
     static final String INVENTORY_SYNC = "inventorySync";
@@ -35,13 +37,11 @@ class BenchmarkUtils {
         + " threshold of '%d'.";
 
 
-    static void saveNewResult(@Nonnull final String version,
-                              @Nonnull final String sync,
-                              @Nonnull final String benchmark,
-                              final double newResult) throws IOException {
+    static void saveNewResult(@Nonnull final String sync, @Nonnull final String benchmark, final double newResult)
+        throws IOException {
 
         final JsonNode rootNode = new ObjectMapper().readTree(getFileContent());
-        final JsonNode withNewResult = addNewResult(rootNode, version, sync, benchmark, newResult);
+        final JsonNode withNewResult = addNewResult(rootNode, sync, benchmark, newResult);
         writeToFile(withNewResult.toString());
     }
 
@@ -54,21 +54,20 @@ class BenchmarkUtils {
 
     @Nonnull
     private static JsonNode addNewResult(@Nonnull final JsonNode originalRoot,
-                                         @Nonnull final String version,
                                          @Nonnull final String sync,
                                          @Nonnull final String benchmark,
                                          final double newResult) {
 
         ObjectNode rootNode = (ObjectNode) originalRoot;
-        ObjectNode versionNode = (ObjectNode) rootNode.get(version);
+        ObjectNode branchNode = (ObjectNode) rootNode.get(BRANCH_NAME);
 
         // If version doesn't exist yet, create a new JSON object for the new version.
-        if (versionNode == null) {
-            versionNode = createVersionNode();
-            rootNode.set(version, versionNode);
+        if (branchNode == null) {
+            branchNode = createVersionNode();
+            rootNode.set(BRANCH_NAME, branchNode);
         }
 
-        final ObjectNode syncNode = (ObjectNode) versionNode.get(sync);
+        final ObjectNode syncNode = (ObjectNode) branchNode.get(sync);
         final ObjectNode benchmarkNode = (ObjectNode) syncNode.get(benchmark);
 
         // Add new result.

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 
 import static java.util.Optional.ofNullable;
 
-class BenchmarkUtils {
+final class BenchmarkUtils {
     private static final String BENCHMARK_RESULTS_FILE_NAME = "benchmarks.json";
     private static final String BENCHMARK_RESULTS_FILE_DIR = ofNullable(System.getenv("CI_BUILD_DIR"))
         .map(path -> path + "/tmp_git_dir/benchmarks/").orElse("");

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -38,6 +38,8 @@ class BenchmarkUtils {
     static final String UPDATES_ONLY = "updatesOnly";
     static final String CREATES_AND_UPDATES = "mix";
     static final int NUMBER_OF_RESOURCE_UNDER_TEST = 1000;
+    static final String THRESHOLD_EXCEEDED_ERROR = "Total execution time of benchmark '%d' took longer than allowed"
+        + " threshold of '%d'.";
 
 
     static void saveNewResult(@Nonnull final String version,

--- a/src/benchmark/java/com/commercetools/sync/benchmark/CategorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/CategorySyncBenchmark.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.benchmark;
 
-import com.commercetools.sync.commons.utils.SyncSolutionInfo;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -17,19 +16,19 @@ public class CategorySyncBenchmark {
     @Test
     public void sync_NewCategories_ShouldCreateCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, CATEGORY_SYNC, CREATES_ONLY, 20000);
+        saveNewResult(CATEGORY_SYNC, CREATES_ONLY, 20000);
     }
 
     @Test
     public void sync_ExistingCategories_ShouldUpdateCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, CATEGORY_SYNC, UPDATES_ONLY, 10000);
+        saveNewResult(CATEGORY_SYNC, UPDATES_ONLY, 10000);
     }
 
     @Test
     public void sync_WithSomeExistingCategories_ShouldSyncCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, CATEGORY_SYNC, CREATES_AND_UPDATES, 30000);
+        saveNewResult(CATEGORY_SYNC, CREATES_AND_UPDATES, 30000);
     }
 
 }

--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -26,9 +26,7 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.INVENTORY_SYNC;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.calculateDiff;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.ChannelITUtils.deleteChannels;
@@ -71,11 +69,11 @@ public class InventorySyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSync;
 
 
-        // Caclulate sync time and assert on threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, INVENTORY_SYNC, CREATES_ONLY, totalTime);
-        assertThat(diff).withFailMessage(format("Diff of benchmark '%e' is longer than expected"
-                            + " threshold of '%d'.", diff, THRESHOLD))
-                        .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~86 seconds)
+        final int threshold = 100000;
+        assertThat(totalTime).withFailMessage(format("Total Execution Time of benchmark '%d' is longer than expected"
+                            + " threshold of '%d'.", totalTime, threshold))
+                             .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (total number of existing inventories)
         final CompletableFuture<Integer> totalNumberOfInventories =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -69,8 +69,8 @@ public class InventorySyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSync;
 
 
-        // assert on threshold (based on history of benchmarks; highest was ~85 seconds)
-        final int threshold = 145000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~9 seconds)
+        final int threshold = 69000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -69,7 +69,7 @@ public class InventorySyncBenchmark {
 
 
         // assert on threshold (based on history of benchmarks; highest was ~9 seconds)
-        final int threshold = 69000; // 1 minute higher than highest benchmark
+        final int threshold = 18000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.benchmark;
 
-import com.commercetools.sync.commons.utils.SyncSolutionInfo;
 import com.commercetools.sync.inventories.InventorySync;
 import com.commercetools.sync.inventories.InventorySyncOptions;
 import com.commercetools.sync.inventories.InventorySyncOptionsBuilder;
@@ -89,21 +88,21 @@ public class InventorySyncBenchmark {
         assertThat(inventorySyncStatistics)
             .hasValues(NUMBER_OF_RESOURCE_UNDER_TEST, NUMBER_OF_RESOURCE_UNDER_TEST, 0, 0);
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, INVENTORY_SYNC, CREATES_ONLY, totalTime);
+        saveNewResult(INVENTORY_SYNC, CREATES_ONLY, totalTime);
     }
 
     @Ignore
     @Test
     public void sync_ExistingInventories_ShouldUpdateInventories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, INVENTORY_SYNC, UPDATES_ONLY, 50000);
+        saveNewResult(INVENTORY_SYNC, UPDATES_ONLY, 50000);
     }
 
     @Ignore
     @Test
     public void sync_WithSomeExistingInventories_ShouldSyncInventories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, INVENTORY_SYNC, CREATES_AND_UPDATES, 30000);
+        saveNewResult(INVENTORY_SYNC, CREATES_AND_UPDATES, 30000);
     }
 
     @Nonnull

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -34,9 +34,7 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.PRODUCT_SYNC;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.calculateDiff;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
@@ -110,11 +108,12 @@ public class ProductSyncBenchmark {
         final ProductSyncStatistics syncStatistics = executeBlocking(productSync.sync(productDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, CREATES_ONLY, totalTime);
-        assertThat(diff)
-            .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                diff, THRESHOLD))
-            .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~162 seconds)
+        final int threshold = 180000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (total number of existing products)
         final CompletableFuture<Integer> totalNumberOfProducts =
@@ -157,12 +156,12 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, UPDATES_ONLY, totalTime);
-        assertThat(diff)
-            .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.", diff,
-                THRESHOLD))
-            .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~194 seconds)
+        final int threshold = 210000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated products)
         final CompletableFuture<Integer> totalNumberOfUpdatedProducts =
@@ -221,12 +220,12 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, CREATES_AND_UPDATES, totalTime);
-        assertThat(diff)
-            .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.", diff,
-                THRESHOLD))
-            .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~187 seconds)
+        final int threshold = 210000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated products)
         final CompletableFuture<Integer> totalNumberOfUpdatedProducts =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -1,7 +1,6 @@
 package com.commercetools.sync.benchmark;
 
 
-import com.commercetools.sync.commons.utils.SyncSolutionInfo;
 import com.commercetools.sync.products.ProductSync;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
@@ -129,7 +128,7 @@ public class ProductSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, CREATES_ONLY, totalTime);
+        saveNewResult(PRODUCT_SYNC, CREATES_ONLY, totalTime);
     }
 
     @Test
@@ -188,7 +187,7 @@ public class ProductSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, UPDATES_ONLY, totalTime);
+        saveNewResult(PRODUCT_SYNC, UPDATES_ONLY, totalTime);
     }
 
     @Test
@@ -251,7 +250,7 @@ public class ProductSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_SYNC, CREATES_AND_UPDATES, totalTime);
+        saveNewResult(PRODUCT_SYNC, CREATES_AND_UPDATES, totalTime);
     }
 
     @Nonnull

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -109,8 +109,8 @@ public class ProductSyncBenchmark {
         final ProductSyncStatistics syncStatistics = executeBlocking(productSync.sync(productDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks, highest was ~162 seconds)
-        final int threshold = 220000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks, highest was ~16 seconds)
+        final int threshold = 76000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -155,8 +155,8 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // assert on threshold (based on history of benchmarks; highest was ~194 seconds)
-        final int threshold = 250000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~19 seconds)
+        final int threshold = 79000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -217,8 +217,8 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // assert on threshold (based on history of benchmarks; highest was ~187 seconds)
-        final int threshold = 250000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~19 seconds)
+        final int threshold = 79000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -34,6 +34,7 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.PRODUCT_SYNC;
+import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD_EXCEEDED_ERROR;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
@@ -108,12 +109,10 @@ public class ProductSyncBenchmark {
         final ProductSyncStatistics syncStatistics = executeBlocking(productSync.sync(productDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~162 seconds)
-        final int threshold = 180000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks, highest was ~162 seconds)
+        final int threshold = 220000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (total number of existing products)
         final CompletableFuture<Integer> totalNumberOfProducts =
@@ -156,12 +155,10 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // assert on threshold (based on previous benchmarks; highest was ~194 seconds)
-        final int threshold = 210000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~194 seconds)
+        final int threshold = 250000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated products)
         final CompletableFuture<Integer> totalNumberOfUpdatedProducts =
@@ -220,12 +217,10 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
 
-        // assert on threshold (based on previous benchmarks; highest was ~187 seconds)
-        final int threshold = 210000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~187 seconds)
+        final int threshold = 250000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated products)
         final CompletableFuture<Integer> totalNumberOfUpdatedProducts =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -109,7 +109,7 @@ public class ProductSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks, highest was ~16 seconds)
-        final int threshold = 76000; // 1 minute higher than highest benchmark
+        final int threshold = 32000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -155,7 +155,7 @@ public class ProductSyncBenchmark {
 
 
         // assert on threshold (based on history of benchmarks; highest was ~19 seconds)
-        final int threshold = 79000; // 1 minute higher than highest benchmark
+        final int threshold = 38000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -217,7 +217,7 @@ public class ProductSyncBenchmark {
 
 
         // assert on threshold (based on history of benchmarks; highest was ~19 seconds)
-        final int threshold = 79000; // 1 minute higher than highest benchmark
+        final int threshold = 38000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -31,6 +31,7 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.PRODUCT_TYPE_SYNC;
+import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD_EXCEEDED_ERROR;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
@@ -83,21 +84,19 @@ public class ProductTypeSyncBenchmark {
 
     @Test
     public void sync_NewProductTypes_ShouldCreateProductTypes() throws IOException {
+        // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
-
-        // Sync drafts
         final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~120 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~120 seconds)
+        final int threshold = 180000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (total number of existing product types)
         final CompletableFuture<Integer> totalNumberOfProductTypes =
@@ -120,8 +119,8 @@ public class ProductTypeSyncBenchmark {
 
     @Test
     public void sync_ExistingProductTypes_ShouldUpdateProductTypes() throws IOException {
+        // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
-
         // Create drafts to target project with different attribute definition name
         CompletableFuture.allOf(
                 productTypeDrafts.stream()
@@ -133,19 +132,17 @@ public class ProductTypeSyncBenchmark {
                                  .toArray(CompletableFuture[]::new))
                          .join();
 
-        // Sync new drafts
         final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~129 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~129 seconds)
+        final int threshold = 189000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated product types)
         final CompletableFuture<Integer> totalNumberOfUpdatedProductTypes =
@@ -180,6 +177,7 @@ public class ProductTypeSyncBenchmark {
 
     @Test
     public void sync_WithSomeExistingProductTypes_ShouldSyncProductTypes() throws IOException {
+        // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final int halfNumberOfDrafts = productTypeDrafts.size() / 2;
         final List<ProductTypeDraft> firstHalf = productTypeDrafts.subList(0, halfNumberOfDrafts);
@@ -194,19 +192,17 @@ public class ProductTypeSyncBenchmark {
                                          .toArray(CompletableFuture[]::new))
                          .join();
 
-        // Sync new drafts
         final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~127 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~127 seconds)
+        final int threshold = 190000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated product types)
         final CompletableFuture<Integer> totalNumberOfProductTypesWithOldName =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.benchmark;
 
-import com.commercetools.sync.commons.utils.SyncSolutionInfo;
 import com.commercetools.sync.producttypes.ProductTypeSync;
 import com.commercetools.sync.producttypes.ProductTypeSyncOptions;
 import com.commercetools.sync.producttypes.ProductTypeSyncOptionsBuilder;
@@ -114,7 +113,7 @@ public class ProductTypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, CREATES_ONLY, totalTime);
+        saveNewResult(PRODUCT_TYPE_SYNC, CREATES_ONLY, totalTime);
     }
 
     @Test
@@ -172,7 +171,7 @@ public class ProductTypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, UPDATES_ONLY, totalTime);
+        saveNewResult(PRODUCT_TYPE_SYNC, UPDATES_ONLY, totalTime);
     }
 
     @Test
@@ -232,7 +231,7 @@ public class ProductTypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
+        saveNewResult(PRODUCT_TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
     }
 
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -31,9 +31,7 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.PRODUCT_TYPE_SYNC;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.calculateDiff;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.ATTRIBUTE_DEFINITION_DRAFT_1;
@@ -94,11 +92,12 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, CREATES_ONLY, totalTime);
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~120 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (total number of existing product types)
         final CompletableFuture<Integer> totalNumberOfProductTypes =
@@ -141,12 +140,12 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, UPDATES_ONLY, totalTime);
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~129 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated product types)
         final CompletableFuture<Integer> totalNumberOfUpdatedProductTypes =
@@ -202,14 +201,12 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff =
-            calculateDiff(SyncSolutionInfo.LIB_VERSION, PRODUCT_TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
-
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~127 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated product types)
         final CompletableFuture<Integer> totalNumberOfProductTypesWithOldName =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -93,7 +93,7 @@ public class ProductTypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~12 seconds)
-        final int threshold = 72000; // 1 minute higher than highest benchmark
+        final int threshold = 24000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -139,7 +139,7 @@ public class ProductTypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
-        final int threshold = 73000; // 1 minute higher than highest benchmark
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -199,7 +199,7 @@ public class ProductTypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
-        final int threshold = 73000; // 1 minute higher than highest benchmark
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -93,8 +93,8 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~120 seconds)
-        final int threshold = 180000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~12 seconds)
+        final int threshold = 72000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -139,8 +139,8 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~129 seconds)
-        final int threshold = 189000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 73000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -199,8 +199,8 @@ public class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~127 seconds)
-        final int threshold = 190000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 73000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.benchmark;
 
-import com.commercetools.sync.commons.utils.SyncSolutionInfo;
 import com.commercetools.sync.types.TypeSync;
 import com.commercetools.sync.types.TypeSyncOptions;
 import com.commercetools.sync.types.TypeSyncOptionsBuilder;
@@ -122,7 +121,7 @@ public class TypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, CREATES_ONLY, totalTime);
+        saveNewResult(TYPE_SYNC, CREATES_ONLY, totalTime);
     }
 
     @Test
@@ -179,7 +178,7 @@ public class TypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, UPDATES_ONLY, totalTime);
+        saveNewResult(TYPE_SYNC, UPDATES_ONLY, totalTime);
     }
 
     @Test
@@ -239,7 +238,7 @@ public class TypeSyncBenchmark {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
 
-        saveNewResult(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
+        saveNewResult(TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
     }
 
     @Nonnull

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -101,8 +101,8 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~133 seconds)
-        final int threshold = 190000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 73000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -146,8 +146,8 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~126 seconds)
-        final int threshold = 190000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 73000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -206,8 +206,8 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~123 seconds)
-        final int threshold = 180000; // 1 minute higher than highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~12 seconds)
+        final int threshold = 72000; // 1 minute higher than highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -32,10 +32,8 @@ import java.util.stream.IntStream;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATES;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.TYPE_SYNC;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
-import static com.commercetools.sync.benchmark.BenchmarkUtils.calculateDiff;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
@@ -102,11 +100,12 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, CREATES_ONLY, totalTime);
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~133 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (total number of existing types)
         final CompletableFuture<Integer> totalNumberOfTypes =
@@ -148,12 +147,12 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, UPDATES_ONLY, totalTime);
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~126 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated types)
         final CompletableFuture<Integer> totalNumberOfUpdatedTypes =
@@ -209,12 +208,12 @@ public class TypeSyncBenchmark {
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // Calculate time taken for benchmark and assert it lies within threshold
-        final double diff = calculateDiff(SyncSolutionInfo.LIB_VERSION, TYPE_SYNC, CREATES_AND_UPDATES, totalTime);
-        assertThat(diff)
-                .withFailMessage(format("Diff of benchmark '%e' is longer than expected threshold of '%d'.",
-                        diff, THRESHOLD))
-                .isLessThanOrEqualTo(THRESHOLD);
+        // assert on threshold (based on previous benchmarks; highest was ~123 seconds)
+        final int threshold = 150000;
+        assertThat(totalTime)
+            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
+                totalTime, threshold))
+            .isLessThanOrEqualTo(threshold);
 
         // Assert actual state of CTP project (number of updated types)
         final CompletableFuture<Integer> totalNumberOfUpdatedTypesWithOldFieldDefinitionName =

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -101,7 +101,7 @@ public class TypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
-        final int threshold = 73000; // 1 minute higher than highest benchmark
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -146,7 +146,7 @@ public class TypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
-        final int threshold = 73000; // 1 minute higher than highest benchmark
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -206,7 +206,7 @@ public class TypeSyncBenchmark {
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
         // assert on threshold (based on history of benchmarks; highest was ~12 seconds)
-        final int threshold = 72000; // 1 minute higher than highest benchmark
+        final int threshold = 24000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATES;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.NUMBER_OF_RESOURCE_UNDER_TEST;
+import static com.commercetools.sync.benchmark.BenchmarkUtils.THRESHOLD_EXCEEDED_ERROR;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.TYPE_SYNC;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
@@ -91,21 +92,19 @@ public class TypeSyncBenchmark {
 
     @Test
     public void sync_NewTypes_ShouldCreateTypes() throws IOException {
+        // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
-
-        // Sync drafts
         final TypeSync typeSync = new TypeSync(typeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~133 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~133 seconds)
+        final int threshold = 190000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (total number of existing types)
         final CompletableFuture<Integer> totalNumberOfTypes =
@@ -128,8 +127,8 @@ public class TypeSyncBenchmark {
 
     @Test
     public void sync_ExistingTypes_ShouldUpdateTypes() throws IOException {
+        // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
-
         // Create drafts to target project with different field type name
         CompletableFuture.allOf(typeDrafts.stream()
                                           .map(TypeDraftBuilder::of)
@@ -140,19 +139,17 @@ public class TypeSyncBenchmark {
                                           .toArray(CompletableFuture[]::new))
                          .join();
 
-        // Sync new drafts
         final TypeSync typeSync = new TypeSync(typeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~126 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~126 seconds)
+        final int threshold = 190000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated types)
         final CompletableFuture<Integer> totalNumberOfUpdatedTypes =
@@ -187,6 +184,7 @@ public class TypeSyncBenchmark {
 
     @Test
     public void sync_WithSomeExistingTypes_ShouldSyncTypes() throws IOException {
+        // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final int halfNumberOfDrafts = typeDrafts.size() / 2;
         final List<TypeDraft> firstHalf = typeDrafts.subList(0, halfNumberOfDrafts);
@@ -201,19 +199,17 @@ public class TypeSyncBenchmark {
                                          .toArray(CompletableFuture[]::new))
                          .join();
 
-        // Sync new drafts
         final TypeSync typeSync = new TypeSync(typeSyncOptions);
 
+        // benchmark
         final long beforeSyncTime = System.currentTimeMillis();
         final TypeSyncStatistics syncStatistics = executeBlocking(typeSync.sync(typeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on previous benchmarks; highest was ~123 seconds)
-        final int threshold = 150000;
-        assertThat(totalTime)
-            .withFailMessage(format("Total execution time of benchmark '%d' is longer than expected threshold of '%d'.",
-                totalTime, threshold))
-            .isLessThanOrEqualTo(threshold);
+        // assert on threshold (based on history of benchmarks; highest was ~123 seconds)
+        final int threshold = 180000; // 1 minute higher than highest benchmark
+        assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
+                             .isLessThan(threshold);
 
         // Assert actual state of CTP project (number of updated types)
         final CompletableFuture<Integer> totalNumberOfUpdatedTypesWithOldFieldDefinitionName =


### PR DESCRIPTION
#### Summary
Addresses some points in #246 

#### Description
1. number of resources is now 1000 which should be good enough and will decrease exec time. The threshold is also be decreased accordingly.
2. Benchmarks are now set to run once on every trigger.
3. Benchmarks are now triggered on every push to master with the commit message matching `Merge pull request`... -> which means on every merge to master basically.
3. Threshold is now hardcoded for every benchmark according to a factor of 10 (because now the resources is 10 times less than before) of the maximum of the history of benchmarks so far. However, this can be readjusted when we have enough data again for this new number of resources.

#### Relevant Issues
#246 

#### Todo

- Tests
    ~- [ ] Unit ~
    ~- [ ] Integration~
~- [ ] Documentation~
- [x] Add Release Notes entry.
