### PR TITLE
#379 add cart discount statistics with unit tests

### DIFF
--- a/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
@@ -1,0 +1,24 @@
+package com.commercetools.sync.cartdiscounts.helpers;
+
+import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
+
+import static java.lang.String.format;
+
+public class CartDiscountSyncStatistics extends BaseSyncStatistics {
+
+    /**
+     * Builds a summary of the cart discount sync statistics instance that looks like the following example:
+     *
+     * <p>"Summary: 2 cart discounts were processed in total (0 created, 0 updated and 0 failed to sync)."
+     *
+     * @return a summary message of the cart discount sync statistics instance.
+     */
+    @Override
+    public String getReportMessage() {
+        reportMessage = format(
+            "Summary: %s cart discounts were processed in total (%s created, %s updated and %s failed to sync).",
+            getProcessed(), getCreated(), getUpdated(), getFailed());
+
+        return reportMessage;
+    }
+}

--- a/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
@@ -4,7 +4,7 @@ import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
 import static java.lang.String.format;
 
-public class CartDiscountSyncStatistics extends BaseSyncStatistics {
+public final class CartDiscountSyncStatistics extends BaseSyncStatistics {
 
     /**
      * Builds a summary of the cart discount sync statistics instance that looks like the following example:

--- a/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountSyncUtils.java
@@ -7,7 +7,6 @@ import io.sphere.sdk.commands.UpdateAction;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Optional;
 
 import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildChangeCartPredicateUpdateAction;
 import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildChangeIsActiveUpdateAction;
@@ -19,8 +18,6 @@ import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActio
 import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildChangeValueUpdateAction;
 import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildSetDescriptionUpdateAction;
 import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildSetValidDatesUpdateAction;
-import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildSetValidFromUpdateAction;
-import static com.commercetools.sync.cartdiscounts.utils.CartDiscountUpdateActionUtils.buildSetValidUntilUpdateAction;
 import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
 
 public final class CartDiscountSyncUtils {

--- a/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtils.java
@@ -224,7 +224,6 @@ public final class CartDiscountUpdateActionUtils {
      * Compares the {@link ZonedDateTime} validFrom and {@link ZonedDateTime} validUntil values
      * of a {@link CartDiscount} and a {@link CartDiscountDraft}
      * and returns an {@link UpdateAction}&lt;{@link CartDiscount}&gt; as a result in an {@link Optional}.
-     *
      * - If both the {@link CartDiscount} and the {@link CartDiscountDraft} have different validFrom
      * and same validUntil values, then 'setValidFrom' update action returned.
      * - If both the {@link CartDiscount} and the {@link CartDiscountDraft} have the same validFrom
@@ -250,9 +249,10 @@ public final class CartDiscountUpdateActionUtils {
         final Optional<UpdateAction<CartDiscount>> setValidUntilUpdateAction =
             buildSetValidUntilUpdateAction(oldCartDiscount, newCartDiscount);
 
-        if (setValidFromUpdateAction.isPresent() && setValidUntilUpdateAction.isPresent())
+        if (setValidFromUpdateAction.isPresent() && setValidUntilUpdateAction.isPresent()) {
             return Optional.of(
                 SetValidFromAndUntil.of(newCartDiscount.getValidFrom(), newCartDiscount.getValidUntil()));
+        }
 
         return setValidFromUpdateAction.isPresent() ? setValidFromUpdateAction : setValidUntilUpdateAction;
     }

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -180,7 +180,7 @@ public abstract class BaseSyncStatistics {
         latestBatchProcessingTimeInMillis = System.currentTimeMillis() - this.latestBatchStartTime;
         latestBatchProcessingTimeInDays = TimeUnit.MILLISECONDS.toDays(latestBatchProcessingTimeInMillis);
         latestBatchProcessingTimeInHours = TimeUnit.MILLISECONDS.toHours(latestBatchProcessingTimeInMillis);
-        latestBatchProcessingTimeInMinutes = TimeUnit.MILLISECONDS.toMinutes(latestBatchProcessingTimeInHours);
+        latestBatchProcessingTimeInMinutes = TimeUnit.MILLISECONDS.toMinutes(latestBatchProcessingTimeInMillis);
         latestBatchProcessingTimeInSeconds = TimeUnit.MILLISECONDS.toSeconds(latestBatchProcessingTimeInMillis);
     }
 
@@ -235,7 +235,7 @@ public abstract class BaseSyncStatistics {
 
     /**
      * Gets the number of hours it took to process.
-     * 
+     *
      * <p>Note: This method isn't thread-safe and shouldn't be used in a concurrent context.
      *
      * @return number of hours taken to process.

--- a/src/test/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatisticsTest.java
@@ -1,0 +1,28 @@
+package com.commercetools.sync.cartdiscounts.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CartDiscountSyncStatisticsTest {
+    private CartDiscountSyncStatistics cartDiscountSyncStatistics;
+
+    @Before
+    public void setup() {
+        cartDiscountSyncStatistics = new CartDiscountSyncStatistics();
+    }
+
+    @Test
+    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+        cartDiscountSyncStatistics.incrementCreated(1);
+        cartDiscountSyncStatistics.incrementFailed(2);
+        cartDiscountSyncStatistics.incrementUpdated(3);
+        cartDiscountSyncStatistics.incrementProcessed(6);
+
+        assertThat(cartDiscountSyncStatistics.getReportMessage())
+            .isEqualTo("Summary: 6 cart discounts were processed in total "
+                + "(1 created, 3 updated and 2 failed to sync).");
+    }
+}

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/CartDiscountSyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/CartDiscountSyncStatisticsAssert.java
@@ -1,0 +1,13 @@
+package com.commercetools.sync.commons.asserts.statistics;
+
+import com.commercetools.sync.cartdiscounts.helpers.CartDiscountSyncStatistics;
+
+import javax.annotation.Nullable;
+
+public final class CartDiscountSyncStatisticsAssert extends
+    AbstractSyncStatisticsAssert<CartDiscountSyncStatisticsAssert, CartDiscountSyncStatistics> {
+
+    CartDiscountSyncStatisticsAssert(@Nullable final CartDiscountSyncStatistics actual) {
+        super(actual, CartDiscountSyncStatisticsAssert.class);
+    }
+}


### PR DESCRIPTION
#### Description
<!-- Describe the changes in this PR here and provide some context -->

Add cart discount statistic object for CartDiscountSync. The statistics for cart discount does not have any custom cases. Check the main docs for what statistics are used for https://commercetools.github.io/commercetools-sync-java/doc/usage/PRODUCT_SYNC/#running-the-sync

#### Relevant Issues
#378 This PR's also fixing the simple typo issue 31e8a30
