### PR TITLE
Migrate to junit5 completely

### DIFF
--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -1,6 +1,6 @@
 ext{
     commercetoolsJvmSdkVersion = '1.37.0'
-    mockitoVersion = '2.27.0'
+    mockitoJunitJupiterVersion = '2.27.0'
     jupiterApiVersion = '5.4.2'
     assertjVersion = '3.12.2'
     checkstyleVersion = '8.2'
@@ -14,7 +14,7 @@ dependencies {
     implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${commercetoolsJvmSdkVersion}"
     implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
     implementation "com.google.code.findbugs:annotations:${findbugsVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoJunitJupiterVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${jupiterApiVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${jupiterApiVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${jupiterApiVersion}"

--- a/src/benchmark/java/com/commercetools/sync/benchmark/CategorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/CategorySyncBenchmark.java
@@ -1,7 +1,8 @@
 package com.commercetools.sync.benchmark;
 
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import java.io.IOException;
 
@@ -10,23 +11,23 @@ import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_AND_UPDATE
 import static com.commercetools.sync.benchmark.BenchmarkUtils.CREATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.UPDATES_ONLY;
 import static com.commercetools.sync.benchmark.BenchmarkUtils.saveNewResult;
-@Ignore
-public class CategorySyncBenchmark {
+@Disabled
+class CategorySyncBenchmark {
 
     @Test
-    public void sync_NewCategories_ShouldCreateCategories() throws IOException {
+    void sync_NewCategories_ShouldCreateCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
         saveNewResult(CATEGORY_SYNC, CREATES_ONLY, 20000);
     }
 
     @Test
-    public void sync_ExistingCategories_ShouldUpdateCategories() throws IOException {
+    void sync_ExistingCategories_ShouldUpdateCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
         saveNewResult(CATEGORY_SYNC, UPDATES_ONLY, 10000);
     }
 
     @Test
-    public void sync_WithSomeExistingCategories_ShouldSyncCategories() throws IOException {
+    void sync_WithSomeExistingCategories_ShouldSyncCategories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
         saveNewResult(CATEGORY_SYNC, CREATES_AND_UPDATES, 30000);
     }

--- a/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/InventorySyncBenchmark.java
@@ -8,10 +8,10 @@ import io.sphere.sdk.inventory.InventoryEntryDraft;
 import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.inventory.queries.InventoryEntryQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -38,23 +38,23 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class InventorySyncBenchmark {
-    @Before
-    public void setup() {
+class InventorySyncBenchmark {
+    @BeforeEach
+    void setup() {
         deleteInventoryEntries(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         deleteChannels(CTP_TARGET_CLIENT);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteInventoryEntries(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         deleteChannels(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_NewInventories_ShouldCreateInventories() throws IOException {
+    void sync_NewInventories_ShouldCreateInventories() throws IOException {
         // preparation
         final List<InventoryEntryDraft> inventoryEntryDrafts = buildInventoryDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final InventorySyncOptions inventorySyncOptions = InventorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -91,16 +91,16 @@ public class InventorySyncBenchmark {
         saveNewResult(INVENTORY_SYNC, CREATES_ONLY, totalTime);
     }
 
-    @Ignore
+    @Disabled
     @Test
-    public void sync_ExistingInventories_ShouldUpdateInventories() throws IOException {
+    void sync_ExistingInventories_ShouldUpdateInventories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
         saveNewResult(INVENTORY_SYNC, UPDATES_ONLY, 50000);
     }
 
-    @Ignore
+    @Disabled
     @Test
-    public void sync_WithSomeExistingInventories_ShouldSyncInventories() throws IOException {
+    void sync_WithSomeExistingInventories_ShouldSyncInventories() throws IOException {
         // TODO: SHOULD BE IMPLEMENTED.
         saveNewResult(INVENTORY_SYNC, CREATES_AND_UPDATES, 30000);
     }

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductSyncBenchmark.java
@@ -15,10 +15,11 @@ import io.sphere.sdk.products.queries.ProductProjectionQuery;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -51,23 +52,23 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncBenchmark {
+class ProductSyncBenchmark {
     private static ProductType productType;
     private ProductSyncOptions syncOptions;
     private List<String> errorCallBackMessages;
     private List<String> warningCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, ENGLISH,
             OLD_CATEGORY_CUSTOM_TYPE_NAME, CTP_TARGET_CLIENT);
         productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
 
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         syncOptions = buildSyncOptions();
@@ -92,13 +93,13 @@ public class ProductSyncBenchmark {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_NewProducts_ShouldCreateProducts() throws IOException {
+    void sync_NewProducts_ShouldCreateProducts() throws IOException {
         final List<ProductDraft> productDrafts = buildProductDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
 
         // Sync drafts
@@ -132,7 +133,7 @@ public class ProductSyncBenchmark {
     }
 
     @Test
-    public void sync_ExistingProducts_ShouldUpdateProducts() throws IOException {
+    void sync_ExistingProducts_ShouldUpdateProducts() throws IOException {
         final List<ProductDraft> productDrafts = buildProductDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         // Create drafts to target project with different descriptions
         CompletableFuture.allOf(productDrafts.stream()
@@ -191,7 +192,7 @@ public class ProductSyncBenchmark {
     }
 
     @Test
-    public void sync_WithSomeExistingProducts_ShouldSyncProducts() throws IOException {
+    void sync_WithSomeExistingProducts_ShouldSyncProducts() throws IOException {
         final List<ProductDraft> productDrafts = buildProductDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final int halfNumberOfDrafts = productDrafts.size() / 2;
         final List<ProductDraft> firstHalf = productDrafts.subList(0, halfNumberOfDrafts);

--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -11,9 +11,9 @@ import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -42,20 +42,20 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductTypeSyncBenchmark {
+class ProductTypeSyncBenchmark {
 
     private ProductTypeSyncOptions productTypeSyncOptions;
     private List<String> errorCallBackMessages;
     private List<String> warningCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductTypes(CTP_TARGET_CLIENT);
     }
 
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteProductTypes(CTP_TARGET_CLIENT);
         productTypeSyncOptions = buildSyncOptions();
@@ -82,7 +82,7 @@ public class ProductTypeSyncBenchmark {
     }
 
     @Test
-    public void sync_NewProductTypes_ShouldCreateProductTypes() throws IOException {
+    void sync_NewProductTypes_ShouldCreateProductTypes() throws IOException {
         // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
@@ -117,7 +117,7 @@ public class ProductTypeSyncBenchmark {
     }
 
     @Test
-    public void sync_ExistingProductTypes_ShouldUpdateProductTypes() throws IOException {
+    void sync_ExistingProductTypes_ShouldUpdateProductTypes() throws IOException {
         // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         // Create drafts to target project with different attribute definition name
@@ -175,7 +175,7 @@ public class ProductTypeSyncBenchmark {
     }
 
     @Test
-    public void sync_WithSomeExistingProductTypes_ShouldSyncProductTypes() throws IOException {
+    void sync_WithSomeExistingProductTypes_ShouldSyncProductTypes() throws IOException {
         // preparation
         final List<ProductTypeDraft> productTypeDrafts = buildProductTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final int halfNumberOfDrafts = productTypeDrafts.size() / 2;

--- a/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/TypeSyncBenchmark.java
@@ -12,10 +12,10 @@ import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.TypeCreateCommand;
 import io.sphere.sdk.types.queries.TypeQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -45,25 +45,25 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TypeSyncBenchmark {
+class TypeSyncBenchmark {
 
     private TypeSyncOptions typeSyncOptions;
     private List<String> errorCallBackMessages;
     private List<String> warningCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterEach
+    static void tearDown() {
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteTypes(CTP_TARGET_CLIENT);
         typeSyncOptions = buildSyncOptions();
@@ -90,7 +90,7 @@ public class TypeSyncBenchmark {
     }
 
     @Test
-    public void sync_NewTypes_ShouldCreateTypes() throws IOException {
+    void sync_NewTypes_ShouldCreateTypes() throws IOException {
         // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final TypeSync typeSync = new TypeSync(typeSyncOptions);
@@ -125,7 +125,7 @@ public class TypeSyncBenchmark {
     }
 
     @Test
-    public void sync_ExistingTypes_ShouldUpdateTypes() throws IOException {
+    void sync_ExistingTypes_ShouldUpdateTypes() throws IOException {
         // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         // Create drafts to target project with different field type name
@@ -182,7 +182,7 @@ public class TypeSyncBenchmark {
     }
 
     @Test
-    public void sync_WithSomeExistingTypes_ShouldSyncTypes() throws IOException {
+    void sync_WithSomeExistingTypes_ShouldSyncTypes() throws IOException {
         // preparation
         final List<TypeDraft> typeDrafts = buildTypeDrafts(NUMBER_OF_RESOURCE_UNDER_TEST);
         final int halfNumberOfDrafts = typeDrafts.size() / 2;

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/ClientConfigurationUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/ClientConfigurationUtilsIT.java
@@ -2,20 +2,20 @@ package com.commercetools.sync.integration.commons;
 
 import com.commercetools.sync.commons.utils.ClientConfigurationUtils;
 import com.commercetools.sync.integration.commons.utils.SphereClientUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ClientConfigurationUtilsIT {
+class ClientConfigurationUtilsIT {
 
     @Test
-    public void createClient_WithSameConfig_ReturnsSameClient() {
+    void createClient_WithSameConfig_ReturnsSameClient() {
         assertThat(ClientConfigurationUtils.createClient(SphereClientUtils.CTP_SOURCE_CLIENT_CONFIG))
             .isEqualTo(ClientConfigurationUtils.createClient(SphereClientUtils.CTP_SOURCE_CLIENT_CONFIG));
     }
 
     @Test
-    public void createClient_WithDifferentConfig_ReturnDifferentClient() {
+    void createClient_WithDifferentConfig_ReturnDifferentClient() {
         assertThat(ClientConfigurationUtils.createClient(SphereClientUtils.CTP_SOURCE_CLIENT_CONFIG))
             .isNotEqualTo(ClientConfigurationUtils.createClient(SphereClientUtils.CTP_TARGET_CLIENT_CONFIG));
     }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/CtpQueryUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/CtpQueryUtilsIT.java
@@ -4,10 +4,10 @@ package com.commercetools.sync.integration.commons;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.queries.CategoryQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -26,13 +26,13 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CtpQueryUtilsIT {
+class CtpQueryUtilsIT {
 
     /**
      * Delete all categories and types from target project. Then create custom types for target CTP project categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH, "anyName", CTP_TARGET_CLIENT);
@@ -42,22 +42,22 @@ public class CtpQueryUtilsIT {
      * Deletes Categories and Types from target CTP projects, then it populates target CTP project with category test
      * data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_TARGET_CLIENT);
     }
 
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void queryAll_WithKeyCollectorConsumerOn100CategoriesWithCustomPageSize_ShouldCollectKeys() {
+    void queryAll_WithKeyCollectorConsumerOn100CategoriesWithCustomPageSize_ShouldCollectKeys() {
         final int numberOfCategories = 100;
         createCategories(CTP_TARGET_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, numberOfCategories));
@@ -71,7 +71,7 @@ public class CtpQueryUtilsIT {
     }
 
     @Test
-    public void queryAll_WithKeyCollectorConsumerOn600Categories_ShouldCollectKeys() {
+    void queryAll_WithKeyCollectorConsumerOn600Categories_ShouldCollectKeys() {
         final int numberOfCategories = 600;
         final List<CategoryDraft> categoryDrafts = getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, numberOfCategories);
@@ -87,7 +87,7 @@ public class CtpQueryUtilsIT {
     }
 
     @Test
-    public void queryAll_WithCategoryCollectorCallbackWithUniformPageSplitting_ShouldFetchAllCategories() {
+    void queryAll_WithCategoryCollectorCallbackWithUniformPageSplitting_ShouldFetchAllCategories() {
         final int numberOfCategories = 10;
         createCategories(CTP_TARGET_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, numberOfCategories));
@@ -110,7 +110,7 @@ public class CtpQueryUtilsIT {
     }
 
     @Test
-    public void queryAll_WithCategoryCollectorCallbackWithNonUniformPageSplitting_ShouldFetchAllCategories() {
+    void queryAll_WithCategoryCollectorCallbackWithNonUniformPageSplitting_ShouldFetchAllCategories() {
         final int numberOfCategories = 7;
         createCategories(CTP_TARGET_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, numberOfCategories));
@@ -128,7 +128,7 @@ public class CtpQueryUtilsIT {
     }
 
     @Test
-    public void queryAll_WithCategoryCollectorCallbackOn600Categories_ShouldFetchAllCategories() {
+    void queryAll_WithCategoryCollectorCallbackOn600Categories_ShouldFetchAllCategories() {
         final int numberOfCategories = 600;
         createCategories(CTP_TARGET_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, numberOfCategories));

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -323,4 +323,7 @@ public final class CategoryITUtils {
                                             categoryOrderHintKeyMap.put(category.getKey(), categoryOrderHintValue)));
         return CategoryOrderHints.of(categoryOrderHintKeyMap);
     }
+
+    private CategoryITUtils() {
+    }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.integration.commons.utils;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereRequest;
-import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.PriceDraft;
 import io.sphere.sdk.products.PriceDraftBuilder;
 import io.sphere.sdk.products.Product;
@@ -35,6 +35,7 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndC
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.deleteProductTypes;
 import static com.commercetools.sync.integration.commons.utils.StateITUtils.deleteStates;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.deleteTaxCategories;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -118,7 +119,7 @@ public final class ProductITUtils {
      */
     @Nonnull
     private static SphereRequest<Product> buildUnpublishRequest(@Nonnull final Product product) {
-        return ProductUpdateCommand.of(product, Unpublish.of());
+        return ProductUpdateCommand.of(product, singletonList(Unpublish.of()));
     }
 
     /**
@@ -127,16 +128,17 @@ public final class ProductITUtils {
      * <p>TODO: GITHUB ISSUE#152
      *
      * @param productDraft     the product draft to attach the channel reference on its variants' prices.
-     * @param channelReference the channel reference to attach on the product draft's variants' prices.
+     * @param channelResourceIdentifier the channel reference to attach on the product draft's variants' prices.
      * @return the product draft with the supplied references attached on the product draft's variants' prices.
      */
     public static ProductDraft getDraftWithPriceReferences(@Nonnull final ProductDraft productDraft,
-                                                           @Nullable final Reference<Channel> channelReference,
+                                                           @Nullable final ResourceIdentifier<Channel>
+                                                               channelResourceIdentifier,
                                                            @Nullable final CustomFieldsDraft customFieldsDraft) {
         final List<ProductVariantDraft> allVariants = productDraft
             .getVariants().stream().map(productVariant -> {
                 final List<PriceDraft> priceDraftsWithChannelReferences = getPriceDraftsWithReferences(productVariant,
-                    channelReference, customFieldsDraft);
+                    channelResourceIdentifier, customFieldsDraft);
                 return ProductVariantDraftBuilder.of(productVariant)
                                                  .prices(priceDraftsWithChannelReferences)
                                                  .build();
@@ -146,7 +148,7 @@ public final class ProductITUtils {
         return ofNullable(productDraft.getMasterVariant())
             .map(masterVariant -> {
                 final List<PriceDraft> priceDraftsWithReferences = getPriceDraftsWithReferences(masterVariant,
-                    channelReference, customFieldsDraft);
+                    channelResourceIdentifier, customFieldsDraft);
                 final ProductVariantDraft masterVariantWithPriceDrafts =
                     ProductVariantDraftBuilder.of(masterVariant)
                                               .prices(priceDraftsWithReferences)
@@ -175,7 +177,7 @@ public final class ProductITUtils {
     @Nonnull
     private static List<PriceDraft> getPriceDraftsWithReferences(
         @Nonnull final ProductVariantDraft productVariant,
-        @Nullable final Reference<Channel> channelReference,
+        @Nullable final ResourceIdentifier<Channel> channelReference,
         @Nullable final CustomFieldsDraft customFieldsDraft) {
 
         return productVariant.getPrices()

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.integration.commons.utils;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereRequest;
-import io.sphere.sdk.models.ResourceIdentifier;
+import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.PriceDraft;
 import io.sphere.sdk.products.PriceDraftBuilder;
 import io.sphere.sdk.products.Product;
@@ -128,17 +128,16 @@ public final class ProductITUtils {
      * <p>TODO: GITHUB ISSUE#152
      *
      * @param productDraft     the product draft to attach the channel reference on its variants' prices.
-     * @param channelResourceIdentifier the channel reference to attach on the product draft's variants' prices.
+     * @param channelReference the channel reference to attach on the product draft's variants' prices.
      * @return the product draft with the supplied references attached on the product draft's variants' prices.
      */
     public static ProductDraft getDraftWithPriceReferences(@Nonnull final ProductDraft productDraft,
-                                                           @Nullable final ResourceIdentifier<Channel>
-                                                               channelResourceIdentifier,
+                                                           @Nullable final Reference<Channel> channelReference,
                                                            @Nullable final CustomFieldsDraft customFieldsDraft) {
         final List<ProductVariantDraft> allVariants = productDraft
             .getVariants().stream().map(productVariant -> {
                 final List<PriceDraft> priceDraftsWithChannelReferences = getPriceDraftsWithReferences(productVariant,
-                    channelResourceIdentifier, customFieldsDraft);
+                    channelReference, customFieldsDraft);
                 return ProductVariantDraftBuilder.of(productVariant)
                                                  .prices(priceDraftsWithChannelReferences)
                                                  .build();
@@ -148,7 +147,7 @@ public final class ProductITUtils {
         return ofNullable(productDraft.getMasterVariant())
             .map(masterVariant -> {
                 final List<PriceDraft> priceDraftsWithReferences = getPriceDraftsWithReferences(masterVariant,
-                    channelResourceIdentifier, customFieldsDraft);
+                    channelReference, customFieldsDraft);
                 final ProductVariantDraft masterVariantWithPriceDrafts =
                     ProductVariantDraftBuilder.of(masterVariant)
                                               .prices(priceDraftsWithReferences)
@@ -177,7 +176,7 @@ public final class ProductITUtils {
     @Nonnull
     private static List<PriceDraft> getPriceDraftsWithReferences(
         @Nonnull final ProductVariantDraft productVariant,
-        @Nullable final ResourceIdentifier<Channel> channelReference,
+        @Nullable final Reference<Channel> channelReference,
         @Nullable final CustomFieldsDraft customFieldsDraft) {
 
         return productVariant.getPrices()

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
@@ -14,10 +14,10 @@ import io.sphere.sdk.client.ErrorResponseException;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.types.CustomFieldsDraft;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -142,7 +142,7 @@ class CategorySyncIT {
         assertThat(callBackWarningResponses).isEmpty();
     }
 
-    @Ignore("TODO - GITHUB ISSUE#138: Test should be adjusted after reference resolution refactoring")
+    @Disabled("TODO - GITHUB ISSUE#138: Test should be adjusted after reference resolution refactoring")
     @Test
     void syncDrafts_WithUpdatedCategoriesWithoutReferenceKeys_ShouldNotSyncCategories() {
         createCategories(CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
@@ -14,11 +14,11 @@ import io.sphere.sdk.client.ErrorResponseException;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.types.CustomFieldsDraft;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +48,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CategorySyncIT {
+class CategorySyncIT {
     private CategorySync categorySync;
 
     private List<String> callBackErrorResponses = new ArrayList<>();
@@ -59,8 +59,8 @@ public class CategorySyncIT {
      * Delete all categories and types from source and target project. Then create custom types for source and target
      * CTP project categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -72,8 +72,8 @@ public class CategorySyncIT {
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteAllCategories(CTP_SOURCE_CLIENT);
 
@@ -97,15 +97,15 @@ public class CategorySyncIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void syncDrafts_withChangesOnly_ShouldUpdateCategories() {
+    void syncDrafts_withChangesOnly_ShouldUpdateCategories() {
         createCategories(CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, 2));
 
@@ -124,7 +124,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_withNewCategories_ShouldCreateCategories() {
+    void syncDrafts_withNewCategories_ShouldCreateCategories() {
         createCategories(CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, 3));
 
@@ -144,7 +144,7 @@ public class CategorySyncIT {
 
     @Ignore("TODO - GITHUB ISSUE#138: Test should be adjusted after reference resolution refactoring")
     @Test
-    public void syncDrafts_WithUpdatedCategoriesWithoutReferenceKeys_ShouldNotSyncCategories() {
+    void syncDrafts_WithUpdatedCategoriesWithoutReferenceKeys_ShouldNotSyncCategories() {
         createCategories(CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new",
             null, 2));
 
@@ -188,7 +188,7 @@ public class CategorySyncIT {
 
     @Test
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
-    public void syncDrafts_withNewShuffledBatchOfCategories_ShouldCreateCategories() {
+    void syncDrafts_withNewShuffledBatchOfCategories_ShouldCreateCategories() {
         //-----------------Test Setup------------------------------------
         // Delete all categories in target project
         deleteAllCategories(CTP_TARGET_CLIENT);
@@ -229,7 +229,7 @@ public class CategorySyncIT {
 
     @Test
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
-    public void syncDrafts_withExistingShuffledCategoriesWithChangingCategoryHierarchy_ShouldUpdateCategories() {
+    void syncDrafts_withExistingShuffledCategoriesWithChangingCategoryHierarchy_ShouldUpdateCategories() {
         //-----------------Test Setup------------------------------------
         // Delete all categories in target project
         deleteAllCategories(CTP_TARGET_CLIENT);
@@ -283,7 +283,7 @@ public class CategorySyncIT {
 
     @Test
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
-    public void syncDrafts_withExistingCategoriesThatChangeParents_ShouldUpdateCategories() {
+    void syncDrafts_withExistingCategoriesThatChangeParents_ShouldUpdateCategories() {
         //-----------------Test Setup------------------------------------
         // Delete all categories in target project
         deleteAllCategories(CTP_TARGET_CLIENT);
@@ -326,7 +326,7 @@ public class CategorySyncIT {
 
     @Test
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
-    public void syncDrafts_withANonExistingNewParent_ShouldUpdateCategories() {
+    void syncDrafts_withANonExistingNewParent_ShouldUpdateCategories() {
         //-----------------Test Setup------------------------------------
         // Delete all categories in target project
         deleteAllCategories(CTP_TARGET_CLIENT);
@@ -394,7 +394,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_fromCategoriesWithoutKeys_ShouldNotUpdateCategories() {
+    void syncDrafts_fromCategoriesWithoutKeys_ShouldNotUpdateCategories() {
         final CategoryDraft oldCategoryDraft1 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat1"), LocalizedString.of(Locale.ENGLISH, "furniture1"))
             .custom(getCustomFieldsDraft())

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeNameIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeNameIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeName;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -21,15 +21,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeNameIT {
+class ChangeNameIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -47,23 +47,23 @@ public class ChangeNameIT {
     /**
      * Cleans the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -87,7 +87,7 @@ public class ChangeNameIT {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -108,7 +108,7 @@ public class ChangeNameIT {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Create a mock new category in the source project.
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.GERMAN, "klassische moebel",

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeOrderHintIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeOrderHintIT.java
@@ -9,10 +9,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeOrderHint;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +26,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeOrderHintIT {
+class ChangeOrderHintIT {
     private static Category oldCategory;
     private List<String> callBackResponses = new ArrayList<>();
     private CategorySyncOptions categorySyncOptions;
@@ -35,8 +35,8 @@ public class ChangeOrderHintIT {
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -55,8 +55,8 @@ public class ChangeOrderHintIT {
     /**
      * Deletes all the categories in the source CTP project and the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         callBackResponses = new ArrayList<>();
         categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -67,15 +67,15 @@ public class ChangeOrderHintIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .orderHint("0.2")
@@ -100,7 +100,7 @@ public class ChangeOrderHintIT {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .orderHint(oldCategory.getOrderHint())
@@ -123,7 +123,7 @@ public class ChangeOrderHintIT {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithNullValue_ShouldNotBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithNullValue_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .orderHint(null)

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
@@ -9,8 +9,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeParent;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeParentIT.java
@@ -11,8 +11,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +25,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeParentIT {
+class ChangeParentIT {
     private static Category oldCategory;
     private static Category oldCategoryParent;
     private List<String> callBackResponses = new ArrayList<>();
@@ -36,8 +35,8 @@ public class ChangeParentIT {
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -65,8 +64,8 @@ public class ChangeParentIT {
     /**
      * Deletes all the categories in the source CTP project and the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         callBackResponses = new ArrayList<>();
         categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -77,15 +76,15 @@ public class ChangeParentIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraftParent = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "parent-name"), LocalizedString.of(Locale.ENGLISH, "parent-slug"))
             .build();
@@ -117,7 +116,7 @@ public class ChangeParentIT {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .build();
@@ -140,7 +139,7 @@ public class ChangeParentIT {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithNullValue_ShouldTriggerCallback() {
+    void buildChangeParentUpdateAction_WithNullValue_ShouldTriggerCallback() {
         // Prepare new category draft from source project's root category which has no parent.
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeSlugIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/ChangeSlugIT.java
@@ -8,10 +8,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeSlug;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -22,15 +22,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeSlugIT {
+class ChangeSlugIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -48,23 +48,23 @@ public class ChangeSlugIT {
     /**
      * Deletes all the categories in the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "new-classic-furniture", Locale.GERMAN, "neue-klassische-moebel"))
@@ -88,7 +88,7 @@ public class ChangeSlugIT {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .build();
@@ -108,7 +108,7 @@ public class ChangeSlugIT {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.GERMAN, "klassische-moebel", Locale.ENGLISH, "classic-furniture"))

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetDescriptionIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetDescriptionIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetDescription;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -21,15 +21,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetDescriptionIT {
+class SetDescriptionIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -48,23 +48,23 @@ public class SetDescriptionIT {
     /**
      * Deletes all the categories in the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .description(LocalizedString.of(Locale.ENGLISH, "cool description"))
@@ -86,7 +86,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildChangeDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .description(oldCategory.getDescription())
@@ -107,7 +107,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildChangeDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildChangeDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .description(LocalizedString.of(Locale.GERMAN, "nett Beschreibung", Locale.ENGLISH, "nice description"))
@@ -127,7 +127,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildChangeDescriptionUpdateAction_WithNullValue_ShouldNotBuildUpdateAction() {
+    void buildChangeDescriptionUpdateAction_WithNullValue_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .build();

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetExternalIdIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetExternalIdIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetExternalId;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class SetExternalIdIT {
+class SetExternalIdIT {
     private static Category oldCategory;
     private List<String> callBackResponses = new ArrayList<>();
 
@@ -32,8 +32,8 @@ public class SetExternalIdIT {
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -52,8 +52,8 @@ public class SetExternalIdIT {
     /**
      * Deletes all the categories in the source CTP project and the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         callBackResponses = new ArrayList<>();
     }
@@ -61,15 +61,15 @@ public class SetExternalIdIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildSetExternalIdHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetExternalIdHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .externalId("externalId2")
@@ -93,7 +93,7 @@ public class SetExternalIdIT {
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
             .externalId(oldCategory.getExternalId())

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaDescriptionIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaDescriptionIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -21,15 +21,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaDescriptionIT {
+class SetMetaDescriptionIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -49,23 +49,23 @@ public class SetMetaDescriptionIT {
     /**
      * Deletes all the categories in the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -90,7 +90,7 @@ public class SetMetaDescriptionIT {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -111,7 +111,7 @@ public class SetMetaDescriptionIT {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaKeywordsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaKeywordsIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaKeywords;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -21,15 +21,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaKeywordsIT {
+class SetMetaKeywordsIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -49,23 +49,23 @@ public class SetMetaKeywordsIT {
     /**
      * Deletes all the categories in the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -90,7 +90,7 @@ public class SetMetaKeywordsIT {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -111,7 +111,7 @@ public class SetMetaKeywordsIT {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaTitleIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/updateactionutils/SetMetaTitleIT.java
@@ -7,10 +7,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -21,15 +21,15 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaTitleIT {
+class SetMetaTitleIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -49,23 +49,23 @@ public class SetMetaTitleIT {
     /**
      * Deletes all the categories in the source CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
     }
 
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_SOURCE_CLIENT);
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -90,7 +90,7 @@ public class SetMetaTitleIT {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))
@@ -113,7 +113,7 @@ public class SetMetaTitleIT {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "modern classic furniture"),
                 LocalizedString.of(Locale.ENGLISH, "classic-furniture", Locale.GERMAN, "klassische-moebel"))

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductReferenceResolverIT.java
@@ -15,10 +15,10 @@ import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateType;
 import io.sphere.sdk.taxcategories.TaxCategory;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +49,7 @@ import static com.commercetools.sync.products.utils.ProductReferenceReplacementU
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductReferenceResolverIT {
+class ProductReferenceResolverIT {
     private static ProductType productTypeSource;
     private static ProductType noKeyProductTypeSource;
 
@@ -67,8 +67,8 @@ public class ProductReferenceResolverIT {
      * Delete all product related test data from target and source projects. Then creates custom types for both
      * CTP projects categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
 
@@ -99,8 +99,8 @@ public class ProductReferenceResolverIT {
      * Deletes Products and Types from target CTP projects, then it populates target CTP project with product test
      * data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllProducts(CTP_TARGET_CLIENT);
         deleteAllProducts(CTP_SOURCE_CLIENT);
 
@@ -123,14 +123,14 @@ public class ProductReferenceResolverIT {
         productSync = new ProductSync(syncOptions);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
     }
 
     @Test
-    public void sync_withNewProductWithExistingCategoryAndProductTypeReferences_ShouldCreateProduct() {
+    void sync_withNewProductWithExistingCategoryAndProductTypeReferences_ShouldCreateProduct() {
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
             productTypeSource.toReference(), oldTaxCategory.toReference(), oldProductState.toReference(),
             categoryReferencesWithIds, createRandomCategoryOrderHints(categoryReferencesWithIds));
@@ -152,7 +152,7 @@ public class ProductReferenceResolverIT {
     }
 
     @Test
-    public void sync_withNewProductWithNoProductTypeKey_ShouldFailCreatingTheProduct() {
+    void sync_withNewProductWithNoProductTypeKey_ShouldFailCreatingTheProduct() {
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
             noKeyProductTypeSource.toReference(), oldTaxCategory.toReference(), oldProductState.toReference(),
             categoryReferencesWithIds, createRandomCategoryOrderHints(categoryReferencesWithIds));

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
@@ -30,10 +30,10 @@ import io.sphere.sdk.states.StateType;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -82,7 +82,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncIT {
+class ProductSyncIT {
     private static ProductType sourceProductType;
     private static ProductType targetProductType;
 
@@ -110,8 +110,8 @@ public class ProductSyncIT {
      * Delete all product related test data from target and source projects. Then creates for both CTP projects price
      * channels, product types, tax categories, categories, custom types for categories and product states.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
 
@@ -152,8 +152,8 @@ public class ProductSyncIT {
      * Deletes Products from the source and target CTP projects, clears the callback collections then it instantiates a
      * new {@link ProductSync} instance.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         deleteAllProducts(CTP_SOURCE_CLIENT);
@@ -188,14 +188,14 @@ public class ProductSyncIT {
         return updateActions;
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
     }
 
     @Test
-    public void sync_withChangesOnly_ShouldUpdateProducts() {
+    void sync_withChangesOnly_ShouldUpdateProducts() {
         final ProductDraft existingProductDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
             targetProductType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
             targetCategoryReferencesWithIds, createRandomCategoryOrderHints(targetCategoryReferencesWithIds));
@@ -220,7 +220,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withChangesOnlyAndUnPublish_ShouldUpdateProducts() {
+    void sync_withChangesOnlyAndUnPublish_ShouldUpdateProducts() {
         final ProductDraft existingProductDraft = createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH,
             targetProductType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
             targetCategoryReferencesWithIds, createRandomCategoryOrderHints(targetCategoryReferencesWithIds));
@@ -250,7 +250,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withPriceReferences_ShouldUpdateProducts() {
+    void sync_withPriceReferences_ShouldUpdateProducts() {
         final ProductDraft existingProductDraft = createProductDraft(PRODUCT_KEY_1_WITH_PRICES_RESOURCE_PATH,
             targetProductType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
             targetCategoryReferencesWithIds, createRandomCategoryOrderHints(targetCategoryReferencesWithIds));
@@ -291,7 +291,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withProductTypeReference_ShouldUpdateProducts() {
+    void sync_withProductTypeReference_ShouldUpdateProducts() {
         // Preparation
         // Create custom options with whitelisting and action filter callback..
         final ProductSyncOptions customSyncOptions =
@@ -414,7 +414,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withChangedAttributes_ShouldUpdateProducts() {
+    void sync_withChangedAttributes_ShouldUpdateProducts() {
         // Preparation
         // Create custom options with whitelisting and action filter callback..
         final ProductSyncOptions customSyncOptions =
@@ -481,7 +481,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withEmptySetAttribute_ShouldCreateProductWithAnEmptySetAttribute() {
+    void sync_withEmptySetAttribute_ShouldCreateProductWithAnEmptySetAttribute() {
         // Preparation
         // Create custom options with whitelisting and action filter callback..
         final ProductSyncOptions customSyncOptions =

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncWithAssetsIT.java
@@ -25,10 +25,10 @@ import io.sphere.sdk.products.commands.updateactions.SetAssetCustomType;
 import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.types.Type;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -58,7 +58,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncWithAssetsIT {
+class ProductSyncWithAssetsIT {
     private static final String ASSETS_CUSTOM_TYPE_KEY = "assetsCustomTypeKey";
     private static ProductType sourceProductType;
     private static ProductType targetProductType;
@@ -76,8 +76,8 @@ public class ProductSyncWithAssetsIT {
      * Delete all product related test data from target and source projects. Then creates for both CTP projects product
      * types and asset custom types.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
 
@@ -95,8 +95,8 @@ public class ProductSyncWithAssetsIT {
      * Deletes Products from the source and target CTP projects, clears the callback collections then it instantiates a
      * new {@link ProductSync} instance.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         deleteAllProducts(CTP_SOURCE_CLIENT);
@@ -130,14 +130,14 @@ public class ProductSyncWithAssetsIT {
         return updateActions;
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         deleteProductSyncTestData(CTP_SOURCE_CLIENT);
     }
 
     @Test
-    public void sync_withNewProductWithAssets_shouldCreateProduct() {
+    void sync_withNewProductWithAssets_shouldCreateProduct() {
         final List<AssetDraft> assetDraftsToCreateOnExistingProduct = asList(
             createAssetDraft("1", ofEnglish("1"), sourceAssetCustomType.getId()),
             createAssetDraft("2", ofEnglish("2"), sourceAssetCustomType.getId()),
@@ -181,7 +181,7 @@ public class ProductSyncWithAssetsIT {
     }
 
     @Test
-    public void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
+    void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
         final Map<String, JsonNode> customFieldsJsonMap = new HashMap<>();
         customFieldsJsonMap.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(true));
 

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/templates/beforeupdatecallback/KeepOtherVariantsSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/templates/beforeupdatecallback/KeepOtherVariantsSyncIT.java
@@ -11,10 +11,10 @@ import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.queries.QueryPredicate;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
@@ -35,9 +36,8 @@ import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 
-public class KeepOtherVariantsSyncIT {
+class KeepOtherVariantsSyncIT {
 
     private static ProductType productType;
     private Product oldProduct;
@@ -51,8 +51,8 @@ public class KeepOtherVariantsSyncIT {
      * Delete all product related test data from target project. Then creates a productType for the products of the
      * target CTP project.
      */
-    @BeforeClass
-    public static void setupAllTests() {
+    @BeforeAll
+    static void setupAllTests() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
@@ -64,8 +64,8 @@ public class KeepOtherVariantsSyncIT {
      * 4. Creates a product in the target CTP project with 1 variant other than the master
      * variant.
      */
-    @Before
-    public void setupPerTest() {
+    @BeforeEach
+    void setupPerTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         syncOptions = getProductSyncOptions();
@@ -96,13 +96,13 @@ public class KeepOtherVariantsSyncIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withRemovedVariants_shouldNotRemoveVariants() {
+    void sync_withRemovedVariants_shouldNotRemoveVariants() {
         final ProductDraft productDraft =
             createProductDraftBuilder(PRODUCT_NO_VARS_RESOURCE_PATH, referenceOfId(productType.getKey()))
                 .build();
@@ -130,6 +130,5 @@ public class KeepOtherVariantsSyncIT {
         assertThat(productOptional).isNotEmpty();
         final Product fetchedProduct = productOptional.get();
         assertThat(fetchedProduct.getMasterData().getCurrent().getVariants()).hasSize(1);
-
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeSyncIT.java
@@ -12,7 +12,7 @@ import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,7 @@ public class ProductTypeSyncIT {
      * Deletes product types from source and target CTP projects.
      * Populates source and target CTP projects with test data.
      */
-    @Before
+    @BeforeEach
     public void setup() {
         deleteProductTypesFromTargetAndSource();
         populateSourceProject();
@@ -43,7 +43,7 @@ public class ProductTypeSyncIT {
      * Deletes all the test data from the {@code CTP_SOURCE_CLIENT} and the {@code CTP_SOURCE_CLIENT} projects that
      * were set up in this test class.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         deleteProductTypesFromTargetAndSource();
     }

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeSyncIT.java
@@ -10,8 +10,8 @@ import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -26,14 +26,14 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductTypeSyncIT {
+class ProductTypeSyncIT {
 
     /**
      * Deletes product types from source and target CTP projects.
      * Populates source and target CTP projects with test data.
      */
     @BeforeEach
-    public void setup() {
+    void setup() {
         deleteProductTypesFromTargetAndSource();
         populateSourceProject();
         populateTargetProject();
@@ -44,12 +44,12 @@ public class ProductTypeSyncIT {
      * were set up in this test class.
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         deleteProductTypesFromTargetAndSource();
     }
 
     @Test
-    public void sync_WithoutUpdates_ShouldReturnProperStatistics() {
+    void sync_WithoutUpdates_ShouldReturnProperStatistics() {
         // preparation
         final List<ProductType> productTypes = CTP_SOURCE_CLIENT
             .execute(ProductTypeQuery.of())
@@ -90,7 +90,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdates_ShouldReturnProperStatistics() {
+    void sync_WithUpdates_ShouldReturnProperStatistics() {
         // preparation
         final List<ProductType> productTypes = CTP_SOURCE_CLIENT
             .execute(ProductTypeQuery.of())

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/types/TypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/types/TypeSyncIT.java
@@ -9,8 +9,8 @@ import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.queries.TypeQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -25,14 +25,14 @@ import static com.commercetools.sync.integration.commons.utils.TypeITUtils.popul
 import static com.commercetools.sync.integration.commons.utils.TypeITUtils.populateTargetProject;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TypeSyncIT {
+class TypeSyncIT {
 
     /**
      * Deletes types from source and target CTP projects.
      * Populates source and target CTP projects with test data.
      */
     @BeforeEach
-    public void setup() {
+    void setup() {
         deleteTypesFromTargetAndSource();
         populateSourceProject();
         populateTargetProject();
@@ -43,12 +43,12 @@ public class TypeSyncIT {
      * were set up in this test class.
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void sync_WithoutUpdates_ShouldReturnProperStatistics() {
+    void sync_WithoutUpdates_ShouldReturnProperStatistics() {
         // preparation
         final List<Type> types = CTP_SOURCE_CLIENT
             .execute(TypeQuery.of())
@@ -92,7 +92,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdates_ShouldReturnProperStatistics() {
+    void sync_WithUpdates_ShouldReturnProperStatistics() {
         // preparation
         final List<Type> types = CTP_SOURCE_CLIENT
             .execute(TypeQuery.of())

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/types/TypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/types/TypeSyncIT.java
@@ -11,7 +11,7 @@ import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.queries.TypeQuery;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ public class TypeSyncIT {
      * Deletes types from source and target CTP projects.
      * Populates source and target CTP projects with test data.
      */
-    @Before
+    @BeforeEach
     public void setup() {
         deleteTypesFromTargetAndSource();
         populateSourceProject();
@@ -42,7 +42,7 @@ public class TypeSyncIT {
      * Deletes all the test data from the {@code CTP_SOURCE_CLIENT} and the {@code CTP_SOURCE_CLIENT} projects that
      * were set up in this test class.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         deleteTypesFromTargetAndSource();
     }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -19,11 +19,11 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -54,15 +54,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 
-public class CategorySyncIT {
+class CategorySyncIT {
     private CategorySync categorySync;
     private static final String oldCategoryKey = "oldCategoryKey";
 
     /**
      * Delete all categories and types from target project. Then create custom types for target CTP project categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
@@ -72,8 +72,8 @@ public class CategorySyncIT {
     /**
      * Deletes Categories and Types from target CTP project, then it populates it with category test data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         deleteAllCategories(CTP_TARGET_CLIENT);
 
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -94,22 +94,22 @@ public class CategorySyncIT {
     /**
      * Cleans up the target test data that were built in each test.
      */
-    @After
-    public void tearDownTest() {
+    @AfterEach
+    void tearDownTest() {
         deleteAllCategories(CTP_TARGET_CLIENT);
     }
 
     /**
      * Cleans up the entire target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void syncDrafts_WithANewCategoryWithNewSlug_ShouldCreateCategory() {
+    void syncDrafts_WithANewCategoryWithNewSlug_ShouldCreateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture"))
@@ -124,7 +124,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithANewCategoryWithDuplicateSlug_ShouldNotCreateCategory() {
+    void syncDrafts_WithANewCategoryWithDuplicateSlug_ShouldNotCreateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "furniture"))
@@ -139,7 +139,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithCategoryWithNoChanges_ShouldNotUpdateCategory() {
+    void syncDrafts_WithCategoryWithNoChanges_ShouldNotUpdateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"),
@@ -155,7 +155,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithChangedCategory_ShouldUpdateCategory() {
+    void syncDrafts_WithChangedCategory_ShouldUpdateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
@@ -171,7 +171,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewCategoryWithSuccess() {
+    void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewCategoryWithSuccess() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdate();
 
@@ -219,7 +219,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry();
 
@@ -277,7 +277,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry();
 
@@ -334,7 +334,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithNewCategoryWithExistingParent_ShouldCreateCategory() {
+    void syncDrafts_WithNewCategoryWithExistingParent_ShouldCreateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"),
@@ -351,7 +351,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDraft_withARemovedCustomType_ShouldUpdateCategory() {
+    void syncDraft_withARemovedCustomType_ShouldUpdateCategory() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "furniture"))
@@ -365,7 +365,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithMultipleBatchSyncing_ShouldSync() {
+    void syncDrafts_WithMultipleBatchSyncing_ShouldSync() {
         // Existing array of [1, 2, 3, oldCategoryKey]
         final CategoryDraft oldCategoryDraft1 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "cat1"), LocalizedString.of(Locale.ENGLISH, "furniture1"))
@@ -450,7 +450,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithMultipleBatchSyncingWithAlreadyProcessedDrafts_ShouldSync() {
+    void syncDrafts_WithMultipleBatchSyncingWithAlreadyProcessedDrafts_ShouldSync() {
         // Category draft coming from external source.
         CategoryDraft categoryDraft1 = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "new name"),
@@ -485,7 +485,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithOneBatchSyncing_ShouldSync() {
+    void syncDrafts_WithOneBatchSyncing_ShouldSync() {
         final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
 
         // Category draft coming from external source.
@@ -548,7 +548,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithSameSlugDraft_ShouldNotSyncIt() {
+    void syncDrafts_WithSameSlugDraft_ShouldNotSyncIt() {
         final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
 
         // Category draft coming from external source.
@@ -612,7 +612,7 @@ public class CategorySyncIT {
 
 
     @Test
-    public void syncDrafts_WithValidAndInvalidCustomTypeKeys_ShouldSyncCorrectly() {
+    void syncDrafts_WithValidAndInvalidCustomTypeKeys_ShouldSyncCorrectly() {
         final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
         final String newCustomTypeKey = "newKey";
         createCategoriesCustomType(newCustomTypeKey, Locale.ENGLISH, "newCustomTypeName", CTP_TARGET_CLIENT);
@@ -640,7 +640,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithValidCustomFieldsChange_ShouldSyncIt() {
+    void syncDrafts_WithValidCustomFieldsChange_ShouldSyncIt() {
         final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
 
         final Map<String, JsonNode> customFieldsJsons = new HashMap<>();
@@ -666,7 +666,7 @@ public class CategorySyncIT {
     }
 
     @Test
-    public void syncDrafts_WithDraftWithAMissingParentKey_ShouldNotSyncIt() {
+    void syncDrafts_WithDraftWithAMissingParentKey_ShouldNotSyncIt() {
         // Category draft coming from external source.
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "new-furniture"))

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeNameIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeNameIT.java
@@ -7,9 +7,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeName;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -19,14 +19,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeNameIT {
+class ChangeNameIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
 
@@ -43,15 +43,15 @@ public class ChangeNameIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different name
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"),
@@ -70,7 +70,7 @@ public class ChangeNameIT {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of name
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture", Locale.GERMAN, "Möbel"),
@@ -85,7 +85,7 @@ public class ChangeNameIT {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with same name as root
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeOrderHintIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeOrderHintIT.java
@@ -9,10 +9,10 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeOrderHint;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeOrderHintIT {
+class ChangeOrderHintIT {
     private static Category oldCategory;
     private List<String> callBackResponses = new ArrayList<>();
     private CategorySyncOptions categorySyncOptions;
@@ -33,8 +33,8 @@ public class ChangeOrderHintIT {
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
@@ -51,8 +51,8 @@ public class ChangeOrderHintIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
@@ -60,8 +60,8 @@ public class ChangeOrderHintIT {
     /**
      * Cleans the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         callBackResponses = new ArrayList<>();
         categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
                                                         .warningCallback(callBackResponses::add)
@@ -69,7 +69,7 @@ public class ChangeOrderHintIT {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different orderHint
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -88,7 +88,7 @@ public class ChangeOrderHintIT {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same orderHint as root category
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -104,7 +104,7 @@ public class ChangeOrderHintIT {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithNullValue_ShouldTriggerCallback() {
+    void buildChangeOrderHintUpdateAction_WithNullValue_ShouldTriggerCallback() {
         // Prepare new category draft with no orderHint
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
@@ -10,8 +10,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeParent;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeParentIT.java
@@ -12,8 +12,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +25,7 @@ import static com.commercetools.sync.integration.commons.utils.SphereClientUtils
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeParentIT {
+class ChangeParentIT {
     private static Category oldCategory;
     private List<String> callBackResponses = new ArrayList<>();
     private CategorySyncOptions categorySyncOptions;
@@ -35,8 +34,8 @@ public class ChangeParentIT {
      * Deletes Categories and Types from source and target CTP projects, then it populates target CTP project with
      * category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
 
@@ -61,8 +60,8 @@ public class ChangeParentIT {
     /**
      * Cleans the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         callBackResponses = new ArrayList<>();
         categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
                                                         .warningCallback(callBackResponses::add)
@@ -72,14 +71,14 @@ public class ChangeParentIT {
     /**
      * Cleans up the target test data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Create a mock category in the target project under this parent.
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -101,7 +100,7 @@ public class ChangeParentIT {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with the same parent: targetProjectRootCategory
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -118,7 +117,7 @@ public class ChangeParentIT {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithNullValue_ShouldTriggerCallback() {
+    void buildChangeParentUpdateAction_WithNullValue_ShouldTriggerCallback() {
         // Prepare new category draft with no parent
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeSlugIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeSlugIT.java
@@ -7,7 +7,8 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.ChangeSlug;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeSlugIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/ChangeSlugIT.java
@@ -8,8 +8,7 @@ import io.sphere.sdk.categories.commands.updateactions.ChangeSlug;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -19,14 +18,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChangeSlugIT {
+class ChangeSlugIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
 
@@ -42,15 +41,15 @@ public class ChangeSlugIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different slug
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), LocalizedString.of(Locale.ENGLISH, "classic-furniture"))
@@ -67,7 +66,7 @@ public class ChangeSlugIT {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of slug
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(),
@@ -82,7 +81,7 @@ public class ChangeSlugIT {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same slug
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetDescriptionIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetDescriptionIT.java
@@ -7,9 +7,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetDescription;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -19,14 +19,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetDescriptionIT {
+class SetDescriptionIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
@@ -44,15 +44,15 @@ public class SetDescriptionIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different description
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -70,7 +70,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of description
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -86,7 +86,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same description as root category
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -101,7 +101,7 @@ public class SetDescriptionIT {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithNullValue_ShouldTriggerCallback() {
+    void buildSetDescriptionUpdateAction_WithNullValue_ShouldTriggerCallback() {
         // Prepare new category draft with no description
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetExternalIdIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetExternalIdIT.java
@@ -10,8 +10,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,15 +22,15 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetExternalIdIT {
+class SetExternalIdIT {
     private static Category oldCategory;
     private List<String> callBackResponses = new ArrayList<>();
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         final CategoryDraft oldCategoryDraft = CategoryDraftBuilder
@@ -48,8 +47,8 @@ public class SetExternalIdIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
@@ -57,13 +56,13 @@ public class SetExternalIdIT {
     /**
      * Cleans the callback response collector.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         callBackResponses = new ArrayList<>();
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetExternalIdUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different externalId
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())
@@ -82,7 +81,7 @@ public class SetExternalIdIT {
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same externalId as root category
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(oldCategory.getName(), oldCategory.getSlug())

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetExternalIdIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetExternalIdIT.java
@@ -8,8 +8,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetExternalId;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaDescriptionIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaDescriptionIT.java
@@ -8,9 +8,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -20,14 +20,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaDescriptionIT {
+class SetMetaDescriptionIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
 
@@ -48,15 +48,15 @@ public class SetMetaDescriptionIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different MetaDescription
         final CategoryDraft newCategory = CategoryDraftBuilder.of(
             LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -77,7 +77,7 @@ public class SetMetaDescriptionIT {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of MetaDescription
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(
@@ -96,7 +96,7 @@ public class SetMetaDescriptionIT {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same order of locales of MetaDescription
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaKeywordsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaKeywordsIT.java
@@ -7,9 +7,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -19,14 +19,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaKeywordsIT {
+class SetMetaKeywordsIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         // Create a mock old category in the target project.
@@ -47,15 +47,15 @@ public class SetMetaKeywordsIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different MetaKeywords
         final CategoryDraft newCategory = CategoryDraftBuilder.of(
             LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -76,7 +76,7 @@ public class SetMetaKeywordsIT {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of MetaKeywords
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(
@@ -95,7 +95,7 @@ public class SetMetaKeywordsIT {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same order of locales of MetaKeywords
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaTitleIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/updateactionutils/SetMetaTitleIT.java
@@ -8,9 +8,9 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
@@ -20,14 +20,14 @@ import static com.commercetools.sync.integration.commons.utils.ITUtils.deleteTyp
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetMetaTitleIT {
+class SetMetaTitleIT {
     private static Category oldCategory;
 
     /**
      * Deletes Categories and Types from the target CTP projects, then it populates it with category test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
 
@@ -49,15 +49,15 @@ public class SetMetaTitleIT {
     /**
      * Cleans up the target data that was built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         // Prepare new category draft with a different MetaTitle
         final CategoryDraft newCategory = CategoryDraftBuilder.of(
             LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -78,7 +78,7 @@ public class SetMetaTitleIT {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentLocaleOrder_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a different order of locales of MetaTitle
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(
@@ -97,7 +97,7 @@ public class SetMetaTitleIT {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         // Prepare new category draft with a same order of locales of MetaTitle
         final CategoryDraft newCategory = CategoryDraftBuilder
             .of(

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
@@ -8,8 +8,7 @@ import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.types.Type;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -34,7 +33,7 @@ public class CategoryReferenceReplacementUtilsIT {
      * Delete all categories and types from source and target project. Then create custom types for source and target
      * CTP project categories.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
@@ -43,7 +42,7 @@ public class CategoryReferenceReplacementUtilsIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/utils/CategoryReferenceReplacementUtilsIT.java
@@ -7,7 +7,8 @@ import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -27,14 +28,14 @@ import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CategoryReferenceReplacementUtilsIT {
+class CategoryReferenceReplacementUtilsIT {
 
     /**
      * Delete all categories and types from source and target project. Then create custom types for source and target
      * CTP project categories.
      */
     @BeforeAll
-    public static void setup() {
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
@@ -43,13 +44,13 @@ public class CategoryReferenceReplacementUtilsIT {
      * Cleans up the target and source test data that were built in this test class.
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypesFromTargetAndSource();
     }
 
     @Test
-    public void buildCategoryQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
+    void buildCategoryQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
         final CategoryDraft parentDraft = CategoryDraftBuilder.of(ofEnglish("parent"), ofEnglish("parent"))
                                                                 .build();
         final Category parentCategory =

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductReferenceResolverIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductReferenceResolverIT.java
@@ -9,10 +9,10 @@ import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.commons.helpers.BaseReferenceResolver.BLANK_ID_VALUE_ON_RESOURCE_IDENTIFIER;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_NAME;
@@ -39,9 +40,8 @@ import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 
-public class ProductReferenceResolverIT {
+class ProductReferenceResolverIT {
 
     private static ProductType productType;
     private static List<Category> categories;
@@ -49,8 +49,8 @@ public class ProductReferenceResolverIT {
     private List<String> warningCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
             OLD_CATEGORY_CUSTOM_TYPE_NAME, CTP_TARGET_CLIENT);
@@ -58,8 +58,8 @@ public class ProductReferenceResolverIT {
         productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
 
-    @Before
-    public void setupPerTest() {
+    @BeforeEach
+    void setupPerTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
     }
@@ -84,13 +84,13 @@ public class ProductReferenceResolverIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withNewProductWithInvalidCategoryReferences_ShouldFailCreatingTheProduct() {
+    void sync_withNewProductWithInvalidCategoryReferences_ShouldFailCreatingTheProduct() {
         // Create a list of category references that contains one valid and one invalid reference.
         final List<Reference<Category>> invalidCategoryReferences = new ArrayList<>();
         invalidCategoryReferences.add(Category.referenceOfId(categories.get(0).getId()));

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncFilterIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncFilterIT.java
@@ -17,10 +17,10 @@ import io.sphere.sdk.products.commands.updateactions.ChangeName;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.SetCategoryOrderHint;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +54,7 @@ import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncFilterIT {
+class ProductSyncFilterIT {
 
     private static ProductType productType;
     private static List<Reference<Category>> categoryReferencesWithIds;
@@ -69,8 +69,8 @@ public class ProductSyncFilterIT {
      * Delete all product related test data from target project. Then create custom types for the categories and a
      * productType for the products of the target CTP project.
      */
-    @BeforeClass
-    public static void setupAllTests() {
+    @BeforeAll
+    static void setupAllTests() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
                 OLD_CATEGORY_CUSTOM_TYPE_NAME, CTP_TARGET_CLIENT);
@@ -87,8 +87,8 @@ public class ProductSyncFilterIT {
      * {@link ProductSyncOptions} instances.
      * 4. Create a product in the target CTP project.
      */
-    @Before
-    public void setupPerTest() {
+    @BeforeEach
+    void setupPerTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         syncOptionsBuilder = getProductSyncOptionsBuilder();
@@ -124,13 +124,13 @@ public class ProductSyncFilterIT {
                                         .beforeUpdateCallback(actionsCallBack);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withChangedProductBlackListingCategories_shouldUpdateProductWithoutCategories() {
+    void sync_withChangedProductBlackListingCategories_shouldUpdateProductWithoutCategories() {
         final ProductDraft productDraft =
                 createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH, referenceOfId(productType.getKey()), null,
                     null, categoryReferencesWithKeys, createRandomCategoryOrderHints(categoryReferencesWithKeys));
@@ -155,7 +155,7 @@ public class ProductSyncFilterIT {
     }
 
     @Test
-    public void sync_withChangedProductWhiteListingName_shouldOnlyUpdateProductName() {
+    void sync_withChangedProductWhiteListingName_shouldOnlyUpdateProductName() {
         final ProductDraft productDraft =
                 createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH, referenceOfId(productType.getKey()), null,
                     null, categoryReferencesWithKeys, createRandomCategoryOrderHints(categoryReferencesWithKeys));

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
@@ -37,10 +37,10 @@ import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateType;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -86,7 +86,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class ProductSyncIT {
+class ProductSyncIT {
     private static ProductType productType;
     private static TaxCategory targetTaxCategory;
     private static State targetProductState;
@@ -104,8 +104,8 @@ public class ProductSyncIT {
      * Delete all product related test data from the target project. Then creates for the target CTP project price
      * a product type, a tax category, 2 categories, custom types for the categories and a product state.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
             OLD_CATEGORY_CUSTOM_TYPE_NAME, CTP_TARGET_CLIENT);
@@ -128,8 +128,8 @@ public class ProductSyncIT {
      * Deletes Products and Types from the target CTP project, then it populates target CTP project with product test
      * data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         syncOptions = buildSyncOptions();
@@ -156,13 +156,13 @@ public class ProductSyncIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withNewProduct_shouldCreateProduct() {
+    void sync_withNewProduct_shouldCreateProduct() {
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             ProductType.referenceOfId(productType.getKey()))
             .taxCategory(null)
@@ -179,7 +179,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withNewProductAndBeforeCreateCallback_shouldCreateProduct() {
+    void sync_withNewProductAndBeforeCreateCallback_shouldCreateProduct() {
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
                 ProductType.referenceOfId(productType.getKey()))
                 .taxCategory(null)
@@ -224,7 +224,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withNewProductWithExistingSlug_shouldNotCreateProduct() {
+    void sync_withNewProductWithExistingSlug_shouldNotCreateProduct() {
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             ProductType.referenceOfId(productType.getKey()))
             .taxCategory(null)
@@ -271,7 +271,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withEqualProduct_shouldNotUpdateProduct() {
+    void sync_withEqualProduct_shouldNotUpdateProduct() {
         final ProductDraft productDraft =
             createProductDraft(PRODUCT_KEY_1_RESOURCE_PATH, ProductType.referenceOfId(productType.getKey()),
                 TaxCategory.referenceOfId(targetTaxCategory.getKey()), State.referenceOfId(targetProductState.getKey()),
@@ -288,7 +288,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withChangedProduct_shouldUpdateProduct() {
+    void sync_withChangedProduct_shouldUpdateProduct() {
         final ProductDraft productDraft =
             createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH, ProductType.referenceOfId(productType.getKey()),
                 TaxCategory.referenceOfId(targetTaxCategory.getKey()), State.referenceOfId(targetProductState.getKey()),
@@ -305,7 +305,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withChangedProductButConcurrentModificationException_shouldRetryAndUpdateProduct() {
+    void sync_withChangedProductButConcurrentModificationException_shouldRetryAndUpdateProduct() {
         // preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdate();
 
@@ -345,7 +345,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
         // preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry();
 
@@ -397,7 +397,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
         // preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry();
 
@@ -448,7 +448,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withMultipleBatchSyncing_ShouldSync() {
+    void sync_withMultipleBatchSyncing_ShouldSync() {
         // Prepare existing products with keys: productKey1, productKey2, productKey3.
         final ProductDraft key2Draft = createProductDraft(PRODUCT_KEY_2_RESOURCE_PATH,
             productType.toReference(), targetTaxCategory.toReference(), targetProductState.toReference(),
@@ -516,7 +516,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withSingleBatchSyncing_ShouldSync() {
+    void sync_withSingleBatchSyncing_ShouldSync() {
         // Prepare batches from external source
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             ProductType.referenceOfId(productType.getKey()), TaxCategory.referenceOfId(targetTaxCategory.getKey()),
@@ -584,7 +584,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withSameSlugInSingleBatch_ShouldNotSyncIt() {
+    void sync_withSameSlugInSingleBatch_ShouldNotSyncIt() {
         // Prepare batches from external source
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             ProductType.referenceOfId(productType.getKey()), TaxCategory.referenceOfId(targetTaxCategory.getKey()),
@@ -675,7 +675,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withADraftsWithBlankKeysInBatch_ShouldNotSyncItAndTriggerErrorCallBack() {
+    void sync_withADraftsWithBlankKeysInBatch_ShouldNotSyncItAndTriggerErrorCallBack() {
         // Prepare batches from external source
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             ProductType.reference(productType.getKey()), TaxCategory.referenceOfId(targetTaxCategory.getKey()),
@@ -725,7 +725,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withANullDraftInBatch_ShouldNotSyncItAndTriggerErrorCallBack() {
+    void sync_withANullDraftInBatch_ShouldNotSyncItAndTriggerErrorCallBack() {
         // Prepare batches from external source
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             ProductType.reference(productType.getKey()), null, null,
@@ -746,7 +746,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withSameDraftsWithChangesInBatch_ShouldRetryUpdateBecauseOfConcurrentModificationExceptions() {
+    void sync_withSameDraftsWithChangesInBatch_ShouldRetryUpdateBecauseOfConcurrentModificationExceptions() {
         // Prepare batches from external source
         final ProductDraft productDraft = createProductDraft(PRODUCT_KEY_1_CHANGED_RESOURCE_PATH,
             ProductType.reference(productType.getKey()), null, null,
@@ -778,7 +778,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withProductBundle_shouldCreateProductReferencingExistingProduct() {
+    void sync_withProductBundle_shouldCreateProductReferencingExistingProduct() {
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             ProductType.referenceOfId(productType.getKey()))
             .taxCategory(null)
@@ -814,7 +814,7 @@ public class ProductSyncIT {
     }
 
     @Test
-    public void sync_withProductContainingAttributeChanges_shouldSyncProductCorrectly() {
+    void sync_withProductContainingAttributeChanges_shouldSyncProductCorrectly() {
         // preparation
         final List<UpdateAction<Product>> updateActions = new ArrayList<>();
         final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithAssetsIT.java
@@ -29,10 +29,10 @@ import io.sphere.sdk.products.commands.updateactions.SetAssetCustomType;
 import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.types.Type;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -62,7 +62,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncWithAssetsIT {
+class ProductSyncWithAssetsIT {
     private static final String ASSETS_CUSTOM_TYPE_KEY = "assetsCustomTypeKey";
 
     private static ProductType productType;
@@ -79,8 +79,8 @@ public class ProductSyncWithAssetsIT {
      * Delete all product related test data from the target project. Then creates for the target CTP project a product
      * type and an asset custom type.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         assetsCustomType = createAssetsCustomType(ASSETS_CUSTOM_TYPE_KEY, Locale.ENGLISH,
             "assetsCustomTypeName", CTP_TARGET_CLIENT);
@@ -92,8 +92,8 @@ public class ProductSyncWithAssetsIT {
      * Deletes Products and Types from the target CTP project, then it populates target CTP project with product test
      * data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         productSync = new ProductSync(buildSyncOptions());
@@ -140,13 +140,13 @@ public class ProductSyncWithAssetsIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withNewProductWithAssets_shouldCreateProduct() {
+    void sync_withNewProductWithAssets_shouldCreateProduct() {
         final List<AssetDraft> assetDrafts =
             singletonList(createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY));
 
@@ -175,7 +175,7 @@ public class ProductSyncWithAssetsIT {
     }
 
     @Test
-    public void sync_withNewProductWithAssetsWithDuplicateKeys_shouldNotCreateProductAndTriggerErrorCallback() {
+    void sync_withNewProductWithAssetsWithDuplicateKeys_shouldNotCreateProductAndTriggerErrorCallback() {
         final List<AssetDraft> assetDrafts = asList(
             createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
             createAssetDraft("4", ofEnglish("duplicate asset"), ASSETS_CUSTOM_TYPE_KEY));
@@ -211,7 +211,7 @@ public class ProductSyncWithAssetsIT {
     }
 
     @Test
-    public void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
+    void sync_withMatchingProductWithAssetChanges_shouldUpdateProduct() {
 
         final Map<String, JsonNode> customFieldsJsonMap = new HashMap<>();
         customFieldsJsonMap.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(true));
@@ -269,7 +269,7 @@ public class ProductSyncWithAssetsIT {
     }
 
     @Test
-    public void sync_withMatchingProductWithNewVariantWithAssets_shouldUpdateAddAssetsToNewVariant() {
+    void sync_withMatchingProductWithNewVariantWithAssets_shouldUpdateAddAssetsToNewVariant() {
 
         final Map<String, JsonNode> customFieldsJsonMap = new HashMap<>();
         customFieldsJsonMap.put(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(true));
@@ -335,7 +335,7 @@ public class ProductSyncWithAssetsIT {
     }
 
     @Test
-    public void sync_withMatchingProductWithDuplicateAssets_shouldFailToUpdateProductAndTriggerErrorCallback() {
+    void sync_withMatchingProductWithDuplicateAssets_shouldFailToUpdateProductAndTriggerErrorCallback() {
         final List<AssetDraft> assetDrafts = asList(
             createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),
             createAssetDraft("4", ofEnglish("4"), ASSETS_CUSTOM_TYPE_KEY),

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -31,10 +31,10 @@ import io.sphere.sdk.products.queries.ProductProjectionByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
@@ -93,7 +93,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncWithPricesIT {
+class ProductSyncWithPricesIT {
     private static ProductType productType;
     private static Type customType1;
     private static Type customType2;
@@ -112,8 +112,8 @@ public class ProductSyncWithPricesIT {
      * Delete all product related test data from the target project. Then creates price custom types, customer groups,
      * channels and a product type for the target CTP project.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
 
         customType1 = createPricesCustomType("customType1", Locale.ENGLISH,
@@ -134,8 +134,8 @@ public class ProductSyncWithPricesIT {
     /**
      * Deletes Products from the target CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         productSync = new ProductSync(buildSyncOptions());
@@ -168,13 +168,13 @@ public class ProductSyncWithPricesIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildUpdateActions() {
+    void sync_withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildUpdateActions() {
         // Preparation
         final ProductDraft existingProductDraft = ProductDraftBuilder
             .of(productType.toReference(), ofEnglish("draftName"), ofEnglish("existingSlug"),
@@ -211,7 +211,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void sync_withAllMatchingPrices_ShouldNotBuildActions() {
+    void sync_withAllMatchingPrices_ShouldNotBuildActions() {
         // Preparation
         final List<PriceDraft> oldPrices = asList(
             DRAFT_US_111_USD,
@@ -254,7 +254,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void withNonEmptyNewPricesButEmptyExistingPrices_ShouldAddAllNewPrices() {
+    void withNonEmptyNewPricesButEmptyExistingPrices_ShouldAddAllNewPrices() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_US_111_USD,
@@ -306,7 +306,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void withNonEmptyNewWithDuplicatesPricesButEmptyExistingPrices_ShouldNotSyncPrices() {
+    void withNonEmptyNewWithDuplicatesPricesButEmptyExistingPrices_ShouldNotSyncPrices() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_US_111_USD,
@@ -369,7 +369,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void sync_withNullNewPrices_ShouldRemoveAllPrices() {
+    void sync_withNullNewPrices_ShouldRemoveAllPrices() {
         // Preparation
         final List<PriceDraft> oldPrices = asList(
             DRAFT_US_111_USD,
@@ -422,7 +422,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void sync_withSomeChangedMatchingPrices_ShouldAddAndRemovePrices() {
+    void sync_withSomeChangedMatchingPrices_ShouldAddAndRemovePrices() {
         // Preparation
         final List<PriceDraft> oldPrices = asList(
             DRAFT_DE_111_EUR,
@@ -496,7 +496,7 @@ public class ProductSyncWithPricesIT {
     }
 
     @Test
-    public void withMixedCasesOfPriceMatches_ShouldBuildActions() {
+    void withMixedCasesOfPriceMatches_ShouldBuildActions() {
         // Preparation
         createExistingProductWithPrices();
         final ProductDraft newProductDraft = createProductDraftWithNewPrices();
@@ -721,7 +721,7 @@ public class ProductSyncWithPricesIT {
      * @param prices      the list of prices to compare to the list of price drafts.
      * @param priceDrafts the list of price drafts to compare to the list of prices.
      */
-    public static void assertPricesAreEqual(@Nonnull final List<Price> prices,
+    static void assertPricesAreEqual(@Nonnull final List<Price> prices,
                                             @Nonnull final List<PriceDraft> priceDrafts) {
 
         final Map<PriceCompositeId, Price> priceMap = collectionToMap(prices, PriceCompositeId::of);

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/SyncSingleLocaleIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/SyncSingleLocaleIT.java
@@ -22,10 +22,10 @@ import io.sphere.sdk.products.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.products.queries.ProductProjectionQuery;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +50,7 @@ import static io.sphere.sdk.producttypes.ProductType.referenceOfId;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SyncSingleLocaleIT {
+class SyncSingleLocaleIT {
     private static ProductType productType;
     private ProductSync productSync;
     private List<String> errorCallBackMessages;
@@ -62,8 +62,8 @@ public class SyncSingleLocaleIT {
      * Delete all product related test data from the target project. Then creates price custom types, customer groups,
      * channels and a product type for the target CTP project.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
@@ -71,8 +71,8 @@ public class SyncSingleLocaleIT {
     /**
      * Deletes Products from the target CTP project.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
         productSync = new ProductSync(buildSyncOptions());
@@ -108,13 +108,13 @@ public class SyncSingleLocaleIT {
                                         .build();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_withSingleLocaleBeforeUpdateCallback_ShouldSyncCorrectly() {
+    void sync_withSingleLocaleBeforeUpdateCallback_ShouldSyncCorrectly() {
         // Preparation
         final LocalizedString nameTarget = ofEnglish("name_target").plus(Locale.FRENCH, "nom_target");
         final LocalizedString nameSource = ofEnglish("name_source").plus(Locale.FRENCH, "nom_source");

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
@@ -15,8 +15,9 @@ import io.sphere.sdk.products.commands.updateactions.MoveImageToPosition;
 import io.sphere.sdk.products.commands.updateactions.RemoveImage;
 import io.sphere.sdk.products.queries.ProductByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/BuildProductVariantImageUpdateActionsIT.java
@@ -17,8 +17,7 @@ import io.sphere.sdk.products.queries.ProductByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -37,7 +36,7 @@ import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class BuildProductVariantImageUpdateActionsIT {
+class BuildProductVariantImageUpdateActionsIT {
     private static final String DRAFTS_ROOT = "com/commercetools/sync/integration/externalsource/products/"
         + "utils/imageUpdateActions/";
     private static final String PRODUCT_WITH_IMAGES_1_2_3 = DRAFTS_ROOT + "draftWithMVImages-1-2-3.json";
@@ -57,22 +56,22 @@ public class BuildProductVariantImageUpdateActionsIT {
      * Delete all product related test data from target and source projects. Then creates product types in both
      * CTP projects.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     /**
      * Create old product from the draft.
      */
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         clearSyncTestCollections();
         deleteAllProducts(CTP_TARGET_CLIENT);
 
@@ -107,7 +106,7 @@ public class BuildProductVariantImageUpdateActionsIT {
     }
 
     @Test
-    public void sync_WithNullImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
+    void sync_WithNullImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
         assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_NULL_IMAGES, PRODUCT_WITH_NULL_IMAGES);
 
     }
@@ -147,12 +146,12 @@ public class BuildProductVariantImageUpdateActionsIT {
     }
 
     @Test
-    public void sync_WithEmptyImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
+    void sync_WithEmptyImageLists_ShouldNotBuildImageUpdateActionAndSyncCorrectly() {
         assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_EMPTY_IMAGES, PRODUCT_WITH_EMPTY_IMAGES);
     }
 
     @Test
-    public void sync_WithNullNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithNullNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
         // Prepare existing product before sync.
         final ProductDraft oldProductDraft =
             ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))
@@ -184,7 +183,7 @@ public class BuildProductVariantImageUpdateActionsIT {
     }
 
     @Test
-    public void sync_WithEmptyNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithEmptyNewImageList_ShouldBuildRemoveImageUpdateActionsAndSyncCorrectly() {
         assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_IMAGES_1_2_3,
             PRODUCT_WITH_EMPTY_IMAGES, RemoveImage.class);
 
@@ -225,24 +224,24 @@ public class BuildProductVariantImageUpdateActionsIT {
     }
 
     @Test
-    public void sync_WithNullOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithNullOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
         assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_NULL_IMAGES,
             PRODUCT_WITH_IMAGES_1_2_3, AddExternalImage.class);
     }
 
     @Test
-    public void sync_WithEmpyOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithEmpyOldImageList_ShouldBuildAddExternalImageUpdateActionsAndSyncCorrectly() {
         assertProductSyncShouldBuildRemoveImageUpdateActions(PRODUCT_WITH_EMPTY_IMAGES,
             PRODUCT_WITH_IMAGES_1_2_3, AddExternalImage.class);
     }
 
     @Test
-    public void sync_WithIdenticalNonNullImageLists_ShouldNotBuildImageUpdateActions() {
+    void sync_WithIdenticalNonNullImageLists_ShouldNotBuildImageUpdateActions() {
         assertProductSyncShouldNotBuildImageUpdateActions(PRODUCT_WITH_IMAGES_1_2_3, PRODUCT_WITH_IMAGES_1_2_3);
     }
 
     @Test
-    public void sync_WithDifferentImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithDifferentImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
         // Prepare existing product before sync.
         final ProductDraft oldProductDraft =
             ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))
@@ -280,7 +279,7 @@ public class BuildProductVariantImageUpdateActionsIT {
     }
 
     @Test
-    public void sync_WithDifferentOrderedImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
+    void sync_WithDifferentOrderedImageLists_ShouldBuildImageUpdateActionsAndSyncCorrectly() {
         // Prepare existing product before sync.
         final ProductDraft oldProductDraft =
             ProductDraftBuilder.of(readObjectFromResource(PRODUCT_WITH_IMAGES_1_2_3, ProductDraft.class))

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -30,8 +30,7 @@ import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.utils.MoneyImpl;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -66,25 +65,25 @@ import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductReferenceReplacementUtilsIT {
+class ProductReferenceReplacementUtilsIT {
     /**
      * Delete all product related test data from the target project.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     /**
      * Delete all product related test data from the target project.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void buildProductQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
+    void buildProductQuery_Always_ShouldFetchProductWithAllExpandedReferences() {
         final ProductType productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
         final TaxCategory taxCategory = createTaxCategory(CTP_TARGET_CLIENT);
         final State state = createState(CTP_TARGET_CLIENT, StateType.PRODUCT_STATE);

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductReferenceReplacementUtilsIT.java
@@ -29,7 +29,8 @@ import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.utils.MoneyImpl;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
@@ -14,20 +14,21 @@ import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.queries.ProductByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
-import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ProductUpdateActionUtilsIT {

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/utils/ProductUpdateActionUtilsIT.java
@@ -16,8 +16,7 @@ import io.sphere.sdk.products.queries.ProductByKeyGet;
 import io.sphere.sdk.producttypes.ProductType;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +30,7 @@ import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductUpdateActionUtilsIT {
+class ProductUpdateActionUtilsIT {
 
     private static final String DRAFTS_ROOT = "com/commercetools/sync/integration/externalsource/products/utils/";
     private static final String NEW_PRODUCT = DRAFTS_ROOT + "productDraftNewIT.json";
@@ -43,22 +42,22 @@ public class ProductUpdateActionUtilsIT {
      * Delete all product related test data from target and source projects. Then creates custom types for both
      * CTP projects categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         targetProductType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     /**
      * Create old product from the draft.
      */
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         ProductDraft productDraftOld = SphereJsonUtils.readObjectFromResource(OLD_PRODUCT, ProductDraft.class);
         ProductDraft productDraft = ProductDraftBuilder.of(productDraftOld)
             .productType(ResourceIdentifier.ofKey(targetProductType.getKey()))
@@ -67,7 +66,7 @@ public class ProductUpdateActionUtilsIT {
     }
 
     @Test
-    public void buildVariantsUpdateActions_shouldUpdateVariants() {
+    void buildVariantsUpdateActions_shouldUpdateVariants() {
         final List<String> errors = new ArrayList<>();
         final List<String> warnings = new ArrayList<>();
 

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -29,9 +29,9 @@ import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
 import io.sphere.sdk.producttypes.commands.ProductTypeUpdateCommand;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -68,14 +68,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeSyncIT {
+class ProductTypeSyncIT {
 
     /**
      * Deletes product types from the target CTP project.
      * Populates target CTP project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteProductTypes(CTP_TARGET_CLIENT);
         populateTargetProject();
     }
@@ -84,13 +84,13 @@ public class ProductTypeSyncIT {
      * Deletes all the test data from the {@code CTP_TARGET_CLIENT} project that
      * were set up in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void sync_WithUpdatedProductType_ShouldUpdateProductType() {
+    void sync_WithUpdatedProductType_ShouldUpdateProductType() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_1,
@@ -124,7 +124,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithNewProductType_ShouldCreateProductType() {
+    void sync_WithNewProductType_ShouldCreateProductType() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_2,
@@ -159,7 +159,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedProductType_WithNewAttribute_ShouldUpdateProductTypeAddingAttribute() {
+    void sync_WithUpdatedProductType_WithNewAttribute_ShouldUpdateProductTypeAddingAttribute() {
         // preparation
         // Adding ATTRIBUTE_DEFINITION_DRAFT_3
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
@@ -193,7 +193,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedProductType_WithoutOldAttribute_ShouldUpdateProductTypeRemovingAttribute() {
+    void sync_WithUpdatedProductType_WithoutOldAttribute_ShouldUpdateProductTypeRemovingAttribute() {
         // Removing ATTRIBUTE_DEFINITION_DRAFT_2
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_1,
@@ -222,7 +222,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedProductType_ChangingAttributeOrder_ShouldUpdateProductTypeChangingAttributeOrder() {
+    void sync_WithUpdatedProductType_ChangingAttributeOrder_ShouldUpdateProductTypeChangingAttributeOrder() {
         // Changing order from ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2 to
         // ATTRIBUTE_DEFINITION_DRAFT_2, ATTRIBUTE_DEFINITION_DRAFT_1
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
@@ -255,7 +255,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedAttributeDefinition_ShouldUpdateProductTypeUpdatingAttribute() {
+    void sync_WithUpdatedAttributeDefinition_ShouldUpdateProductTypeUpdatingAttribute() {
         // Updating ATTRIBUTE_DEFINITION_1 (name = "attr_name_1") changing the label, attribute constraint, input tip,
         // input hint, isSearchable fields.
         final AttributeDefinitionDraft attributeDefinitionDraftUpdated = AttributeDefinitionDraftBuilder
@@ -298,7 +298,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutKey_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutKey_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // Draft without key throws an error
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             null,
@@ -340,7 +340,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithNullDraft_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithNullDraft_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = null;
         final List<String> errorMessages = new ArrayList<>();
@@ -376,7 +376,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithErrorCreatingTheProductType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorCreatingTheProductType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
 
         // Invalid attribute definition due to having the same name as an already existing one but different
@@ -431,7 +431,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithErrorUpdatingTheProductType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorUpdatingTheProductType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
 
         // Invalid attribute definition due to having an invalid name.
@@ -484,7 +484,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutName_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutName_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         // Draft without "name" throws a commercetools exception because "name" is a required value
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
@@ -531,7 +531,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutAttributeType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutAttributeType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(
@@ -590,7 +590,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewProductTypeWithSuccess() {
+    void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewProductTypeWithSuccess() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdate();
 
@@ -644,7 +644,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry();
 
@@ -708,7 +708,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
+    void syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry();
 
@@ -771,7 +771,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithSeveralBatches_ShouldReturnProperStatistics() {
+    void sync_WithSeveralBatches_ShouldReturnProperStatistics() {
         // Default batch size is 50 (check ProductTypeSyncOptionsBuilder) so we have 2 batches of 50
         final List<ProductTypeDraft> productTypeDrafts = IntStream
             .range(0, 100)
@@ -797,7 +797,7 @@ public class ProductTypeSyncIT {
     }
 
     @Test
-    public void sync_WithSetOfEnumsAndSetOfLenumsChanges_ShouldUpdateProductType() {
+    void sync_WithSetOfEnumsAndSetOfLenumsChanges_ShouldUpdateProductType() {
         // preparation
         final AttributeDefinitionDraft withSetOfEnumsOld = AttributeDefinitionDraftBuilder
             .of(

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/types/TypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/types/TypeSyncIT.java
@@ -25,9 +25,9 @@ import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.TypeCreateCommand;
 import io.sphere.sdk.types.commands.TypeUpdateCommand;
 import io.sphere.sdk.types.queries.TypeQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -66,14 +66,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 
-public class TypeSyncIT {
+class TypeSyncIT {
 
     /**
      * Deletes types from the target CTP projects.
      * Populates the target CTP project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteTypes(CTP_TARGET_CLIENT);
         populateTargetProject();
     }
@@ -82,14 +82,14 @@ public class TypeSyncIT {
      * Deletes all the test data from the {@code CTP_SOURCE_CLIENT} and the {@code CTP_SOURCE_CLIENT} projects that
      * were set up in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
 
     @Test
-    public void sync_WithUpdatedType_ShouldUpdateType() {
+    void sync_WithUpdatedType_ShouldUpdateType() {
         // preparation
         final Optional<Type> oldTypeBefore = getTypeByKey(CTP_TARGET_CLIENT, TYPE_KEY_1);
         assertThat(oldTypeBefore).isNotEmpty();
@@ -129,7 +129,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithNewType_ShouldCreateType() {
+    void sync_WithNewType_ShouldCreateType() {
         //preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 TYPE_KEY_2,
@@ -165,7 +165,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedType_WithNewFieldDefinitions_ShouldUpdateTypeAddingFieldDefinition() {
+    void sync_WithUpdatedType_WithNewFieldDefinitions_ShouldUpdateTypeAddingFieldDefinition() {
         //preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 TYPE_KEY_1,
@@ -199,7 +199,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedType_WithoutOldFieldDefinition_ShouldUpdateTypeRemovingFieldDefinition() {
+    void sync_WithUpdatedType_WithoutOldFieldDefinition_ShouldUpdateTypeRemovingFieldDefinition() {
         final Optional<Type> oldTypeBefore = getTypeByKey(CTP_TARGET_CLIENT, TYPE_KEY_1);
         assertThat(oldTypeBefore).isNotEmpty();
 
@@ -230,7 +230,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedType_ChangingFieldDefinitionOrder_ShouldUpdateTypeChangingFieldDefinitionOrder() {
+    void sync_WithUpdatedType_ChangingFieldDefinitionOrder_ShouldUpdateTypeChangingFieldDefinitionOrder() {
         //preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 TYPE_KEY_1,
@@ -262,7 +262,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithUpdatedType_WithUpdatedFieldDefinition_ShouldUpdateTypeUpdatingFieldDefinition() {
+    void sync_WithUpdatedType_WithUpdatedFieldDefinition_ShouldUpdateTypeUpdatingFieldDefinition() {
         //preparation
         final FieldDefinition fieldDefinitionUpdated = FieldDefinition.of(
                 StringFieldType.of(),
@@ -301,7 +301,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutKey_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutKey_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 null,
                 TYPE_NAME_1,
@@ -344,7 +344,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithNullDraft_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithNullDraft_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         //preparation
         final TypeDraft newTypeDraft = null;
         final List<String> errorMessages = new ArrayList<>();
@@ -381,7 +381,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutName_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutName_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         // Draft without "name" throws a commercetools exception because "name" is a required value
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
@@ -430,7 +430,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithoutFieldDefinitionType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithoutFieldDefinitionType_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         //preparation
         final FieldDefinition fieldDefinition = FieldDefinition.of(
                 null,
@@ -485,7 +485,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithSeveralBatches_ShouldReturnProperStatistics() {
+    void sync_WithSeveralBatches_ShouldReturnProperStatistics() {
         // preparation
         // Default batch size is 50 (check TypeSyncOptionsBuilder) so we have 2 batches of 50
         final List<TypeDraft> typeDrafts = IntStream
@@ -571,7 +571,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithConcurrentModificationException_ShouldRetryToUpdateNewTypeWithSuccess() {
+    void sync_WithConcurrentModificationException_ShouldRetryToUpdateNewTypeWithSuccess() {
         // Preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdate();
 
@@ -622,7 +622,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
+    void sync_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
         //preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry();
 
@@ -686,7 +686,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync__WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
+    void sync__WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
         //preparation
         final SphereClient spyClient = buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry();
 
@@ -748,7 +748,7 @@ public class TypeSyncIT {
     }
 
     @Test
-    public void sync_WithSetOfEnumsAndSetOfLenumsChanges_ShouldUpdateTypeAddingFieldDefinition() {
+    void sync_WithSetOfEnumsAndSetOfLenumsChanges_ShouldUpdateTypeAddingFieldDefinition() {
         //preparation
         final FieldDefinition withSetOfEnumsOld = FieldDefinition.of(
             SetFieldType.of(

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
@@ -14,10 +14,10 @@ import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.inventory.expansion.InventoryEntryExpansionModel;
 import io.sphere.sdk.inventory.queries.InventoryEntryQuery;
 import io.sphere.sdk.models.Reference;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -58,14 +58,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Contains integration tests of inventory sync.
  */
-public class InventorySyncIT {
+class InventorySyncIT {
 
     /**
      * Deletes inventories and supply channels from source and target CTP projects.
      * Populates source and target CTP projects with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
@@ -77,15 +77,15 @@ public class InventorySyncIT {
      * Deletes all the test data from the {@code CTP_SOURCE_CLIENT} and the {@code CTP_SOURCE_CLIENT} projects that
      * were set up in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
     }
 
     @Test
-    public void sync_WithUpdatedInventory_ShouldUpdateInventory() {
+    void sync_WithUpdatedInventory_ShouldUpdateInventory() {
         //Ensure that old entry has correct values before sync.
         final Optional<InventoryEntry> oldInventoryBeforeSync =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);
@@ -111,7 +111,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithNewInventory_ShouldCreateInventory() {
+    void sync_WithNewInventory_ShouldCreateInventory() {
         //Ensure that old entry has correct values before sync.
         final Optional<InventoryEntry> oldInventoryBeforeSync =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_2, null);
@@ -136,7 +136,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithExpandedReferenceToExistingSupplyChannel_ShouldUpdateInventory() {
+    void sync_WithExpandedReferenceToExistingSupplyChannel_ShouldUpdateInventory() {
         //Fetch existing Channel of key SUPPLY_CHANNEL_KEY_1 from target project.
         final Optional<Channel> supplyChannel = getChannelByKey(CTP_TARGET_CLIENT, SUPPLY_CHANNEL_KEY_1);
         assertThat(supplyChannel).isNotEmpty();
@@ -167,7 +167,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithKeyToExistingSupplyChannelInPlaceOfReferenceId_ShouldUpdateInventory() {
+    void sync_WithKeyToExistingSupplyChannelInPlaceOfReferenceId_ShouldUpdateInventory() {
         /*
          * Fetch existing Channel of key SUPPLY_CHANNEL_KEY_1 from target project.
          * This is done only for test assertion reasons, not necessary for sync.
@@ -208,7 +208,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithNewSupplyChannelAndChannelsEnsured_ShouldCreateNewSupplyChannel() {
+    void sync_WithNewSupplyChannelAndChannelsEnsured_ShouldCreateNewSupplyChannel() {
         //Ensure that supply channel doesn't exist before sync.
         final Optional<Channel> oldSupplyChannelBeforeSync = getChannelByKey(CTP_TARGET_CLIENT, SUPPLY_CHANNEL_KEY_2);
         assertThat(oldSupplyChannelBeforeSync).isEmpty();
@@ -234,7 +234,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithExpandedReferencesToSourceChannels_ShouldUpdateInventoriesWithoutChannelCreation() {
+    void sync_WithExpandedReferencesToSourceChannels_ShouldUpdateInventoriesWithoutChannelCreation() {
         //Ensure channels in target project before sync
         final ChannelQuery targetChannelsQuery = ChannelQuery.of().withPredicates(channelQueryModel ->
                 channelQueryModel.roles().containsAny(singletonList(ChannelRole.INVENTORY_SUPPLY)));
@@ -283,7 +283,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_FromSourceToTargetProjectWithChannelsEnsured_ShouldReturnProperStatistics() {
+    void sync_FromSourceToTargetProjectWithChannelsEnsured_ShouldReturnProperStatistics() {
         //Fetch new inventories from source project. Convert them to drafts.
         final List<InventoryEntry> inventoryEntries = CTP_SOURCE_CLIENT.execute(
             InventoryEntryQuery.of()
@@ -307,7 +307,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_FromSourceToTargetWithoutChannelsEnsured_ShouldReturnProperStatistics() {
+    void sync_FromSourceToTargetWithoutChannelsEnsured_ShouldReturnProperStatistics() {
         //Fetch new inventories from source project. Convert them to drafts.
         final List<InventoryEntry> inventoryEntries = CTP_SOURCE_CLIENT
             .execute(InventoryEntryQuery.of()
@@ -326,9 +326,9 @@ public class InventorySyncIT {
         assertThat(inventorySyncStatistics).hasValues(3, 0, 1, 1);
     }
 
-    @Ignore
+    @Disabled
     @Test
-    public void sync_WithBatchProcessing_ShouldCreateAllGivenInventories() {
+    void sync_WithBatchProcessing_ShouldCreateAllGivenInventories() {
         //Ensure inventory entries amount in target project before sync.
         final List<InventoryEntry> oldEntriesBeforeSync = CTP_TARGET_CLIENT.execute(InventoryEntryQuery.of())
             .toCompletableFuture().join().getResults();
@@ -355,7 +355,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_ShouldReturnProperStatisticsObject() {
+    void sync_ShouldReturnProperStatisticsObject() {
         //Fetch new inventories from source project. Convert them to drafts.
         final List<InventoryEntry> inventoryEntries = CTP_SOURCE_CLIENT
             .execute(InventoryEntryQuery.of()
@@ -376,7 +376,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithCustomErrorCallback_ShouldExecuteCallbackOnError() {
+    void sync_WithCustomErrorCallback_ShouldExecuteCallbackOnError() {
         //Fetch new inventories from source project. Convert them to drafts.
         final List<InventoryEntry> inventoryEntries = CTP_SOURCE_CLIENT
             .execute(InventoryEntryQuery.of()
@@ -401,7 +401,7 @@ public class InventorySyncIT {
     }
 
     @Test
-    public void sync_WithSyncDifferentBatchesConcurrently_ShouldReturnProperStatistics() {
+    void sync_WithSyncDifferentBatchesConcurrently_ShouldReturnProperStatistics() {
         //Prepare new inventories.
         final List<InventoryEntryDraft> newDrafts = IntStream.range(100,160)
             .mapToObj(i -> InventoryEntryDraftBuilder.of(String.valueOf(i), QUANTITY_ON_STOCK_1).build())

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventoryUpdateActionUtilsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventoryUpdateActionUtilsIT.java
@@ -14,9 +14,9 @@ import io.sphere.sdk.inventory.commands.InventoryEntryUpdateCommand;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.CustomFieldsDraftBuilder;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +43,7 @@ import static com.commercetools.sync.inventories.utils.InventoryUpdateActionUtil
 import static com.commercetools.sync.inventories.utils.InventoryUpdateActionUtils.buildSetSupplyChannelAction;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InventoryUpdateActionUtilsIT {
+class InventoryUpdateActionUtilsIT {
 
     private static final String CUSTOM_FIELD_VALUE = "custom-value-1";
 
@@ -51,8 +51,8 @@ public class InventoryUpdateActionUtilsIT {
      * Deletes inventories and supply channels from source and target CTP projects.
      * Populates target CTP projects with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
@@ -63,15 +63,15 @@ public class InventoryUpdateActionUtilsIT {
      * Deletes all the test data from the {@code CTP_SOURCE_CLIENT} and the {@code CTP_SOURCE_CLIENT} projects that
      * were set up in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
     }
 
     @Test
-    public void buildChangeQuantityAction_ShouldBuildActionThatUpdatesQuantity() {
+    void buildChangeQuantityAction_ShouldBuildActionThatUpdatesQuantity() {
         //Fetch old inventory and ensure its quantity on stock.
         final Optional<InventoryEntry> oldEntryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);
@@ -98,7 +98,7 @@ public class InventoryUpdateActionUtilsIT {
     }
 
     @Test
-    public void buildSetRestockableInDaysAction_ShouldBuildActionThatUpdatesRestockableInDays() {
+    void buildSetRestockableInDaysAction_ShouldBuildActionThatUpdatesRestockableInDays() {
         //Fetch old inventory and ensure its restockable in days.
         final Optional<InventoryEntry> oldEntryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);
@@ -125,7 +125,7 @@ public class InventoryUpdateActionUtilsIT {
     }
 
     @Test
-    public void buildSetExpectedDeliveryAction_ShouldBuildActionThatUpdatesExpectedDelivery() {
+    void buildSetExpectedDeliveryAction_ShouldBuildActionThatUpdatesExpectedDelivery() {
         //Fetch old inventory and ensure its expected delivery.
         final Optional<InventoryEntry> oldEntryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);
@@ -152,7 +152,7 @@ public class InventoryUpdateActionUtilsIT {
     }
 
     @Test
-    public void buildSetSupplyChannelAction_ShouldBuildActionThatUpdatesSupplyChannel() {
+    void buildSetSupplyChannelAction_ShouldBuildActionThatUpdatesSupplyChannel() {
         //Fetch old inventory and ensure it has no supply channel.
         final Optional<InventoryEntry> oldInventoryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);
@@ -187,7 +187,7 @@ public class InventoryUpdateActionUtilsIT {
     }
 
     @Test
-    public void buildCustomUpdateActions_ShouldBuildActionThatSetCustomField() {
+    void buildCustomUpdateActions_ShouldBuildActionThatSetCustomField() {
         //Fetch old inventory and ensure it has custom fields.
         final Optional<InventoryEntry> oldInventoryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/CategoryServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/CategoryServiceImplIT.java
@@ -20,10 +20,10 @@ import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.utils.CompletableFutureUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CategoryServiceImplIT {
+class CategoryServiceImplIT {
     private CategoryService categoryService;
     private Category oldCategory;
     private static final String oldCategoryKey = "oldCategoryKey";
@@ -64,8 +64,8 @@ public class CategoryServiceImplIT {
     /**
      * Delete all categories and types from target project. Then create custom types for target CTP project categories.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH, "anyName", CTP_TARGET_CLIENT);
@@ -75,8 +75,8 @@ public class CategoryServiceImplIT {
      * Deletes Categories and Types from target CTP projects, then it populates target CTP project with category test
      * data.
      */
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
         warningCallBackMessages = new ArrayList<>();
@@ -113,14 +113,14 @@ public class CategoryServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteAllCategories(CTP_TARGET_CLIENT);
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void cacheKeysToIds_ShouldCacheCategoryKeysOnlyFirstTime() {
+    void cacheKeysToIds_ShouldCacheCategoryKeysOnlyFirstTime() {
         Map<String, String> cache = categoryService.cacheKeysToIds().toCompletableFuture().join();
         assertThat(cache).hasSize(1);
 
@@ -141,7 +141,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void cacheKeysToIds_WithTargetCategoriesWithNoKeys_ShouldGiveAWarningAboutKeyNotSetAndNotCacheKey() {
+    void cacheKeysToIds_WithTargetCategoriesWithNoKeys_ShouldGiveAWarningAboutKeyNotSetAndNotCacheKey() {
         // Create new category without key
         final CategoryDraft categoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "classic furniture"),
@@ -161,7 +161,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingCategoriesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
+    void fetchMatchingCategoriesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
         final Set<Category> fetchedCategories = categoryService.fetchMatchingCategoriesByKeys(Collections.emptySet())
                                                                .toCompletableFuture().join();
         assertThat(fetchedCategories).isEmpty();
@@ -170,7 +170,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingCategoriesByKeys_WithAllExistingSetOfKeys_ShouldReturnSetOfCategories() {
+    void fetchMatchingCategoriesByKeys_WithAllExistingSetOfKeys_ShouldReturnSetOfCategories() {
         final Set<String> keys =  new HashSet<>();
         keys.add(oldCategoryKey);
         final Set<Category> fetchedCategories = categoryService.fetchMatchingCategoriesByKeys(keys)
@@ -181,7 +181,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingCategoriesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
+    void fetchMatchingCategoriesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         when(spyClient.execute(any(CategoryQuery.class)))
@@ -211,7 +211,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingCategoriesByKeys_WithSomeExistingSetOfKeys_ShouldReturnSetOfCategories() {
+    void fetchMatchingCategoriesByKeys_WithSomeExistingSetOfKeys_ShouldReturnSetOfCategories() {
         final Set<String> keys =  new HashSet<>();
         keys.add(oldCategoryKey);
         keys.add("new-key");
@@ -223,7 +223,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCategoryId_WithNonExistingCategory_ShouldNotFetchACategory() {
+    void fetchCachedCategoryId_WithNonExistingCategory_ShouldNotFetchACategory() {
         final Optional<String> categoryId = categoryService.fetchCachedCategoryId("non-existing-category-key")
                                                            .toCompletableFuture()
                                                            .join();
@@ -233,7 +233,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCategoryId_WithExistingCategory_ShouldFetchCategoryAndCache() {
+    void fetchCachedCategoryId_WithExistingCategory_ShouldFetchCategoryAndCache() {
         final Optional<String> categoryId = categoryService.fetchCachedCategoryId(oldCategory.getKey())
                                                            .toCompletableFuture()
                                                            .join();
@@ -243,7 +243,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCategoryId_ShouldCacheCategoryKeysOnlyFirstTime() {
+    void fetchCachedCategoryId_ShouldCacheCategoryKeysOnlyFirstTime() {
         // Fetch any category to populate cache
         categoryService.fetchCachedCategoryId("anyKey").toCompletableFuture().join();
 
@@ -266,7 +266,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCategoryId_WithBlankKey_ShouldReturnFutureContainingEmptyOptional() {
+    void fetchCachedCategoryId_WithBlankKey_ShouldReturnFutureContainingEmptyOptional() {
         // test
         final Optional<String> result = categoryService.fetchCachedCategoryId("").toCompletableFuture().join();
 
@@ -277,7 +277,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void createCategory_WithValidCategory_ShouldCreateCategoryAndCacheId() {
+    void createCategory_WithValidCategory_ShouldCreateCategoryAndCacheId() {
         // preparation
         final String newCategoryKey = "newCategoryKey";
         final CategoryDraft categoryDraft = CategoryDraftBuilder
@@ -334,7 +334,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void createCategory_WithBlankKey_ShouldNotCreateCategory() {
+    void createCategory_WithBlankKey_ShouldNotCreateCategory() {
         // preparation
         final String newCategoryKey = "";
         final CategoryDraft categoryDraft = CategoryDraftBuilder
@@ -356,7 +356,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void createCategory_WithDuplicateSlug_ShouldNotCreateCategory() {
+    void createCategory_WithDuplicateSlug_ShouldNotCreateCategory() {
         // preparation
         final String newCategoryKey = "newCat";
         final CategoryDraft categoryDraft = CategoryDraftBuilder
@@ -410,7 +410,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void updateCategory_WithValidChanges_ShouldUpdateCategoryCorrectly() {
+    void updateCategory_WithValidChanges_ShouldUpdateCategoryCorrectly() {
         final Optional<Category> categoryOptional = CTP_TARGET_CLIENT
             .execute(CategoryQuery
                 .of()
@@ -445,7 +445,7 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void updateCategory_WithInvalidChanges_ShouldNotUpdateCategory() {
+    void updateCategory_WithInvalidChanges_ShouldNotUpdateCategory() {
         // Create a mock new category in the target project.
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(Locale.ENGLISH, "furniture"), LocalizedString.of(Locale.ENGLISH, "furniture1"))
@@ -497,28 +497,28 @@ public class CategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCategory_WithExistingCategoryKey_ShouldFetchCategory() {
+    void fetchCategory_WithExistingCategoryKey_ShouldFetchCategory() {
         final Optional<Category> fetchedCategoryOptional =
             executeBlocking(categoryService.fetchCategory(oldCategoryKey));
         assertThat(fetchedCategoryOptional).contains(oldCategory);
     }
 
     @Test
-    public void fetchCategory_WithBlankKey_ShouldNotFetchCategory() {
+    void fetchCategory_WithBlankKey_ShouldNotFetchCategory() {
         final Optional<Category> fetchedCategoryOptional =
             executeBlocking(categoryService.fetchCategory(StringUtils.EMPTY));
         assertThat(fetchedCategoryOptional).isEmpty();
     }
 
     @Test
-    public void fetchCategory_WithNullKey_ShouldNotFetchCategory() {
+    void fetchCategory_WithNullKey_ShouldNotFetchCategory() {
         final Optional<Category> fetchedCategoryOptional =
             executeBlocking(categoryService.fetchCategory(null));
         assertThat(fetchedCategoryOptional).isEmpty();
     }
 
     @Test
-    public void fetchCategory_WithBadGateWayExceptionAlways_ShouldFail() {
+    void fetchCategory_WithBadGateWayExceptionAlways_ShouldFail() {
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         when(spyClient.execute(any(CategoryQuery.class)))

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/ChannelServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/ChannelServiceImplIT.java
@@ -10,9 +10,9 @@ import io.sphere.sdk.channels.ChannelDraftBuilder;
 import io.sphere.sdk.channels.ChannelRole;
 import io.sphere.sdk.channels.commands.ChannelCreateCommand;
 import io.sphere.sdk.channels.queries.ChannelQuery;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -24,7 +24,7 @@ import static com.commercetools.sync.integration.inventories.utils.InventoryITUt
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChannelServiceImplIT {
+class ChannelServiceImplIT {
     private ChannelService channelService;
     private static final String CHANNEL_KEY = "channel_key";
 
@@ -32,8 +32,8 @@ public class ChannelServiceImplIT {
      * Deletes inventories and supply channels from source and target CTP projects.
      * Populates target CTP project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
@@ -46,15 +46,15 @@ public class ChannelServiceImplIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
     }
 
     @Test
-    public void fetchCachedChannelId_WithNonExistingChannel_ShouldNotFetchAChannel() {
+    void fetchCachedChannelId_WithNonExistingChannel_ShouldNotFetchAChannel() {
         Optional<String> channelId = channelService.fetchCachedChannelId(CHANNEL_KEY)
                                                    .toCompletableFuture()
                                                    .join();
@@ -62,7 +62,7 @@ public class ChannelServiceImplIT {
     }
 
     @Test
-    public void fetchCachedChannelId_WithExistingChannel_ShouldFetchChannelAndCache() {
+    void fetchCachedChannelId_WithExistingChannel_ShouldFetchChannelAndCache() {
         final ChannelDraft draft = ChannelDraftBuilder.of(CHANNEL_KEY)
                                                       .roles(singleton(ChannelRole.INVENTORY_SUPPLY))
                                                       .build();
@@ -71,7 +71,7 @@ public class ChannelServiceImplIT {
     }
 
     @Test
-    public void fetchCachedChannelId_WithNewlyCreatedChannelAfterCaching_ShouldNotFetchNewChannel() {
+    void fetchCachedChannelId_WithNewlyCreatedChannelAfterCaching_ShouldNotFetchNewChannel() {
         // Fetch any channel to populate cache
         channelService.fetchCachedChannelId("anyChannelKey").toCompletableFuture().join();
 
@@ -89,7 +89,7 @@ public class ChannelServiceImplIT {
     }
 
     @Test
-    public void createChannel_ShouldCreateChannel() {
+    void createChannel_ShouldCreateChannel() {
         final String newChannelKey = "new_channel_key";
         final Channel result = channelService.createChannel(newChannelKey)
                                              .toCompletableFuture()
@@ -109,7 +109,7 @@ public class ChannelServiceImplIT {
     }
 
     @Test
-    public void createAndCacheChannel_ShouldCreateChannelAndCacheIt() {
+    void createAndCacheChannel_ShouldCreateChannelAndCacheIt() {
         final String newChannelKey = "new_channel_key";
         final Channel result = channelService.createAndCacheChannel(newChannelKey)
                                              .toCompletableFuture()

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomerGroupServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomerGroupServiceImplIT.java
@@ -8,9 +8,9 @@ import io.sphere.sdk.customergroups.CustomerGroup;
 import io.sphere.sdk.customergroups.CustomerGroupDraft;
 import io.sphere.sdk.customergroups.CustomerGroupDraftBuilder;
 import io.sphere.sdk.customergroups.commands.CustomerGroupCreateCommand;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -23,7 +23,7 @@ import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CustomerGroupServiceImplIT {
+class CustomerGroupServiceImplIT {
     private CustomerGroupService customerGroupService;
     private static final String CUSTOMER_GROUP_KEY = "customerGroup_key";
     private static final String CUSTOMER_GROUP_NAME = "customerGroup_name";
@@ -34,8 +34,8 @@ public class CustomerGroupServiceImplIT {
     /**
      * Deletes customer group from the target CTP projects, then it populates the project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteCustomerGroups(CTP_TARGET_CLIENT);
         warnings = new ArrayList<>();
         oldCustomerGroup = createCustomerGroup(CTP_TARGET_CLIENT, CUSTOMER_GROUP_NAME, CUSTOMER_GROUP_KEY);
@@ -48,13 +48,13 @@ public class CustomerGroupServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteCustomerGroups(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void fetchCachedCustomerGroupId_WithNonExistingCustomerGroup_ShouldNotFetchACustomerGroup() {
+    void fetchCachedCustomerGroupId_WithNonExistingCustomerGroup_ShouldNotFetchACustomerGroup() {
         final Optional<String> customerGroupId = customerGroupService.fetchCachedCustomerGroupId("nonExistingKey")
                                                                      .toCompletableFuture()
                                                                      .join();
@@ -62,7 +62,7 @@ public class CustomerGroupServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCustomerGroupId_WithExistingCustomerGroup_ShouldFetchCustomerGroupAndCache() {
+    void fetchCachedCustomerGroupId_WithExistingCustomerGroup_ShouldFetchCustomerGroupAndCache() {
         final Optional<String> customerGroupId = customerGroupService
             .fetchCachedCustomerGroupId(oldCustomerGroup.getKey())
             .toCompletableFuture()
@@ -72,7 +72,7 @@ public class CustomerGroupServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCustomerGroupId_OnSecondTime_ShouldNotFindCustomerGroupInCache() {
+    void fetchCachedCustomerGroupId_OnSecondTime_ShouldNotFindCustomerGroupInCache() {
         // Fetch any key to populate cache
         customerGroupService.fetchCachedCustomerGroupId("anyKey").toCompletableFuture().join();
 
@@ -92,7 +92,7 @@ public class CustomerGroupServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCustomerGroupId_WithNullKey_ShouldReturnFutureWithEmptyOptional() {
+    void fetchCachedCustomerGroupId_WithNullKey_ShouldReturnFutureWithEmptyOptional() {
         final Optional<String> customerGroupId = customerGroupService.fetchCachedCustomerGroupId(null)
                                                                      .toCompletableFuture()
                                                                      .join();
@@ -102,7 +102,7 @@ public class CustomerGroupServiceImplIT {
     }
 
     @Test
-    public void fetchCachedCustomerGroupId_WithExistingCustomerGroupWithNullKey_ShouldReturnFutureWithEmptyOptional() {
+    void fetchCachedCustomerGroupId_WithExistingCustomerGroupWithNullKey_ShouldReturnFutureWithEmptyOptional() {
         // Create new customerGroup
         final CustomerGroupDraft customerGroupDraft = CustomerGroupDraftBuilder.of("name")
                                                                                .build();

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/InventoryServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/InventoryServiceImplIT.java
@@ -9,9 +9,9 @@ import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.inventory.commands.updateactions.ChangeQuantity;
 import io.sphere.sdk.inventory.commands.updateactions.SetExpectedDelivery;
 import io.sphere.sdk.inventory.commands.updateactions.SetRestockableInDays;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +36,7 @@ import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InventoryServiceImplIT {
+class InventoryServiceImplIT {
 
     private InventoryService inventoryService;
 
@@ -44,8 +44,8 @@ public class InventoryServiceImplIT {
      * Deletes inventories and supply channels from source and target CTP projects.
      * Populates target CTP project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
@@ -56,15 +56,15 @@ public class InventoryServiceImplIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteInventoryEntriesFromTargetAndSource();
         deleteTypesFromTargetAndSource();
         deleteChannelsFromTargetAndSource();
     }
 
     @Test
-    public void fetchInventoryEntriesBySku_ShouldReturnCorrectInventoryEntriesWithoutReferenceExpansion() {
+    void fetchInventoryEntriesBySku_ShouldReturnCorrectInventoryEntriesWithoutReferenceExpansion() {
         final Set<String> skus = singleton(SKU_1);
         final List<InventoryEntry> result = inventoryService.fetchInventoryEntriesBySkus(skus)
                                                             .toCompletableFuture()
@@ -85,7 +85,7 @@ public class InventoryServiceImplIT {
     }
 
     @Test
-    public void createInventoryEntry_ShouldCreateCorrectInventoryEntry() {
+    void createInventoryEntry_ShouldCreateCorrectInventoryEntry() {
         //prepare draft and create
         final InventoryEntryDraft inventoryEntryDraft = InventoryEntryDraftBuilder
             .of(SKU_2, QUANTITY_ON_STOCK_2, EXPECTED_DELIVERY_2, RESTOCKABLE_IN_DAYS_2, null)
@@ -107,7 +107,7 @@ public class InventoryServiceImplIT {
     }
 
     @Test
-    public void updateInventoryEntry_ShouldUpdateInventoryEntry() {
+    void updateInventoryEntry_ShouldUpdateInventoryEntry() {
         //fetch existing inventory entry and assert its state
         final Optional<InventoryEntry> existingEntryOptional =
             getInventoryEntryBySkuAndSupplyChannel(CTP_TARGET_CLIENT, SKU_1, null);

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductServiceImplIT.java
@@ -28,10 +28,10 @@ import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.queries.QueryPredicate;
 import io.sphere.sdk.utils.CompletableFutureUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,7 +89,7 @@ public class ProductServiceImplIT {
      * Delete all product related test data from target project. Then creates custom types for target CTP project
      * categories.
      */
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
@@ -103,7 +103,7 @@ public class ProductServiceImplIT {
      * Deletes Products and Types from target CTP projects, then it populates target CTP project with product test
      * data.
      */
-    @Before
+    @BeforeEach
     public void setupTest() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
@@ -136,7 +136,7 @@ public class ProductServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductServiceImplIT.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductServiceImplIT {
+class ProductServiceImplIT {
     private ProductService productService;
     private static ProductType productType;
     private static List<Reference<Category>> categoryReferencesWithIds;
@@ -90,7 +90,7 @@ public class ProductServiceImplIT {
      * categories.
      */
     @BeforeAll
-    public static void setup() {
+    static void setup() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
         createCategoriesCustomType(OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH,
             OLD_CATEGORY_CUSTOM_TYPE_NAME, CTP_TARGET_CLIENT);
@@ -104,7 +104,7 @@ public class ProductServiceImplIT {
      * data.
      */
     @BeforeEach
-    public void setupTest() {
+    void setupTest() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
         warningCallBackMessages = new ArrayList<>();
@@ -137,12 +137,12 @@ public class ProductServiceImplIT {
      * Cleans up the target test data that were built in this test class.
      */
     @AfterAll
-    public static void tearDown() {
+    static void tearDown() {
         deleteProductSyncTestData(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void getIdFromCacheOrFetch_WithNotCachedExistingProduct_ShouldFetchProduct() {
+    void getIdFromCacheOrFetch_WithNotCachedExistingProduct_ShouldFetchProduct() {
         final Optional<String> productId = productService.getIdFromCacheOrFetch(product.getKey())
                                                          .toCompletableFuture()
                                                          .join();
@@ -152,7 +152,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void getIdFromCacheOrFetch_WithNullProductKey_ShouldReturnEmptyOptional() {
+    void getIdFromCacheOrFetch_WithNullProductKey_ShouldReturnEmptyOptional() {
         final Optional<String> productId = productService.getIdFromCacheOrFetch(null)
                                                          .toCompletableFuture()
                                                          .join();
@@ -162,7 +162,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void getIdFromCacheOrFetch_WithCachedExistingProduct_ShouldFetchFromCache() {
+    void getIdFromCacheOrFetch_WithCachedExistingProduct_ShouldFetchFromCache() {
         final String oldKey = product.getKey();
         final Optional<String> oldProductId = productService.getIdFromCacheOrFetch(oldKey)
                                                             .toCompletableFuture()
@@ -194,7 +194,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void cacheKeysToIds_WithEmptyKeys_ShouldReturnCurrentCache() {
+    void cacheKeysToIds_WithEmptyKeys_ShouldReturnCurrentCache() {
         Map<String, String> cache = productService.cacheKeysToIds(emptySet()).toCompletableFuture().join();
         assertThat(cache).hasSize(0); // Since cache is empty
 
@@ -209,7 +209,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void cacheKeysToIds_WithAlreadyCachedKeys_ShouldNotMakeRequestsAndReturnCurrentCache() {
+    void cacheKeysToIds_WithAlreadyCachedKeys_ShouldNotMakeRequestsAndReturnCurrentCache() {
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(spyClient)
                                                                                .errorCallback(
@@ -242,7 +242,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void cacheKeysToIds_WithSomeEmptyKeys_ShouldReturnCorrectCache() {
+    void cacheKeysToIds_WithSomeEmptyKeys_ShouldReturnCorrectCache() {
         final Set<String> productKeys = new HashSet<>();
         productKeys.add(product.getKey());
         productKeys.add(null);
@@ -255,7 +255,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductsByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
+    void fetchMatchingProductsByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
         final Set<Product> fetchedProducts = productService.fetchMatchingProductsByKeys(Collections.emptySet())
                                                            .toCompletableFuture().join();
         assertThat(fetchedProducts).isEmpty();
@@ -264,7 +264,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductsByKeys_WithAllExistingSetOfKeys_ShouldReturnSetOfProducts() {
+    void fetchMatchingProductsByKeys_WithAllExistingSetOfKeys_ShouldReturnSetOfProducts() {
         final Set<Product> fetchedProducts = productService.fetchMatchingProductsByKeys(singleton(product.getKey()))
                                                            .toCompletableFuture().join();
         assertThat(fetchedProducts).hasSize(1);
@@ -273,7 +273,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductsByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
+    void fetchMatchingProductsByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
         // preparation
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
@@ -302,7 +302,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductsByKeys_WithSomeExistingSetOfKeys_ShouldReturnSetOfProducts() {
+    void fetchMatchingProductsByKeys_WithSomeExistingSetOfKeys_ShouldReturnSetOfProducts() {
         final Set<String> keys =  new HashSet<>();
         keys.add(product.getKey());
         keys.add("new-key");
@@ -314,7 +314,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductsByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedProductsIds() {
+    void fetchMatchingProductsByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedProductsIds() {
         final String oldKey = product.getKey();
         final Set<Product> fetchedProducts = productService.fetchMatchingProductsByKeys(singleton(oldKey))
                                                            .toCompletableFuture().join();
@@ -337,7 +337,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void createProduct_WithValidProduct_ShouldCreateProductAndCacheId() {
+    void createProduct_WithValidProduct_ShouldCreateProductAndCacheId() {
         // preparation
         final ProductDraft productDraft1 = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             productType.toReference())
@@ -391,7 +391,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void createProduct_WithBlankKey_ShouldNotCreateProduct() {
+    void createProduct_WithBlankKey_ShouldNotCreateProduct() {
         // preparation
         final String newKey = "";
         final ProductDraft productDraft1 = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
@@ -416,7 +416,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void createProduct_WithDuplicateSlug_ShouldNotCreateProduct() {
+    void createProduct_WithDuplicateSlug_ShouldNotCreateProduct() {
         // Create product with same slug as existing product
         final String newKey = "newKey";
         final ProductDraft productDraft1 = createProductDraftBuilder(PRODUCT_KEY_1_RESOURCE_PATH,
@@ -475,7 +475,7 @@ public class ProductServiceImplIT {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    public void updateProduct_WithValidChanges_ShouldUpdateProductCorrectly() {
+    void updateProduct_WithValidChanges_ShouldUpdateProductCorrectly() {
         final String newProductName = "This is my new name!";
         final ChangeName changeNameUpdateAction = ChangeName
             .of(LocalizedString.of(Locale.GERMAN, newProductName));
@@ -504,7 +504,7 @@ public class ProductServiceImplIT {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    public void updateProduct_WithInvalidChanges_ShouldNotUpdateProduct() {
+    void updateProduct_WithInvalidChanges_ShouldNotUpdateProduct() {
         final ProductDraft productDraft1 = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             productType.toReference())
             .categories(emptyList())
@@ -557,7 +557,7 @@ public class ProductServiceImplIT {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    public void updateProduct_WithMoreThan500Actions_ShouldNotFail() {
+    void updateProduct_WithMoreThan500Actions_ShouldNotFail() {
         // Update the product 501 times with a different name every time.
         final int numberOfUpdateActions = 501;
         final List<UpdateAction<Product>> updateActions =
@@ -588,7 +588,7 @@ public class ProductServiceImplIT {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    public void updateProduct_WithMoreThan500ImageAdditions_ShouldHaveAllNewImages() {
+    void updateProduct_WithMoreThan500ImageAdditions_ShouldHaveAllNewImages() {
         final Integer productMasterVariantId = product.getMasterData().getStaged().getMasterVariant().getId();
 
         // Update the product by adding 600 images in separate update actions
@@ -625,7 +625,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchProduct_WithExistingKey_ShouldReturnProduct() {
+    void fetchProduct_WithExistingKey_ShouldReturnProduct() {
         final Optional<Product> fetchedProductOptional = productService.fetchProduct(product.getKey())
                                                                        .toCompletableFuture()
                                                                        .join();
@@ -636,7 +636,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchProduct_WithNonExistingKey_ShouldNotReturnProduct() {
+    void fetchProduct_WithNonExistingKey_ShouldNotReturnProduct() {
         final Optional<Product> fetchedProductOptional = productService.fetchProduct("someNonExistingKey")
                                                                        .toCompletableFuture()
                                                                        .join();
@@ -646,7 +646,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchProduct_WithNullKey_ShouldNotReturnProduct() {
+    void fetchProduct_WithNullKey_ShouldNotReturnProduct() {
         final Optional<Product> fetchedProductOptional = productService.fetchProduct(null)
                                                                        .toCompletableFuture()
                                                                        .join();
@@ -656,7 +656,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchProduct_WithBlankKey_ShouldNotReturnProduct() {
+    void fetchProduct_WithBlankKey_ShouldNotReturnProduct() {
         final Optional<Product> fetchedProductOptional = productService.fetchProduct(StringUtils.EMPTY)
                                                                        .toCompletableFuture()
                                                                        .join();
@@ -666,7 +666,7 @@ public class ProductServiceImplIT {
     }
 
     @Test
-    public void fetchProduct_WithBadGatewayException_ShouldFail() {
+    void fetchProduct_WithBadGatewayException_ShouldFail() {
         // preparation
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductTypeServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/ProductTypeServiceImplIT.java
@@ -15,9 +15,9 @@ import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
 import io.sphere.sdk.producttypes.commands.updateactions.SetKey;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeServiceImplIT {
+class ProductTypeServiceImplIT {
     private ProductTypeService productTypeService;
     private static final String OLD_PRODUCT_TYPE_KEY = "old_product_type_key";
     private static final String OLD_PRODUCT_TYPE_NAME = "old_product_type_name";
@@ -57,8 +57,8 @@ public class ProductTypeServiceImplIT {
     /**
      * Deletes product types from the target CTP project, then it populates the project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
 
@@ -72,13 +72,13 @@ public class ProductTypeServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteProductTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void fetchCachedProductTypeId_WithNonExistingProductType_ShouldNotFetchAProductType() {
+    void fetchCachedProductTypeId_WithNonExistingProductType_ShouldNotFetchAProductType() {
         final Optional<String> productTypeId = productTypeService.fetchCachedProductTypeId("non-existing-type-key")
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -86,7 +86,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchCachedProductTypeId_WithExistingProductType_ShouldFetchProductTypeAndCache() {
+    void fetchCachedProductTypeId_WithExistingProductType_ShouldFetchProductTypeAndCache() {
         final Optional<String> productTypeId = productTypeService.fetchCachedProductTypeId(OLD_PRODUCT_TYPE_KEY)
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -94,7 +94,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchCachedProductAttributeMetaDataMap_WithMetadataCache_ShouldReturnAnyAttributeMetadata() {
+    void fetchCachedProductAttributeMetaDataMap_WithMetadataCache_ShouldReturnAnyAttributeMetadata() {
         final Optional<String> productTypeId = productTypeService.fetchCachedProductTypeId(OLD_PRODUCT_TYPE_KEY)
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -110,7 +110,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchCachedProductAttributeMetaDataMap_WithoutMetadataCache_ShouldReturnAnyAttributeMetadata() {
+    void fetchCachedProductAttributeMetaDataMap_WithoutMetadataCache_ShouldReturnAnyAttributeMetadata() {
         final Optional<ProductType> productTypeOptional = CTP_TARGET_CLIENT
             .execute(ProductTypeQuery.of().byKey(OLD_PRODUCT_TYPE_KEY))
             .toCompletableFuture()
@@ -129,7 +129,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductTypesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
+    void fetchMatchingProductTypesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
         final Set<String> typeKeys = new HashSet<>();
         final Set<ProductType> matchingProductTypes = productTypeService.fetchMatchingProductTypesByKeys(typeKeys)
                                                                         .toCompletableFuture()
@@ -141,7 +141,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductTypesByKeys_WithNonExistingKeys_ShouldReturnEmptySet() {
+    void fetchMatchingProductTypesByKeys_WithNonExistingKeys_ShouldReturnEmptySet() {
         final Set<String> typeKeys = new HashSet<>();
         typeKeys.add("type_key_1");
         typeKeys.add("type_key_2");
@@ -156,7 +156,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductTypesByKeys_WithAnyExistingKeys_ShouldReturnASetOfProductTypes() {
+    void fetchMatchingProductTypesByKeys_WithAnyExistingKeys_ShouldReturnASetOfProductTypes() {
         final Set<String> typeKeys = new HashSet<>();
         typeKeys.add(OLD_PRODUCT_TYPE_KEY);
 
@@ -171,7 +171,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductTypesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
+    void fetchMatchingProductTypesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         when(spyClient.execute(any(ProductTypeQuery.class)))
@@ -200,7 +200,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingProductTypesByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedProductTypeIds() {
+    void fetchMatchingProductTypesByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedProductTypeIds() {
         final Set<ProductType> fetchedProductTypes = productTypeService.fetchMatchingProductTypesByKeys(
             singleton(OLD_PRODUCT_TYPE_KEY))
                                                                        .toCompletableFuture().join();
@@ -230,7 +230,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void createProductType_WithValidProductType_ShouldCreateProductTypeAndCacheId() {
+    void createProductType_WithValidProductType_ShouldCreateProductTypeAndCacheId() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_1,
@@ -277,7 +277,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void createProductType_WithInvalidProductType_ShouldHaveEmptyOptionalAsAResult() {
+    void createProductType_WithInvalidProductType_ShouldHaveEmptyOptionalAsAResult() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             "",
@@ -307,7 +307,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void createProductType_WithDuplicateKey_ShouldHaveEmptyOptionalAsAResult() {
+    void createProductType_WithDuplicateKey_ShouldHaveEmptyOptionalAsAResult() {
         //preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             OLD_PRODUCT_TYPE_KEY,
@@ -354,7 +354,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void updateProductType_WithValidChanges_ShouldUpdateProductTypeCorrectly() {
+    void updateProductType_WithValidChanges_ShouldUpdateProductTypeCorrectly() {
         final Optional<ProductType> productTypeOptional = CTP_TARGET_CLIENT
             .execute(ProductTypeQuery.of()
                                      .withPredicates(productTypeQueryModel -> productTypeQueryModel.key().is(
@@ -384,7 +384,7 @@ public class ProductTypeServiceImplIT {
     }
 
     @Test
-    public void updateProductType_WithInvalidChanges_ShouldCompleteExceptionally() {
+    void updateProductType_WithInvalidChanges_ShouldCompleteExceptionally() {
         final Optional<ProductType> typeOptional = CTP_TARGET_CLIENT
             .execute(ProductTypeQuery
                 .of()

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/StateServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/StateServiceImplIT.java
@@ -9,9 +9,9 @@ import io.sphere.sdk.states.StateDraft;
 import io.sphere.sdk.states.StateDraftBuilder;
 import io.sphere.sdk.states.StateType;
 import io.sphere.sdk.states.commands.StateCreateCommand;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -22,7 +22,7 @@ import static com.commercetools.sync.integration.commons.utils.StateITUtils.dele
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StateServiceImplIT {
+class StateServiceImplIT {
     private static final StateType STATE_TYPE = StateType.PRODUCT_STATE;
 
     private State oldState;
@@ -32,8 +32,8 @@ public class StateServiceImplIT {
     /**
      * Deletes states from the target CTP projects, then it populates the project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteStates(CTP_TARGET_CLIENT, STATE_TYPE);
         warnings = new ArrayList<>();
         oldState = createState(CTP_TARGET_CLIENT, STATE_TYPE);
@@ -46,13 +46,13 @@ public class StateServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteStates(CTP_TARGET_CLIENT, STATE_TYPE);
     }
 
     @Test
-    public void fetchCachedStateId_WithNonExistingState_ShouldNotFetchAState() {
+    void fetchCachedStateId_WithNonExistingState_ShouldNotFetchAState() {
         final Optional<String> stateId = stateService.fetchCachedStateId("non-existing-state-key")
                                                      .toCompletableFuture()
                                                      .join();
@@ -61,7 +61,7 @@ public class StateServiceImplIT {
     }
 
     @Test
-    public void fetchCachedStateId_WithExistingState_ShouldFetchStateAndCache() {
+    void fetchCachedStateId_WithExistingState_ShouldFetchStateAndCache() {
         final Optional<String> stateId = stateService.fetchCachedStateId(oldState.getKey())
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -70,7 +70,7 @@ public class StateServiceImplIT {
     }
 
     @Test
-    public void fetchCachedStateId_OnSecondTime_ShouldNotFindStateInCache() {
+    void fetchCachedStateId_OnSecondTime_ShouldNotFindStateInCache() {
         // Fetch any key to populate cache
         stateService.fetchCachedStateId("anyKey").toCompletableFuture().join();
 
@@ -90,7 +90,7 @@ public class StateServiceImplIT {
     }
 
     @Test
-    public void fetchCachedStateId_WithNullKey_ShouldReturnFutureWithEmptyOptional() {
+    void fetchCachedStateId_WithNullKey_ShouldReturnFutureWithEmptyOptional() {
         final Optional<String> stateId = stateService.fetchCachedStateId(null)
                                                      .toCompletableFuture()
                                                      .join();

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/TaxCategoryServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/TaxCategoryServiceImplIT.java
@@ -8,9 +8,9 @@ import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.taxcategories.TaxCategoryDraft;
 import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
 import io.sphere.sdk.taxcategories.commands.TaxCategoryCreateCommand;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -24,7 +24,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TaxCategoryServiceImplIT {
+class TaxCategoryServiceImplIT {
     private TaxCategoryService taxCategoryService;
     private TaxCategory oldTaxCategory;
     private ArrayList<String> warnings;
@@ -32,8 +32,8 @@ public class TaxCategoryServiceImplIT {
     /**
      * Deletes tax categories from the target CTP projects, then it populates target CTP project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         deleteTaxCategories(CTP_TARGET_CLIENT);
         warnings = new ArrayList<>();
         oldTaxCategory = createTaxCategory(CTP_TARGET_CLIENT);
@@ -46,13 +46,13 @@ public class TaxCategoryServiceImplIT {
     /**
      * Cleans up the target and source test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteTaxCategories(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void fetchCachedTaxCategoryId_WithNonExistingTaxCategory_ShouldNotFetchATaxCategory() {
+    void fetchCachedTaxCategoryId_WithNonExistingTaxCategory_ShouldNotFetchATaxCategory() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId("non-existing-key")
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -61,7 +61,7 @@ public class TaxCategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedTaxCategoryId_WithExistingTaxCategory_ShouldFetchProductTypeAndCache() {
+    void fetchCachedTaxCategoryId_WithExistingTaxCategory_ShouldFetchProductTypeAndCache() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(oldTaxCategory.getKey())
                                                                  .toCompletableFuture()
                                                                  .join();
@@ -70,7 +70,7 @@ public class TaxCategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedTaxCategoryId_OnSecondTime_ShouldNotFindProductTypeInCache() {
+    void fetchCachedTaxCategoryId_OnSecondTime_ShouldNotFindProductTypeInCache() {
         // Fetch any key to populate cache
         taxCategoryService.fetchCachedTaxCategoryId("anyKey").toCompletableFuture().join();
 
@@ -92,7 +92,7 @@ public class TaxCategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedTaxCategoryId_WithTaxCategoryExistingWithNoKey_ShouldTriggerWarningCallback() {
+    void fetchCachedTaxCategoryId_WithTaxCategoryExistingWithNoKey_ShouldTriggerWarningCallback() {
         // Create new taxCategory without key
         final TaxCategoryDraft taxCategoryDraft = TaxCategoryDraftBuilder
             .of("newTaxCategory", singletonList(createTaxRateDraft()), oldTaxCategory.getDescription())
@@ -110,7 +110,7 @@ public class TaxCategoryServiceImplIT {
     }
 
     @Test
-    public void fetchCachedTaxCategoryId_WithWithNullKey_ShouldReturnFutureWithEmptyOptional() {
+    void fetchCachedTaxCategoryId_WithWithNullKey_ShouldReturnFutureWithEmptyOptional() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(null)
                                                                  .toCompletableFuture()
                                                                  .join();

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/TypeServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/TypeServiceImplIT.java
@@ -18,9 +18,9 @@ import io.sphere.sdk.types.commands.updateactions.ChangeName;
 import io.sphere.sdk.types.queries.TypeQuery;
 import io.sphere.sdk.utils.CompletableFutureUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TypeServiceImplIT {
+class TypeServiceImplIT {
     private TypeService typeService;
     private static final String OLD_TYPE_KEY = "old_type_key";
     private static final String OLD_TYPE_NAME = "old_type_name";
@@ -61,8 +61,8 @@ public class TypeServiceImplIT {
     /**
      * Deletes types from the target CTP project, then it populates the project with test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
 
@@ -82,13 +82,13 @@ public class TypeServiceImplIT {
     /**
      * Cleans up the target test data that were built in this test class.
      */
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         deleteTypes(CTP_TARGET_CLIENT);
     }
 
     @Test
-    public void fetchCachedTypeId_WithNonExistingType_ShouldNotFetchAType() {
+    void fetchCachedTypeId_WithNonExistingType_ShouldNotFetchAType() {
         final Optional<String> typeId = typeService.fetchCachedTypeId("non-existing-type-key")
                                                    .toCompletableFuture()
                                                    .join();
@@ -98,7 +98,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchCachedTypeId_WithExistingType_ShouldFetchTypeAndCache() {
+    void fetchCachedTypeId_WithExistingType_ShouldFetchTypeAndCache() {
         final Optional<String> typeId = typeService.fetchCachedTypeId(OLD_TYPE_KEY)
                                                    .toCompletableFuture()
                                                    .join();
@@ -108,7 +108,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingTypesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
+    void fetchMatchingTypesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
         final Set<String> typeKeys = new HashSet<>();
         final Set<Type> matchingTypes = typeService.fetchMatchingTypesByKeys(typeKeys)
                                                    .toCompletableFuture()
@@ -120,7 +120,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingTypesByKeys_WithNonExistingKeys_ShouldReturnEmptySet() {
+    void fetchMatchingTypesByKeys_WithNonExistingKeys_ShouldReturnEmptySet() {
         final Set<String> typeKeys = new HashSet<>();
         typeKeys.add("type_key_1");
         typeKeys.add("type_key_2");
@@ -135,7 +135,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingTypesByKeys_WithAnyExistingKeys_ShouldReturnASetOfTypes() {
+    void fetchMatchingTypesByKeys_WithAnyExistingKeys_ShouldReturnASetOfTypes() {
         final Set<String> typeKeys = new HashSet<>();
         typeKeys.add(OLD_TYPE_KEY);
 
@@ -149,7 +149,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingTypesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
+    void fetchMatchingTypesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
         // Mock sphere client to return BadGatewayException on any request.
         final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
         when(spyClient.execute(any(TypeQuery.class)))
@@ -179,7 +179,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchMatchingTypesByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedTypeIds() {
+    void fetchMatchingTypesByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedTypeIds() {
         final Set<Type> fetchedTypes = typeService.fetchMatchingTypesByKeys(singleton(OLD_TYPE_KEY))
                                                   .toCompletableFuture().join();
         assertThat(fetchedTypes).hasSize(1);
@@ -210,7 +210,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void createType_WithValidType_ShouldCreateTypeAndCacheId() {
+    void createType_WithValidType_ShouldCreateTypeAndCacheId() {
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 TYPE_KEY_1,
                 TYPE_NAME_1,
@@ -256,7 +256,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void createType_WithInvalidType_ShouldHaveEmptyOptionalAsAResult() {
+    void createType_WithInvalidType_ShouldHaveEmptyOptionalAsAResult() {
         //preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
                 "",
@@ -288,7 +288,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void createType_WithDuplicateKey_ShouldHaveEmptyOptionalAsAResult() {
+    void createType_WithDuplicateKey_ShouldHaveEmptyOptionalAsAResult() {
         //preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
             OLD_TYPE_KEY,
@@ -337,7 +337,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void updateType_WithValidChanges_ShouldUpdateTypeCorrectly() {
+    void updateType_WithValidChanges_ShouldUpdateTypeCorrectly() {
         final Optional<Type> typeOptional = CTP_TARGET_CLIENT
                 .execute(TypeQuery.of()
                                   .withPredicates(typeQueryModel -> typeQueryModel.key().is(OLD_TYPE_KEY)))
@@ -364,7 +364,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void updateType_WithInvalidChanges_ShouldCompleteExceptionally() {
+    void updateType_WithInvalidChanges_ShouldCompleteExceptionally() {
         final Optional<Type> typeOptional = CTP_TARGET_CLIENT
                 .execute(TypeQuery.of()
                                   .withPredicates(typeQueryModel -> typeQueryModel.key().is(OLD_TYPE_KEY)))
@@ -382,7 +382,7 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchType_WithExistingTypeKey_ShouldFetchType() {
+    void fetchType_WithExistingTypeKey_ShouldFetchType() {
         final Optional<Type> typeOptional = CTP_TARGET_CLIENT
             .execute(TypeQuery.of()
                               .withPredicates(typeQueryModel -> typeQueryModel.key().is(OLD_TYPE_KEY)))
@@ -395,14 +395,14 @@ public class TypeServiceImplIT {
     }
 
     @Test
-    public void fetchType_WithBlankKey_ShouldNotFetchType() {
+    void fetchType_WithBlankKey_ShouldNotFetchType() {
         final Optional<Type> fetchedTypeOptional =
             executeBlocking(typeService.fetchType(StringUtils.EMPTY));
         assertThat(fetchedTypeOptional).isEmpty();
     }
 
     @Test
-    public void fetchType_WithNullKey_ShouldNotFetchType() {
+    void fetchType_WithNullKey_ShouldNotFetchType() {
         final Optional<Type> fetchedTypeOptional =
             executeBlocking(typeService.fetchType(null));
         assertThat(fetchedTypeOptional).isEmpty();

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncOptionsBuilderTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.categories.CategoryDraftBuilder;
 import io.sphere.sdk.categories.commands.updateactions.ChangeName;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,18 +26,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-public class CategorySyncOptionsBuilderTest {
+class CategorySyncOptionsBuilderTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private CategorySyncOptionsBuilder categorySyncOptionsBuilder = CategorySyncOptionsBuilder.of(CTP_CLIENT);
 
     @Test
-    public void of_WithClient_ShouldCreateCategorySyncOptionsBuilder() {
+    void of_WithClient_ShouldCreateCategorySyncOptionsBuilder() {
         final CategorySyncOptionsBuilder builder = CategorySyncOptionsBuilder.of(CTP_CLIENT);
         assertThat(builder).isNotNull();
     }
 
     @Test
-    public void build_WithClient_ShouldBuildCategorySyncOptions() {
+    void build_WithClient_ShouldBuildCategorySyncOptions() {
         final CategorySyncOptions categorySyncOptions = categorySyncOptionsBuilder.build();
         assertThat(categorySyncOptions).isNotNull();
         assertThat(categorySyncOptions.getBeforeUpdateCallback()).isNull();
@@ -49,7 +49,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
         final TriFunction<List<UpdateAction<Category>>, CategoryDraft, Category, List<UpdateAction<Category>>>
             beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> emptyList();
         categorySyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
@@ -59,7 +59,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
         final Function<CategoryDraft, CategoryDraft> draftFunction = categoryDraft -> null;
         categorySyncOptionsBuilder.beforeCreateCallback(draftFunction);
 
@@ -68,7 +68,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void errorCallBack_WithCallBack_ShouldSetCallBack() {
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final BiConsumer<String, Throwable> mockErrorCallBack = (errorMessage, errorException) -> {
         };
         categorySyncOptionsBuilder.errorCallback(mockErrorCallBack);
@@ -78,7 +78,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void warningCallBack_WithCallBack_ShouldSetCallBack() {
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final Consumer<String> mockWarningCallBack = (warningMessage) -> {
         };
         categorySyncOptionsBuilder.warningCallback(mockWarningCallBack);
@@ -88,7 +88,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void getThis_ShouldReturnCorrectInstance() {
+    void getThis_ShouldReturnCorrectInstance() {
         final CategorySyncOptionsBuilder instance = categorySyncOptionsBuilder.getThis();
         assertThat(instance).isNotNull();
         assertThat(instance).isInstanceOf(CategorySyncOptionsBuilder.class);
@@ -96,7 +96,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void categorySyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+    void categorySyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder
             .of(CTP_CLIENT)
             .batchSize(30)
@@ -107,7 +107,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_CLIENT)
                                                                                   .batchSize(10)
                                                                                   .build();
@@ -115,7 +115,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
         final CategorySyncOptions categorySyncOptionsWithZeroBatchSize = CategorySyncOptionsBuilder.of(CTP_CLIENT)
                                                                                   .batchSize(0)
                                                                                   .build();
@@ -131,7 +131,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_CLIENT)
                                                                                   .build();
         assertThat(categorySyncOptions.getBeforeUpdateCallback()).isNull();
@@ -143,7 +143,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
         final TriFunction<List<UpdateAction<Category>>, CategoryDraft, Category, List<UpdateAction<Category>>>
             beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> emptyList();
 
@@ -161,7 +161,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<Category>>, CategoryDraft, Category, List<UpdateAction<Category>>>
             beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
 
@@ -183,7 +183,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
         final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
 
         final CategorySyncOptions categorySyncOptions =
@@ -202,7 +202,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraft() {
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraft() {
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_CLIENT)
                                                                                   .build();
         assertThat(categorySyncOptions.getBeforeCreateCallback()).isNull();
@@ -213,7 +213,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredList() {
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredList() {
         final Function<CategoryDraft, CategoryDraft> draftFunction = categoryDraft ->
                 CategoryDraftBuilder.of(categoryDraft)
                                     .key(categoryDraft.getKey() + "_filterPostFix")
@@ -235,7 +235,7 @@ public class CategorySyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
         final Function<CategoryDraft, CategoryDraft> draftFunction = categoryDraft -> null;
 
         final CategorySyncOptions syncOptions = CategorySyncOptionsBuilder.of(CTP_CLIENT)

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncOptionsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncOptionsTest.java
@@ -7,8 +7,8 @@ import io.sphere.sdk.categories.commands.updateactions.ChangeName;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,20 +18,20 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class CategorySyncOptionsTest {
+class CategorySyncOptionsTest {
     private CategorySyncOptionsBuilder categorySyncOptionsBuilder;
 
     /**
      * Initializes an instance of {@link CategorySyncOptionsBuilder} to be used in the unit test methods of this test
      * class.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         categorySyncOptionsBuilder = CategorySyncOptionsBuilder.of(mock(SphereClient.class));
     }
 
     @Test
-    public void getUpdateActionsFilter_WithFilter_ShouldApplyFilterOnList() {
+    void getUpdateActionsFilter_WithFilter_ShouldApplyFilterOnList() {
         final TriFunction<List<UpdateAction<Category>>, CategoryDraft, Category, List<UpdateAction<Category>>>
             clearListFilter = (updateActions, newCategory, oldCategory) -> Collections.emptyList();
         categorySyncOptionsBuilder.beforeUpdateCallback(clearListFilter);
@@ -50,7 +50,7 @@ public class CategorySyncOptionsTest {
     }
 
     @Test
-    public void build_WithOnlyRequiredFieldsSet_ShouldReturnProperOptionsInstance() {
+    void build_WithOnlyRequiredFieldsSet_ShouldReturnProperOptionsInstance() {
         final CategorySyncOptions options = CategorySyncOptionsBuilder.of(mock(SphereClient.class)).build();
         assertThat(options).isNotNull();
         assertThat(options.getBatchSize()).isEqualTo(CategorySyncOptionsBuilder.BATCH_SIZE_DEFAULT);

--- a/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/categories/CategorySyncTest.java
@@ -14,8 +14,8 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CategorySyncTest {
+class CategorySyncTest {
     private CategorySyncOptions categorySyncOptions;
     private List<String> errorCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
@@ -80,8 +80,8 @@ public class CategorySyncTest {
      * Initializes instances of  {@link CategorySyncOptions} and {@link CategorySync} which will be used by some
      * of the unit test methods in this test class.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
         final SphereClient ctpClient = mock(SphereClient.class);
@@ -94,7 +94,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithEmptyListOfDrafts_ShouldNotProcessAnyCategories() {
+    void sync_WithEmptyListOfDrafts_ShouldNotProcessAnyCategories() {
         final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
         final CategorySync mockCategorySync =
             new CategorySync(categorySyncOptions, getMockTypeService(), mockCategoryService);
@@ -108,7 +108,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithANullDraft_ShouldBeCountedAsFailed() {
+    void sync_WithANullDraft_ShouldBeCountedAsFailed() {
         final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
         final CategorySync mockCategorySync =
             new CategorySync(categorySyncOptions, getMockTypeService(), mockCategoryService);
@@ -124,7 +124,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithADraftWithNoSetKey_ShouldFailSync() {
+    void sync_WithADraftWithNoSetKey_ShouldFailSync() {
         final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
         final CategorySync mockCategorySync =
             new CategorySync(categorySyncOptions, getMockTypeService(), mockCategoryService);
@@ -143,7 +143,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithNoExistingCategory_ShouldCreateCategory() {
+    void sync_WithNoExistingCategory_ShouldCreateCategory() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService = mockCategoryService(emptySet(), mockCategory);
         final CategorySync mockCategorySync =
@@ -160,7 +160,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingCategory_ShouldUpdateCategory() {
+    void sync_WithExistingCategory_ShouldUpdateCategory() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService =
             mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -178,7 +178,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithIdenticalExistingCategory_ShouldNotUpdateCategory() {
+    void sync_WithIdenticalExistingCategory_ShouldNotUpdateCategory() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryDraft identicalCategoryDraft = CategoryDraftBuilder.of(mockCategory).build();
         final CategoryService mockCategoryService =
@@ -196,7 +196,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingCategoryButWithNullParentReference_ShouldFailSync() {
+    void sync_WithExistingCategoryButWithNullParentReference_ShouldFailSync() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService =
             mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -218,7 +218,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingCategoryButWithNoCustomType_ShouldSync() {
+    void sync_WithExistingCategoryButWithNoCustomType_ShouldSync() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService =
             mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -240,7 +240,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingCategoryButWithEmptyParentReference_ShouldFailSync() {
+    void sync_WithExistingCategoryButWithEmptyParentReference_ShouldFailSync() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService =
             mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -263,7 +263,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingCategoryButWithEmptyCustomTypeReference_ShouldFailSync() {
+    void sync_WithExistingCategoryButWithEmptyCustomTypeReference_ShouldFailSync() {
         final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key");
         final CategoryService mockCategoryService =
             mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -286,7 +286,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void requiresChangeParentUpdateAction_WithTwoDifferentParents_ShouldReturnTrue() {
+    void requiresChangeParentUpdateAction_WithTwoDifferentParents_ShouldReturnTrue() {
         final String parentId = "parentId";
         final Category category = mock(Category.class);
         when(category.getParent()).thenReturn(Category.referenceOfId(parentId));
@@ -300,7 +300,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void requiresChangeParentUpdateAction_WithTwoIdenticalParents_ShouldReturnFalse() {
+    void requiresChangeParentUpdateAction_WithTwoIdenticalParents_ShouldReturnFalse() {
         final String parentId = "parentId";
         final Category category = mock(Category.class);
         when(category.getParent()).thenReturn(Category.referenceOfId(parentId));
@@ -314,7 +314,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void requiresChangeParentUpdateAction_WithNonExistingParents_ShouldReturnFalse() {
+    void requiresChangeParentUpdateAction_WithNonExistingParents_ShouldReturnFalse() {
         final Category category = mock(Category.class);
         when(category.getParent()).thenReturn(null);
 
@@ -326,7 +326,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithBatchSizeSet_ShouldCallSyncOnEachBatch() {
+    void sync_WithBatchSizeSet_ShouldCallSyncOnEachBatch() {
         // preparation
         final int batchSize = 1;
         final CategorySyncOptions categorySyncOptions = CategorySyncOptionsBuilder
@@ -369,7 +369,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithDefaultBatchSize_ShouldCallSyncOnEachBatch() {
+    void sync_WithDefaultBatchSize_ShouldCallSyncOnEachBatch() {
         // preparation
         final int numberOfCategoryDrafts  = 160;
         final List<Category> mockedCreatedCategories =
@@ -404,7 +404,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithFailOnCachingKeysToIds_ShouldTriggerErrorCallbackAndReturnProperStats() {
+    void sync_WithFailOnCachingKeysToIds_ShouldTriggerErrorCallbackAndReturnProperStats() {
         // preparation
         final SphereClient mockClient = mock(SphereClient.class);
         when(mockClient.execute(any(CategoryQuery.class)))
@@ -447,7 +447,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithFailOnFetchingCategories_ShouldTriggerErrorCallbackAndReturnProperStats() {
+    void sync_WithFailOnFetchingCategories_ShouldTriggerErrorCallbackAndReturnProperStats() {
         // preparation
         final SphereClient mockClient = mock(SphereClient.class);
 
@@ -506,7 +506,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
         final CategoryDraft categoryDraft =
             getMockCategoryDraft(Locale.ENGLISH, "name", "foo", "parentKey", "customTypeId", new HashMap<>());
@@ -532,7 +532,7 @@ public class CategorySyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
         final CategoryDraft categoryDraft =
             getMockCategoryDraft(Locale.ENGLISH, "name", "1", "parentKey", "customTypeId", new HashMap<>());

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryAssetActionFactoryTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryAssetActionFactoryTest.java
@@ -6,14 +6,14 @@ import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.commands.updateactions.AddAsset;
 import io.sphere.sdk.categories.commands.updateactions.ChangeAssetOrder;
 import io.sphere.sdk.categories.commands.updateactions.RemoveAsset;
+import io.sphere.sdk.categories.commands.updateactions.SetAssetTags;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.models.AssetDraftBuilder;
-import io.sphere.sdk.categories.commands.updateactions.SetAssetTags;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -24,11 +24,11 @@ import static org.assertj.core.util.Lists.emptyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryAssetActionFactoryTest {
+class CategoryAssetActionFactoryTest {
     private CategoryAssetActionFactory categoryAssetActionFactory;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final CategorySyncOptions syncOptions = CategorySyncOptionsBuilder.of(mock(SphereClient.class))
                                                                           .build();
 
@@ -36,7 +36,7 @@ public class CategoryAssetActionFactoryTest {
     }
 
     @Test
-    public void buildRemoveAssetAction_always_ShouldBuildCorrectAction() {
+    void buildRemoveAssetAction_always_ShouldBuildCorrectAction() {
         final UpdateAction<Category> action = categoryAssetActionFactory.buildRemoveAssetAction("foo");
         assertThat(action).isNotNull();
         assertThat(action).isInstanceOf(RemoveAsset.class);
@@ -46,7 +46,7 @@ public class CategoryAssetActionFactoryTest {
     }
 
     @Test
-    public void buildChangeAssetOrderAction_always_ShouldBuildCorrectAction() {
+    void buildChangeAssetOrderAction_always_ShouldBuildCorrectAction() {
         final UpdateAction<Category> action = categoryAssetActionFactory.buildChangeAssetOrderAction(emptyList());
         assertThat(action).isNotNull();
         assertThat(action).isInstanceOf(ChangeAssetOrder.class);
@@ -55,7 +55,7 @@ public class CategoryAssetActionFactoryTest {
     }
 
     @Test
-    public void buildAddAssetAction_always_ShouldBuildCorrectAction() {
+    void buildAddAssetAction_always_ShouldBuildCorrectAction() {
         final AssetDraft assetDraft = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
                                                        .build();
 
@@ -70,7 +70,7 @@ public class CategoryAssetActionFactoryTest {
     }
 
     @Test
-    public void buildAssetActions_always_ShouldBuildCorrectAction() {
+    void buildAssetActions_always_ShouldBuildCorrectAction() {
         final Asset asset = mock(Asset.class);
         when(asset.getKey()).thenReturn("assetKey");
         when(asset.getName()).thenReturn(ofEnglish("assetName"));

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolverTest.java
@@ -16,9 +16,9 @@ import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryReferenceResolverTest {
+class CategoryReferenceResolverTest {
 
     private TypeService typeService;
     private CategoryService categoryService;
@@ -54,8 +54,8 @@ public class CategoryReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         typeService = getMockTypeService();
         categoryService = mock(CategoryService.class);
         when(categoryService.fetchCachedCategoryId(CACHED_CATEGORY_KEY))
@@ -65,7 +65,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveAssetsReferences_WithEmptyAssets_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithEmptyAssets_ShouldNotResolveAssets() {
         final CategoryDraftBuilder categoryDraftBuilder =
             getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key", CACHED_CATEGORY_KEY,
                 "customTypeId", new HashMap<>())
@@ -79,7 +79,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveAssetsReferences_WithNullAssets_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithNullAssets_ShouldNotResolveAssets() {
         final CategoryDraftBuilder categoryDraftBuilder =
             getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key", CACHED_CATEGORY_KEY,
                 "customTypeId", new HashMap<>())
@@ -93,7 +93,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveAssetsReferences_WithANullAsset_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithANullAsset_ShouldNotResolveAssets() {
         final CategoryDraftBuilder categoryDraftBuilder =
             getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key", CACHED_CATEGORY_KEY,
                 "customTypeId", new HashMap<>()).assets(singletonList(null));
@@ -106,7 +106,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveAssetsReferences_WithAssetReferences_ShouldResolveAssets() {
+    void resolveAssetsReferences_WithAssetReferences_ShouldResolveAssets() {
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft
             .ofTypeIdAndJson("customTypeId", new HashMap<>());
 
@@ -131,9 +131,9 @@ public class CategoryReferenceResolverTest {
     }
 
 
-    @Ignore("TODO: SHOULD COMPLETE EXCEPTIONALLY. GITHUB ISSUE#219")
+    @Disabled("TODO: SHOULD COMPLETE EXCEPTIONALLY. GITHUB ISSUE#219")
     @Test
-    public void resolveParentReference_WithNonExistentParentCategory_ShouldNotResolveParentReference() {
+    void resolveParentReference_WithNonExistentParentCategory_ShouldNotResolveParentReference() {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(categoryService.fetchCachedCategoryId(CACHED_CATEGORY_KEY))
@@ -148,7 +148,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
+    void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
 
@@ -165,7 +165,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             CACHED_CATEGORY_KEY, "customTypeId", new HashMap<>());
         when(typeService.fetchCachedTypeId(anyString()))
@@ -181,7 +181,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveParentReference_WithEmptyIdOnParentReference_ShouldNotResolveParentReference() {
+    void resolveParentReference_WithEmptyIdOnParentReference_ShouldNotResolveParentReference() {
         final CategoryDraftBuilder categoryDraft = CategoryDraftBuilder.of(ofEnglish("foo"), ofEnglish("bar"));
         categoryDraft.key("key");
         categoryDraft.parent(Category.referenceOfId("").toResourceIdentifier());
@@ -196,7 +196,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveParentReference_WithNullIdOnParentReference_ShouldNotResolveParentReference() {
+    void resolveParentReference_WithNullIdOnParentReference_ShouldNotResolveParentReference() {
         final CategoryDraftBuilder categoryDraft = CategoryDraftBuilder.of(ofEnglish("foo"), ofEnglish("bar"));
         categoryDraft.key("key");
         categoryDraft.parent(Category.referenceOfId(null).toResourceIdentifier());
@@ -211,7 +211,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             "parentKey", "customTypeId", new HashMap<>());
 
@@ -232,7 +232,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CategoryDraftBuilder categoryDraft = getMockCategoryDraftBuilder(Locale.ENGLISH, "myDraft", "key",
             "parentKey", "customTypeId", new HashMap<>());
 
@@ -248,7 +248,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveReferences_WithNoCustomTypeReferenceAndNoParentReference_ShouldNotResolveReferences() {
+    void resolveReferences_WithNoCustomTypeReferenceAndNoParentReference_ShouldNotResolveReferences() {
         final CategoryDraft categoryDraft = mock(CategoryDraft.class);
         when(categoryDraft.getName()).thenReturn(LocalizedString.of(Locale.ENGLISH, "myDraft"));
         when(categoryDraft.getKey()).thenReturn("key");

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
@@ -1,8 +1,8 @@
 package com.commercetools.sync.categories.helpers;
 
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -13,61 +13,61 @@ import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class CategorySyncStatisticsTest {
+class CategorySyncStatisticsTest {
 
     private CategorySyncStatistics categorySyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         categorySyncStatistics = new CategorySyncStatistics();
     }
 
     @Test
-    public void getUpdated_WithNoUpdated_ShouldReturnZero() {
+    void getUpdated_WithNoUpdated_ShouldReturnZero() {
         assertThat(categorySyncStatistics.getUpdated()).hasValue(0);
     }
 
     @Test
-    public void incrementUpdated_ShouldIncrementUpdatedValue() {
+    void incrementUpdated_ShouldIncrementUpdatedValue() {
         categorySyncStatistics.incrementUpdated();
         assertThat(categorySyncStatistics.getUpdated()).hasValue(1);
     }
 
     @Test
-    public void getCreated_WithNoCreated_ShouldReturnZero() {
+    void getCreated_WithNoCreated_ShouldReturnZero() {
         assertThat(categorySyncStatistics.getCreated()).hasValue(0);
     }
 
     @Test
-    public void incrementCreated_ShouldIncrementCreatedValue() {
+    void incrementCreated_ShouldIncrementCreatedValue() {
         categorySyncStatistics.incrementCreated();
         assertThat(categorySyncStatistics.getCreated()).hasValue(1);
     }
 
     @Test
-    public void getProcessed_WithNoProcessed_ShouldReturnZero() {
+    void getProcessed_WithNoProcessed_ShouldReturnZero() {
         assertThat(categorySyncStatistics.getProcessed()).hasValue(0);
     }
 
     @Test
-    public void incrementProcessed_ShouldIncrementProcessedValue() {
+    void incrementProcessed_ShouldIncrementProcessedValue() {
         categorySyncStatistics.incrementProcessed();
         assertThat(categorySyncStatistics.getProcessed()).hasValue(1);
     }
 
     @Test
-    public void getFailed_WithNoFailed_ShouldReturnZero() {
+    void getFailed_WithNoFailed_ShouldReturnZero() {
         assertThat(categorySyncStatistics.getFailed()).hasValue(0);
     }
 
     @Test
-    public void incrementFailed_ShouldIncrementFailedValue() {
+    void incrementFailed_ShouldIncrementFailedValue() {
         categorySyncStatistics.incrementFailed();
         assertThat(categorySyncStatistics.getFailed()).hasValue(1);
     }
 
     @Test
-    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
         categorySyncStatistics.incrementCreated(1);
         categorySyncStatistics.incrementFailed(1);
         categorySyncStatistics.incrementUpdated(1);
@@ -78,7 +78,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void getNumberOfCategoriesWithMissingParents_WithEmptyMap_ShouldReturn0() {
+    void getNumberOfCategoriesWithMissingParents_WithEmptyMap_ShouldReturn0() {
         final ConcurrentHashMap<String, Set<String>> catKeysWithMissingParents = new ConcurrentHashMap<>();
         categorySyncStatistics.setCategoryKeysWithMissingParents(catKeysWithMissingParents);
 
@@ -86,7 +86,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void getNumberOfCategoriesWithMissingParents_WithEmptyValue_ShouldReturn0() {
+    void getNumberOfCategoriesWithMissingParents_WithEmptyValue_ShouldReturn0() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         categoryKeysWithMissingParents.put("parent2", emptySet());
 
@@ -95,7 +95,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void getNumberOfCategoriesWithMissingParents_WithNonEmptyMap_ShouldReturnCorrectNumberOfChildren() {
+    void getNumberOfCategoriesWithMissingParents_WithNonEmptyMap_ShouldReturnCorrectNumberOfChildren() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> firstMissingParentChildrenKeys = new HashSet<>();
         firstMissingParentChildrenKeys.add("key1");
@@ -115,7 +115,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void getCategoryKeysWithMissingParents_WithAnyMap_ShouldGetUnmodifiableMapCorrectly() {
+    void getCategoryKeysWithMissingParents_WithAnyMap_ShouldGetUnmodifiableMapCorrectly() {
         final ConcurrentHashMap<String, Set<String>> catKeysWithMissingParents = new ConcurrentHashMap<>();
         categorySyncStatistics.setCategoryKeysWithMissingParents(catKeysWithMissingParents);
 
@@ -128,7 +128,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void putMissingParentCategoryChildKey_OnAnEmptyList_ShouldAddNewParentEntryInTheMap() {
+    void putMissingParentCategoryChildKey_OnAnEmptyList_ShouldAddNewParentEntryInTheMap() {
         final String parentKey = "parentKey";
         final String childKey = "childKey";
         categorySyncStatistics.putMissingParentCategoryChildKey(parentKey, childKey);
@@ -142,7 +142,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void putMissingParentCategoryChildKey_OnANonEmptyListWithNewParent_ShouldAddNewParentEntryInTheMap() {
+    void putMissingParentCategoryChildKey_OnANonEmptyListWithNewParent_ShouldAddNewParentEntryInTheMap() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> existingChildrenKeys = new HashSet<>();
         existingChildrenKeys.add("key1");
@@ -172,7 +172,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void putMissingParentCategoryChildKey_OnNonEmptyListWithExistingParent_ShouldAddParentToExistingEntry() {
+    void putMissingParentCategoryChildKey_OnNonEmptyListWithExistingParent_ShouldAddParentToExistingEntry() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> existingChildrenKeys = new HashSet<>();
         existingChildrenKeys.add("key1");
@@ -195,12 +195,12 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void getMissingParentKey_OAnEmptyList_ShouldReturnAnEmptyOptional() {
+    void getMissingParentKey_OAnEmptyList_ShouldReturnAnEmptyOptional() {
         assertThat(categorySyncStatistics.getMissingParentKey("foo")).isEmpty();
     }
 
     @Test
-    public void getMissingParentKey_OnANonEmptyList_ShouldReturnCorrectParentKeyInOptional() {
+    void getMissingParentKey_OnANonEmptyList_ShouldReturnCorrectParentKeyInOptional() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> existingChildrenKeys = new HashSet<>();
         existingChildrenKeys.add("key1");
@@ -215,14 +215,14 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void removeChildCategoryKeyFromMissingParentsMap_OnAEmptyList_ShouldNotAffectTheMap() {
+    void removeChildCategoryKeyFromMissingParentsMap_OnAEmptyList_ShouldNotAffectTheMap() {
         assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isEmpty();
         categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("foo");
         assertThat(categorySyncStatistics.getCategoryKeysWithMissingParents()).isEmpty();
     }
 
     @Test
-    public void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListButNonExistingKey_ShouldNotAffectTheMap() {
+    void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListButNonExistingKey_ShouldNotAffectTheMap() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> existingChildrenKeys = new HashSet<>();
         existingChildrenKeys.add("key1");
@@ -246,7 +246,7 @@ public class CategorySyncStatisticsTest {
     }
 
     @Test
-    public void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListWithExistingKey_ShouldNotAffectTheMap() {
+    void removeChildCategoryKeyFromMissingParentsMap_OnANonEmptyListWithExistingKey_ShouldNotAffectTheMap() {
         final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents = new ConcurrentHashMap<>();
         final Set<String> existingChildrenKeys = new HashSet<>();
         existingChildrenKeys.add("key1");

--- a/src/test/java/com/commercetools/sync/categories/utils/CategoryAssetUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategoryAssetUpdateActionUtilsTest.java
@@ -22,7 +22,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,12 +47,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryAssetUpdateActionUtilsTest {
+class CategoryAssetUpdateActionUtilsTest {
     private static final CategorySyncOptions SYNC_OPTIONS = CategorySyncOptionsBuilder
         .of(mock(SphereClient.class)).build();
 
     @Test
-    public void buildActions_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildActions_WithDifferentValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
         final LocalizedString newName = LocalizedString.of(Locale.GERMAN, "newName");
 
@@ -106,7 +106,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithIdenticalValues_ShouldBuildUpdateAction() {
+    void buildActions_WithIdenticalValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
 
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
@@ -137,7 +137,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAssetNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeAssetNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
         final LocalizedString newName = LocalizedString.of(Locale.GERMAN, "newName");
 
@@ -155,7 +155,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAssetNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeAssetNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
 
         final Asset oldAsset = mock(Asset.class);
@@ -170,7 +170,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final LocalizedString oldDesc = LocalizedString.of(Locale.GERMAN, "oldDesc");
         final LocalizedString newDesc = LocalizedString.of(Locale.GERMAN, "newDesc");
 
@@ -189,7 +189,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final LocalizedString oldDesc = LocalizedString.of(Locale.GERMAN, "oldDesc");
 
         final Asset oldAsset = mock(Asset.class);
@@ -205,7 +205,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithNullOldValue_ShouldBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithNullOldValue_ShouldBuildUpdateAction() {
         final LocalizedString newDesc = LocalizedString.of(Locale.GERMAN, "newDesc");
 
         final Asset oldAsset = mock(Asset.class);
@@ -223,7 +223,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final Set<String> oldTags = new HashSet<>();
         oldTags.add("oldTag");
         final Set<String> newTags = new HashSet<>();
@@ -244,7 +244,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final Set<String> oldTags = new HashSet<>();
         oldTags.add("oldTag");
 
@@ -262,7 +262,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithNullOldValues_ShouldBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithNullOldValues_ShouldBuildUpdateAction() {
         final Set<String> newTags = new HashSet<>();
         newTags.add("newTag");
 
@@ -281,7 +281,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetSourcesUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetAssetSourcesUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final List<AssetSource> oldAssetSources = singletonList(AssetSourceBuilder.ofUri("oldUri").build());
         final List<AssetSource> newAssetSources = singletonList(AssetSourceBuilder.ofUri("newUri").build());
 
@@ -300,7 +300,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetSourcesUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetSourcesUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final List<AssetSource> oldAssetSources = singletonList(AssetSourceBuilder.ofUri("oldUri").build());
 
         final Asset oldAsset = mock(Asset.class);
@@ -316,7 +316,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildCustomUpdateActions_WithSameValues_ShouldNotBuildUpdateAction() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
@@ -343,7 +343,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildCustomUpdateActions_WithDifferentValues_ShouldBuildUpdateAction() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
@@ -374,7 +374,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullOldValues_ShouldBuildUpdateAction() {
+    void buildCustomUpdateActions_WithNullOldValues_ShouldBuildUpdateAction() {
 
         final Map<String, JsonNode> newCustomFieldsMap = new HashMap<>();
         newCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(false));
@@ -399,7 +399,7 @@ public class CategoryAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithBadCustomFieldData_ShouldNotBuildUpdateActionAndTriggerErrorCallback() {
+    void buildCustomUpdateActions_WithBadCustomFieldData_ShouldNotBuildUpdateActionAndTriggerErrorCallback() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));

--- a/src/test/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtilsTest.java
@@ -9,7 +9,7 @@ import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,10 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryReferenceReplacementUtilsTest {
+class CategoryReferenceReplacementUtilsTest {
 
     @Test
-    public void
+    void
         replaceCategoryReferenceIdsWithKeys_WithAllExpandedCategoryReferences_ShouldReturnReferencesWithReplacedKeys() {
         final String parentId = UUID.randomUUID().toString();
         final Type mockCustomType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
@@ -80,7 +80,7 @@ public class CategoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceCategoryReferenceIdsWithKeys_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String parentId = UUID.randomUUID().toString();
         final String customTypeId = UUID.randomUUID().toString();
@@ -131,7 +131,7 @@ public class CategoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void buildCategoryQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
+    void buildCategoryQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
         final CategoryQuery categoryQuery = CategoryReferenceReplacementUtils.buildCategoryQuery();
         assertThat(categoryQuery.expansionPaths()).containsExactly(
             ExpansionPath.of("custom.type"),

--- a/src/test/java/com/commercetools/sync/categories/utils/CategorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategorySyncUtilsTest.java
@@ -23,8 +23,8 @@ import io.sphere.sdk.models.AssetDraftBuilder;
 import io.sphere.sdk.models.AssetSourceBuilder;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.ResourceIdentifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Locale;
@@ -36,7 +36,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class CategorySyncUtilsTest {
+class CategorySyncUtilsTest {
     private Category mockOldCategory;
     private CategorySyncOptions categorySyncOptions;
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
@@ -60,8 +60,8 @@ public class CategorySyncUtilsTest {
     /**
      * Initializes an instance of {@link CategorySyncOptions} and {@link Category}.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         categorySyncOptions = CategorySyncOptionsBuilder.of(CTP_CLIENT)
                                                         .build();
 
@@ -79,7 +79,7 @@ public class CategorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithDifferentNameValues_ShouldBuildUpdateActions() {
+    void buildActions_FromDraftsWithDifferentNameValues_ShouldBuildUpdateActions() {
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(LOCALE, "differentName"), LocalizedString.of(LOCALE, CATEGORY_SLUG))
             .key(CATEGORY_KEY)
@@ -101,7 +101,7 @@ public class CategorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActions() {
+    void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActions() {
 
         final CategoryDraft newCategoryDraft = CategoryDraftBuilder
             .of(LocalizedString.of(LOCALE, "differentName"), LocalizedString.of(LOCALE, "differentSlug"))

--- a/src/test/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategoryUpdateActionUtilsTest.java
@@ -18,7 +18,7 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.ResourceIdentifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryUpdateActionUtilsTest {
+class CategoryUpdateActionUtilsTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private static final CategorySyncOptions CATEGORY_SYNC_OPTIONS = CategorySyncOptionsBuilder.of(CTP_CLIENT).build();
     private static final Locale LOCALE = Locale.GERMAN;
@@ -66,7 +66,7 @@ public class CategoryUpdateActionUtilsTest {
         MOCK_OLD_CATEGORY_PARENT_ID);
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getName()).thenReturn(LocalizedString.of(LOCALE, "newName"));
 
@@ -79,7 +79,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getName()).thenReturn(null);
 
@@ -92,7 +92,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameName = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameName.getName())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
@@ -105,7 +105,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getSlug()).thenReturn(LocalizedString.of(LOCALE, "newSlug"));
 
@@ -118,7 +118,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getSlug()).thenReturn(null);
 
@@ -131,7 +131,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameSlug = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameSlug.getSlug())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_SLUG));
@@ -144,7 +144,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getDescription()).thenReturn(LocalizedString.of(LOCALE, "newDescription"));
 
@@ -158,7 +158,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameDescription = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameDescription.getDescription())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_DESCRIPTION));
@@ -171,7 +171,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
+    void buildSetDescriptionUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
         when(MOCK_OLD_CATEGORY.getId()).thenReturn("oldCatId");
         final CategoryDraft newCategory = mock(CategoryDraft.class);
         when(newCategory.getDescription()).thenReturn(null);
@@ -189,7 +189,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getParent()).thenReturn(Category.referenceOfId("2").toResourceIdentifier());
 
@@ -203,7 +203,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeParentUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameParent = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameParent.getParent())
             .thenReturn(Category.referenceOfId(MOCK_OLD_CATEGORY_PARENT_ID));
@@ -216,7 +216,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
+    void buildChangeParentUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
         when(MOCK_OLD_CATEGORY.getId()).thenReturn("oldCatId");
         final CategoryDraft newCategory = mock(CategoryDraft.class);
         when(newCategory.getParent()).thenReturn(null);
@@ -240,7 +240,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeParentUpdateAction_WithBothNullValues_ShouldNotBuildUpdateActionAndNotCallCallback() {
+    void buildChangeParentUpdateAction_WithBothNullValues_ShouldNotBuildUpdateActionAndNotCallCallback() {
         when(MOCK_OLD_CATEGORY.getId()).thenReturn("oldCatId");
         when(MOCK_OLD_CATEGORY.getParent()).thenReturn(null);
         final CategoryDraft newCategory = mock(CategoryDraft.class);
@@ -264,7 +264,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getOrderHint()).thenReturn("099");
 
@@ -278,7 +278,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildChangeOrderHintUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameOrderHint = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameOrderHint.getOrderHint()).thenReturn(MOCK_OLD_CATEGORY_ORDERHINT);
 
@@ -291,7 +291,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
+    void buildChangeOrderHintUpdateAction_WithNullValues_ShouldNotBuildUpdateActionAndCallCallback() {
         when(MOCK_OLD_CATEGORY.getId()).thenReturn("oldCatId");
         final CategoryDraft newCategory = mock(CategoryDraft.class);
         when(newCategory.getOrderHint()).thenReturn(null);
@@ -315,7 +315,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeOrderHintUpdateAction_WithBothNullValues_ShouldNotBuildUpdateActionAndNotCallCallback() {
+    void buildChangeOrderHintUpdateAction_WithBothNullValues_ShouldNotBuildUpdateActionAndNotCallCallback() {
         when(MOCK_OLD_CATEGORY.getId()).thenReturn("oldCatId");
         when(MOCK_OLD_CATEGORY.getOrderHint()).thenReturn(null);
         final CategoryDraft newCategory = mock(CategoryDraft.class);
@@ -339,7 +339,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaTitle()).thenReturn(LocalizedString.of(LOCALE, "newMetaTitle"));
 
@@ -353,7 +353,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaTitle()).thenReturn(null);
 
@@ -367,7 +367,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameTitle = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameTitle.getMetaTitle())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_META_TITLE));
@@ -380,7 +380,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaKeywords()).thenReturn(LocalizedString.of(LOCALE, "newMetaKW"));
 
@@ -394,7 +394,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaKeywords()).thenReturn(null);
 
@@ -407,7 +407,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameMetaKeywords = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameMetaKeywords.getMetaKeywords())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_META_KEYWORDS));
@@ -420,7 +420,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaDescription()).thenReturn(LocalizedString.of(LOCALE, "newMetaDesc"));
 
@@ -434,7 +434,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getMetaDescription()).thenReturn(null);
 
@@ -447,7 +447,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
         final CategoryDraft newCategoryDraftWithSameMetaDescription = mock(CategoryDraft.class);
         when(newCategoryDraftWithSameMetaDescription.getMetaDescription())
             .thenReturn(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_META_DESCRIPTION));
@@ -460,7 +460,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildSetExternalIdUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getExternalId()).thenReturn("newExternalId");
 
@@ -474,7 +474,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+    void buildSetExternalIdUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getExternalId()).thenReturn(null);
 
@@ -488,7 +488,7 @@ public class CategoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateActions() {
+    void buildSetExternalIdUpdateAction_WithSameValues_ShouldNotBuildUpdateActions() {
         final CategoryDraft newCategoryDraft = mock(CategoryDraft.class);
         when(newCategoryDraft.getExternalId()).thenReturn(MOCK_OLD_CATEGORY_EXTERNAL_ID);
 

--- a/src/test/java/com/commercetools/sync/categories/utils/categoryupdateactionutils/BuildAssetsUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/categoryupdateactionutils/BuildAssetsUpdateActionsTest.java
@@ -17,7 +17,7 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.AssetDraftBuilder;
 import io.sphere.sdk.models.AssetSourceBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildAssetsUpdateActionsTest {
+class BuildAssetsUpdateActionsTest {
     private static final String RES_ROOT =
         "com/commercetools/sync/categories/utils/categoryupdateactionutils/assets/";
     private static final String CATEGORY_DRAFT_WITH_ASSETS_ABC = RES_ROOT + "category-draft-with-assets-abc.json";
@@ -55,7 +55,7 @@ public class BuildAssetsUpdateActionsTest {
                                                                                       .build();
 
     @Test
-    public void buildAssetsUpdateActions_WithNullNewAssetsAndExistingAssets_ShouldBuild3RemoveActions() {
+    void buildAssetsUpdateActions_WithNullNewAssetsAndExistingAssets_ShouldBuild3RemoveActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
 
         final List<UpdateAction<Category>> updateActions =
@@ -69,7 +69,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithNullNewAssetsAndNoOldAssets_ShouldNotBuildActions() {
+    void buildAssetsUpdateActions_WithNullNewAssetsAndNoOldAssets_ShouldNotBuildActions() {
         final Category oldCategory = mock(Category.class);
         when(oldCategory.getAssets()).thenReturn(emptyList());
 
@@ -81,7 +81,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithNewAssetsAndNoOldAssets_ShouldBuild3AddActions() {
+    void buildAssetsUpdateActions_WithNewAssetsAndNoOldAssets_ShouldBuild3AddActions() {
         final Category oldCategory = mock(Category.class);
         when(oldCategory.getAssets()).thenReturn(emptyList());
 
@@ -105,7 +105,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithIdenticalAssets_ShouldNotBuildUpdateActions() {
+    void buildAssetsUpdateActions_WithIdenticalAssets_ShouldNotBuildUpdateActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, CategoryDraft.class);
@@ -118,7 +118,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithDuplicateAssetKeys_ShouldNotBuildActionsAndTriggerErrorCb() {
+    void buildAssetsUpdateActions_WithDuplicateAssetKeys_ShouldNotBuildActionsAndTriggerErrorCb() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABB, CategoryDraft.class);
@@ -148,7 +148,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithSameAssetPositionButChangesWithin_ShouldBuildUpdateActions() {
+    void buildAssetsUpdateActions_WithSameAssetPositionButChangesWithin_ShouldBuildUpdateActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC_WITH_CHANGES,
             CategoryDraft.class);
@@ -173,7 +173,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithOneMissingAsset_ShouldBuildRemoveAssetAction() {
+    void buildAssetsUpdateActions_WithOneMissingAsset_ShouldBuildRemoveAssetAction() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_AB,
             CategoryDraft.class);
@@ -186,7 +186,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithOneExtraAsset_ShouldBuildAddAssetAction() {
+    void buildAssetsUpdateActions_WithOneExtraAsset_ShouldBuildAddAssetAction() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABCD, CategoryDraft.class);
@@ -203,7 +203,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithOneAssetSwitch_ShouldBuildRemoveAndAddAssetActions() {
+    void buildAssetsUpdateActions_WithOneAssetSwitch_ShouldBuildRemoveAndAddAssetActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABD,
             CategoryDraft.class);
@@ -221,7 +221,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithDifferent_ShouldBuildChangeAssetOrderAction() {
+    void buildAssetsUpdateActions_WithDifferent_ShouldBuildChangeAssetOrderAction() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_CAB, CategoryDraft.class);
@@ -233,7 +233,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    void buildAssetsUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_CB, CategoryDraft.class);
@@ -245,7 +245,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildAssetsUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ACBD, CategoryDraft.class);
@@ -262,7 +262,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithAddedAssetInBetween_ShouldBuildAddWithCorrectPositionActions() {
+    void buildAssetsUpdateActions_WithAddedAssetInBetween_ShouldBuildAddWithCorrectPositionActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ADBC, CategoryDraft.class);
@@ -278,7 +278,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAssetActions() {
+    void buildAssetsUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAssetActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft =
             readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_CBD, CategoryDraft.class);
@@ -297,7 +297,7 @@ public class BuildAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildAssetsUpdateActions_WithAddedRemovedAndDifOrderAndNewName_ShouldBuildAllDiffAssetActions() {
+    void buildAssetsUpdateActions_WithAddedRemovedAndDifOrderAndNewName_ShouldBuildAllDiffAssetActions() {
         final Category oldCategory = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_ABC, Category.class);
         final CategoryDraft newCategoryDraft = readObjectFromResource(CATEGORY_DRAFT_WITH_ASSETS_CBD_WITH_CHANGES,
             CategoryDraft.class);

--- a/src/test/java/com/commercetools/sync/commons/BaseSyncTest.java
+++ b/src/test/java/com/commercetools/sync/commons/BaseSyncTest.java
@@ -2,7 +2,7 @@ package com.commercetools.sync.commons;
 
 import io.sphere.sdk.client.BadRequestException;
 import io.sphere.sdk.client.ConcurrentModificationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -12,11 +12,10 @@ import static com.commercetools.sync.commons.BaseSync.executeSupplierIfConcurren
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class BaseSyncTest {
+class BaseSyncTest {
 
     @Test
-    public void
-        executeSupplierIfConcurrentModificationException_WithConcModExceptionAsCause_ShouldExecuteFirstSupplier() {
+    void executeSupplierIfConcurrentModificationException_WithConcModExceptionAsCause_ShouldExecuteFirstSupplier() {
         final CompletionException sphereException = new CompletionException(new ConcurrentModificationException());
         final Supplier<Optional<String>> firstSupplier = () -> Optional.of("firstSupplier");
         final Supplier<Optional<String>> secondSupplier = () -> Optional.of("SecondSupplier");
@@ -26,8 +25,7 @@ public class BaseSyncTest {
     }
 
     @Test
-    public void
-        executeSupplierIfConcurrentModificationException_WithBadRequestExceptionAsCause_ShouldExecuteSecondSupplier() {
+    void executeSupplierIfConcurrentModificationException_WithBadRequestExceptionAsCause_ShouldExecuteSecondSupplier() {
         final CompletionException sphereException = new CompletionException(new BadRequestException("Bad Request!"));
         final Supplier<Optional<String>> firstSupplier = () -> Optional.of("firstSupplier");
         final Supplier<Optional<String>> secondSupplier = () -> Optional.of("SecondSupplier");
@@ -37,8 +35,7 @@ public class BaseSyncTest {
     }
 
     @Test
-    public void
-        executeSupplierIfConcurrentModificationException_WithConcurrentModException_ShouldExecuteSecondSupplier() {
+    void executeSupplierIfConcurrentModificationException_WithConcurrentModException_ShouldExecuteSecondSupplier() {
         final ConcurrentModificationException sphereException = new ConcurrentModificationException();
         final Supplier<Optional<String>> firstSupplier = () -> Optional.of("firstSupplier");
         final Supplier<Optional<String>> secondSupplier = () -> Optional.of("SecondSupplier");

--- a/src/test/java/com/commercetools/sync/commons/exceptions/BuildUpdateActionExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/BuildUpdateActionExceptionTest.java
@@ -1,13 +1,14 @@
 package com.commercetools.sync.commons.exceptions;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildUpdateActionExceptionTest {
+class BuildUpdateActionExceptionTest {
 
     @Test
-    public void buildUpdateActionException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    void buildUpdateActionException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
 
         assertThatThrownBy(() -> {
@@ -18,7 +19,7 @@ public class BuildUpdateActionExceptionTest {
     }
 
     @Test
-    public void buildUpdateActionException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    void buildUpdateActionException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
         final IllegalArgumentException cause = new IllegalArgumentException();
 
@@ -30,7 +31,7 @@ public class BuildUpdateActionExceptionTest {
     }
 
     @Test
-    public void buildUpdateActionException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    void buildUpdateActionException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
         final IllegalArgumentException cause = new IllegalArgumentException();
 
         assertThatThrownBy(() -> {

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateKeyExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateKeyExceptionTest.java
@@ -1,13 +1,14 @@
 package com.commercetools.sync.commons.exceptions;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class DuplicateKeyExceptionTest {
+class DuplicateKeyExceptionTest {
 
     @Test
-    public void duplicateKeyException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    void duplicateKeyException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
 
         assertThatThrownBy(() -> {
@@ -18,7 +19,7 @@ public class DuplicateKeyExceptionTest {
     }
 
     @Test
-    public void duplicateKeyException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    void duplicateKeyException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
         final IllegalArgumentException cause = new IllegalArgumentException();
 
@@ -30,7 +31,7 @@ public class DuplicateKeyExceptionTest {
     }
 
     @Test
-    public void duplicateKeyException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    void duplicateKeyException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
         final IllegalArgumentException cause = new IllegalArgumentException();
 
         assertThatThrownBy(() -> {

--- a/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/DuplicateNameExceptionTest.java
@@ -1,12 +1,13 @@
 package com.commercetools.sync.commons.exceptions;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class DuplicateNameExceptionTest {
+class DuplicateNameExceptionTest {
     @Test
-    public void duplicateNameException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    void duplicateNameException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
 
         assertThatThrownBy(() -> {
@@ -17,7 +18,7 @@ public class DuplicateNameExceptionTest {
     }
 
     @Test
-    public void duplicateNameException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    void duplicateNameException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
         final IllegalArgumentException cause = new IllegalArgumentException();
 
@@ -29,7 +30,7 @@ public class DuplicateNameExceptionTest {
     }
 
     @Test
-    public void duplicateNameException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    void duplicateNameException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
         final IllegalArgumentException cause = new IllegalArgumentException();
 
         assertThatThrownBy(() -> {

--- a/src/test/java/com/commercetools/sync/commons/exceptions/ReferenceResolutionExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/exceptions/ReferenceResolutionExceptionTest.java
@@ -1,12 +1,13 @@
 package com.commercetools.sync.commons.exceptions;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ReferenceResolutionExceptionTest {
+class ReferenceResolutionExceptionTest {
     @Test
-    public void referenceResolutionException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    void referenceResolutionException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
 
         assertThatThrownBy(() -> {
@@ -17,7 +18,7 @@ public class ReferenceResolutionExceptionTest {
     }
 
     @Test
-    public void referenceResolutionException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    void referenceResolutionException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
         final String message = "foo";
         final IllegalArgumentException cause = new IllegalArgumentException();
 
@@ -29,7 +30,7 @@ public class ReferenceResolutionExceptionTest {
     }
 
     @Test
-    public void referenceResolutionException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    void referenceResolutionException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
         final IllegalArgumentException cause = new IllegalArgumentException();
 
         assertThatThrownBy(() -> {

--- a/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/AssetReferenceResolverTest.java
@@ -11,8 +11,8 @@ import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Objects;
@@ -29,21 +29,21 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AssetReferenceResolverTest {
+class AssetReferenceResolverTest {
     private TypeService typeService;
     private ProductSyncOptions syncOptions;
 
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         typeService = getMockTypeService();
         syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         final String customTypeKey = "customTypeKey";
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson(customTypeKey, new HashMap<>());
         final AssetDraftBuilder assetDraftBuilder = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
@@ -64,7 +64,7 @@ public class AssetReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CustomFieldsDraft customFieldsDraft = mock(CustomFieldsDraft.class);
         final ResourceIdentifier<Type> typeReference = ResourceIdentifier.ofId(null);
         when(customFieldsDraft.getType()).thenReturn(typeReference);
@@ -84,7 +84,7 @@ public class AssetReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson("", new HashMap<>());
         final AssetDraftBuilder assetDraftBuilder = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
                                                                      .key("assetKey")
@@ -101,7 +101,7 @@ public class AssetReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
+    void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
         final String customTypeKey = "customTypeKey";
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson(customTypeKey, new HashMap<>());
         final AssetDraftBuilder assetDraftBuilder = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
@@ -122,7 +122,7 @@ public class AssetReferenceResolverTest {
     }
 
     @Test
-    public void resolveReferences_WithNoCustomTypeReference_ShouldNotResolveReferences() {
+    void resolveReferences_WithNoCustomTypeReference_ShouldNotResolveReferences() {
         final AssetDraft assetDraft = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
                                                        .key("assetKey")
                                                        .build();

--- a/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
@@ -2,92 +2,92 @@ package com.commercetools.sync.commons.helpers;
 
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
 import io.netty.util.internal.StringUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BaseSyncStatisticsTest {
+class BaseSyncStatisticsTest {
     private BaseSyncStatistics baseSyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         baseSyncStatistics = new CategorySyncStatistics();
     }
 
     @Test
-    public void getUpdated_WithNoUpdated_ShouldReturnZero() {
+    void getUpdated_WithNoUpdated_ShouldReturnZero() {
         assertThat(baseSyncStatistics.getUpdated()).hasValue(0);
     }
 
     @Test
-    public void incrementUpdated_WithNoSpecifiedTimes_ShouldIncrementUpdatedValue() {
+    void incrementUpdated_WithNoSpecifiedTimes_ShouldIncrementUpdatedValue() {
         baseSyncStatistics.incrementUpdated();
         assertThat(baseSyncStatistics.getUpdated()).hasValue(1);
     }
 
     @Test
-    public void incrementUpdated_WithSpecifiedTimes_ShouldIncrementUpdatedValue() {
+    void incrementUpdated_WithSpecifiedTimes_ShouldIncrementUpdatedValue() {
         baseSyncStatistics.incrementUpdated(5);
         assertThat(baseSyncStatistics.getUpdated()).hasValue(5);
     }
 
     @Test
-    public void getCreated_WithNoCreated_ShouldReturnZero() {
+    void getCreated_WithNoCreated_ShouldReturnZero() {
         assertThat(baseSyncStatistics.getCreated()).hasValue(0);
     }
 
     @Test
-    public void incrementCreated_WithNoSpecifiedTimes_ShouldIncrementCreatedValue() {
+    void incrementCreated_WithNoSpecifiedTimes_ShouldIncrementCreatedValue() {
         baseSyncStatistics.incrementCreated();
         assertThat(baseSyncStatistics.getCreated()).hasValue(1);
     }
 
     @Test
-    public void incrementCreated_WithSpecifiedTimes_ShouldIncrementCreatedValue() {
+    void incrementCreated_WithSpecifiedTimes_ShouldIncrementCreatedValue() {
         baseSyncStatistics.incrementCreated(2);
         assertThat(baseSyncStatistics.getCreated()).hasValue(2);
     }
 
     @Test
-    public void getProcessed_WithNoProcessed_ShouldReturnZero() {
+    void getProcessed_WithNoProcessed_ShouldReturnZero() {
         assertThat(baseSyncStatistics.getProcessed()).hasValue(0);
     }
 
     @Test
-    public void incrementProcessed_WithNoSpecifiedTimes_ShouldIncrementProcessedValue() {
+    void incrementProcessed_WithNoSpecifiedTimes_ShouldIncrementProcessedValue() {
         baseSyncStatistics.incrementProcessed();
         assertThat(baseSyncStatistics.getProcessed()).hasValue(1);
     }
 
     @Test
-    public void incrementProcessed_WithSpecifiedTimes_ShouldIncrementProcessedValue() {
+    void incrementProcessed_WithSpecifiedTimes_ShouldIncrementProcessedValue() {
         baseSyncStatistics.incrementProcessed(2);
         assertThat(baseSyncStatistics.getProcessed()).hasValue(2);
     }
 
     @Test
-    public void getFailed_WithNoFailed_ShouldReturnZero() {
+    void getFailed_WithNoFailed_ShouldReturnZero() {
         assertThat(baseSyncStatistics.getFailed()).hasValue(0);
     }
 
     @Test
-    public void incrementFailed_WithNoSpecifiedTimes_ShouldIncrementFailedValue() {
+    void incrementFailed_WithNoSpecifiedTimes_ShouldIncrementFailedValue() {
         baseSyncStatistics.incrementFailed();
         assertThat(baseSyncStatistics.getFailed()).hasValue(1);
     }
 
     @Test
-    public void incrementFailed_WithSpecifiedTimes_ShouldIncrementFailedValue() {
+    void incrementFailed_WithSpecifiedTimes_ShouldIncrementFailedValue() {
         baseSyncStatistics.incrementFailed(3);
         assertThat(baseSyncStatistics.getFailed()).hasValue(3);
     }
 
     @Test
-    public void calculateProcessingTime_ShouldSetProcessingTimeInAllUnitsAndHumanReadableString() throws
+    void calculateProcessingTime_ShouldSetProcessingTimeInAllUnitsAndHumanReadableString() throws
         InterruptedException {
         assertThat(baseSyncStatistics.getLatestBatchProcessingTimeInMillis()).isEqualTo(0);
         assertThat(baseSyncStatistics.getLatestBatchHumanReadableProcessingTime()).isEqualTo(StringUtil.EMPTY_STRING);

--- a/src/test/java/com/commercetools/sync/commons/helpers/CategoryReferencePairTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/CategoryReferencePairTest.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.commons.helpers;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.products.CategoryOrderHints;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,10 +11,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class CategoryReferencePairTest {
+class CategoryReferencePairTest {
 
     @Test
-    public void of_WithBothReferencesAndCategoryOrderHints_ShouldSetBoth() {
+    void of_WithBothReferencesAndCategoryOrderHints_ShouldSetBoth() {
         final List<Reference<Category>> categoryReferences =
             Arrays.asList(Category.referenceOfId("cat1"), Category.referenceOfId("cat2"));
         final CategoryOrderHints categoryOrderHints = CategoryOrderHints.of("cat1", "0.12");
@@ -28,7 +28,7 @@ public class CategoryReferencePairTest {
     }
 
     @Test
-    public void of_WithNullCategoryOrderHints_ShouldSetReferencesOnly() {
+    void of_WithNullCategoryOrderHints_ShouldSetReferencesOnly() {
         final List<Reference<Category>> categoryReferences =
             Arrays.asList(Category.referenceOfId("cat1"), Category.referenceOfId("cat2"));
         final CategoryReferencePair categoryReferencePair =

--- a/src/test/java/com/commercetools/sync/commons/utils/AssetReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/AssetReferenceReplacementUtilsTest.java
@@ -4,7 +4,7 @@ import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -16,10 +16,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AssetReferenceReplacementUtilsTest {
+class AssetReferenceReplacementUtilsTest {
 
     @Test
-    public void replaceAssetsReferencesIdsWithKeys_WithAllExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void replaceAssetsReferencesIdsWithKeys_WithAllExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         // preparation
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
 
@@ -38,7 +38,7 @@ public class AssetReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAssetsReferencesIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedRefs() {
+    void replaceAssetsReferencesIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedRefs() {
         // preparation
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
 
@@ -61,7 +61,7 @@ public class AssetReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAssetsReferencesIdsWithKeys_WithNonExpandedRefs_ShouldReturnReferencesWithoutReplacedKeys() {
+    void replaceAssetsReferencesIdsWithKeys_WithNonExpandedRefs_ShouldReturnReferencesWithoutReplacedKeys() {
         // preparation
         final String customTypeId = UUID.randomUUID().toString();
 

--- a/src/test/java/com/commercetools/sync/commons/utils/CategoryAssetCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CategoryAssetCustomUpdateActionUtilsTest.java
@@ -10,21 +10,21 @@ import io.sphere.sdk.categories.commands.updateactions.SetAssetCustomType;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.Asset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
 import static io.sphere.sdk.models.ResourceIdentifier.ofId;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryAssetCustomUpdateActionUtilsTest {
+class CategoryAssetCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithCategoryAsset_ShouldBuildCategoryUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithCategoryAsset_ShouldBuildCategoryUpdateAction() {
         final Asset asset = mock(Asset.class);
         when(asset.getKey()).thenReturn("assetKey");
         final String newCustomTypeId = "key";
@@ -42,7 +42,7 @@ public class CategoryAssetCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithCategoryAsset_ShouldBuildChannelUpdateAction() {
+    void buildRemoveCustomTypeAction_WithCategoryAsset_ShouldBuildChannelUpdateAction() {
         final String assetKey = "assetKey";
 
         final UpdateAction<Category> updateAction =
@@ -54,7 +54,7 @@ public class CategoryAssetCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithCategoryAsset_ShouldBuildCategoryUpdateAction() {
+    void buildSetCustomFieldAction_WithCategoryAsset_ShouldBuildCategoryUpdateAction() {
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
         final String customFieldName = "name";
         final String assetKey = "assetKey";

--- a/src/test/java/com/commercetools/sync/commons/utils/CategoryCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CategoryCustomUpdateActionUtilsTest.java
@@ -9,7 +9,7 @@ import io.sphere.sdk.categories.commands.updateactions.SetCustomField;
 import io.sphere.sdk.categories.commands.updateactions.SetCustomType;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -19,10 +19,10 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class CategoryCustomUpdateActionUtilsTest {
+class CategoryCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
         final String newCustomTypeId = "key";
 
         final UpdateAction<Category> updateAction =
@@ -36,7 +36,7 @@ public class CategoryCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
+    void buildRemoveCustomTypeAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
         final UpdateAction<Category> updateAction =
             new CategoryCustomActionBuilder().buildRemoveCustomTypeAction(null, null);
 
@@ -45,7 +45,7 @@ public class CategoryCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
+    void buildSetCustomFieldAction_WithCategoryResource_ShouldBuildCategoryUpdateAction() {
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
         final String customFieldName = "name";
 

--- a/src/test/java/com/commercetools/sync/commons/utils/ChannelCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ChannelCustomUpdateActionUtilsTest.java
@@ -9,22 +9,21 @@ import io.sphere.sdk.channels.commands.updateactions.SetCustomField;
 import io.sphere.sdk.channels.commands.updateactions.SetCustomType;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
-
 import static io.sphere.sdk.models.ResourceIdentifier.ofId;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class ChannelCustomUpdateActionUtilsTest {
+class ChannelCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
         final Channel channel = mock(Channel.class);
         final Map<String, JsonNode> fieldsJsonMap = new HashMap<>();
         final String customTypeId = "key";
@@ -41,7 +40,7 @@ public class ChannelCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
+    void buildRemoveCustomTypeAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
         final UpdateAction<Channel> updateAction =
             new ChannelCustomActionBuilder().buildRemoveCustomTypeAction(null, null);
 
@@ -50,7 +49,7 @@ public class ChannelCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
+    void buildSetCustomFieldAction_WithChannelResource_ShouldBuildChannelUpdateAction() {
         final String customFieldName = "name";
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
 

--- a/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CollectionUtilsTest.java
@@ -1,7 +1,7 @@
 package com.commercetools.sync.commons.utils;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -20,16 +20,16 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-public class CollectionUtilsTest {
+class CollectionUtilsTest {
 
     @Test
-    public void filterCollection_emptyCases() throws Exception {
+    void filterCollection_emptyCases() {
         assertThat(filterCollection(null, i -> true)).isEmpty();
         assertThat(filterCollection(Collections.emptyList(), i -> true)).isEmpty();
     }
 
     @Test
-    public void filterCollection_normalCases() throws Exception {
+    void filterCollection_normalCases() {
         List<String> abcd = asList("a", "b", "c", "d");
         assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "b", "c", "d");
         assertThat(filterCollection(abcd, s -> false)).isEmpty();
@@ -37,7 +37,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void filterCollection_duplicates() throws Exception {
+    void filterCollection_duplicates() {
         List<String> abcd = asList("a", "b", "c", "d", "d", "c", "g", "a");
         assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "a", "b", "c", "c", "d", "d", "g");
         assertThat(filterCollection(abcd, s -> false)).isEmpty();
@@ -45,13 +45,13 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void collectionToSet_emptyCases() throws Exception {
+    void collectionToSet_emptyCases() {
         assertThat(collectionToSet(null, i -> i)).isEmpty();
         assertThat(collectionToSet(Collections.emptyList(), i -> i)).isEmpty();
     }
 
     @Test
-    public void collectionToSet_normalCases() throws Exception {
+    void collectionToSet_normalCases() {
         List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
         assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
@@ -59,7 +59,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void collectionToSet_duplicates() throws Exception {
+    void collectionToSet_duplicates() {
         List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4), Pair.of("d", 5), Pair.of("b", 6));
         // 2 duplicate keys should be suppressed
@@ -69,7 +69,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void collectionToMap_emptyCases() throws Exception {
+    void collectionToMap_emptyCases() {
         assertThat(collectionToMap(null, k -> k)).isEmpty();
         assertThat(collectionToMap(null, k -> k, v -> v)).isEmpty();
         assertThat(collectionToMap(Collections.emptyList(), k -> k)).isEmpty();
@@ -77,7 +77,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void collectionToMap_normalCases() throws Exception {
+    void collectionToMap_normalCases() {
         List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
 
@@ -97,7 +97,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void collectionToMap_duplicates() throws Exception {
+    void collectionToMap_duplicates() {
         List<Pair<String, Integer>> abcd = asList(
                 Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4), Pair.of("d", 5), Pair.of("b", 6));
 
@@ -117,7 +117,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withNullInstances_returnsNonNullInstances() {
+    void emptyIfNull_withNullInstances_returnsNonNullInstances() {
         Collection<String> nonNullEmptyCollection = emptyIfNull((Collection<String>)null);
         assertThat(nonNullEmptyCollection).isNotNull();
         assertThat(nonNullEmptyCollection).isEmpty();
@@ -136,7 +136,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withArrayList_returnsSameInstance() {
+    void emptyIfNull_withArrayList_returnsSameInstance() {
         ArrayList<String> arrayListCollection = new ArrayList<>();
         arrayListCollection.add("a");
         arrayListCollection.add("b");
@@ -147,7 +147,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withHashSet_returnsSameInstance() {
+    void emptyIfNull_withHashSet_returnsSameInstance() {
         HashSet<String> arrayListCollection = new HashSet<>();
         arrayListCollection.add("woot");
         arrayListCollection.add("hack");
@@ -158,7 +158,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withListInstances_returnsNonNullList() {
+    void emptyIfNull_withListInstances_returnsNonNullList() {
         List<String> originalListToTest = asList("a", "b");
 
         List<String> actualListToTest = emptyIfNull(originalListToTest);
@@ -167,7 +167,7 @@ public class CollectionUtilsTest {
     }
 
     @Test
-    public void emptyIfNull_withMapInstances_returnsNonNullMap() {
+    void emptyIfNull_withMapInstances_returnsNonNullMap() {
         Map<String, Integer> mapToTest = new HashMap<>();
         mapToTest.put("X", 10);
         mapToTest.put("Y", 11);

--- a/src/test/java/com/commercetools/sync/commons/utils/CommonTypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CommonTypeUpdateActionUtilsTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.categories.commands.updateactions.ChangeName;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -14,12 +14,12 @@ import java.util.Optional;
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CommonTypeUpdateActionUtilsTest {
+class CommonTypeUpdateActionUtilsTest {
     private static final Locale LOCALE = Locale.GERMAN;
     private static final String MOCK_OLD_CATEGORY_NAME = "categoryName";
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithDifferentFieldValues_ShouldBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithDifferentFieldValues_ShouldBuildUpdateAction() {
         final LocalizedString oldLocalisedString = LocalizedString.of(LOCALE, "Apfel");
         final LocalizedString newLocalisedString = LocalizedString.of(LOCALE, "Milch");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
@@ -34,7 +34,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithEmptyOldFields_ShouldBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithEmptyOldFields_ShouldBuildUpdateAction() {
         final LocalizedString oldLocalisedString = LocalizedString.of(new HashMap<>());
         final LocalizedString newLocalisedString = LocalizedString.of(LOCALE, "Milch");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
@@ -49,7 +49,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithEmptyFields_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithEmptyFields_ShouldNotBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
         final Optional<UpdateAction<Category>> updateActionForLocalizedStrings =
@@ -61,7 +61,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithSameValues_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithSameValues_ShouldNotBuildUpdateAction() {
         final LocalizedString oldLocalisedString = LocalizedString.of(LOCALE, "Milch");
         final LocalizedString newLocalisedString = LocalizedString.of(LOCALE, "Milch");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
@@ -75,7 +75,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithSameValuesButDifferentFieldOrder_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithSameValuesButDifferentFieldOrder_ShouldNotBuildUpdateAction() {
         final LocalizedString oldLocalisedString = LocalizedString.of(LOCALE, "Milch")
                                                                   .plus(Locale.FRENCH, "Lait")
                                                                   .plus(Locale.ENGLISH, "Milk");
@@ -95,7 +95,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithNullValues_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithNullValues_ShouldNotBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName
             .of(LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
         final Optional<UpdateAction<Category>> updateActionForReferences =
@@ -106,7 +106,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForLocalizedStrings_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForLocalizedStrings_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Category>> updateActionForReferences =
             buildUpdateAction(null, null, () -> null);
 
@@ -115,7 +115,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForReferences_WithDifferentTypeReferenceIds_ShouldBuildUpdateAction() {
+    void buildUpdateActionForReferences_WithDifferentTypeReferenceIds_ShouldBuildUpdateAction() {
         final Reference<Category> oldCategoryReference = Category.referenceOfId("1");
         Reference<Category> newCategoryReference = Category.referenceOfId("2");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
@@ -130,7 +130,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForReferences_WithOneNullReference_ShouldBuildUpdateAction() {
+    void buildUpdateActionForReferences_WithOneNullReference_ShouldBuildUpdateAction() {
         final Reference<Category> categoryReference = Category.referenceOfId("1");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
@@ -144,7 +144,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForReferences_WithSameCategoryReferences_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForReferences_WithSameCategoryReferences_ShouldNotBuildUpdateAction() {
         final Reference<Category> categoryReference = Category.referenceOfId("1");
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
@@ -157,7 +157,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForReferences_WithNullReferences_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForReferences_WithNullReferences_ShouldNotBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
         final Optional<UpdateAction<Category>> updateActionForReferences =
@@ -168,7 +168,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForReferences_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForReferences_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Category>> updateActionForReferences =
             buildUpdateAction(null, null, () -> null);
 
@@ -177,7 +177,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForStrings_WithDifferentStrings_ShouldBuildUpdateAction() {
+    void buildUpdateActionForStrings_WithDifferentStrings_ShouldBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
 
@@ -190,7 +190,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForStrings_WithOneNullString_ShouldBuildUpdateAction() {
+    void buildUpdateActionForStrings_WithOneNullString_ShouldBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
 
@@ -203,7 +203,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForStrings_WithSameStrings_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForStrings_WithSameStrings_ShouldNotBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
 
@@ -215,7 +215,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForStrings_WithNullStrings_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForStrings_WithNullStrings_ShouldNotBuildUpdateAction() {
         final UpdateAction<Category> mockUpdateAction = ChangeName.of(
             LocalizedString.of(LOCALE, MOCK_OLD_CATEGORY_NAME));
         final Optional<UpdateAction<Category>> updateActionForStrings =
@@ -226,7 +226,7 @@ public class CommonTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildUpdateActionForStrings_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
+    void buildUpdateActionForStrings_WithNullUpdateAction_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Category>> updateActionForStrings =
             buildUpdateAction(null, null, () -> null);
 

--- a/src/test/java/com/commercetools/sync/commons/utils/CustomTypeReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CustomTypeReferenceReplacementUtilsTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CustomTypeReferenceReplacementUtilsTest {
+class CustomTypeReferenceReplacementUtilsTest {
 
     @Test
-    public void replaceCustomTypeIdWithKeys_WithNullCustomType_ShouldReturnNullCustomFields() {
+    void replaceCustomTypeIdWithKeys_WithNullCustomType_ShouldReturnNullCustomFields() {
         final Category mockCategory = mock(Category.class);
 
         final CustomFieldsDraft customFieldsDraft = replaceCustomTypeIdWithKeys(mockCategory);
@@ -26,7 +26,7 @@ public class CustomTypeReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceCustomTypeIdWithKeys_WithExpandedCategory_ShouldReturnCustomFieldsDraft() {
+    void replaceCustomTypeIdWithKeys_WithExpandedCategory_ShouldReturnCustomFieldsDraft() {
         // preparation
         final Category mockCategory = mock(Category.class);
         final CustomFields mockCustomFields  = mock(CustomFields.class);
@@ -47,7 +47,7 @@ public class CustomTypeReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceCustomTypeIdWithKeys_WithNonExpandedCategory_ShouldReturnReferenceWithoutReplacedKey() {
+    void replaceCustomTypeIdWithKeys_WithNonExpandedCategory_ShouldReturnReferenceWithoutReplacedKey() {
         // preparation
         final Category mockCategory = mock(Category.class);
         final CustomFields mockCustomFields  = mock(CustomFields.class);

--- a/src/test/java/com/commercetools/sync/commons/utils/CustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/CustomUpdateActionUtilsTest.java
@@ -26,7 +26,7 @@ import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomType;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,12 +49,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CustomUpdateActionUtilsTest {
+class CustomUpdateActionUtilsTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private static final CategorySyncOptions CATEGORY_SYNC_OPTIONS = CategorySyncOptionsBuilder.of(CTP_CLIENT).build();
 
     @Test
-    public void buildCustomUpdateActions_WithNonNullCustomFieldsWithDifferentTypes_ShouldBuildUpdateActions() {
+    void buildCustomUpdateActions_WithNonNullCustomFieldsWithDifferentTypes_ShouldBuildUpdateActions() {
         final Asset oldAsset = mock(Asset.class);
         final CustomFields oldAssetCustomFields = mock(CustomFields.class);
         final Reference<Type> oldAssetCustomFieldsDraftTypeReference = Type.referenceOfId("2");
@@ -80,7 +80,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullOldCustomFields_ShouldBuildUpdateActions() {
+    void buildCustomUpdateActions_WithNullOldCustomFields_ShouldBuildUpdateActions() {
         final Asset oldAsset = mock(Asset.class);
         when(oldAsset.getCustom()).thenReturn(null);
 
@@ -104,7 +104,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullOldCustomFieldsAndBlankNewTypeId_ShouldCallErrorCallBack() {
+    void buildCustomUpdateActions_WithNullOldCustomFieldsAndBlankNewTypeId_ShouldCallErrorCallBack() {
         final Asset oldAsset = mock(Asset.class);
         final String oldAssetId = "oldAssetId";
         when(oldAsset.getId()).thenReturn(oldAssetId);
@@ -139,7 +139,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullNewCustomFields_ShouldBuildUpdateActions() {
+    void buildCustomUpdateActions_WithNullNewCustomFields_ShouldBuildUpdateActions() {
         final Asset oldAsset = mock(Asset.class);
         final String oldAssetId = "oldAssetId";
         when(oldAsset.getId()).thenReturn(oldAssetId);
@@ -161,7 +161,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullIds_ShouldCallSyncOptionsCallBack() {
+    void buildCustomUpdateActions_WithNullIds_ShouldCallSyncOptionsCallBack() {
         final Reference<Type> assetCustomTypeReference = Type.referenceOfId(null);
 
         // Mock old CustomFields
@@ -209,7 +209,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithBothNullCustomFields_ShouldNotBuildUpdateActions() {
+    void buildNonNullCustomFieldsUpdateActions_WithBothNullCustomFields_ShouldNotBuildUpdateActions() {
         final Asset oldAsset = mock(Asset.class);
         when(oldAsset.getCustom()).thenReturn(null);
 
@@ -238,7 +238,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void
+    void
         buildNonNullCustomFieldsUpdateActions_WithSameCategoryTypesButDifferentFieldValues_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
@@ -269,7 +269,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithDifferentCategoryTypeIds_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithDifferentCategoryTypeIds_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -292,7 +292,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullOldCategoryTypeId_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithNullOldCategoryTypeId_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -312,7 +312,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullNewCategoryTypeId_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithNullNewCategoryTypeId_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -347,7 +347,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithSameIdsButNullNewCustomFields_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithSameIdsButNullNewCustomFields_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         final Reference<Type> productPriceTypeReference = Type.referenceOfId("productPriceCustomTypeId");
 
@@ -373,7 +373,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullIds_ShouldThrowBuildUpdateActionException() {
+    void buildNonNullCustomFieldsUpdateActions_WithNullIds_ShouldThrowBuildUpdateActionException() {
         final Reference<Type> productPriceTypeReference = Type.referenceOfId(null);
 
         // Mock old CustomFields
@@ -394,7 +394,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithDifferentCustomFieldValues_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithDifferentCustomFieldValues_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(false));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -415,7 +415,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithNoNewCustomFieldsInOldCustomFields_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithNoNewCustomFieldsInOldCustomFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
 
         final Map<String, JsonNode> newCustomFields = new HashMap<>();
@@ -433,7 +433,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithOldCustomFieldNotInNewFields_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithOldCustomFieldNotInNewFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -451,7 +451,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithSameCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithSameCustomFieldValues_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
@@ -468,7 +468,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithDifferentOrderOfCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithDifferentOrderOfCustomFieldValues_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor",
             JsonNodeFactory.instance.objectNode().put("de", "rot").put("es", "rojo"));
@@ -486,7 +486,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithEmptyCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithEmptyCustomFieldValues_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode());
 
@@ -501,7 +501,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithEmptyCustomFields_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithEmptyCustomFields_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
 
         final Map<String, JsonNode> newCustomFields = new HashMap<>();
@@ -514,7 +514,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNewOrModifiedCustomFieldsUpdateActions_WithNewOrModifiedCustomFields_ShouldBuildUpdateActions() {
+    void buildNewOrModifiedCustomFieldsUpdateActions_WithNewOrModifiedCustomFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
 
@@ -531,7 +531,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNewOrModifiedCustomFieldsUpdateActions_WithNoNewOrModifiedCustomFields_ShouldNotBuildActions() {
+    void buildNewOrModifiedCustomFieldsUpdateActions_WithNoNewOrModifiedCustomFields_ShouldNotBuildActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -547,7 +547,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemovedCustomFieldsUpdateActions_WithRemovedCustomField_ShouldBuildUpdateActions() {
+    void buildRemovedCustomFieldsUpdateActions_WithRemovedCustomField_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -565,7 +565,7 @@ public class CustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemovedCustomFieldsUpdateActions_WithNoRemovedCustomField_ShouldNotBuildUpdateActions() {
+    void buildRemovedCustomFieldsUpdateActions_WithNoRemovedCustomField_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
 

--- a/src/test/java/com/commercetools/sync/commons/utils/EnumValuesUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/EnumValuesUpdateActionUtilsTest.java
@@ -7,30 +7,30 @@ import io.sphere.sdk.producttypes.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
 import static com.commercetools.sync.commons.utils.EnumValuesUpdateActionUtils.buildActions;
 import static com.commercetools.sync.commons.utils.EnumValuesUpdateActionUtils.buildAddEnumValuesUpdateActions;
 import static com.commercetools.sync.commons.utils.EnumValuesUpdateActionUtils.buildChangeEnumValuesOrderUpdateAction;
 import static com.commercetools.sync.commons.utils.EnumValuesUpdateActionUtils.buildMatchingEnumValuesUpdateActions;
 import static com.commercetools.sync.commons.utils.EnumValuesUpdateActionUtils.buildRemoveEnumValuesUpdateAction;
+import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
 import static com.commercetools.sync.commons.utils.PlainEnumValueFixtures.*;
 import static com.commercetools.sync.producttypes.utils.PlainEnumValueUpdateActionUtils.buildChangeLabelAction;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnumValuesUpdateActionUtilsTest {
+class EnumValuesUpdateActionUtilsTest {
 
     private static final String attributeDefinitionName = "attribute_definition_name_1";
 
     @Test
-    public void buildActions_WithoutCallbacks_ShouldNotBuildActions() {
+    void buildActions_WithoutCallbacks_ShouldNotBuildActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABCD,
@@ -44,7 +44,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutRemoveCallback_ShouldNotBuildRemoveAction() {
+    void buildActions_WithoutRemoveCallback_ShouldNotBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             null,
@@ -60,7 +60,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNullNewEnumValues_ShouldJustBuildRemoveActions() {
+    void buildActions_WithNullNewEnumValues_ShouldJustBuildRemoveActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             null,
@@ -80,7 +80,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithEmptyNewEnumValues_ShouldJustBuildRemoveActions() {
+    void buildActions_WithEmptyNewEnumValues_ShouldJustBuildRemoveActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             Collections.emptyList(),
@@ -100,7 +100,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithRemoveCallback_ShouldBuildRemoveAction() {
+    void buildActions_WithRemoveCallback_ShouldBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             null,
@@ -116,7 +116,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutMatchingEnumCallback_ShouldNotBuildMatchingActions() {
+    void buildActions_WithoutMatchingEnumCallback_ShouldNotBuildMatchingActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             null,
@@ -133,7 +133,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithMatchingEnumCallback_ShouldBuildMatchingActions() {
+    void buildActions_WithMatchingEnumCallback_ShouldBuildMatchingActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_AB_WITH_DIFFERENT_LABEL,
@@ -149,7 +149,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutAddEnumCallback_ShouldNotBuildAddEnumActions() {
+    void buildActions_WithoutAddEnumCallback_ShouldNotBuildAddEnumActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_ABC,
@@ -165,7 +165,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithAddEnumCallback_ShouldBuildAddEnumActions() {
+    void buildActions_WithAddEnumCallback_ShouldBuildAddEnumActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_ABC,
@@ -181,7 +181,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutChangeOrderEnumCallback_ShouldNotBuildChangeOrderEnumActions() {
+    void buildActions_WithoutChangeOrderEnumCallback_ShouldNotBuildChangeOrderEnumActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             ENUM_VALUES_CAB,
@@ -201,7 +201,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangeOrderEnumCallback_ShouldBuildChangeOrderEnumActions() {
+    void buildActions_WithChangeOrderEnumCallback_ShouldBuildChangeOrderEnumActions() {
         final List<UpdateAction<ProductType>> updateActions = buildActions(attributeDefinitionName,
             ENUM_VALUES_ABC,
             ENUM_VALUES_CAB,
@@ -221,7 +221,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveEnumValuesUpdateAction_WithNullNewEnumValues_ShouldBuildRemoveActions() {
+    void buildRemoveEnumValuesUpdateAction_WithNullNewEnumValues_ShouldBuildRemoveActions() {
         final Optional<UpdateAction<ProductType>> updateAction = buildRemoveEnumValuesUpdateAction(
             attributeDefinitionName,
             ENUM_VALUES_ABC,
@@ -234,7 +234,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildMatchingEnumValuesUpdateActions_WithDifferentEnumValues_ShouldBuildChangeLabelActions() {
+    void buildMatchingEnumValuesUpdateActions_WithDifferentEnumValues_ShouldBuildChangeLabelActions() {
         final List<UpdateAction<ProductType>> updateActions = buildMatchingEnumValuesUpdateActions(
             attributeDefinitionName,
             ENUM_VALUES_AB,
@@ -247,7 +247,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildMatchingEnumValuesUpdateActions_WithSameNewEnumValues_ShouldNotBuildChangeLabelActions() {
+    void buildMatchingEnumValuesUpdateActions_WithSameNewEnumValues_ShouldNotBuildChangeLabelActions() {
         final List<UpdateAction<ProductType>> updateActions = buildMatchingEnumValuesUpdateActions(
             attributeDefinitionName,
             ENUM_VALUES_AB,
@@ -258,7 +258,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddEnumValuesUpdateActions_WithNewEnumValues_ShouldBuildAddActions() {
+    void buildAddEnumValuesUpdateActions_WithNewEnumValues_ShouldBuildAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildAddEnumValuesUpdateActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_ABC,
@@ -270,7 +270,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddEnumValuesUpdateActions_WithSameEnumValues_ShouldNotBuildAddActions() {
+    void buildAddEnumValuesUpdateActions_WithSameEnumValues_ShouldNotBuildAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildAddEnumValuesUpdateActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_AB,
@@ -280,7 +280,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeEnumValuesOrderUpdateAction_WithNewEnumValues_ShouldBuildAddActions() {
+    void buildChangeEnumValuesOrderUpdateAction_WithNewEnumValues_ShouldBuildAddActions() {
         final Optional<UpdateAction<ProductType>> updateAction =
             buildChangeEnumValuesOrderUpdateAction(attributeDefinitionName,
                 ENUM_VALUES_ABC,
@@ -296,7 +296,7 @@ public class EnumValuesUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeEnumValuesOrderUpdateAction_WithSameEnumValues_ShouldNotBuildAddActions() {
+    void buildChangeEnumValuesOrderUpdateAction_WithSameEnumValues_ShouldNotBuildAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildAddEnumValuesUpdateActions(attributeDefinitionName,
             ENUM_VALUES_AB,
             ENUM_VALUES_AB,

--- a/src/test/java/com/commercetools/sync/commons/utils/FilterUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/FilterUtilsTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.products.ImageDimensions;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.commands.updateactions.AddExternalImage;
 import io.sphere.sdk.products.commands.updateactions.RemoveImage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,7 +19,7 @@ import static com.commercetools.sync.products.ActionGroup.PRICES;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FilterUtilsTest {
+class FilterUtilsTest {
 
     private  final  List<UpdateAction<Product>> passingUpdateActions = Arrays.asList(
         AddExternalImage.of(Image.of("url2", ImageDimensions.of(10, 10)), 0),
@@ -30,7 +30,7 @@ public class FilterUtilsTest {
         singletonList(RemoveImage.of("anyUrl", 0));
 
     @Test
-    public void executeSupplierIfPassesFilter_WithGroupInBlackList_ShouldFilterOutOnlyThisGroup() {
+    void executeSupplierIfPassesFilter_WithGroupInBlackList_ShouldFilterOutOnlyThisGroup() {
         final SyncFilter syncFilter = SyncFilter.ofBlackList(IMAGES);
 
         final List<UpdateAction<Product>> updateActionsAfterImagesFilter =
@@ -50,7 +50,7 @@ public class FilterUtilsTest {
     }
 
     @Test
-    public void executeSupplierIfPassesFilter_WithGroupNotInBlackList_ShouldFilterInThisGroup() {
+    void executeSupplierIfPassesFilter_WithGroupNotInBlackList_ShouldFilterInThisGroup() {
         final SyncFilter syncFilter = SyncFilter.ofBlackList(PRICES);
         final List<UpdateAction<Product>> updateActionsAfterImagesFilter =
             executeSupplierIfPassesFilter(syncFilter, IMAGES, () -> passingUpdateActions , () -> defaultActions);
@@ -64,7 +64,7 @@ public class FilterUtilsTest {
     }
 
     @Test
-    public void executeSupplierIfPassesFilter_WithGroupInWhiteList_ShouldFilterInOnlyThisGroup() {
+    void executeSupplierIfPassesFilter_WithGroupInWhiteList_ShouldFilterInOnlyThisGroup() {
         final SyncFilter syncFilter = SyncFilter.ofWhiteList(PRICES);
 
         final List<UpdateAction<Product>> updateActionsAfterPricesFilter =
@@ -84,7 +84,7 @@ public class FilterUtilsTest {
     }
 
     @Test
-    public void executeSupplierIfPassesFilter_WithDefault_ShouldFilterInEveryThing() {
+    void executeSupplierIfPassesFilter_WithDefault_ShouldFilterInEveryThing() {
         final SyncFilter syncFilter = SyncFilter.of();
 
         final List<UpdateAction<Product>> updateActionsAfterPricesFilter =

--- a/src/test/java/com/commercetools/sync/commons/utils/GenericUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/GenericUpdateActionUtilsTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.Asset;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,10 +18,10 @@ import static com.commercetools.sync.commons.utils.GenericUpdateActionUtils.buil
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class GenericUpdateActionUtilsTest {
+class GenericUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithNullNewIdCategoryAsset_ShouldNotBuildCategoryUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithNullNewIdCategoryAsset_ShouldNotBuildCategoryUpdateAction() {
         final ArrayList<String> errorMessages = new ArrayList<>();
         final BiConsumer<String, Throwable> updateActionErrorCallBack =
             (errorMessage, exception) -> errorMessages.add(errorMessage);

--- a/src/test/java/com/commercetools/sync/commons/utils/InventoryEntryCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/InventoryEntryCustomUpdateActionUtilsTest.java
@@ -9,7 +9,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.inventory.InventoryEntry;
 import io.sphere.sdk.inventory.commands.updateactions.SetCustomField;
 import io.sphere.sdk.inventory.commands.updateactions.SetCustomType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -19,10 +19,10 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class InventoryEntryCustomUpdateActionUtilsTest {
+class InventoryEntryCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithInventoryResource_ShouldBuildInventoryUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithInventoryResource_ShouldBuildInventoryUpdateAction() {
         final String newCustomTypeId = "key";
 
         final UpdateAction<InventoryEntry> updateAction =
@@ -37,7 +37,7 @@ public class InventoryEntryCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithInventoryResource_ShouldBuildChannelUpdateAction() {
+    void buildRemoveCustomTypeAction_WithInventoryResource_ShouldBuildChannelUpdateAction() {
         final UpdateAction<InventoryEntry> updateAction =
             new InventoryCustomActionBuilder().buildRemoveCustomTypeAction(null, null);
 
@@ -46,7 +46,7 @@ public class InventoryEntryCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithInventoryResource_ShouldBuildInventoryUpdateAction() {
+    void buildSetCustomFieldAction_WithInventoryResource_ShouldBuildInventoryUpdateAction() {
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
         final String customFieldName = "name";
 

--- a/src/test/java/com/commercetools/sync/commons/utils/OptionalUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/OptionalUtilsTest.java
@@ -11,7 +11,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OptionalUtilsTest {
 

--- a/src/test/java/com/commercetools/sync/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
@@ -10,22 +10,22 @@ import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.commands.updateactions.SetAssetCustomField;
 import io.sphere.sdk.products.commands.updateactions.SetAssetCustomType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
 import static com.commercetools.sync.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
 import static io.sphere.sdk.models.ResourceIdentifier.ofId;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductAssetCustomUpdateActionUtilsTest {
+class ProductAssetCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithProductAsset_ShouldBuildProductUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithProductAsset_ShouldBuildProductUpdateAction() {
         final Asset asset = mock(Asset.class);
         when(asset.getKey()).thenReturn("assetKey");
         final String newCustomTypeId = "key";
@@ -43,7 +43,7 @@ public class ProductAssetCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithProductAsset_ShouldBuildChannelUpdateAction() {
+    void buildRemoveCustomTypeAction_WithProductAsset_ShouldBuildChannelUpdateAction() {
         final int variantId = 1;
         final UpdateAction<Product> updateAction =
             new AssetCustomActionBuilder().buildRemoveCustomTypeAction(variantId, "assetKey");
@@ -54,7 +54,7 @@ public class ProductAssetCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithProductAsset_ShouldBuildProductUpdateAction() {
+    void buildSetCustomFieldAction_WithProductAsset_ShouldBuildProductUpdateAction() {
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
         final String customFieldName = "name";
         final String assetKey = "assetKey";

--- a/src/test/java/com/commercetools/sync/commons/utils/ProductPriceCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ProductPriceCustomUpdateActionUtilsTest.java
@@ -11,7 +11,7 @@ import io.sphere.sdk.products.Price;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomField;
 import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductPriceCustomUpdateActionUtilsTest {
+class ProductPriceCustomUpdateActionUtilsTest {
 
     @Test
-    public void buildTypedSetCustomTypeUpdateAction_WithProductPrice_ShouldBuildProductUpdateAction() {
+    void buildTypedSetCustomTypeUpdateAction_WithProductPrice_ShouldBuildProductUpdateAction() {
         final Price price = mock(Price.class);
         when(price.getId()).thenReturn("priceId");
         final String newCustomTypeId = "key";
@@ -42,7 +42,7 @@ public class ProductPriceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemoveCustomTypeAction_WithProductPrice_ShouldBuildChannelUpdateAction() {
+    void buildRemoveCustomTypeAction_WithProductPrice_ShouldBuildChannelUpdateAction() {
         final String priceId = "1";
         final UpdateAction<Product> updateAction = new PriceCustomActionBuilder().buildRemoveCustomTypeAction(1,
             priceId);
@@ -53,7 +53,7 @@ public class ProductPriceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldAction_WithProductPrice_ShouldBuildProductUpdateAction() {
+    void buildSetCustomFieldAction_WithProductPrice_ShouldBuildProductUpdateAction() {
         final String priceId = "1";
         final String customFieldName = "name";
         final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");

--- a/src/test/java/com/commercetools/sync/commons/utils/QueryAllTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/QueryAllTest.java
@@ -6,8 +6,8 @@ import io.sphere.sdk.categories.queries.CategoryQuery;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereRequest;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class QueryAllTest {
+class QueryAllTest {
     private static final String CATEGORY_KEY = "catKey";
     private static final String CATEGORY_ID = UUID.randomUUID().toString();
     private static final SphereClient sphereClient = mock(SphereClient.class);
@@ -34,8 +34,8 @@ public class QueryAllTest {
      * to always return a {@link PagedQueryResult} containing 4 identical mock categories on every call of
      * {@link SphereClient#execute(SphereRequest)}.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         final Category mockCategory = mock(Category.class);
         when(mockCategory.getKey()).thenReturn(CATEGORY_KEY);
         when(mockCategory.getId()).thenReturn(CATEGORY_ID);
@@ -47,7 +47,7 @@ public class QueryAllTest {
     }
 
     @Test
-    public void run_WithCallback_ShouldApplyCallback() {
+    void run_WithCallback_ShouldApplyCallback() {
         final QueryAll<Category, CategoryQuery, Optional<Category>> query =
             QueryAll.of(sphereClient, CategoryQuery.of(), DEFAULT_PAGE_SIZE);
 
@@ -64,7 +64,7 @@ public class QueryAllTest {
     }
 
     @Test
-    public void run_WithConsumer_ShouldApplyConsumer() {
+    void run_WithConsumer_ShouldApplyConsumer() {
         final QueryAll<Category, CategoryQuery, Void> query =
             QueryAll.of(sphereClient, CategoryQuery.of(), DEFAULT_PAGE_SIZE);
         final List<String> categoryIds = new ArrayList<>();

--- a/src/test/java/com/commercetools/sync/commons/utils/ResourceCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ResourceCustomUpdateActionUtilsTest.java
@@ -20,8 +20,8 @@ import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,8 +33,8 @@ import java.util.function.BiConsumer;
 
 import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildNewOrModifiedCustomFieldsUpdateActions;
 import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildNonNullCustomFieldsUpdateActions;
-import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildRemovedCustomFieldsUpdateActions;
 import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildPrimaryResourceCustomUpdateActions;
+import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildRemovedCustomFieldsUpdateActions;
 import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildSetCustomFieldsUpdateActions;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,14 +42,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ResourceCustomUpdateActionUtilsTest {
+class ResourceCustomUpdateActionUtilsTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private ArrayList<String> errorMessages;
     private ArrayList<Throwable> exceptions;
     private CategorySyncOptions categorySyncOptions;
 
-    @Before
-    public void setupTest() {
+    @BeforeEach
+    void setupTest() {
         errorMessages = new ArrayList<>();
         exceptions = new ArrayList<>();
         final BiConsumer<String, Throwable> updateActionErrorCallBack = (errorMessage, exception) -> {
@@ -63,8 +63,7 @@ public class ResourceCustomUpdateActionUtilsTest {
                                                         .build();
     }
 
-    @Test
-    public void buildResourceCustomUpdateActions_WithNonNullCustomFieldsWithDifferentTypes_ShouldBuildUpdateActions() {
+    @Test void buildResourceCustomUpdateActions_WithNonNullCustomFieldsWithDifferentTypes_ShouldBuildUpdateActions() {
         final Category oldCategory = mock(Category.class);
         final CustomFields oldCategoryCustomFields = mock(CustomFields.class);
         final Reference<Type> oldCategoryCustomFieldsDraftTypeReference = Type.referenceOfId("2");
@@ -91,7 +90,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildResourceCustomUpdateActions_WithNullOldCustomFields_ShouldBuildUpdateActions() {
+    void buildResourceCustomUpdateActions_WithNullOldCustomFields_ShouldBuildUpdateActions() {
         final Category oldCategory = mock(Category.class);
         when(oldCategory.getCustom()).thenReturn(null);
 
@@ -110,7 +109,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildResourceCustomUpdateActions_WithNullOldCustomFieldsAndBlankNewTypeId_ShouldCallErrorCallBack() {
+    void buildResourceCustomUpdateActions_WithNullOldCustomFieldsAndBlankNewTypeId_ShouldCallErrorCallBack() {
         final Category oldCategory = mock(Category.class);
         when(oldCategory.getCustom()).thenReturn(null);
         final String oldCategoryId = "oldCategoryId";
@@ -136,7 +135,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildResourceCustomUpdateActions_WithNullNewCustomFields_ShouldBuildUpdateActions() {
+    void buildResourceCustomUpdateActions_WithNullNewCustomFields_ShouldBuildUpdateActions() {
         final Category oldCategory = mock(Category.class);
         final CustomFields oldCategoryCustomFields = mock(CustomFields.class);
         when(oldCategory.getCustom()).thenReturn(oldCategoryCustomFields);
@@ -157,7 +156,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildResourceCustomUpdateActions_WithNullIds_ShouldCallSyncOptionsCallBack() {
+    void buildResourceCustomUpdateActions_WithNullIds_ShouldCallSyncOptionsCallBack() {
         final Reference<Type> categoryTypeReference = Type.referenceOfId(null);
 
         // Mock old CustomFields
@@ -192,7 +191,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithBothNullCustomFields_ShouldNotBuildUpdateActions() {
+    void buildNonNullCustomFieldsUpdateActions_WithBothNullCustomFields_ShouldNotBuildUpdateActions() {
         final Category oldCategory = mock(Category.class);
         when(oldCategory.getCustom()).thenReturn(null);
 
@@ -210,8 +209,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void
-        buildNonNullCustomFieldsUpdateActions_WithSameCategoryTypesButDifferentFieldValues_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithSameCategoryTypesButDifferentFieldValues_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -242,7 +240,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithDifferentCategoryTypeIds_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithDifferentCategoryTypeIds_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -264,7 +262,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullOldCategoryTypeId_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithNullOldCategoryTypeId_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -286,7 +284,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullNewCategoryTypeId_TriggersErrorCallbackAndNoAction()
+    void buildNonNullCustomFieldsUpdateActions_WithNullNewCategoryTypeId_TriggersErrorCallbackAndNoAction()
         throws BuildUpdateActionException {
         // Mock old CustomFields
         final CustomFields oldCustomFieldsMock = mock(CustomFields.class);
@@ -317,7 +315,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithSameIdsButNullNewCustomFields_ShouldBuildUpdateActions()
+    void buildNonNullCustomFieldsUpdateActions_WithSameIdsButNullNewCustomFields_ShouldBuildUpdateActions()
         throws BuildUpdateActionException {
         final Reference<Type> categoryTypeReference = Type.referenceOfId("categoryCustomTypeId");
 
@@ -346,7 +344,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNonNullCustomFieldsUpdateActions_WithNullIds_ShouldThrowBuildUpdateActionException() {
+    void buildNonNullCustomFieldsUpdateActions_WithNullIds_ShouldThrowBuildUpdateActionException() {
         final Reference<Type> categoryTypeReference = Type.referenceOfId(null);
 
         // Mock old CustomFields
@@ -372,7 +370,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithDifferentCustomFieldValues_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithDifferentCustomFieldValues_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(false));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -394,7 +392,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithNoNewCustomFieldsInOldCustomFields_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithNoNewCustomFieldsInOldCustomFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
 
         final Map<String, JsonNode> newCustomFields = new HashMap<>();
@@ -413,7 +411,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithOldCustomFieldNotInNewFields_ShouldBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithOldCustomFieldNotInNewFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -432,7 +430,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithSameCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithSameCustomFieldValues_ShouldNotBuildUpdateActions() {
         final BooleanNode oldBooleanFieldValue = JsonNodeFactory.instance.booleanNode(true);
         final ObjectNode oldLocalizedFieldValue = JsonNodeFactory.instance.objectNode().put("de", "rot");
 
@@ -453,7 +451,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithDifferentOrderOfCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithDifferentOrderOfCustomFieldValues_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor",
             JsonNodeFactory.instance.objectNode().put("de", "rot").put("es", "rojo"));
@@ -471,7 +469,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithEmptyCustomFieldValues_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithEmptyCustomFieldValues_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode());
 
@@ -487,7 +485,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetCustomFieldsUpdateActions_WithEmptyCustomFields_ShouldNotBuildUpdateActions() {
+    void buildSetCustomFieldsUpdateActions_WithEmptyCustomFields_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         final Map<String, JsonNode> newCustomFields = new HashMap<>();
 
@@ -500,7 +498,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildNewOrModifiedCustomFieldsUpdateActions_WithNewOrModifiedCustomFields_ShouldBuildUpdateActions() {
+    void buildNewOrModifiedCustomFieldsUpdateActions_WithNewOrModifiedCustomFields_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
 
@@ -519,7 +517,7 @@ public class ResourceCustomUpdateActionUtilsTest {
 
 
     @Test
-    public void buildNewOrModifiedCustomFieldsUpdateActions_WithNoNewOrModifiedCustomFields_ShouldNotBuildActions() {
+    void buildNewOrModifiedCustomFieldsUpdateActions_WithNoNewOrModifiedCustomFields_ShouldNotBuildActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -536,7 +534,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemovedCustomFieldsUpdateActions_WithRemovedCustomField_ShouldBuildUpdateActions() {
+    void buildRemovedCustomFieldsUpdateActions_WithRemovedCustomField_ShouldBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red"));
@@ -555,7 +553,7 @@ public class ResourceCustomUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildRemovedCustomFieldsUpdateActions_WithNoRemovedCustomField_ShouldNotBuildUpdateActions() {
+    void buildRemovedCustomFieldsUpdateActions_WithNoRemovedCustomField_ShouldNotBuildUpdateActions() {
         final Map<String, JsonNode> oldCustomFields = new HashMap<>();
         oldCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
 

--- a/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ResourceIdentifierUtilsTest.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.commons.utils;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -12,15 +12,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ResourceIdentifierUtilsTest {
+class ResourceIdentifierUtilsTest {
 
     @Test
-    public void toResourceIdentifierIfNotNull_WithNullResource_ShouldReturnNull() {
+    void toResourceIdentifierIfNotNull_WithNullResource_ShouldReturnNull() {
         assertThat(toResourceIdentifierIfNotNull(null)).isNull();
     }
 
     @Test
-    public void toResourceIdentifierIfNotNull_WithNonNullResource_ShouldReturnCorrectResourceIdentifier() {
+    void toResourceIdentifierIfNotNull_WithNonNullResource_ShouldReturnCorrectResourceIdentifier() {
         final Category category = mock(Category.class);
         when(category.getId()).thenReturn(UUID.randomUUID().toString());
         when(category.toResourceIdentifier()).thenCallRealMethod();
@@ -34,7 +34,7 @@ public class ResourceIdentifierUtilsTest {
     }
 
     @Test
-    public void toResourceIdentifierIfNotNull_WithNonNullReference_ShouldReturnCorrectResourceIdentifier() {
+    void toResourceIdentifierIfNotNull_WithNonNullReference_ShouldReturnCorrectResourceIdentifier() {
         final Reference<Category> categoryReference = Category.referenceOfId("foo");
 
         final ResourceIdentifier<Category> categoryResourceIdentifier = toResourceIdentifierIfNotNull(

--- a/src/test/java/com/commercetools/sync/commons/utils/StreamUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/StreamUtilsTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -9,24 +10,24 @@ import static com.commercetools.sync.commons.utils.StreamUtils.filterNullAndMap;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StreamUtilsTest {
+class StreamUtilsTest {
 
     @Test
-    public void filterNullAndMap_emptyStream_ShouldReturnAnEmptyStream() {
+    void filterNullAndMap_emptyStream_ShouldReturnAnEmptyStream() {
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.empty(), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
         assertThat(mappedList).isEmpty();
     }
 
     @Test
-    public void filterNullAndMap_streamWithOnlyNullElements_ShouldReturnAnEmptyStream() {
+    void filterNullAndMap_streamWithOnlyNullElements_ShouldReturnAnEmptyStream() {
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.of(null, null, null), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
         assertThat(mappedList).isEmpty();
     }
 
     @Test
-    public void filterNullAndMap_streamWithOneNullElement_ShouldReturnAnEmptyStream() {
+    void filterNullAndMap_streamWithOneNullElement_ShouldReturnAnEmptyStream() {
         final String nullString = null;
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.of(nullString), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
@@ -34,7 +35,7 @@ public class StreamUtilsTest {
     }
 
     @Test
-    public void filterNullAndMap_singleElementStream_ShouldReturnMappedStream() {
+    void filterNullAndMap_singleElementStream_ShouldReturnMappedStream() {
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.of("foo"), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
         assertThat(mappedList).isNotEmpty();
@@ -42,7 +43,7 @@ public class StreamUtilsTest {
     }
 
     @Test
-    public void filterNullAndMap_multipleElementsStream_ShouldReturnMappedStream() {
+    void filterNullAndMap_multipleElementsStream_ShouldReturnMappedStream() {
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.of("james", "hetfield"), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
         assertThat(mappedList).isNotEmpty();
@@ -50,7 +51,7 @@ public class StreamUtilsTest {
     }
 
     @Test
-    public void filterNullAndMap_nonEmptyStreamWithNullElements_ShouldReturnMappedStream() {
+    void filterNullAndMap_nonEmptyStreamWithNullElements_ShouldReturnMappedStream() {
         final Stream<Integer> mappedStream = filterNullAndMap(Stream.of("james", "hetfield", null), String::length);
         final List<Integer> mappedList = mappedStream.collect(toList());
         assertThat(mappedList).isNotEmpty();

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
@@ -4,7 +4,7 @@ package com.commercetools.sync.commons.utils;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.models.Reference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class SyncUtilsTest {
+class SyncUtilsTest {
 
     @Test
-    public void batchElements_WithValidSize_ShouldReturnCorrectBatches() {
+    void batchElements_WithValidSize_ShouldReturnCorrectBatches() {
         final int numberOfCategoryDrafts = 160;
         final int batchSize = 10;
         final ArrayList<CategoryDraft> categoryDrafts = new ArrayList<>();
@@ -41,13 +41,13 @@ public class SyncUtilsTest {
     }
 
     @Test
-    public void batchElements_WithUniformSeparation_ShouldReturnCorrectBatches() {
+    void batchElements_WithUniformSeparation_ShouldReturnCorrectBatches() {
         batchStringElementsAndAssertAfterBatching(100, 10);
         batchStringElementsAndAssertAfterBatching(3, 1);
     }
 
     @Test
-    public void batchElements_WithNonUniformSeparation_ShouldReturnCorrectBatches() {
+    void batchElements_WithNonUniformSeparation_ShouldReturnCorrectBatches() {
         batchStringElementsAndAssertAfterBatching(100, 9);
         batchStringElementsAndAssertAfterBatching(3, 2);
     }
@@ -98,13 +98,13 @@ public class SyncUtilsTest {
     }
 
     @Test
-    public void batchElements_WithEmptyListAndAnySize_ShouldReturnNoBatches() {
+    void batchElements_WithEmptyListAndAnySize_ShouldReturnNoBatches() {
         final List<List<CategoryDraft>> batches = batchElements(new ArrayList<>(), 100);
         assertThat(batches.size()).isEqualTo(0);
     }
 
     @Test
-    public void batchElements_WithNegativeSize_ShouldReturnNoBatches() {
+    void batchElements_WithNegativeSize_ShouldReturnNoBatches() {
         final int numberOfCategoryDrafts = 160;
         final ArrayList<CategoryDraft> categoryDrafts = new ArrayList<>();
 
@@ -117,14 +117,14 @@ public class SyncUtilsTest {
     }
 
     @Test
-    public void replaceReferenceIdWithKey_WithNullReference_ShouldReturnNullReference() {
+    void replaceReferenceIdWithKey_WithNullReference_ShouldReturnNullReference() {
         final Reference<Object> keyReplacedReference = replaceReferenceIdWithKey(null,
             () -> Reference.of(Category.referenceTypeId(), "id"));
         assertThat(keyReplacedReference).isNull();
     }
 
     @Test
-    public void replaceReferenceIdWithKey_WithExpandedCategoryReference_ShouldReturnCategoryReferenceWithKey() {
+    void replaceReferenceIdWithKey_WithExpandedCategoryReference_ShouldReturnCategoryReferenceWithKey() {
         final String categoryKey = "categoryKey";
         final Category mockCategory = mock(Category.class);
         when(mockCategory.getKey()).thenReturn(categoryKey);
@@ -139,7 +139,7 @@ public class SyncUtilsTest {
     }
 
     @Test
-    public void replaceReferenceIdWithKey_WithNonExpandedCategoryReference_ShouldReturnReferenceWithoutReplacedKey() {
+    void replaceReferenceIdWithKey_WithNonExpandedCategoryReference_ShouldReturnReferenceWithoutReplacedKey() {
         final String categoryUuid = UUID.randomUUID().toString();
         final Reference<Category> categoryReference = Reference.ofResourceTypeIdAndId(Category.referenceTypeId(),
             categoryUuid);

--- a/src/test/java/com/commercetools/sync/commons/utils/TriFunctionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/TriFunctionTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
 import io.sphere.sdk.products.commands.updateactions.SetSku;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -21,10 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TriFunctionTest {
+class TriFunctionTest {
 
     @Test
-    public void apply_WithUpdateActionLocaleFilter_ShouldReturnCorrectResult() {
+    void apply_WithUpdateActionLocaleFilter_ShouldReturnCorrectResult() {
         final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
             updateActionFilter = TriFunctionTest::filterEnglishNameChangesOnly;
 
@@ -69,7 +69,7 @@ public class TriFunctionTest {
     }
 
     @Test
-    public void apply_WithIntegerParams_ShouldReturnCorrectResult() {
+    void apply_WithIntegerParams_ShouldReturnCorrectResult() {
         final TriFunction<Integer, Integer, Integer, String>
             sumToString = (num1, num2, num3) -> {
                 num1 = num1 != null ? num1 : 0;

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/CollectionOfFuturesToFutureOfCollectionTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/CollectionOfFuturesToFutureOfCollectionTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -19,7 +20,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CollectionOfFuturesToFutureOfCollectionTest {
+class CollectionOfFuturesToFutureOfCollectionTest {
 
     /**
      * List to List : empty values.
@@ -29,27 +30,27 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      **/
 
     @Test
-    public void empty_ListToList_ReturnsFutureOfEmptyList() {
+    void empty_ListToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<List<String>> future = collectionOfFuturesToFutureOfCollection(
             new ArrayList<CompletableFuture<String>>(), toList());
         assertThat(future.join()).isEqualTo(emptyList());
     }
 
     @Test
-    public void empty_ListToSet_ReturnsFutureOfEmptySet() {
+    void empty_ListToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<Set<String>> future = collectionOfFuturesToFutureOfCollection(
             new ArrayList<CompletableFuture<String>>(), toSet());
         assertThat(future.join()).isEqualTo(emptySet());
     }
 
     @Test
-    public void empty_SetToSet_ReturnsFutureOfEmptySet() {
+    void empty_SetToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<Set<String>> future = collectionOfFuturesToFutureOfCollection(new HashSet<>(), toSet());
         assertThat(future.join()).isEqualTo(emptySet());
     }
 
     @Test
-    public void empty_SetToList_ReturnsFutureOfEmptySet() {
+    void empty_SetToList_ReturnsFutureOfEmptySet() {
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(new HashSet<>(), toList());
         assertThat(future.join()).isEqualTo(emptyList());
@@ -64,7 +65,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      */
 
     @Test
-    public void singleNull_ListToList_ReturnsFutureOfEmptyList() {
+    void singleNull_ListToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(singletonList(nullFuture), toList());
@@ -72,7 +73,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void singleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    void singleNull_ListToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(singletonList(nullFuture), toSet());
@@ -80,7 +81,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void singleNull_SetToSet_ReturnsFutureOfEmptySet() {
+    void singleNull_SetToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(singleton(nullFuture), toSet());
@@ -88,7 +89,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void singleNull_SetToList_ReturnsFutureOfEmptyList() {
+    void singleNull_SetToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(singleton(nullFuture), toList());
@@ -101,7 +102,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      */
 
     @Test
-    public void multipleNull_ListToList_ReturnsFutureOfEmptyList() {
+    void multipleNull_ListToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(asList(nullFuture, nullFuture), toList());
@@ -109,7 +110,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multipleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    void multipleNull_ListToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<String> nullFuture = null;
         final CompletableFuture<Set<String>> future = collectionOfFuturesToFutureOfCollection(
             asList(nullFuture, nullFuture), toSet());
@@ -124,7 +125,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      */
 
     @Test
-    public void single_ListToList_ReturnsFutureOfList() {
+    void single_ListToList_ReturnsFutureOfList() {
         final String result = "value1";
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(singletonList(completedFuture(result)), toList());
@@ -132,7 +133,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void single_ListToSet_ReturnsFutureOfSet() {
+    void single_ListToSet_ReturnsFutureOfSet() {
         final String result = "value1";
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(singletonList(completedFuture(result)), toSet());
@@ -140,7 +141,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void single_SetToSet_ReturnsFutureOfSet() {
+    void single_SetToSet_ReturnsFutureOfSet() {
         final String result = "value1";
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(singleton(completedFuture(result)), toSet());
@@ -148,7 +149,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void single_SetToList_ReturnsFutureOfList() {
+    void single_SetToList_ReturnsFutureOfList() {
         final String result = "value1";
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(singleton(completedFuture(result)), toList());
@@ -163,7 +164,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      */
 
     @Test
-    public void multiple_ListToListNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
+    void multiple_ListToListNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(asList(completedFuture("foo"), completedFuture("bar")), toList());
         final List<String> result = future.join();
@@ -172,7 +173,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_ListToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
+    void multiple_ListToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(asList(completedFuture("foo"), completedFuture("bar")), toSet());
         final Set<String> result = future.join();
@@ -181,7 +182,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_SetToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
+    void multiple_SetToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
         final Set<CompletableFuture<String>> set = new HashSet<>();
         set.add(completedFuture("foo"));
         set.add(completedFuture("bar"));
@@ -193,7 +194,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_SetToListMappingNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
+    void multiple_SetToListMappingNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
         final Set<CompletableFuture<String>> set = new HashSet<>();
         set.add(completedFuture("foo"));
         set.add(completedFuture("bar"));
@@ -212,7 +213,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
      */
 
     @Test
-    public void multiple_ListToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
+    void multiple_ListToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
         final CompletableFuture<List<String>> future =
             collectionOfFuturesToFutureOfCollection(asList(completedFuture("foo"), completedFuture("foo")), toList());
         final List<String> result = future.join();
@@ -221,7 +222,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_ListToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
+    void multiple_ListToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
         final CompletableFuture<Set<String>> future =
             collectionOfFuturesToFutureOfCollection(asList(completedFuture("foo"), completedFuture("foo")), toSet());
         final Set<String> result = future.join();
@@ -230,7 +231,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_SetToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
+    void multiple_SetToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
         final Set<CompletableFuture<String>> set = new HashSet<>();
         set.add(completedFuture("foo"));
         set.add(completedFuture("foo"));
@@ -242,7 +243,7 @@ public class CollectionOfFuturesToFutureOfCollectionTest {
     }
 
     @Test
-    public void multiple_SetToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
+    void multiple_SetToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
         final Set<CompletableFuture<String>> set = new HashSet<>();
         set.add(completedFuture("foo"));
         set.add(completedFuture("foo"));

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapStreamValuesToFutureOfCompletedValuesTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapStreamValuesToFutureOfCompletedValuesTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -17,21 +18,21 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapStreamValuesToFutureOfCompletedValuesTest {
+class MapStreamValuesToFutureOfCompletedValuesTest {
     /**
      * Stream to List : empty values.
      * Stream to Set : empty values.
      **/
 
     @Test
-    public void empty_StreamToList_ReturnsFutureOfEmptyList() {
+    void empty_StreamToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             Stream.<String>empty(), CompletableFuture::completedFuture, toList());
         assertThat(futureList.join()).isEqualTo(emptyList());
     }
 
     @Test
-    public void empty_StreamToSet_ReturnsFutureOfEmptySet() {
+    void empty_StreamToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(Stream.<String>empty(),
             CompletableFuture::completedFuture, toSet());
         assertThat(future.join()).isEqualTo(emptySet());
@@ -44,7 +45,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void singleNull_StreamToList_ReturnsFutureOfEmptyList() {
+    void singleNull_StreamToList_ReturnsFutureOfEmptyList() {
         final String nullString = null;
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             Stream.of(nullString), CompletableFuture::completedFuture, toList());
@@ -52,7 +53,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void singleNull_StreamToSet_ReturnsFutureOfEmptySet() {
+    void singleNull_StreamToSet_ReturnsFutureOfEmptySet() {
         final String nullString = null;
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             Stream.of(nullString), CompletableFuture::completedFuture, toSet());
@@ -65,7 +66,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multipleNull_StreamToList_ReturnsFutureOfEmptyList() {
+    void multipleNull_StreamToList_ReturnsFutureOfEmptyList() {
         final String nullString = null;
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             Stream.of(nullString, nullString), CompletableFuture::completedFuture, toList());
@@ -73,7 +74,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multipleNull_StreamToSet_ReturnsFutureOfEmptySet() {
+    void multipleNull_StreamToSet_ReturnsFutureOfEmptySet() {
         final String nullString = null;
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             Stream.of(nullString, nullString), CompletableFuture::completedFuture, toSet());
@@ -88,7 +89,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void single_StreamToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_StreamToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -97,7 +98,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_StreamToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_StreamToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -106,7 +107,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_StreamToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_StreamToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -115,7 +116,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_StreamToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_StreamToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo"), element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -131,7 +132,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multiple_StreamToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_StreamToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo", "bar"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -140,7 +141,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_StreamToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(Stream.of("foo", "bar"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -149,7 +150,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_StreamToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("john", "smith"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -158,7 +159,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_StreamToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(Stream.of("john", "smith"),
             element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -174,7 +175,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multiple_StreamToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_StreamToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("foo", "foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -183,7 +184,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_StreamToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(Stream.of("foo", "foo"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -192,7 +193,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_StreamToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             Stream.of("john", "john"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -201,7 +202,7 @@ public class MapStreamValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_StreamToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(Stream.of("john", "john"),
             element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFutureOfCompletedValuesStreamTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFutureOfCompletedValuesStreamTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -17,21 +18,21 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapValuesToFutureOfCompletedValuesStreamTest {
+class MapValuesToFutureOfCompletedValuesStreamTest {
     /**
      * List to stream : empty values.
      * Set to stream : empty values.
      **/
 
     @Test
-    public void empty_ListToStream_ReturnsFutureOfEmptyStream() {
+    void empty_ListToStream_ReturnsFutureOfEmptyStream() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             new ArrayList<String>(), CompletableFuture::completedFuture);
         assertThat(future.join().collect(toList())).isEqualTo(emptyList());
     }
 
     @Test
-    public void empty_SetToStream_ReturnsFutureOfEmptyStream() {
+    void empty_SetToStream_ReturnsFutureOfEmptyStream() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             new HashSet<String>(), CompletableFuture::completedFuture);
         assertThat(future.join().collect(toList())).isEqualTo(emptyList());
@@ -44,7 +45,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
      */
 
     @Test
-    public void singleNull_ListToStream_ReturnsFutureOfEmptyStream() {
+    void singleNull_ListToStream_ReturnsFutureOfEmptyStream() {
         final String nullString = null;
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             singletonList(nullString), CompletableFuture::completedFuture);
@@ -52,7 +53,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void singleNull_SetToStream_ReturnsFutureOfEmptyStream() {
+    void singleNull_SetToStream_ReturnsFutureOfEmptyStream() {
         final String nullString = null;
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             singleton(nullString), CompletableFuture::completedFuture);
@@ -64,7 +65,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
      */
 
     @Test
-    public void multipleNull_ListToStream_ReturnsFutureOfEmptyStream() {
+    void multipleNull_ListToStream_ReturnsFutureOfEmptyStream() {
         final String nullString = null;
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             asList(nullString, nullString), CompletableFuture::completedFuture);
@@ -79,7 +80,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
      */
 
     @Test
-    public void single_ListWithSameTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
+    void single_ListWithSameTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.concat("POSTFIX")));
         final Stream<String> result = future.join();
@@ -87,7 +88,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void single_SetWithSameTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
+    void single_SetWithSameTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.concat("POSTFIX")));
         final Stream<String> result = future.join();
@@ -95,7 +96,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void single_ListWithDiffTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
+    void single_ListWithDiffTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
         final CompletableFuture<Stream<Integer>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.length()));
         final Stream<Integer> result = future.join();
@@ -103,7 +104,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void single_SetWithDiffTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
+    void single_SetWithDiffTypeMapping_ReturnsFutureOfStreamOfMappedValue() {
         final CompletableFuture<Stream<Integer>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.length()));
         final Stream<Integer> result = future.join();
@@ -119,7 +120,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
      */
 
     @Test
-    public void multiple_ListWithSameTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
+    void multiple_ListWithSameTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             asList("foo", "bar"), element -> completedFuture(element.concat("POSTFIX")));
         final Stream<String> result = future.join();
@@ -127,7 +128,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_SetWithSameTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
+    void multiple_SetWithSameTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -139,7 +140,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_ListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
+    void multiple_ListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
         final CompletableFuture<Stream<Integer>> future = mapValuesToFutureOfCompletedValues(
             asList("john", "smith"), element -> completedFuture(element.length()));
         final Stream<Integer> result = future.join();
@@ -147,7 +148,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_SetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
+    void multiple_SetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfStreamOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("john");
         set.add("smith");
@@ -166,7 +167,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
      */
 
     @Test
-    public void multiple_ListWithSameTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
+    void multiple_ListWithSameTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
         final CompletableFuture<Stream<String>> future = mapValuesToFutureOfCompletedValues(
             asList("foo", "foo"), element -> completedFuture(element.concat("POSTFIX")));
         final Stream<String> result = future.join();
@@ -174,7 +175,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_SetWithSameTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
+    void multiple_SetWithSameTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -186,7 +187,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_ListWithDiffTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
+    void multiple_ListWithDiffTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
         final CompletableFuture<Stream<Integer>> future = mapValuesToFutureOfCompletedValues(
             asList("john", "john"), element -> completedFuture(element.length()));
         final Stream<Integer> result = future.join();
@@ -194,7 +195,7 @@ public class MapValuesToFutureOfCompletedValuesStreamTest {
     }
 
     @Test
-    public void multiple_SetWithDiffTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
+    void multiple_SetWithDiffTypeMappingDuplicates_ReturnsFutureOfStreamOfMappedValuesWithDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFutureOfCompletedValuesTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFutureOfCompletedValuesTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -19,7 +20,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapValuesToFutureOfCompletedValuesTest {
+class MapValuesToFutureOfCompletedValuesTest {
     /**
      * List to List : empty values.
      * List to Set : empty values.
@@ -28,28 +29,28 @@ public class MapValuesToFutureOfCompletedValuesTest {
      **/
 
     @Test
-    public void empty_ListToList_ReturnsFutureOfEmptyList() {
+    void empty_ListToList_ReturnsFutureOfEmptyList() {
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             new ArrayList<String>(), CompletableFuture::completedFuture, toList());
         assertThat(futureList.join()).isEqualTo(emptyList());
     }
 
     @Test
-    public void empty_ListToSet_ReturnsFutureOfEmptySet() {
+    void empty_ListToSet_ReturnsFutureOfEmptySet() {
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             new ArrayList<String>(), CompletableFuture::completedFuture, toSet());
         assertThat(futureSet.join()).isEqualTo(emptySet());
     }
 
     @Test
-    public void empty_SetToSet_ReturnsFutureOfEmptyList() {
+    void empty_SetToSet_ReturnsFutureOfEmptyList() {
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             new HashSet<String>(), CompletableFuture::completedFuture, toList());
         assertThat(futureList.join()).isEqualTo(emptyList());
     }
 
     @Test
-    public void empty_SetToList_ReturnsFutureOfEmptySet() {
+    void empty_SetToList_ReturnsFutureOfEmptySet() {
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             new HashSet<String>(), CompletableFuture::completedFuture, toSet());
         assertThat(futureSet.join()).isEqualTo(emptySet());
@@ -64,7 +65,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void singleNull_ListToList_ReturnsFutureOfEmptyList() {
+    void singleNull_ListToList_ReturnsFutureOfEmptyList() {
         final String nullString = null;
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             singletonList(nullString), CompletableFuture::completedFuture, toList());
@@ -72,7 +73,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void singleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    void singleNull_ListToSet_ReturnsFutureOfEmptySet() {
         final String nullString = null;
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             singletonList(nullString), CompletableFuture::completedFuture, toSet());
@@ -80,7 +81,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void singleNull_SetToSet_ReturnsFutureOfEmptyList() {
+    void singleNull_SetToSet_ReturnsFutureOfEmptyList() {
         final String nullString = null;
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             singleton(nullString), CompletableFuture::completedFuture, toList());
@@ -88,7 +89,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void singleNull_SetToList_ReturnsFutureOfEmptySet() {
+    void singleNull_SetToList_ReturnsFutureOfEmptySet() {
         final String nullString = null;
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             singleton(nullString), CompletableFuture::completedFuture, toSet());
@@ -101,7 +102,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multipleNull_ListToList_ReturnsFutureOfEmptyList() {
+    void multipleNull_ListToList_ReturnsFutureOfEmptyList() {
         final String nullString = null;
         final CompletableFuture<List<String>> futureList = mapValuesToFutureOfCompletedValues(
             asList(nullString, nullString), CompletableFuture::completedFuture, toList());
@@ -109,7 +110,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multipleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    void multipleNull_ListToSet_ReturnsFutureOfEmptySet() {
         final String nullString = null;
         final CompletableFuture<Set<String>> futureSet = mapValuesToFutureOfCompletedValues(
             asList(nullString, nullString), CompletableFuture::completedFuture, toSet());
@@ -129,7 +130,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void single_ListToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_ListToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -138,7 +139,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_ListToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_ListToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -147,7 +148,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_SetToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_SetToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -156,7 +157,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_SetToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_SetToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -165,7 +166,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_ListToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_ListToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -174,7 +175,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_ListToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_ListToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(
             singletonList("foo"), element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -183,7 +184,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_SetToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    void single_SetToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -192,7 +193,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void single_SetToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    void single_SetToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             singleton("foo"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -213,7 +214,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multiple_ListToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_ListToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             asList("foo", "bar"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -222,7 +223,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_ListToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(asList("foo", "bar"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -231,7 +232,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_SetToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -244,7 +245,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_SetToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -257,7 +258,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_ListToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             asList("john", "smith"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -266,7 +267,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_ListToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(asList("john", "smith"),
             element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -275,7 +276,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    void multiple_SetToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("john");
         set.add("smith");
@@ -288,7 +289,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    void multiple_SetToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
         final Set<String> set = new HashSet<>();
         set.add("john");
         set.add("smith");
@@ -313,7 +314,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
      */
 
     @Test
-    public void multiple_ListToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_ListToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final CompletableFuture<List<String>> future = mapValuesToFutureOfCompletedValues(
             asList("foo", "foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
         final List<String> result = future.join();
@@ -322,7 +323,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_ListToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final CompletableFuture<Set<String>> future = mapValuesToFutureOfCompletedValues(asList("foo", "foo"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
         final Set<String> result = future.join();
@@ -331,7 +332,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_SetToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -344,7 +345,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_SetToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -357,7 +358,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_ListToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final CompletableFuture<List<Integer>> future = mapValuesToFutureOfCompletedValues(
             asList("john", "john"), element -> completedFuture(element.length()), toList());
         final List<Integer> result = future.join();
@@ -366,7 +367,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_ListToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_ListToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final CompletableFuture<Set<Integer>> future = mapValuesToFutureOfCompletedValues(asList("john", "john"),
             element -> completedFuture(element.length()), toSet());
         final Set<Integer> result = future.join();
@@ -375,7 +376,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    void multiple_SetToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");
@@ -388,7 +389,7 @@ public class MapValuesToFutureOfCompletedValuesTest {
     }
 
     @Test
-    public void multiple_SetToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    void multiple_SetToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
         final Set<String> set = new HashSet<>();
         set.add("foo");
         set.add("bar");

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFuturesTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/MapValuesToFuturesTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -15,21 +16,21 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MapValuesToFuturesTest {
+class MapValuesToFuturesTest {
     /**
      * Stream to List : empty values.
      * Stream to Set : empty values.
      **/
 
     @Test
-    public void empty_StreamToList_ReturnsEmptyList() {
+    void empty_StreamToList_ReturnsEmptyList() {
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.<String>empty(),
             CompletableFuture::completedFuture, toList());
         assertThat(futures).isEmpty();
     }
 
     @Test
-    public void empty_StreamToSet_ReturnsEmptySet() {
+    void empty_StreamToSet_ReturnsEmptySet() {
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.<String>empty(),
             CompletableFuture::completedFuture, toSet());
         assertThat(futures).isEmpty();
@@ -42,7 +43,7 @@ public class MapValuesToFuturesTest {
      */
 
     @Test
-    public void singleNull_StreamToList_ReturnsEmptyList() {
+    void singleNull_StreamToList_ReturnsEmptyList() {
         final String nullString = null;
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of(nullString),
             CompletableFuture::completedFuture, toList());
@@ -50,7 +51,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void singleNull_StreamToSet_ReturnsEmptySet() {
+    void singleNull_StreamToSet_ReturnsEmptySet() {
         final String nullString = null;
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of(nullString),
             CompletableFuture::completedFuture, toSet());
@@ -62,7 +63,7 @@ public class MapValuesToFuturesTest {
      * Stream to Set : multiple null value.
      */
     @Test
-    public void multipleNull_StreamToList_ReturnsEmptyList() {
+    void multipleNull_StreamToList_ReturnsEmptyList() {
         final String nullString = null;
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of(nullString, nullString),
             CompletableFuture::completedFuture, toList());
@@ -70,7 +71,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multipleNull_StreamToSet_ReturnsEmptySet() {
+    void multipleNull_StreamToSet_ReturnsEmptySet() {
         final String nullString = null;
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of(nullString, nullString),
             CompletableFuture::completedFuture, toSet());
@@ -85,7 +86,7 @@ public class MapValuesToFuturesTest {
      */
 
     @Test
-    public void single_StreamToListWithSameTypeMapping_ReturnsListOfMappedValue() {
+    void single_StreamToListWithSameTypeMapping_ReturnsListOfMappedValue() {
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("foo"),
             element -> completedFuture(element.concat("POSTFIX")), toList());
 
@@ -95,7 +96,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void single_StreamToSetWithSameTypeMapping_ReturnsSetOfMappedValue() {
+    void single_StreamToSetWithSameTypeMapping_ReturnsSetOfMappedValue() {
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("foo"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
 
@@ -105,7 +106,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void single_StreamToListWithDiffTypeMapping_ReturnsListOfMappedValue() {
+    void single_StreamToListWithDiffTypeMapping_ReturnsListOfMappedValue() {
         final List<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("foo"),
             element -> completedFuture(element.length()), toList());
 
@@ -115,7 +116,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void single_StreamToSetWithDiffTypeMapping_ReturnsSetOfMappedValue() {
+    void single_StreamToSetWithDiffTypeMapping_ReturnsSetOfMappedValue() {
         final Set<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("foo"),
             element -> completedFuture(element.length()), toSet());
 
@@ -132,7 +133,7 @@ public class MapValuesToFuturesTest {
      */
 
     @Test
-    public void multiple_StreamToListWithSameTypeMappingNoDuplicates_ReturnsListOfMappedValues() {
+    void multiple_StreamToListWithSameTypeMappingNoDuplicates_ReturnsListOfMappedValues() {
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("foo", "bar"),
             element -> completedFuture(element.concat("POSTFIX")), toList());
 
@@ -146,7 +147,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithSameTypeMappingNoDuplicates_ReturnsSetOfMappedValues() {
+    void multiple_StreamToSetWithSameTypeMappingNoDuplicates_ReturnsSetOfMappedValues() {
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("foo", "bar"),
             element -> completedFuture(element.concat("POSTFIX")), toSet());
 
@@ -162,7 +163,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToListWithDiffTypeMappingNoDuplicates_ReturnsListOfMappedValues() {
+    void multiple_StreamToListWithDiffTypeMappingNoDuplicates_ReturnsListOfMappedValues() {
         final List<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("john", "smith"),
             element -> completedFuture(element.length()), toList());
 
@@ -178,7 +179,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithDiffTypeMappingNoDuplicates_ReturnsSetOfMappedValues() {
+    void multiple_StreamToSetWithDiffTypeMappingNoDuplicates_ReturnsSetOfMappedValues() {
         final Set<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("john", "smith"),
             element -> completedFuture(element.length()), toSet());
 
@@ -202,7 +203,7 @@ public class MapValuesToFuturesTest {
      */
 
     @Test
-    public void multiple_StreamToListWithSameTypeMappingDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
+    void multiple_StreamToListWithSameTypeMappingDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
         final List<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("john", "john"),
             CompletableFuture::completedFuture, toList());
 
@@ -218,7 +219,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithSameTypeMappingDuplicates_ReturnsSetOfMappedValuesDuplicates() {
+    void multiple_StreamToSetWithSameTypeMappingDuplicates_ReturnsSetOfMappedValuesDuplicates() {
         final Set<CompletableFuture<String>> futures = mapValuesToFutures(Stream.of("john", "john"),
             CompletableFuture::completedFuture, toSet());
 
@@ -234,7 +235,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToListWithDiffTypeMappingDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
+    void multiple_StreamToListWithDiffTypeMappingDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
         final List<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("john", "john"),
             element -> completedFuture(element.length()), toList());
 
@@ -250,7 +251,7 @@ public class MapValuesToFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetWithDiffTypeMappingDuplicates_ReturnsSetOfMappedValuesWithDuplicates() {
+    void multiple_StreamToSetWithDiffTypeMappingDuplicates_ReturnsSetOfMappedValuesWithDuplicates() {
         final Set<CompletableFuture<Integer>> futures = mapValuesToFutures(Stream.of("john", "john"),
             element -> completedFuture(element.length()), toSet());
 

--- a/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/ToCompletableFuturesTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils/ToCompletableFuturesTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.commons.utils.completablefutureutils;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -18,21 +19,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class ToCompletableFuturesTest {
+class ToCompletableFuturesTest {
     /**
      * Stream to List : empty values.
      * Stream to Set : empty values.
      **/
 
     @Test
-    public void empty_StreamToList_ReturnsEmptyList() {
+    void empty_StreamToList_ReturnsEmptyList() {
         final List<CompletableFuture<String>> futures =
             toCompletableFutures(Stream.<CompletionStage<String>>empty(), toList());
         assertThat(futures).isEmpty();
     }
 
     @Test
-    public void empty_StreamToSet_ReturnsEmptySet() {
+    void empty_StreamToSet_ReturnsEmptySet() {
         final Set<CompletableFuture<String>> futures = toCompletableFutures(Stream.<CompletionStage<String>>empty(),
             toSet());
         assertThat(futures).isEmpty();
@@ -45,14 +46,14 @@ public class ToCompletableFuturesTest {
      */
 
     @Test
-    public void singleNull_StreamToList_ReturnsEmptyList() {
+    void singleNull_StreamToList_ReturnsEmptyList() {
         final CompletionStage<String> nullStage = null;
         final List<CompletableFuture<String>> futures = toCompletableFutures(Stream.of(nullStage), toList());
         assertThat(futures).isEmpty();
     }
 
     @Test
-    public void singleNull_StreamToSet_ReturnsEmptySet() {
+    void singleNull_StreamToSet_ReturnsEmptySet() {
         final CompletionStage<String> nullStage = null;
         final Set<CompletableFuture<String>> futures = toCompletableFutures(Stream.of(nullStage), toSet());
         assertThat(futures).isEmpty();
@@ -63,14 +64,14 @@ public class ToCompletableFuturesTest {
      * Stream to Set : multiple null value.
      */
     @Test
-    public void multipleNull_StreamToList_ReturnsEmptyList() {
+    void multipleNull_StreamToList_ReturnsEmptyList() {
         final CompletionStage<String> nullStage = null;
         final List<CompletableFuture<String>> futures = toCompletableFutures(Stream.of(nullStage, nullStage), toList());
         assertThat(futures).isEmpty();
     }
 
     @Test
-    public void multipleNull_StreamToSet_ReturnsEmptySet() {
+    void multipleNull_StreamToSet_ReturnsEmptySet() {
         final CompletionStage<String> nullStage = null;
         final Set<CompletableFuture<String>> futures = toCompletableFutures(Stream.of(nullStage, nullStage), toSet());
         assertThat(futures).isEmpty();
@@ -82,7 +83,7 @@ public class ToCompletableFuturesTest {
      */
 
     @Test
-    public void single_StreamToList_ReturnsListOfMappedValue() {
+    void single_StreamToList_ReturnsListOfMappedValue() {
         final CompletionStage<String> completionStage = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage.toCompletableFuture()).thenReturn(barFuture);
@@ -96,7 +97,7 @@ public class ToCompletableFuturesTest {
     }
 
     @Test
-    public void single_StreamToSet_ReturnsSetOfMappedValue() {
+    void single_StreamToSet_ReturnsSetOfMappedValue() {
         final CompletionStage<String> completionStage = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage.toCompletableFuture()).thenReturn(barFuture);
@@ -115,7 +116,7 @@ public class ToCompletableFuturesTest {
      */
 
     @Test
-    public void multiple_StreamToListNoDuplicates_ReturnsListOfMappedValues() {
+    void multiple_StreamToListNoDuplicates_ReturnsListOfMappedValues() {
         final CompletionStage<String> completionStage1 = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage1.toCompletableFuture()).thenReturn(barFuture);
@@ -133,7 +134,7 @@ public class ToCompletableFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetNoDuplicates_ReturnsSetOfMappedValues() {
+    void multiple_StreamToSetNoDuplicates_ReturnsSetOfMappedValues() {
         final CompletionStage<String> completionStage1 = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage1.toCompletableFuture()).thenReturn(barFuture);
@@ -157,7 +158,7 @@ public class ToCompletableFuturesTest {
      */
 
     @Test
-    public void multiple_StreamToListDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
+    void multiple_StreamToListDuplicates_ReturnsListOfMappedValuesWithDuplicates() {
         final CompletionStage<String> completionStage = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage.toCompletableFuture()).thenReturn(barFuture);
@@ -171,7 +172,7 @@ public class ToCompletableFuturesTest {
     }
 
     @Test
-    public void multiple_StreamToSetDuplicates_ReturnsSetOfMappedValuesNoDuplicates() {
+    void multiple_StreamToSetDuplicates_ReturnsSetOfMappedValuesNoDuplicates() {
         final CompletionStage<String> completionStage = spy(completedFuture("foo"));
         final CompletableFuture<String> barFuture = completedFuture("bar");
         when(completionStage.toCompletableFuture()).thenReturn(barFuture);

--- a/src/test/java/com/commercetools/sync/internals/utils/UnorderedCollectionSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/internals/utils/UnorderedCollectionSyncUtilsTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
 import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UnorderedCollectionSyncUtilsTest {
+class UnorderedCollectionSyncUtilsTest {
 
     @Test
-    public void buildRemoveUpdateActions_withNullNewDraftsAndEmptyOldCollection_ShouldNotBuildActions() {
+    void buildRemoveUpdateActions_withNullNewDraftsAndEmptyOldCollection_ShouldNotBuildActions() {
         // preparation
         final List<ProductVariant> oldVariants = new ArrayList<>();
         final List<ProductVariantDraft> newDrafts = null;
@@ -38,7 +38,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withNullNewDrafts_ShouldBuildRemoveActionsForEveryDraft() {
+    void buildRemoveUpdateActions_withNullNewDrafts_ShouldBuildRemoveActionsForEveryDraft() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -57,7 +57,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withEmptyNewDrafts_ShouldBuildRemoveActionsForEveryDraft() {
+    void buildRemoveUpdateActions_withEmptyNewDrafts_ShouldBuildRemoveActionsForEveryDraft() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -76,7 +76,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withSomeMatchingDrafts_ShouldBuildRemoveActionsForEveryMissingDraft() {
+    void buildRemoveUpdateActions_withSomeMatchingDrafts_ShouldBuildRemoveActionsForEveryMissingDraft() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -101,7 +101,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withDraftsWithNullKeys_ShouldNotBuildRemoveActionsForDraftsWithNullKeys() {
+    void buildRemoveUpdateActions_withDraftsWithNullKeys_ShouldNotBuildRemoveActionsForDraftsWithNullKeys() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -123,7 +123,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withNullDrafts_ShouldNotBuildRemoveActions() {
+    void buildRemoveUpdateActions_withNullDrafts_ShouldNotBuildRemoveActions() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -144,7 +144,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withNullReturningActionMapper_ShouldBuildActionsWithNoNullElement() {
+    void buildRemoveUpdateActions_withNullReturningActionMapper_ShouldBuildActionsWithNoNullElement() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);
@@ -176,7 +176,7 @@ public class UnorderedCollectionSyncUtilsTest {
     }
 
     @Test
-    public void buildRemoveUpdateActions_withIdenticalNewDraftsAndOldMap_ShouldNotBuildRemoveActions() {
+    void buildRemoveUpdateActions_withIdenticalNewDraftsAndOldMap_ShouldNotBuildRemoveActions() {
         // preparation
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getId()).thenReturn(1);

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncOptionsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncOptionsTest.java
@@ -1,15 +1,15 @@
 package com.commercetools.sync.inventories;
 
 import io.sphere.sdk.client.SphereClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class InventorySyncOptionsTest {
+class InventorySyncOptionsTest {
 
     @Test
-    public void build_WithOnlyRequiredFieldsSet_ShouldReturnProperOptionsInstance() {
+    void build_WithOnlyRequiredFieldsSet_ShouldReturnProperOptionsInstance() {
         final InventorySyncOptions options = InventorySyncOptionsBuilder.of(mock(SphereClient.class)).build();
         assertThat(options).isNotNull();
         assertThat(options.getBatchSize()).isEqualTo(InventorySyncOptionsBuilder.BATCH_SIZE_DEFAULT);
@@ -17,7 +17,7 @@ public class InventorySyncOptionsTest {
     }
 
     @Test
-    public void build_WithAllFieldsSet_ShouldReturnProperOptionsInstance() {
+    void build_WithAllFieldsSet_ShouldReturnProperOptionsInstance() {
         final InventorySyncOptions options = InventorySyncOptionsBuilder.of(mock(SphereClient.class))
                 .batchSize(10)
                 .ensureChannels(true)
@@ -28,7 +28,7 @@ public class InventorySyncOptionsTest {
     }
 
     @Test
-    public void setBatchSize_WithZeroOrNegativePassed_ShouldNotSetBatchSize() {
+    void setBatchSize_WithZeroOrNegativePassed_ShouldNotSetBatchSize() {
         final InventorySyncOptionsBuilder builder = InventorySyncOptionsBuilder.of(mock(SphereClient.class));
         final InventorySyncOptions optionsWithZero = builder.batchSize(0).build();
         final InventorySyncOptions optionsWithNegative = builder.batchSize(-1).build();

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -13,8 +13,8 @@ import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class InventorySyncTest {
+class InventorySyncTest {
 
     private static final String SKU_1 = "1000";
     private static final String SKU_2 = "2000";
@@ -80,8 +80,8 @@ public class InventorySyncTest {
     /**
      * Initialises test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final Channel channel1 = getMockSupplyChannel(REF_1, KEY_1);
 
         final Reference<Channel> expandedReference1 = Channel.referenceOfId(REF_1).filled(channel1);
@@ -115,7 +115,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void getStatistics_ShouldReturnProperStatistics() {
+    void getStatistics_ShouldReturnProperStatistics() {
         final InventorySync inventorySync = getInventorySync(30, false);
         inventorySync.sync(drafts)
                 .toCompletableFuture()
@@ -129,7 +129,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithEmptyList_ShouldNotSync() {
+    void sync_WithEmptyList_ShouldNotSync() {
         final InventorySync inventorySync = getInventorySync(30, false);
         final InventorySyncStatistics stats = inventorySync.sync(emptyList())
                 .toCompletableFuture()
@@ -141,7 +141,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithEnsuredChannels_ShouldCreateEntriesWithUnknownChannels() {
+    void sync_WithEnsuredChannels_ShouldCreateEntriesWithUnknownChannels() {
         final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraft.of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1,
                 Channel.referenceOfId(KEY_3));
         final InventorySync inventorySync = getInventorySync(30, true);
@@ -155,7 +155,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithNotEnsuredChannels_ShouldNotSyncEntriesWithUnknownChannels() {
+    void sync_WithNotEnsuredChannels_ShouldNotSyncEntriesWithUnknownChannels() {
         final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraft.of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1,
                 Channel.referenceOfId(KEY_3));
 
@@ -185,7 +185,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithDraftsWithNullSku_ShouldNotSync() {
+    void sync_WithDraftsWithNullSku_ShouldNotSync() {
         final InventoryEntryDraft draftWithNullSku = InventoryEntryDraft.of(null, 12);
         final InventorySync inventorySync = getInventorySync(30, false);
         final InventorySyncStatistics stats = inventorySync.sync(singletonList(draftWithNullSku))
@@ -200,7 +200,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithDraftsWithEmptySku_ShouldNotSync() {
+    void sync_WithDraftsWithEmptySku_ShouldNotSync() {
         final InventoryEntryDraft draftWithEmptySku = InventoryEntryDraft.of("", 12);
         final InventorySync inventorySync = getInventorySync(30, false);
         final InventorySyncStatistics stats = inventorySync.sync(singletonList(draftWithEmptySku))
@@ -215,7 +215,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExceptionWhenFetchingExistingInventoriesBatch_ShouldProcessThatBatch() {
+    void sync_WithExceptionWhenFetchingExistingInventoriesBatch_ShouldProcessThatBatch() {
         final InventorySyncOptions options = getInventorySyncOptions(1, false);
 
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
@@ -238,7 +238,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExceptionWhenCreatingOrUpdatingEntries_ShouldNotSync() {
+    void sync_WithExceptionWhenCreatingOrUpdatingEntries_ShouldNotSync() {
         final InventorySyncOptions options = getInventorySyncOptions(3, false);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             mock(InventoryEntry.class), mock(InventoryEntry.class));
@@ -259,7 +259,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExceptionWhenUpdatingEntries_ShouldNotSync() {
+    void sync_WithExceptionWhenUpdatingEntries_ShouldNotSync() {
         final InventorySyncOptions options = getInventorySyncOptions(3, false);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             mock(InventoryEntry.class), mock(InventoryEntry.class));
@@ -287,7 +287,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExceptionWhenCreatingEntries_ShouldNotSync() {
+    void sync_WithExceptionWhenCreatingEntries_ShouldNotSync() {
         final InventorySyncOptions options = getInventorySyncOptions(3, false);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             mock(InventoryEntry.class), mock(InventoryEntry.class));
@@ -315,7 +315,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExistingInventoryEntryButWithEmptyCustomTypeReference_ShouldFailSync() {
+    void sync_WithExistingInventoryEntryButWithEmptyCustomTypeReference_ShouldFailSync() {
         final InventorySyncOptions options = getInventorySyncOptions(3, false);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             mock(InventoryEntry.class), mock(InventoryEntry.class));
@@ -346,7 +346,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithNewSupplyChannelAndEnsure_ShouldSync() {
+    void sync_WithNewSupplyChannelAndEnsure_ShouldSync() {
         final InventorySyncOptions options = getInventorySyncOptions(3, true);
 
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
@@ -370,7 +370,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithExceptionWhenCreatingNewSupplyChannel_ShouldTriggerErrorCallbackAndIncrementFailed() {
+    void sync_WithExceptionWhenCreatingNewSupplyChannel_ShouldTriggerErrorCallbackAndIncrementFailed() {
         final InventorySyncOptions options = getInventorySyncOptions(3, true);
 
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
@@ -403,7 +403,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithNullInInputList_ShouldIncrementFailedStatistics() {
+    void sync_WithNullInInputList_ShouldIncrementFailedStatistics() {
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             mock(InventoryEntry.class), mock(InventoryEntry.class));
 
@@ -425,7 +425,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
         final InventoryEntryDraft inventoryEntryDraft = InventoryEntryDraftBuilder.of(SKU_1, 1L)
                                                                                   .build();
@@ -448,7 +448,7 @@ public class InventorySyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
         final InventoryEntryDraft inventoryEntryDraft = InventoryEntryDraftBuilder.of("newSKU", 1L)
                                                                                   .build();

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryEntryIdentifierTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryEntryIdentifierTest.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.inventories.helpers;
 import io.sphere.sdk.channels.Channel;
 import io.sphere.sdk.inventory.InventoryEntry;
 import io.sphere.sdk.inventory.InventoryEntryDraft;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +11,7 @@ import java.util.Map;
 import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockInventoryEntry;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InventoryEntryIdentifierTest {
+class InventoryEntryIdentifierTest {
 
     private static final String SKU = "123";
     private static final String SKU_2 = "321";
@@ -19,7 +19,7 @@ public class InventoryEntryIdentifierTest {
     private static final String CHANNEL_ID_2 = "channel-id-2";
 
     @Test
-    public void of_WithDraftWithoutSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithDraftWithoutSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntryDraft draft = InventoryEntryDraft.of(SKU, 1L);
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(draft);
         assertThat(inventoryEntryIdentifier).isNotNull();
@@ -28,7 +28,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void of_WithDraftWithSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithDraftWithSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, 1L, null, null, Channel.referenceOfId(CHANNEL_ID));
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(draft);
@@ -38,7 +38,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void of_WithEntryWithoutSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithEntryWithoutSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null, null, null);
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
         assertThat(inventoryEntryIdentifier).isNotNull();
@@ -47,7 +47,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void of_WithEntryWithSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithEntryWithSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
@@ -57,7 +57,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void of_WithSkuAndNoSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithSkuAndNoSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(SKU, null);
         assertThat(inventoryEntryIdentifier).isNotNull();
         assertThat(inventoryEntryIdentifier.getInventoryEntrySku()).isEqualTo(SKU);
@@ -65,7 +65,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void of_WithSkuAndSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
+    void of_WithSkuAndSupplyChannel_ShouldBuildInventoryEntryIdentifier() {
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(SKU, CHANNEL_ID);
         assertThat(inventoryEntryIdentifier).isNotNull();
         assertThat(inventoryEntryIdentifier.getInventoryEntrySku()).isEqualTo(SKU);
@@ -73,7 +73,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void equals_WithSimilarEntryAndDraft_ShouldBeTrue() {
+    void equals_WithSimilarEntryAndDraft_ShouldBeTrue() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         final InventoryEntryIdentifier entryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
@@ -85,7 +85,7 @@ public class InventoryEntryIdentifierTest {
 
 
     @Test
-    public void equals_WithDifferentEntryAndDraft_ShouldBeFalse() {
+    void equals_WithDifferentEntryAndDraft_ShouldBeFalse() {
         // Different SKUs, same channels
         InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
@@ -113,7 +113,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void equals_WithNoIdentifier_ShouldBeFalse() {
+    void equals_WithNoIdentifier_ShouldBeFalse() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         final InventoryEntryIdentifier entryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
@@ -122,7 +122,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void equals_WithNullIdentifier_ShouldBeFalse() {
+    void equals_WithNullIdentifier_ShouldBeFalse() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         final InventoryEntryIdentifier entryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
@@ -131,7 +131,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void inventoryEntryIdentifiersCreatedFromSimilarDraftAndEntry_ShouldHaveSameHashCodes() {
+    void inventoryEntryIdentifiersCreatedFromSimilarDraftAndEntry_ShouldHaveSameHashCodes() {
         InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         InventoryEntryIdentifier entryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);
@@ -150,7 +150,7 @@ public class InventoryEntryIdentifierTest {
     }
 
     @Test
-    public void inventoryEntryIdentifier_ShouldWorkAsHashMapKey() {
+    void inventoryEntryIdentifier_ShouldWorkAsHashMapKey() {
         final InventoryEntry inventoryEntry = getMockInventoryEntry(SKU, null, null, null,
             Channel.referenceOfId(CHANNEL_ID), null);
         final InventoryEntryIdentifier inventoryEntryIdentifier = InventoryEntryIdentifier.of(inventoryEntry);

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -15,8 +15,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InventoryReferenceResolverTest {
+class InventoryReferenceResolverTest {
     private TypeService typeService;
     private ChannelService channelService;
     private InventorySyncOptions syncOptions;
@@ -52,16 +52,15 @@ public class InventoryReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         typeService = getMockTypeService();
         channelService = InventorySyncMockUtils.getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
         syncOptions = InventorySyncOptionsBuilder.of(mock(SphereClient.class)).build();
     }
 
     @Test
-    public void
-        resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
+    void resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
         when(channelService.fetchCachedChannelId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -86,7 +85,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void
+    void
         resolveSupplyChannelReference_WithNonExistingChannelAndEnsureChannel_ShouldResolveSupplyChannelReference() {
         final InventorySyncOptions optionsWithEnsureChannels = InventorySyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                           .ensureChannels(true)
@@ -110,7 +109,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
+    void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
         final InventoryEntryDraftBuilder draftBuilder = InventoryEntryDraftBuilder
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(UUID_KEY))
             .custom(CustomFieldsDraft.ofTypeIdAndJson(CUSTOM_TYPE_KEY, new HashMap<>()));
@@ -131,7 +130,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         when(typeService.fetchCachedTypeId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -152,7 +151,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveSupplyChannelReference_WithEmptyIdOnSupplyChannelReference_ShouldNotResolveChannelReference() {
+    void resolveSupplyChannelReference_WithEmptyIdOnSupplyChannelReference_ShouldNotResolveChannelReference() {
         final InventoryEntryDraft draft = InventoryEntryDraft
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(""))
             .withCustom(CustomFieldsDraft.ofTypeIdAndJson(CUSTOM_TYPE_KEY, new HashMap<>()));
@@ -171,7 +170,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveSupplyChannelReference_WithNullIdOnChannelReference_ShouldNotResolveSupplyChannelReference() {
+    void resolveSupplyChannelReference_WithNullIdOnChannelReference_ShouldNotResolveSupplyChannelReference() {
         final InventoryEntryDraft draft = mock(InventoryEntryDraft.class);
         final Reference<Channel> supplyChannelReference = Channel.referenceOfId(null);
         when(draft.getSupplyChannel()).thenReturn(supplyChannelReference);
@@ -190,7 +189,7 @@ public class InventoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final InventoryEntryDraftBuilder draftBuilder = InventoryEntryDraftBuilder
             .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
             .custom(CustomFieldsDraft.ofTypeIdAndJson("", new HashMap<>()));

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventorySyncStatisticsTest.java
@@ -1,21 +1,21 @@
 package com.commercetools.sync.inventories.helpers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InventorySyncStatisticsTest {
+class InventorySyncStatisticsTest {
 
     private InventorySyncStatistics inventorySyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         inventorySyncStatistics = new InventorySyncStatistics();
     }
 
     @Test
-    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
         inventorySyncStatistics.incrementCreated(1);
         inventorySyncStatistics.incrementFailed(1);
         inventorySyncStatistics.incrementUpdated(1);

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtilsTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.inventory.InventoryEntryDraft;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InventoryReferenceReplacementUtilsTest {
+class InventoryReferenceReplacementUtilsTest {
 
     @Test
-    public void
+    void
         replaceInventoriesReferenceIdsWithKeys_WithAllExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         //preparation
         final String customTypeId = UUID.randomUUID().toString();
@@ -62,7 +62,7 @@ public class InventoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceInventoriesReferenceIdsWithKeys_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         //preparation
         final String customTypeId = UUID.randomUUID().toString();
@@ -96,7 +96,7 @@ public class InventoryReferenceReplacementUtilsTest {
 
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
+    void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
         //preparation
         final String channelId = UUID.randomUUID().toString();
         final Reference<Channel> channelReference = Channel.referenceOfId(channelId);
@@ -112,7 +112,7 @@ public class InventoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
+    void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
         //preparation
         final String channelKey = "channelKey";
         final Channel channel = getChannelMock(channelKey);
@@ -130,7 +130,7 @@ public class InventoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithNullChannelReference_ShouldReturnNull() {
+    void replaceChannelReferenceIdWithKey_WithNullChannelReference_ShouldReturnNull() {
         final InventoryEntry inventoryEntry = mock(InventoryEntry.class);
 
         final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(inventoryEntry);

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventorySyncUtilsTest.java
@@ -18,8 +18,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.CustomFieldsDraftBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -31,7 +31,7 @@ import static com.commercetools.sync.inventories.InventorySyncMockUtils.getMockS
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class InventorySyncUtilsTest {
+class InventorySyncUtilsTest {
     private static final String CUSTOM_TYPE_ID = "testId";
     private static final String CUSTOM_FIELD_1_NAME = "testField";
     private static final String CUSTOM_FIELD_2_NAME = "differentField";
@@ -49,8 +49,8 @@ public class InventorySyncUtilsTest {
     /**
      * Initialises test data.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final Channel channel = getMockSupplyChannel("111", "key1");
         final Reference<Channel> reference = Channel.referenceOfId("111").filled(channel);
         final CustomFields customFields = getMockCustomFields(CUSTOM_TYPE_ID, CUSTOM_FIELD_1_NAME,
@@ -65,7 +65,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntries_ShouldReturnEmptyList() {
+    void buildActions_WithSimilarEntries_ShouldReturnEmptyList() {
         List<UpdateAction<InventoryEntry>> actions = InventorySyncUtils
             .buildActions(inventoryEntry, similarDraft, InventorySyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                    .build());
@@ -74,7 +74,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithVariousEntries_ShouldReturnActions() {
+    void buildActions_WithVariousEntries_ShouldReturnActions() {
         List<UpdateAction<InventoryEntry>> actions = InventorySyncUtils
             .buildActions(inventoryEntry, variousDraft, InventorySyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                    .build());
@@ -91,7 +91,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntriesAndSameCustomFields_ShouldReturnEmptyList() {
+    void buildActions_WithSimilarEntriesAndSameCustomFields_ShouldReturnEmptyList() {
         final InventoryEntryDraft draft = InventoryEntryDraftBuilder.of(similarDraft)
                                                                     .custom(getDraftOfCustomField(CUSTOM_FIELD_1_NAME,
                                                                         CUSTOM_FIELD_1_VALUE))
@@ -104,7 +104,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntriesAndNewCustomTypeSet_ShouldReturnActions() {
+    void buildActions_WithSimilarEntriesAndNewCustomTypeSet_ShouldReturnActions() {
         final InventoryEntryDraft draft = InventoryEntryDraftBuilder.of(similarDraft)
                                                                     .custom(getDraftOfCustomField(CUSTOM_FIELD_2_NAME,
                                                                         CUSTOM_FIELD_2_VALUE)).build();
@@ -117,7 +117,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntriesAndRemovedExistingCustomType_ShouldReturnActions() {
+    void buildActions_WithSimilarEntriesAndRemovedExistingCustomType_ShouldReturnActions() {
         final List<UpdateAction<InventoryEntry>> actions = InventorySyncUtils
             .buildActions(inventoryEntryWithCustomField1,
                 similarDraft, InventorySyncOptionsBuilder.of(mock(SphereClient.class)).build());
@@ -128,7 +128,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntriesButDifferentCustomFields_ShouldReturnActions() {
+    void buildActions_WithSimilarEntriesButDifferentCustomFields_ShouldReturnActions() {
         final InventoryEntryDraft draft = InventoryEntryDraftBuilder.of(similarDraft)
                                                                     .custom(getDraftOfCustomField(CUSTOM_FIELD_2_NAME,
                                                                         CUSTOM_FIELD_2_VALUE))
@@ -145,7 +145,7 @@ public class InventorySyncUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSimilarEntriesButDifferentCustomFieldValues_ShouldReturnActions() {
+    void buildActions_WithSimilarEntriesButDifferentCustomFieldValues_ShouldReturnActions() {
         final InventoryEntryDraft draft = InventoryEntryDraftBuilder.of(similarDraft)
                                                                     .custom(getDraftOfCustomField(CUSTOM_FIELD_1_NAME,
                                                                         CUSTOM_FIELD_2_VALUE))

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventoryUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventoryUpdateActionUtilsTest.java
@@ -9,8 +9,8 @@ import io.sphere.sdk.inventory.commands.updateactions.SetExpectedDelivery;
 import io.sphere.sdk.inventory.commands.updateactions.SetRestockableInDays;
 import io.sphere.sdk.inventory.commands.updateactions.SetSupplyChannel;
 import io.sphere.sdk.models.Reference;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InventoryUpdateActionUtilsTest {
+class InventoryUpdateActionUtilsTest {
 
     private static InventoryEntry old;
     private static InventoryEntryDraft newSame;
@@ -35,8 +35,8 @@ public class InventoryUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         final ZonedDateTime date1 = ZonedDateTime.of(2017, 5, 1, 10, 0, 0, 0, ZoneId.of("UTC"));
         final ZonedDateTime date2 = ZonedDateTime.of(2017, 4, 1, 12, 0, 0, 0, ZoneId.of("UTC"));
         
@@ -58,7 +58,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeQuantityAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeQuantityAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildChangeQuantityAction(old, newDifferent);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -67,7 +67,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeQuantityAction_WithNewNullValue_ShouldReturnAction() {
+    void buildChangeQuantityAction_WithNewNullValue_ShouldReturnAction() {
         final InventoryEntryDraft draft = mock(InventoryEntryDraft.class);
         when(draft.getQuantityOnStock()).thenReturn(null);
         final Optional<UpdateAction<InventoryEntry>> result = buildChangeQuantityAction(old, draft);
@@ -78,7 +78,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeQuantityAction_WithNewNullValueAndOldZeroValue_ShouldReturnEmptyOptional() {
+    void buildChangeQuantityAction_WithNewNullValueAndOldZeroValue_ShouldReturnEmptyOptional() {
         final InventoryEntryDraft draft = mock(InventoryEntryDraft.class);
         when(draft.getQuantityOnStock()).thenReturn(null);
         final InventoryEntry entry = mock(InventoryEntry.class);
@@ -89,12 +89,12 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeQuantityAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeQuantityAction_WithSameValues_ShouldReturnEmptyOptional() {
         assertNoUpdatesForSameValues(InventoryUpdateActionUtils::buildChangeQuantityAction);
     }
 
     @Test
-    public void buildSetRestockableInDaysAction_WithDifferentValues_ShouldReturnAction() {
+    void buildSetRestockableInDaysAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetRestockableInDaysAction(old, newDifferent);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -104,7 +104,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetRestockableInDaysAction_WithNewNullValue_ShouldReturnAction() {
+    void buildSetRestockableInDaysAction_WithNewNullValue_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetRestockableInDaysAction(old, newWithNullValues);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -113,12 +113,12 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetRestockableInDaysAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildSetRestockableInDaysAction_WithSameValues_ShouldReturnEmptyOptional() {
         assertNoUpdatesForSameValues(InventoryUpdateActionUtils::buildSetRestockableInDaysAction);
     }
 
     @Test
-    public void buildSetExpectedDeliveryAction_WithDifferentValue_ShouldReturnActions() {
+    void buildSetExpectedDeliveryAction_WithDifferentValue_ShouldReturnActions() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetExpectedDeliveryAction(old, newDifferent);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -128,7 +128,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetExpectedDeliveryAction_WithNewNullValue_ShouldReturnAction() {
+    void buildSetExpectedDeliveryAction_WithNewNullValue_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetExpectedDeliveryAction(old, newWithNullValues);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -137,12 +137,12 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetExpectedDeliveryAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildSetExpectedDeliveryAction_WithSameValues_ShouldReturnEmptyOptional() {
         assertNoUpdatesForSameValues(InventoryUpdateActionUtils::buildSetExpectedDeliveryAction);
     }
 
     @Test
-    public void buildSetSupplyChannelAction_WithDifferentValues_ShouldReturnAction() {
+    void buildSetSupplyChannelAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetSupplyChannelAction(old, newDifferent);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -152,7 +152,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetSupplyChannelAction_WithNewNullValue_ShouldReturnAction() {
+    void buildSetSupplyChannelAction_WithNewNullValue_ShouldReturnAction() {
         final Optional<UpdateAction<InventoryEntry>> result = buildSetSupplyChannelAction(old, newWithNullValues);
         assertThat(result).isNotNull();
         assertThat(result.isPresent()).isTrue();
@@ -161,7 +161,7 @@ public class InventoryUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetSupplyChannelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildSetSupplyChannelAction_WithSameValues_ShouldReturnEmptyOptional() {
         assertNoUpdatesForSameValues(InventoryUpdateActionUtils::buildSetSupplyChannelAction);
     }
 

--- a/src/test/java/com/commercetools/sync/products/ProductSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncOptionsBuilderTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,18 +27,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductSyncOptionsBuilderTest {
+class ProductSyncOptionsBuilderTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private ProductSyncOptionsBuilder productSyncOptionsBuilder = ProductSyncOptionsBuilder.of(CTP_CLIENT);
 
     @Test
-    public void of_WithClient_ShouldCreateProductSyncOptionsBuilder() {
+    void of_WithClient_ShouldCreateProductSyncOptionsBuilder() {
         final ProductSyncOptionsBuilder builder = ProductSyncOptionsBuilder.of(CTP_CLIENT);
         assertThat(builder).isNotNull();
     }
 
     @Test
-    public void build_WithClient_ShouldBuildProductSyncOptions() {
+    void build_WithClient_ShouldBuildProductSyncOptions() {
         final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
         assertThat(productSyncOptions).isNotNull();
         assertThat(productSyncOptions.getSyncFilter()).isNotNull();
@@ -52,14 +52,14 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void syncFilter_WithNoSyncFilter_ShouldSetDefaultFilter() {
+    void syncFilter_WithNoSyncFilter_ShouldSetDefaultFilter() {
         final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
         assertThat(productSyncOptions.getSyncFilter()).isNotNull();
         assertThat(productSyncOptions.getSyncFilter()).isSameAs(SyncFilter.of());
     }
 
     @Test
-    public void syncFilter_WithSyncFilter_ShouldSetFilter() {
+    void syncFilter_WithSyncFilter_ShouldSetFilter() {
         productSyncOptionsBuilder.syncFilter(ofWhiteList(IMAGES));
 
         final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
@@ -67,7 +67,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
         final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
             beforeUpdateCallback = (updateActions, newProduct, oldProduct) -> emptyList();
         productSyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
@@ -77,7 +77,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
         productSyncOptionsBuilder.beforeCreateCallback((newProduct) -> null);
 
         final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
@@ -85,7 +85,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void errorCallBack_WithCallBack_ShouldSetCallBack() {
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final BiConsumer<String, Throwable> mockErrorCallBack = (errorMessage, errorException) -> {
         };
         productSyncOptionsBuilder.errorCallback(mockErrorCallBack);
@@ -95,7 +95,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void warningCallBack_WithCallBack_ShouldSetCallBack() {
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final Consumer<String> mockWarningCallBack = (warningMessage) -> {
         };
         productSyncOptionsBuilder.warningCallback(mockWarningCallBack);
@@ -105,7 +105,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void getThis_ShouldReturnCorrectInstance() {
+    void getThis_ShouldReturnCorrectInstance() {
         final ProductSyncOptionsBuilder instance = productSyncOptionsBuilder.getThis();
         assertThat(instance).isNotNull();
         assertThat(instance).isInstanceOf(ProductSyncOptionsBuilder.class);
@@ -113,7 +113,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void productSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+    void productSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder
             .of(CTP_CLIENT)
             .batchSize(30)
@@ -124,7 +124,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT)
                                                                                .batchSize(10)
                                                                                .build();
@@ -132,7 +132,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
         final ProductSyncOptions productSyncOptionsWithZeroBatchSize = ProductSyncOptionsBuilder.of(CTP_CLIENT)
                                                                                                 .batchSize(0)
                                                                                                 .build();
@@ -148,7 +148,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT)
                                                                                .build();
         assertThat(productSyncOptions.getBeforeUpdateCallback()).isNull();
@@ -161,7 +161,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
             beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT)
@@ -182,7 +182,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
         final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
 
         final ProductSyncOptions productSyncOptions =
@@ -201,7 +201,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
         final TriFunction<List<UpdateAction<Product>>, ProductDraft, Product, List<UpdateAction<Product>>>
             beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> emptyList();
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT)
@@ -218,7 +218,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
         final Function<ProductDraft, ProductDraft> draftFunction =
             productDraft -> ProductDraftBuilder.of(productDraft)
                                                .key(productDraft.getKey() + "_filteredKey").build();
@@ -239,7 +239,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT).build();
         assertThat(productSyncOptions.getBeforeCreateCallback()).isNull();
 
@@ -250,7 +250,7 @@ public class ProductSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyOptional() {
+    void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyOptional() {
         final Function<ProductDraft, ProductDraft> draftFunction = productDraft -> null;
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT)
                                                                                .beforeCreateCallback(draftFunction)

--- a/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
@@ -16,7 +16,7 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,9 +46,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductSyncTest {
+class ProductSyncTest {
+
     @Test
-    public void sync_WithErrorCachingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorCachingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             ProductType.referenceOfId("productTypeKey"))
@@ -109,7 +110,7 @@ public class ProductSyncTest {
     }
 
     @Test
-    public void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
                 ProductType.referenceOfId("productTypeKey"))
@@ -173,7 +174,7 @@ public class ProductSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
             ProductType.referenceOfId("productTypeKey"))
@@ -214,7 +215,7 @@ public class ProductSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
         final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_1_WITH_PRICES_RESOURCE_PATH,
             ProductType.referenceOfId("productTypeKey"))

--- a/src/test/java/com/commercetools/sync/products/SyncFilterTest.java
+++ b/src/test/java/com/commercetools/sync/products/SyncFilterTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.products;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 
@@ -16,17 +17,17 @@ import static com.commercetools.sync.products.SyncFilter.ofBlackList;
 import static com.commercetools.sync.products.SyncFilter.ofWhiteList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SyncFilterTest {
+class SyncFilterTest {
 
     @Test
-    public void of_returnsSameInstanceOfDefaultSyncFilter() {
+    void of_returnsSameInstanceOfDefaultSyncFilter() {
         final SyncFilter syncFilter = SyncFilter.of();
         final SyncFilter otherSyncFilter = SyncFilter.of();
         assertThat(syncFilter).isSameAs(otherSyncFilter);
     }
 
     @Test
-    public void filterActionGroup_WithWhiteListingSingleGroup_ShouldFilterInOnlyThisGroup() {
+    void filterActionGroup_WithWhiteListingSingleGroup_ShouldFilterInOnlyThisGroup() {
         final SyncFilter syncFilter = ofWhiteList(IMAGES);
 
         assertThat(syncFilter.filterActionGroup(IMAGES)).isTrue();
@@ -39,7 +40,7 @@ public class SyncFilterTest {
     }
 
     @Test
-    public void filterActionGroup_WithWhiteListingMultipleGroups_ShouldFilterInOnlyTheseGroups() {
+    void filterActionGroup_WithWhiteListingMultipleGroups_ShouldFilterInOnlyTheseGroups() {
         final SyncFilter syncFilter = ofWhiteList(IMAGES, ATTRIBUTES, CATEGORIES, ASSETS);
 
         assertThat(syncFilter.filterActionGroup(IMAGES)).isTrue();
@@ -52,7 +53,7 @@ public class SyncFilterTest {
     }
 
     @Test
-    public void filterActionGroup_WithBlackListingSingleGroup_ShouldFilterOutOnlyThisGroup() {
+    void filterActionGroup_WithBlackListingSingleGroup_ShouldFilterOutOnlyThisGroup() {
         final SyncFilter syncFilter = ofBlackList(PRICES);
 
         assertThat(syncFilter.filterActionGroup(PRICES)).isFalse();
@@ -64,7 +65,7 @@ public class SyncFilterTest {
     }
 
     @Test
-    public void filterActionGroup_WithBlackListingMultiplGroups_ShouldFilterOutOnlyTheseGroups() {
+    void filterActionGroup_WithBlackListingMultiplGroups_ShouldFilterOutOnlyTheseGroups() {
         final SyncFilter syncFilter = ofBlackList(PRICES, IMAGES, ATTRIBUTES, NAME);
 
         assertThat(syncFilter.filterActionGroup(PRICES)).isFalse();
@@ -78,7 +79,7 @@ public class SyncFilterTest {
     }
 
     @Test
-    public void filterActionGroup_WithDefaultSyncFilterShouldFilterInAllActionGroups() {
+    void filterActionGroup_WithDefaultSyncFilterShouldFilterInAllActionGroups() {
         final SyncFilter syncFilter = SyncFilter.of();
         EnumSet.allOf(ActionGroup.class)
                .forEach(actionGroup -> assertThat(syncFilter.filterActionGroup(actionGroup)).isTrue());

--- a/src/test/java/com/commercetools/sync/products/helpers/BatchProcessorTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/BatchProcessorTest.java
@@ -11,8 +11,8 @@ import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
 import io.sphere.sdk.products.attributes.AttributeDraft;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,13 +38,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BatchProcessorTest {
+class BatchProcessorTest {
     private List<String> errorCallBackMessages;
     private List<Throwable> errorCallBackExceptions;
     private ProductSync productSync;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         errorCallBackMessages = new ArrayList<>();
         errorCallBackExceptions = new ArrayList<>();
         final SphereClient ctpClient = mock(SphereClient.class);
@@ -58,7 +58,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getVariantDraftErrors_WithNullVariant_ShouldHaveValidationErrors() {
+    void getVariantDraftErrors_WithNullVariant_ShouldHaveValidationErrors() {
         final int variantPosition = 0;
         final String productDraftKey = "key";
         final List<String> validationErrors = getVariantDraftErrors(null, variantPosition, productDraftKey);
@@ -69,7 +69,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getVariantDraftErrors_WithNokeyAndSku_ShouldHaveValidationErrors() {
+    void getVariantDraftErrors_WithNokeyAndSku_ShouldHaveValidationErrors() {
         final int variantPosition = 0;
         final String productDraftKey = "key";
         final List<String> validationErrors =
@@ -82,7 +82,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getVariantDraftErrors_WithNoKey_ShouldHaveKeyValidationError() {
+    void getVariantDraftErrors_WithNoKey_ShouldHaveKeyValidationError() {
         final int variantPosition = 0;
         final String productDraftKey = "key";
         final ProductVariantDraft productVariantDraft = mock(ProductVariantDraft.class);
@@ -97,7 +97,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getVariantDraftErrors_WithNoSku_ShouldHaveSkuValidationError() {
+    void getVariantDraftErrors_WithNoSku_ShouldHaveSkuValidationError() {
         final int variantPosition = 0;
         final String productDraftKey = "key";
         final ProductVariantDraft productVariantDraft = mock(ProductVariantDraft.class);
@@ -112,7 +112,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getVariantDraftErrors_WithSkuAndKey_ShouldHaveNoValidationErrors() {
+    void getVariantDraftErrors_WithSkuAndKey_ShouldHaveNoValidationErrors() {
         final String productDraftKey = "key";
         final ProductVariantDraft productVariantDraft = mock(ProductVariantDraft.class);
         when(productVariantDraft.getKey()).thenReturn("key");
@@ -125,7 +125,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void
+    void
         getProductDraftErrorsAndAcceptConsumer_WithNullMvAndNullVariants_ShouldNotAcceptConsumerAndHaveErrors() {
         final AtomicBoolean isConsumerAccepted = new AtomicBoolean(false);
         final ProductDraft productDraft = mock(ProductDraft.class);
@@ -142,7 +142,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void
+    void
         getProductDraftErrorsAndAcceptConsumer_WithNullMvAndNoVariants_ShouldNotAcceptConsumerAndHaveErrors() {
         final AtomicBoolean isConsumerAccepted = new AtomicBoolean(false);
         final ProductDraft productDraft = mock(ProductDraft.class);
@@ -158,7 +158,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void
+    void
         getProductDraftErrorsAndAcceptConsumer_WithNullMvAndValidVariants_ShouldNotAcceptConsumerAndHaveErrors() {
         final AtomicBoolean isConsumerAccepted = new AtomicBoolean(false);
 
@@ -180,7 +180,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void
+    void
         getProductDraftErrorsAndAcceptConsumer_WithInValidMvAndValidVariants_ShouldNotAcceptConsumerAndHaveErrors() {
         final AtomicBoolean isConsumerAccepted = new AtomicBoolean(false);
 
@@ -204,7 +204,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void
+    void
         getProductDraftErrorsAndAcceptConsumer_WithValidMvAndValidVariants_ShouldAcceptConsumerAndNoErrors() {
         final AtomicBoolean isConsumerAccepted = new AtomicBoolean(false);
 
@@ -225,32 +225,32 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getProductKeyFromReference_WithNullJsonNode_ShouldReturnEmptyOpt() {
+    void getProductKeyFromReference_WithNullJsonNode_ShouldReturnEmptyOpt() {
         final NullNode nullNode = JsonNodeFactory.instance.nullNode();
         assertThat(getProductKeyFromReference(nullNode)).isEmpty();
     }
 
     @Test
-    public void getProductKeyFromReference_WithoutAProductReference_ShouldReturnEmptyOpt() {
+    void getProductKeyFromReference_WithoutAProductReference_ShouldReturnEmptyOpt() {
         final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
         objectNode.put("key", "value");
         assertThat(getProductKeyFromReference(objectNode)).isEmpty();
     }
 
     @Test
-    public void getProductKeyFromReference_WithAProductReference_ShouldReturnOptWithRefText() {
+    void getProductKeyFromReference_WithAProductReference_ShouldReturnOptWithRefText() {
         assertThat(getProductKeyFromReference(getProductReferenceWithId("foo"))).contains("foo");
     }
 
     @Test
-    public void getReferencedProductKeysFromSet_WithOnlyNullRefsInSet_ShouldReturnEmptySet() {
+    void getReferencedProductKeysFromSet_WithOnlyNullRefsInSet_ShouldReturnEmptySet() {
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", null, null);
         assertThat(getReferencedProductKeysFromSet(productReferenceSetAttribute.getValue())).isEmpty();
     }
 
     @Test
-    public void getReferencedProductKeysFromSet_WithNullRefsInSet_ShouldReturnSetOfNonNullIds() {
+    void getReferencedProductKeysFromSet_WithNullRefsInSet_ShouldReturnSetOfNonNullIds() {
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", getProductReferenceWithId("foo"),
                 getProductReferenceWithId("bar"));
@@ -259,7 +259,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getReferencedProductKeysFromSet_WithNullAndOtherRefsInSet_ShouldReturnSetOfNonNullIds() {
+    void getReferencedProductKeysFromSet_WithNullAndOtherRefsInSet_ShouldReturnSetOfNonNullIds() {
         final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
         objectNode.put("key", "value");
 
@@ -271,12 +271,12 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getReferencedProductKeys_WithNullDraftValue_ShouldReturnEmptySet() {
+    void getReferencedProductKeys_WithNullDraftValue_ShouldReturnEmptySet() {
         assertThat(getReferencedProductKeys(AttributeDraft.of("foo", null))).isEmpty();
     }
 
     @Test
-    public void getReferencedProductKeys_WithSetAsValue_ShouldReturnSetKeys() {
+    void getReferencedProductKeys_WithSetAsValue_ShouldReturnSetKeys() {
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", getProductReferenceWithId("foo"),
                 getProductReferenceWithId("bar"));
@@ -284,29 +284,29 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void getReferencedProductKeys_WithProductRefAsValue_ShouldReturnKeyinSet() {
+    void getReferencedProductKeys_WithProductRefAsValue_ShouldReturnKeyinSet() {
         final AttributeDraft productReferenceAttribute = AttributeDraft.of("foo", getProductReferenceWithId("foo"));
         assertThat(getReferencedProductKeys(productReferenceAttribute)).containsExactly("foo");
     }
 
     @Test
-    public void getReferencedProductKeys_WithNullAttributes_ShouldReturnEmptySet() {
+    void getReferencedProductKeys_WithNullAttributes_ShouldReturnEmptySet() {
         assertThat(getReferencedProductKeys(ProductVariantDraftBuilder.of().build())).isEmpty();
     }
 
     @Test
-    public void getReferencedProductKeys_WithNoAttributes_ShouldReturnEmptySet() {
+    void getReferencedProductKeys_WithNoAttributes_ShouldReturnEmptySet() {
         assertThat(getReferencedProductKeys(ProductVariantDraftBuilder.of().attributes().build())).isEmpty();
     }
 
     @Test
-    public void getReferencedProductKeys_WithANullAttribute_ShouldReturnEmptySet() {
+    void getReferencedProductKeys_WithANullAttribute_ShouldReturnEmptySet() {
         assertThat(getReferencedProductKeys(ProductVariantDraftBuilder.of().attributes(singletonList(null)).build()))
             .isEmpty();
     }
 
     @Test
-    public void getReferencedProductKeys_WithAProductRefAttribute_ShouldReturnEmptySet() {
+    void getReferencedProductKeys_WithAProductRefAttribute_ShouldReturnEmptySet() {
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", getProductReferenceWithId("foo"),
                 getProductReferenceWithId("bar"));
@@ -321,7 +321,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void validateBatch_WithEmptyBatch_ShouldHaveEmptyResults() {
+    void validateBatch_WithEmptyBatch_ShouldHaveEmptyResults() {
         final BatchProcessor batchProcessor = new BatchProcessor(emptyList(), productSync);
 
         batchProcessor.validateBatch();
@@ -333,7 +333,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void validateBatch_WithANullDraft_ShouldResultInAnError() {
+    void validateBatch_WithANullDraft_ShouldResultInAnError() {
         final BatchProcessor batchProcessor = new BatchProcessor(singletonList(null), productSync);
 
         batchProcessor.validateBatch();
@@ -345,7 +345,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void validateBatch_WithADraftWithNullKey_ShouldResultInAnError() {
+    void validateBatch_WithADraftWithNullKey_ShouldResultInAnError() {
         final ProductDraft productDraft = mock(ProductDraft.class);
         final BatchProcessor batchProcessor = new BatchProcessor(singletonList(productDraft), productSync);
 
@@ -359,7 +359,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void validateBatch_WithADraftWithEmptyKey_ShouldResultInAnError() {
+    void validateBatch_WithADraftWithEmptyKey_ShouldResultInAnError() {
         final ProductDraft productDraft = mock(ProductDraft.class);
         when(productDraft.getKey()).thenReturn("");
 
@@ -374,7 +374,7 @@ public class BatchProcessorTest {
     }
 
     @Test
-    public void validateBatch_WithDrafts_ShouldValidateCorrectly() {
+    void validateBatch_WithDrafts_ShouldValidateCorrectly() {
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", getProductReferenceWithId("foo"),
                 getProductReferenceWithId("bar"));

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceCustomerGroupReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceCustomerGroupReferenceResolverTest.java
@@ -13,8 +13,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.products.PriceDraftBuilder;
 import io.sphere.sdk.utils.MoneyImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Objects;
@@ -32,7 +32,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PriceCustomerGroupReferenceResolverTest {
+class PriceCustomerGroupReferenceResolverTest {
     private static final String CUSTOMER_GROUP_KEY = "customer-group-key_1";
     private static final String CUSTOMER_GROUP_ID = "1";
 
@@ -42,8 +42,8 @@ public class PriceCustomerGroupReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         customerGroupService = getMockCustomerGroupService(getMockCustomerGroup(CUSTOMER_GROUP_ID, CUSTOMER_GROUP_KEY));
         ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
         referenceResolver = new PriceReferenceResolver(syncOptions, mock(TypeService.class), mock(ChannelService.class),
@@ -51,7 +51,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithKeys_ShouldResolveReference() {
+    void resolveCustomerGroupReference_WithKeys_ShouldResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
             .customerGroup(CustomerGroup.referenceOfId("anyKey"));
@@ -64,7 +64,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithNullCustomerGroup_ShouldNotResolveReference() {
+    void resolveCustomerGroupReference_WithNullCustomerGroup_ShouldNotResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR));
 
@@ -74,7 +74,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithNonExistentCustomerGroup_ShouldNotResolveReference() {
+    void resolveCustomerGroupReference_WithNonExistentCustomerGroup_ShouldNotResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
             .customerGroup(CustomerGroup.referenceOfId("nonExistentKey"));
@@ -89,7 +89,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithNullIdOnCustomerGroupReference_ShouldNotResolveReference() {
+    void resolveCustomerGroupReference_WithNullIdOnCustomerGroupReference_ShouldNotResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
             .customerGroup(Reference.of(CustomerGroup.referenceTypeId(), (String)null));
@@ -104,7 +104,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithEmptyIdOnCustomerGroupReference_ShouldNotResolveReference() {
+    void resolveCustomerGroupReference_WithEmptyIdOnCustomerGroupReference_ShouldNotResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
             .customerGroup(CustomerGroup.referenceOfId(""));
@@ -119,7 +119,7 @@ public class PriceCustomerGroupReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomerGroupReference_WithExceptionOnFetch_ShouldNotResolveReference() {
+    void resolveCustomerGroupReference_WithExceptionOnFetch_ShouldNotResolveReference() {
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
             .customerGroup(CustomerGroup.referenceOfId("CustomerGroupKey"));

--- a/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/PriceReferenceResolverTest.java
@@ -17,8 +17,8 @@ import io.sphere.sdk.products.PriceDraftBuilder;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.utils.MoneyImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -39,7 +39,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PriceReferenceResolverTest {
+class PriceReferenceResolverTest {
     private TypeService typeService;
     private ChannelService channelService;
     private CustomerGroupService customerGroupService;
@@ -54,8 +54,8 @@ public class PriceReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         typeService = getMockTypeService();
         channelService = getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
         customerGroupService = getMockCustomerGroupService(getMockCustomerGroup(CUSTOMER_GROUP_ID, CUSTOMER_GROUP_KEY));
@@ -63,7 +63,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNonExistentCustomType_ShouldNotResolveCustomTypeReference() {
         final String customTypeKey = "customTypeKey";
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson(customTypeKey, new HashMap<>());
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
@@ -86,7 +86,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithNullIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CustomFieldsDraft customFieldsDraft = mock(CustomFieldsDraft.class);
         final ResourceIdentifier<Type> typeReference = ResourceIdentifier.ofId(null);
         when(customFieldsDraft.getType()).thenReturn(typeReference);
@@ -108,7 +108,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
+    void resolveCustomTypeReference_WithEmptyIdOnCustomTypeReference_ShouldNotResolveCustomTypeReference() {
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson("", new HashMap<>());
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
             .of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
@@ -127,7 +127,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
+    void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
         final String customTypeKey = "customTypeKey";
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson(customTypeKey, new HashMap<>());
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
@@ -150,7 +150,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveChannelReference_WithNonExistingChannelKey_ShouldResolveChannelReference() {
+    void resolveChannelReference_WithNonExistingChannelKey_ShouldResolveChannelReference() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
         final PriceDraftBuilder priceBuilder = PriceDraftBuilder
@@ -168,7 +168,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void
+    void
         resolveSupplyChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
         when(channelService.fetchCachedChannelId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
@@ -198,7 +198,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void
+    void
         resolveSupplyChannelReference_WithNonExistingChannelAndEnsureChannel_ShouldResolveSupplyChannelReference() {
         final ProductSyncOptions optionsWithEnsureChannels = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                       .ensurePriceChannels(true)
@@ -225,7 +225,7 @@ public class PriceReferenceResolverTest {
     }
 
     @Test
-    public void resolveReferences_WithNoReferences_ShouldNotResolveReferences() {
+    void resolveReferences_WithNoReferences_ShouldNotResolveReferences() {
         final PriceDraft priceDraft = PriceDraftBuilder.of(MoneyImpl.of(BigDecimal.TEN, DefaultCurrencyUnits.EUR))
                                                        .country(CountryCode.DE)
                                                        .build();

--- a/src/test/java/com/commercetools/sync/products/helpers/ProductAssetActionFactoryTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/ProductAssetActionFactoryTest.java
@@ -12,8 +12,8 @@ import io.sphere.sdk.products.commands.updateactions.AddAsset;
 import io.sphere.sdk.products.commands.updateactions.ChangeAssetOrder;
 import io.sphere.sdk.products.commands.updateactions.RemoveAsset;
 import io.sphere.sdk.products.commands.updateactions.SetAssetTags;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -24,11 +24,11 @@ import static org.assertj.core.util.Lists.emptyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductAssetActionFactoryTest {
+class ProductAssetActionFactoryTest {
     private ProductAssetActionFactory productAssetActionFactory;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                         .build();
 
@@ -36,7 +36,7 @@ public class ProductAssetActionFactoryTest {
     }
 
     @Test
-    public void buildRemoveAssetAction_always_ShouldBuildCorrectAction() {
+    void buildRemoveAssetAction_always_ShouldBuildCorrectAction() {
         final UpdateAction<Product> action = productAssetActionFactory.buildRemoveAssetAction("foo");
         assertThat(action).isNotNull();
         assertThat(action).isInstanceOf(RemoveAsset.class);
@@ -47,7 +47,7 @@ public class ProductAssetActionFactoryTest {
     }
 
     @Test
-    public void buildChangeAssetOrderAction_always_ShouldBuildCorrectAction() {
+    void buildChangeAssetOrderAction_always_ShouldBuildCorrectAction() {
         final UpdateAction<Product> action = productAssetActionFactory.buildChangeAssetOrderAction(emptyList());
         assertThat(action).isNotNull();
         assertThat(action).isInstanceOf(ChangeAssetOrder.class);
@@ -58,7 +58,7 @@ public class ProductAssetActionFactoryTest {
     }
 
     @Test
-    public void buildAddAssetAction_always_ShouldBuildCorrectAction() {
+    void buildAddAssetAction_always_ShouldBuildCorrectAction() {
         final AssetDraft assetDraft = AssetDraftBuilder.of(emptyList(), ofEnglish("assetName"))
                                                        .build();
 
@@ -75,7 +75,7 @@ public class ProductAssetActionFactoryTest {
     }
 
     @Test
-    public void buildAssetActions_always_ShouldBuildCorrectAction() {
+    void buildAssetActions_always_ShouldBuildCorrectAction() {
         final Asset asset = mock(Asset.class);
         when(asset.getKey()).thenReturn("assetKey");
         when(asset.getName()).thenReturn(ofEnglish("assetName"));

--- a/src/test/java/com/commercetools/sync/products/helpers/ProductSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/ProductSyncStatisticsTest.java
@@ -1,20 +1,20 @@
 package com.commercetools.sync.products.helpers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductSyncStatisticsTest {
+class ProductSyncStatisticsTest {
     private ProductSyncStatistics productSyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         productSyncStatistics = new ProductSyncStatistics();
     }
 
     @Test
-    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
         productSyncStatistics.incrementCreated(1);
         productSyncStatistics.incrementFailed(1);
         productSyncStatistics.incrementUpdated(1);

--- a/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/VariantReferenceResolverTest.java
@@ -21,8 +21,8 @@ import io.sphere.sdk.products.ProductVariantDraftBuilder;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.utils.MoneyImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -51,7 +51,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class VariantReferenceResolverTest { ;
+class VariantReferenceResolverTest { ;
     private ProductService productService;
 
     private static final String CHANNEL_KEY = "channel-key_1";
@@ -62,8 +62,8 @@ public class VariantReferenceResolverTest { ;
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final TypeService typeService = getMockTypeService();
         final ChannelService channelService = getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
         productService = getMockProductService(PRODUCT_ID);
@@ -73,7 +73,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAssetsReferences_WithEmptyAssets_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithEmptyAssets_ShouldNotResolveAssets() {
         final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of()
                                                                                                 .assets(emptyList());
 
@@ -86,7 +86,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAssetsReferences_WithNullAssets_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithNullAssets_ShouldNotResolveAssets() {
         final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of();
 
         final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
@@ -98,7 +98,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAssetsReferences_WithANullAsset_ShouldNotResolveAssets() {
+    void resolveAssetsReferences_WithANullAsset_ShouldNotResolveAssets() {
         final ProductVariantDraftBuilder productVariantDraftBuilder =
             ProductVariantDraftBuilder.of().assets(singletonList(null));
 
@@ -111,7 +111,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAssetsReferences_WithAssetReferences_ShouldResolveAssets() {
+    void resolveAssetsReferences_WithAssetReferences_ShouldResolveAssets() {
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft
             .ofTypeIdAndJson("customTypeId", new HashMap<>());
 
@@ -134,7 +134,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolvePricesReferences_WithNullPrices_ShouldNotResolvePrices() {
+    void resolvePricesReferences_WithNullPrices_ShouldNotResolvePrices() {
         final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of();
 
         final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
@@ -146,7 +146,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolvePricesReferences_WithANullPrice_ShouldNotResolvePrices() {
+    void resolvePricesReferences_WithANullPrice_ShouldNotResolvePrices() {
         final ProductVariantDraftBuilder productVariantDraftBuilder =
             ProductVariantDraftBuilder.of().prices((PriceDraft) null);
 
@@ -159,7 +159,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolvePricesReferences_WithPriceReferences_ShouldResolvePrices() {
+    void resolvePricesReferences_WithPriceReferences_ShouldResolvePrices() {
         final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft
             .ofTypeIdAndJson("customTypeId", new HashMap<>());
 
@@ -182,7 +182,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributesReferences_WithNullAttributes_ShouldNotResolveAttributes() {
+    void resolveAttributesReferences_WithNullAttributes_ShouldNotResolveAttributes() {
         final ProductVariantDraftBuilder productVariantDraftBuilder = ProductVariantDraftBuilder.of();
 
         final ProductVariantDraftBuilder resolvedBuilder = referenceResolver
@@ -194,7 +194,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributesReferences_WithANullAttribute_ShouldNotResolveAttributes() {
+    void resolveAttributesReferences_WithANullAttribute_ShouldNotResolveAttributes() {
         final ProductVariantDraftBuilder productVariantDraftBuilder =
             ProductVariantDraftBuilder.of().attributes((AttributeDraft) null);
 
@@ -207,7 +207,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributesReferences_WithMixedReference_ShouldResolveProductReferenceAttributes() {
+    void resolveAttributesReferences_WithMixedReference_ShouldResolveProductReferenceAttributes() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);
@@ -248,7 +248,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithEmptyValue_ShouldNotResolveAttribute() {
+    void resolveAttributeReference_WithEmptyValue_ShouldNotResolveAttribute() {
         final AttributeDraft attributeWithEmptyValue =
             AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
 
@@ -259,7 +259,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithNullValue_ShouldNotResolveAttribute() {
+    void resolveAttributeReference_WithNullValue_ShouldNotResolveAttribute() {
         final AttributeDraft attributeWithNullValue =
             AttributeDraft.of("attributeName", null);
 
@@ -270,7 +270,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithTextValue_ShouldNotResolveAttribute() {
+    void resolveAttributeReference_WithTextValue_ShouldNotResolveAttribute() {
         final AttributeDraft attributeWithTextValue =
             AttributeDraft.of("attributeName", "textValue");
 
@@ -281,7 +281,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithProductReferenceAttribute_ShouldResolveAttribute() {
+    void resolveAttributeReference_WithProductReferenceAttribute_ShouldResolveAttribute() {
         when(productService.getIdFromCacheOrFetch(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -298,7 +298,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithNonExistingProductReferenceAttribute_ShouldNotResolveAttribute() {
+    void resolveAttributeReference_WithNonExistingProductReferenceAttribute_ShouldNotResolveAttribute() {
         final ObjectNode attributeValue = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
 
@@ -313,7 +313,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithEmptyReferenceSetAttribute_ShouldNotResolveReferences() {
+    void resolveAttributeReference_WithEmptyReferenceSetAttribute_ShouldNotResolveReferences() {
         final ArrayNode referenceSet = JsonNodeFactory.instance.arrayNode();
 
         final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", referenceSet);
@@ -332,7 +332,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithCategoryReferenceSetAttribute_ShouldNotResolveReferences() {
+    void resolveAttributeReference_WithCategoryReferenceSetAttribute_ShouldNotResolveReferences() {
         final ObjectNode categoryReference = JsonNodeFactory.instance.objectNode();
         categoryReference.put("typeId", "category");
         categoryReference.put("id", UUID.randomUUID().toString());
@@ -362,7 +362,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithProductReferenceSetAttribute_ShouldResolveReferences() {
+    void resolveAttributeReference_WithProductReferenceSetAttribute_ShouldResolveReferences() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttributeDraft =
             getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);
@@ -385,7 +385,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithNullReferenceInSetAttribute_ShouldResolveReferences() {
+    void resolveAttributeReference_WithNullReferenceInSetAttribute_ShouldResolveReferences() {
         final ObjectNode productReference = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute =
             getProductReferenceSetAttributeDraft("foo", productReference, null);
@@ -408,7 +408,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveAttributeReference_WithNonExistingProductReferenceSetAttribute_ShouldNotResolveReferences() {
+    void resolveAttributeReference_WithNonExistingProductReferenceSetAttribute_ShouldNotResolveReferences() {
         when(productService.getIdFromCacheOrFetch(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -430,7 +430,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void
+    void
         resolveAttributeReference_WithSomeExistingProductReferenceSetAttribute_ShouldResolveExistingReferences() {
         when(productService.getIdFromCacheOrFetch("existingKey"))
             .thenReturn(CompletableFuture.completedFuture(Optional.of("existingId")));
@@ -460,20 +460,20 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void isProductReference_WithEmptyValue_ShouldReturnFalse() {
+    void isProductReference_WithEmptyValue_ShouldReturnFalse() {
         final AttributeDraft attributeWithEmptyValue =
             AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
         assertThat(VariantReferenceResolver.isProductReference(attributeWithEmptyValue.getValue())).isFalse();
     }
 
     @Test
-    public void isProductReference_WithTextAttribute_ShouldReturnFalse() {
+    void isProductReference_WithTextAttribute_ShouldReturnFalse() {
         final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "attributeValue");
         assertThat(VariantReferenceResolver.isProductReference(textAttribute.getValue())).isFalse();
     }
 
     @Test
-    public void isProductReference_WithNonReferenceAttribute_ShouldReturnFalse() {
+    void isProductReference_WithNonReferenceAttribute_ShouldReturnFalse() {
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("anyString", "anyValue");
         final AttributeDraft attribute = AttributeDraft.of("attributeName", attributeValue);
@@ -481,7 +481,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void isProductReference_WithCategoryReferenceAttribute_ShouldReturnFalse() {
+    void isProductReference_WithCategoryReferenceAttribute_ShouldReturnFalse() {
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("typeId", "category");
         attributeValue.put("id", UUID.randomUUID().toString());
@@ -490,14 +490,14 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void isProductReference_WithProductReferenceAttribute_ShouldReturnTrue() {
+    void isProductReference_WithProductReferenceAttribute_ShouldReturnTrue() {
         final ObjectNode attributeValue = getProductReferenceWithRandomId();
         final AttributeDraft categoryReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
         assertThat(VariantReferenceResolver.isProductReference(categoryReferenceAttribute.getValue())).isTrue();
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithEmptyValue_ShouldGetEmptyId() {
+    void getResolvedIdFromKeyInReference_WithEmptyValue_ShouldGetEmptyId() {
         final AttributeDraft attributeWithEmptyValue =
             AttributeDraft.of("attributeName", JsonNodeFactory.instance.objectNode());
         final Optional<String> optionalId =
@@ -508,7 +508,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithTextAttribute_ShouldGetEmptyId() {
+    void getResolvedIdFromKeyInReference_WithTextAttribute_ShouldGetEmptyId() {
         final AttributeDraft textAttribute = AttributeDraft.of("attributeName", "attributeValue");
         final Optional<String> optionalId = referenceResolver.getResolvedIdFromKeyInReference(textAttribute.getValue())
                                                              .toCompletableFuture().join();
@@ -516,7 +516,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithNonReferenceAttribute_ShouldGetEmptyId() {
+    void getResolvedIdFromKeyInReference_WithNonReferenceAttribute_ShouldGetEmptyId() {
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("anyString", "anyValue");
         final AttributeDraft attribute = AttributeDraft.of("attributeName", attributeValue);
@@ -527,7 +527,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithNonExistingProductReferenceAttribute_ShouldGetEmptyId() {
+    void getResolvedIdFromKeyInReference_WithNonExistingProductReferenceAttribute_ShouldGetEmptyId() {
         when(productService.getIdFromCacheOrFetch(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -540,7 +540,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithNullIdField_ShouldGetEmptyId() {
+    void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithNullIdField_ShouldGetEmptyId() {
         final ObjectNode attributeValue = JsonNodeFactory.instance.objectNode();
         attributeValue.put("typeId", "product");
         final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
@@ -552,7 +552,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithIdField_ShouldGetId() {
+    void getResolvedIdFromKeyInReference_WithProductReferenceAttributeWithIdField_ShouldGetId() {
         final ObjectNode attributeValue = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceAttribute = AttributeDraft.of("attributeName", attributeValue);
 
@@ -563,7 +563,7 @@ public class VariantReferenceResolverTest { ;
     }
 
     @Test
-    public void resolveReferences_WithNoPriceReferences_ShouldResolveAttributeReferences() {
+    void resolveReferences_WithNoPriceReferences_ShouldResolveAttributeReferences() {
         final ObjectNode productReferenceWithRandomId = getProductReferenceWithRandomId();
         final AttributeDraft productReferenceSetAttribute =
             getProductReferenceSetAttributeDraft("foo", productReferenceWithRandomId);

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
@@ -12,8 +12,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.products.CategoryOrderHints;
 import io.sphere.sdk.products.ProductDraftBuilder;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CategoryReferenceResolverTest {
+class CategoryReferenceResolverTest {
     private static final String CHANNEL_KEY = "channel-key_1";
     private static final String CHANNEL_ID = "1";
     private static final String PRODUCT_TYPE_ID = "productTypeId";
@@ -52,7 +52,7 @@ public class CategoryReferenceResolverTest {
     private static final String PRODUCT_ID = "productId";
 
     @Test
-    public void resolveCategoryReferences_WithCategoryKeysAndCategoryOrderHints_ShouldResolveReferences() {
+    void resolveCategoryReferences_WithCategoryKeysAndCategoryOrderHints_ShouldResolveReferences() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -90,7 +90,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithCategoryKeysAndNoCategoryOrderHints_ShouldResolveReferences() {
+    void resolveCategoryReferences_WithCategoryKeysAndNoCategoryOrderHints_ShouldResolveReferences() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -124,7 +124,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithCategoryKeysAndSomeCategoryOrderHints_ShouldResolveReferences() {
+    void resolveCategoryReferences_WithCategoryKeysAndSomeCategoryOrderHints_ShouldResolveReferences() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -163,7 +163,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithNullCategoryReferences_ShouldNotResolveReferences() {
+    void resolveCategoryReferences_WithNullCategoryReferences_ShouldNotResolveReferences() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -183,9 +183,9 @@ public class CategoryReferenceResolverTest {
             .isCompletedWithValueMatching(resolvedDraft -> resolvedDraft.getCategories().isEmpty());
     }
 
-    @Ignore("TODO: SHOULD FAIL ON RESOLUTION IF NOT FOUND ON FETCH GITHUB ISSUE#219")
+    @Disabled("TODO: SHOULD FAIL ON RESOLUTION IF NOT FOUND ON FETCH GITHUB ISSUE#219")
     @Test
-    public void resolveCategoryReferences_WithANonExistentCategoryReference_ShouldNotResolveReference() {
+    void resolveCategoryReferences_WithANonExistentCategoryReference_ShouldNotResolveReference() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -210,7 +210,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithNullIdOnCategoryReference_ShouldNotResolveReference() {
+    void resolveCategoryReferences_WithNullIdOnCategoryReference_ShouldNotResolveReference() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -235,7 +235,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithEmptyIdOnCategoryReference_ShouldNotResolveReference() {
+    void resolveCategoryReferences_WithEmptyIdOnCategoryReference_ShouldNotResolveReference() {
         // preparation
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
@@ -259,7 +259,7 @@ public class CategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveCategoryReferences_WithExceptionCategoryFetch_ShouldNotResolveReference() {
+    void resolveCategoryReferences_WithExceptionCategoryFetch_ShouldNotResolveReference() {
         final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                                .build();
         final Category category = getMockCategory("categoryKey", "categoryKey");

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/ProductTypeReferenceResolverTest.java
@@ -12,8 +12,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.producttypes.ProductType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeReferenceResolverTest {
+class ProductTypeReferenceResolverTest {
     private static final String CHANNEL_KEY = "channel-key_1";
     private static final String CHANNEL_ID = "1";
     private static final String PRODUCT_TYPE_ID = "productTypeId";
@@ -49,8 +49,8 @@ public class ProductTypeReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         productTypeService = getMockProductTypeService(PRODUCT_TYPE_ID);
         final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                                         .build();
@@ -62,7 +62,7 @@ public class ProductTypeReferenceResolverTest {
     }
 
     @Test
-    public void resolveProductTypeReference_WithKeys_ShouldResolveReference() {
+    void resolveProductTypeReference_WithKeys_ShouldResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("productTypeKey");
 
         final ProductDraftBuilder resolvedDraft = referenceResolver.resolveProductTypeReference(productBuilder)
@@ -73,7 +73,7 @@ public class ProductTypeReferenceResolverTest {
     }
 
     @Test
-    public void resolveProductTypeReference_WithNonExistentProductType_ShouldNotResolveReference() {
+    void resolveProductTypeReference_WithNonExistentProductType_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("anyKey")
             .key("dummyKey");
 
@@ -88,7 +88,7 @@ public class ProductTypeReferenceResolverTest {
     }
 
     @Test
-    public void resolveProductTypeReference_WithNullIdOnProductTypeReference_ShouldNotResolveReference() {
+    void resolveProductTypeReference_WithNullIdOnProductTypeReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRef(
             Reference.of(ProductType.referenceTypeId(), (String)null))
             .key("dummyKey");
@@ -102,7 +102,7 @@ public class ProductTypeReferenceResolverTest {
     }
 
     @Test
-    public void resolveProductTypeReference_WithEmptyIdOnProductTypeReference_ShouldNotResolveReference() {
+    void resolveProductTypeReference_WithEmptyIdOnProductTypeReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId("")
             .key("dummyKey");
 
@@ -115,7 +115,7 @@ public class ProductTypeReferenceResolverTest {
     }
 
     @Test
-    public void resolveProductTypeReference_WithExceptionOnProductTypeFetch_ShouldNotResolveReference() {
+    void resolveProductTypeReference_WithExceptionOnProductTypeFetch_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithProductTypeRefId(PRODUCT_TYPE_ID)
             .key("dummyKey");
 

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/StateReferenceResolverTest.java
@@ -12,8 +12,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.states.State;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class StateReferenceResolverTest {
+class StateReferenceResolverTest {
     private static final String CHANNEL_KEY = "channel-key_1";
     private static final String CHANNEL_ID = "1";
     private static final String PRODUCT_TYPE_ID = "productTypeId";
@@ -48,8 +48,8 @@ public class StateReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         stateService = getMockStateService(STATE_ID);
         final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
         referenceResolver = new ProductReferenceResolver(syncOptions, getMockProductTypeService(PRODUCT_TYPE_ID),
@@ -59,7 +59,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithKeys_ShouldResolveReference() {
+    void resolveStateReference_WithKeys_ShouldResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("stateKey"));
 
@@ -71,7 +71,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithNullState_ShouldNotResolveReference() {
+    void resolveStateReference_WithNullState_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .key("dummyKey");
 
@@ -81,7 +81,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithNonExistentState_ShouldNotResolveReference() {
+    void resolveStateReference_WithNonExistentState_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("nonExistentKey"))
             .key("dummyKey");
@@ -97,7 +97,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithNullIdOnStateReference_ShouldNotResolveReference() {
+    void resolveStateReference_WithNullIdOnStateReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(Reference.of(State.referenceTypeId(), (String)null))
             .key("dummyKey");
@@ -111,7 +111,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithEmptyIdOnStateReference_ShouldNotResolveReference() {
+    void resolveStateReference_WithEmptyIdOnStateReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId(""))
             .key("dummyKey");
@@ -125,7 +125,7 @@ public class StateReferenceResolverTest {
     }
 
     @Test
-    public void resolveStateReference_WithExceptionOnFetch_ShouldNotResolveReference() {
+    void resolveStateReference_WithExceptionOnFetch_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .state(State.referenceOfId("stateKey"))
             .key("dummyKey");

--- a/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/productreferenceresolver/TaxCategoryReferenceResolverTest.java
@@ -12,8 +12,8 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.taxcategories.TaxCategory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TaxCategoryReferenceResolverTest {
+class TaxCategoryReferenceResolverTest {
     private static final String CHANNEL_KEY = "channel-key_1";
     private static final String CHANNEL_ID = "1";
     private static final String PRODUCT_TYPE_ID = "productTypeId";
@@ -48,8 +48,8 @@ public class TaxCategoryReferenceResolverTest {
     /**
      * Sets up the services and the options needed for reference resolution.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         taxCategoryService = getMockTaxCategoryService(TAX_CATEGORY_ID);
         final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class)).build();
         referenceResolver = new ProductReferenceResolver(syncOptions,
@@ -59,7 +59,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithKeys_ShouldResolveReference() {
+    void resolveTaxCategoryReference_WithKeys_ShouldResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("taxCategoryKey"));
 
@@ -71,7 +71,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithNullTaxCategory_ShouldNotResolveReference() {
+    void resolveTaxCategoryReference_WithNullTaxCategory_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .key("dummyKey");
 
@@ -81,7 +81,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithNonExistentTaxCategory_ShouldNotResolveReference() {
+    void resolveTaxCategoryReference_WithNonExistentTaxCategory_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("nonExistentKey"))
             .key("dummyKey");
@@ -97,7 +97,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithNullIdOnTaxCategoryReference_ShouldNotResolveReference() {
+    void resolveTaxCategoryReference_WithNullIdOnTaxCategoryReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(Reference.of(TaxCategory.referenceTypeId(), (String)null))
             .key("dummyKey");
@@ -111,7 +111,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithEmptyIdOnTaxCategoryReference_ShouldNotResolveReference() {
+    void resolveTaxCategoryReference_WithEmptyIdOnTaxCategoryReference_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId(""))
             .key("dummyKey");
@@ -125,7 +125,7 @@ public class TaxCategoryReferenceResolverTest {
     }
 
     @Test
-    public void resolveTaxCategoryReference_WithExceptionOnTaxCategoryFetch_ShouldNotResolveReference() {
+    void resolveTaxCategoryReference_WithExceptionOnTaxCategoryFetch_ShouldNotResolveReference() {
         final ProductDraftBuilder productBuilder = getBuilderWithRandomProductTypeUuid()
             .taxCategory(TaxCategory.referenceOfId("taxCategoryKey"))
             .key("dummyKey");

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtilsTest.java
@@ -23,7 +23,7 @@ import io.sphere.sdk.states.State;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -48,10 +48,10 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductReferenceReplacementUtilsTest {
+class ProductReferenceReplacementUtilsTest {
 
     @Test
-    public void replaceProductsReferenceIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceReferencesWhereExpanded() {
+    void replaceProductsReferenceIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceReferencesWhereExpanded() {
         final String resourceKey = "key";
         final ProductType productType = getProductTypeMock(resourceKey);
         final Reference<ProductType> productTypeReference =
@@ -139,7 +139,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceProductsReferenceIdsWithKeys_WithNullProducts_ShouldSkipNullProducts() {
+    void replaceProductsReferenceIdsWithKeys_WithNullProducts_ShouldSkipNullProducts() {
         final String resourceKey = "key";
         final ProductType productType = getProductTypeMock(resourceKey);
         final Reference<ProductType> productTypeReference =
@@ -212,7 +212,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceProductTypeReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String productTypeId = UUID.randomUUID().toString();
         final Reference<ProductType> productTypeReference = ProductType.referenceOfId(productTypeId);
@@ -227,7 +227,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceProductTypeReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void replaceProductTypeReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         final String productTypeKey = "productTypeKey";
 
         final ProductType productType = getProductTypeMock(productTypeKey);
@@ -246,7 +246,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceProductTypeReferenceIdWithKey_WithNullReferences_ShouldReturnNull() {
+    void replaceProductTypeReferenceIdWithKey_WithNullReferences_ShouldReturnNull() {
         final Product product = mock(Product.class);
         when(product.getProductType()).thenReturn(null);
 
@@ -257,7 +257,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceTaxCategoryReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String taxCategoryId = UUID.randomUUID().toString();
         final Reference<TaxCategory> taxCategoryReference = TaxCategory.referenceOfId(taxCategoryId);
@@ -272,7 +272,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceTaxCategoryReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void replaceTaxCategoryReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         final String taxCategoryKey = "taxCategoryKey";
         final TaxCategory taxCategory = getTaxCategoryMock(taxCategoryKey);
         final Reference<TaxCategory> taxCategoryReference = Reference
@@ -289,7 +289,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceTaxCategoryReferenceIdWithKey_WithNullReference_ShouldReturnNull() {
+    void replaceTaxCategoryReferenceIdWithKey_WithNullReference_ShouldReturnNull() {
         final Product product = mock(Product.class);
         when(product.getTaxCategory()).thenReturn(null);
 
@@ -300,7 +300,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceStateReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
+    void replaceStateReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String stateId = UUID.randomUUID().toString();
         final Reference<State> stateReference = State.referenceOfId(stateId);
         final Product product = mock(Product.class);
@@ -314,7 +314,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceStateReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void replaceStateReferenceIdWithKey_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         final String stateKey = "stateKey";
         final State state = getStateMock(stateKey);
         final Reference<State> stateReference = Reference
@@ -331,7 +331,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceStateReferenceIdWithKey_WithNullReferences_ShouldReturnNull() {
+    void replaceStateReferenceIdWithKey_WithNullReferences_ShouldReturnNull() {
         final Product product = mock(Product.class);
         when(product.getState()).thenReturn(null);
 
@@ -342,7 +342,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void buildProductQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
+    void buildProductQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
         final ProductQuery productQuery = ProductReferenceReplacementUtils.buildProductQuery();
         assertThat(productQuery.expansionPaths())
             .containsExactly(ExpansionPath.of("productType"), ExpansionPath.of("taxCategory"),
@@ -360,7 +360,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceCategoryReferencesIdsWithKeys_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
         final String categoryId = UUID.randomUUID().toString();
         final Set<Reference<Category>> categoryReferences = singleton(Category.referenceOfId(categoryId));
@@ -383,7 +383,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceCategoryReferencesIdsWithKeys_WithNonExpandedReferencesAndNoCategoryOrderHints_ShouldNotReplaceIds() {
         final String categoryId = UUID.randomUUID().toString();
         final Set<Reference<Category>> categoryReferences = singleton(Category.referenceOfId(categoryId));
@@ -404,7 +404,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceCategoryReferencesIdsWithKeys_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void replaceCategoryReferencesIdsWithKeys_WithExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
         final String categoryKey = "categoryKey";
         final Category category = getCategoryMock(categoryKey);
         final Reference<Category> categoryReference =
@@ -433,7 +433,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceCategoryReferencesIdsWithKeys_WithExpandedReferencesAndNoCategoryOrderHints_ShouldReplaceIds() {
+    void replaceCategoryReferencesIdsWithKeys_WithExpandedReferencesAndNoCategoryOrderHints_ShouldReplaceIds() {
         final String categoryKey = "categoryKey";
         final Category category = getCategoryMock(categoryKey);
         final Reference<Category> categoryReference =
@@ -455,7 +455,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void
+    void
         replaceCategoryReferencesIdsWithKeys_WithExpandedReferencesAndSomeCategoryOrderHintsSet_ShouldReplaceIds() {
         final String categoryKey1 = "categoryKey1";
         final String categoryKey2 = "categoryKey2";
@@ -495,7 +495,7 @@ public class ProductReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceCategoryReferencesIdsWithKeys_WithNoReferences_ShouldNotReplaceIds() {
+    void replaceCategoryReferencesIdsWithKeys_WithNoReferences_ShouldNotReplaceIds() {
         final Product product = getProductMock(Collections.emptySet(), null);
 
         final CategoryReferencePair categoryReferencePair =

--- a/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
@@ -39,8 +39,8 @@ import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.search.SearchKeyword;
 import io.sphere.sdk.search.SearchKeywords;
 import io.sphere.sdk.utils.MoneyImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -59,15 +59,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductSyncUtilsTest {
+class ProductSyncUtilsTest {
     private Product oldProduct;
     private ProductSyncOptions productSyncOptions;
 
     /**
      * Initializes an instance of {@link ProductSyncOptions} and {@link Product}.
      */
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
                                                       .build();
 
@@ -75,7 +75,7 @@ public class ProductSyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithDifferentNameValues_ShouldBuildUpdateActions() {
+    void buildActions_FromDraftsWithDifferentNameValues_ShouldBuildUpdateActions() {
         final LocalizedString newName = LocalizedString.of(Locale.ENGLISH, "newName");
         final ProductDraft newProductDraft =
             createProductDraftBuilder(PRODUCT_KEY_1_WITH_PRICES_RESOURCE_PATH,
@@ -91,7 +91,7 @@ public class ProductSyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActions() {
+    void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActions() {
         // preparation
         final ProductDraftBuilder draftBuilder = createProductDraftBuilder(
             PRODUCT_KEY_1_CHANGED_WITH_PRICES_RESOURCE_PATH, ProductType.referenceOfId("anyProductType"));
@@ -162,7 +162,7 @@ public class ProductSyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActionsInCorrectOrder() {
+    void buildActions_FromDraftsWithMultipleDifferentValues_ShouldBuildUpdateActionsInCorrectOrder() {
         final ProductDraftBuilder draftBuilder = createProductDraftBuilder(
             PRODUCT_KEY_1_CHANGED_WITH_PRICES_RESOURCE_PATH, ProductType.referenceOfId("anyProductType"));
 
@@ -220,7 +220,7 @@ public class ProductSyncUtilsTest {
     }
 
     @Test
-    public void buildActions_FromDraftsWithSameNameValues_ShouldNotBuildUpdateActions() {
+    void buildActions_FromDraftsWithSameNameValues_ShouldNotBuildUpdateActions() {
         final ProductDraft newProductDraft =
             createProductDraftBuilder(PRODUCT_KEY_1_WITH_PRICES_RESOURCE_PATH,
                 ProductType.referenceOfId("anyProductType")).build();

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -26,7 +26,7 @@ import io.sphere.sdk.products.commands.updateactions.RemoveImage;
 import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
 import io.sphere.sdk.products.commands.updateactions.SetAttribute;
 import io.sphere.sdk.products.commands.updateactions.SetSku;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 
-public class ProductUpdateActionUtilsTest {
+class ProductUpdateActionUtilsTest {
 
     private static final String RES_ROOT = "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/";
     private static final String OLD_PROD_WITH_VARIANTS = RES_ROOT + "productOld.json";
@@ -73,7 +73,7 @@ public class ProductUpdateActionUtilsTest {
     private static final String NEW_PROD_DRAFT_WITHOUT_MV_SKU = RES_ROOT + "productDraftNew_noMasterVariantSku.json";
 
     @Test
-    public void buildVariantsUpdateActions_updatesVariants() {
+    void buildVariantsUpdateActions_updatesVariants() {
         // preparation
         final Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         final ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
@@ -152,7 +152,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildVariantsUpdateActions_doesNotRemoveMaster() {
+    void buildVariantsUpdateActions_doesNotRemoveMaster() {
         final Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         final ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_MOVE_MASTER);
 
@@ -195,20 +195,20 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyOldMasterVariantKey() {
+    void buildVariantsUpdateActions_withEmptyOldMasterVariantKey() {
         assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITH_VARIANTS_MOVE_MASTER,
             BLANK_OLD_MASTER_VARIANT_KEY);
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyNewMasterVariantOrKey_ShouldNotBuildActionAndTriggerCallback() {
+    void buildVariantsUpdateActions_withEmptyNewMasterVariantOrKey_ShouldNotBuildActionAndTriggerCallback() {
         assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV, BLANK_NEW_MASTER_VARIANT_KEY);
         assertMissingMasterVariantKey(OLD_PROD_WITH_VARIANTS, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
             BLANK_NEW_MASTER_VARIANT_KEY);
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyBothMasterVariantKey_ShouldNotBuildActionAndTriggerCallback() {
+    void buildVariantsUpdateActions_withEmptyBothMasterVariantKey_ShouldNotBuildActionAndTriggerCallback() {
         assertMissingMasterVariantKey(OLD_PROD_WITHOUT_MV_KEY_SKU, NEW_PROD_DRAFT_WITHOUT_MV_KEY,
             BLANK_OLD_MASTER_VARIANT_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
     }
@@ -239,7 +239,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeMasterVariantUpdateAction_changesMasterVariant() {
+    void buildChangeMasterVariantUpdateAction_changesMasterVariant() {
         final Product productOld = createProductFromJson(OLD_PROD_WITH_VARIANTS);
         final ProductDraft productDraftNew = createProductDraftFromJson(NEW_PROD_DRAFT_WITH_VARIANTS_REMOVE_MASTER);
 
@@ -254,12 +254,12 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptyKey_ShouldNotBuildActionAndTriggerCallback() {
+    void buildVariantsUpdateActions_withEmptyKey_ShouldNotBuildActionAndTriggerCallback() {
         assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_KEY, BLANK_NEW_MASTER_VARIANT_KEY);
     }
 
     @Test
-    public void buildVariantsUpdateActions_withEmptySku_ShouldNotBuildActionAndTriggerCallback() {
+    void buildVariantsUpdateActions_withEmptySku_ShouldNotBuildActionAndTriggerCallback() {
         assertChangeMasterVariantEmptyErrorCatcher(NEW_PROD_DRAFT_WITHOUT_MV_SKU, BLANK_NEW_MASTER_VARIANT_SKU);
     }
 
@@ -284,7 +284,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddVariantUpdateActionFromDraft_WithAttribsPricesAndImages_ShouldBuildCorrectAddVariantAction() {
+    void buildAddVariantUpdateActionFromDraft_WithAttribsPricesAndImages_ShouldBuildCorrectAddVariantAction() {
         // preparation
         final List<AttributeDraft> attributeList = emptyList();
         final List<PriceDraft> priceList = emptyList();
@@ -313,7 +313,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddVariantUpdateActionFromDraft_WithNoAssets_BuildsNoAddAssets() {
+    void buildAddVariantUpdateActionFromDraft_WithNoAssets_BuildsNoAddAssets() {
         // preparation
         final ProductVariantDraft productVariantDraft = ProductVariantDraftBuilder.of()
                                                                                   .sku("foo")
@@ -329,7 +329,7 @@ public class ProductUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildAddVariantUpdateActionFromDraft_WithMultipleAssets_BuildsMultipleAddAssetsActions() {
+    void buildAddVariantUpdateActionFromDraft_WithMultipleAssets_BuildsMultipleAddAssetsActions() {
         // preparation
         final List<AssetDraft> assetDrafts = IntStream
             .range(1, 4)

--- a/src/test/java/com/commercetools/sync/products/utils/ProductVariantAssetUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductVariantAssetUpdateActionUtilsTest.java
@@ -22,7 +22,7 @@ import io.sphere.sdk.products.commands.updateactions.SetAssetTags;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,12 +47,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductVariantAssetUpdateActionUtilsTest {
+class ProductVariantAssetUpdateActionUtilsTest {
     private static final ProductSyncOptions SYNC_OPTIONS = ProductSyncOptionsBuilder
         .of(mock(SphereClient.class)).build();
 
     @Test
-    public void buildActions_WithDifferentValues_ShouldBuildUpdateAction() {
+    void buildActions_WithDifferentValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
         final LocalizedString newName = LocalizedString.of(Locale.GERMAN, "newName");
 
@@ -108,7 +108,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithIdenticalValues_ShouldBuildUpdateAction() {
+    void buildActions_WithIdenticalValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
 
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
@@ -139,7 +139,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAssetNameUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildChangeAssetNameUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
         final LocalizedString newName = LocalizedString.of(Locale.GERMAN, "newName");
 
@@ -157,7 +157,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAssetNameUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildChangeAssetNameUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final LocalizedString oldName = LocalizedString.of(Locale.GERMAN, "oldName");
 
         final Asset oldAsset = mock(Asset.class);
@@ -172,7 +172,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString oldDesc = LocalizedString.of(Locale.GERMAN, "oldDesc");
         final LocalizedString newDesc = LocalizedString.of(Locale.GERMAN, "newDesc");
 
@@ -191,7 +191,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithNullOldStagedValues_ShouldBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithNullOldStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newDesc = LocalizedString.of(Locale.GERMAN, "newDesc");
 
         final Asset oldAsset = mock(Asset.class);
@@ -209,7 +209,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final LocalizedString oldDesc = LocalizedString.of(Locale.GERMAN, "oldDesc");
 
         final Asset oldAsset = mock(Asset.class);
@@ -225,7 +225,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final Set<String> oldTags = new HashSet<>();
         oldTags.add("oldTag");
         final Set<String> newTags = new HashSet<>();
@@ -246,7 +246,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithNullOldStagedValues_ShouldBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithNullOldStagedValues_ShouldBuildUpdateAction() {
         final Set<String> newTags = new HashSet<>();
         newTags.add("newTag");
 
@@ -265,7 +265,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetTagsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetTagsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Set<String> oldTags = new HashSet<>();
         oldTags.add("oldTag");
 
@@ -283,7 +283,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetSourcesUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetAssetSourcesUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final List<AssetSource> oldAssetSources = singletonList(AssetSourceBuilder.ofUri("oldUri").build());
         final List<AssetSource> newAssetSources = singletonList(AssetSourceBuilder.ofUri("newUri").build());
 
@@ -302,7 +302,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetAssetSourcesUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetAssetSourcesUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final List<AssetSource> oldAssetSources = singletonList(AssetSourceBuilder.ofUri("oldUri").build());
 
         final Asset oldAsset = mock(Asset.class);
@@ -318,7 +318,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildCustomUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
@@ -345,7 +345,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildCustomUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
@@ -376,7 +376,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithNullOldStagedValues_ShouldBuildUpdateAction() {
+    void buildCustomUpdateActions_WithNullOldStagedValues_ShouldBuildUpdateAction() {
         final Map<String, JsonNode> newCustomFieldsMap = new HashMap<>();
         newCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(false));
         newCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("es", "rojo"));
@@ -401,7 +401,7 @@ public class ProductVariantAssetUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildCustomUpdateActions_WithBadCustomFieldData_ShouldNotBuildUpdateActionAndTriggerErrorCallback() {
+    void buildCustomUpdateActions_WithBadCustomFieldData_ShouldNotBuildUpdateActionAndTriggerErrorCallback() {
         final Map<String, JsonNode> oldCustomFieldsMap = new HashMap<>();
         oldCustomFieldsMap.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
         oldCustomFieldsMap.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));

--- a/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtilsTest.java
@@ -16,7 +16,7 @@ import io.sphere.sdk.products.attributes.AttributeAccess;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -61,10 +61,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class VariantReferenceReplacementUtilsTest {
+class VariantReferenceReplacementUtilsTest {
 
     @Test
-    public void replaceVariantsReferenceIdsWithKeys_WithExpandedReferences_ShouldReturnVariantDraftsWithReplacedKeys() {
+    void replaceVariantsReferenceIdsWithKeys_WithExpandedReferences_ShouldReturnVariantDraftsWithReplacedKeys() {
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
 
         final String channelKey = "channelKey";
@@ -88,7 +88,7 @@ public class VariantReferenceReplacementUtilsTest {
 
         assertThat(variantDrafts).hasSize(1);
         assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
-        final Reference<Channel> channelReferenceAfterReplacement =
+        final ResourceIdentifier<Channel> channelReferenceAfterReplacement =
             variantDrafts.get(0).getPrices().get(0).getChannel();
         assertThat(channelReferenceAfterReplacement).isNotNull();
         // Assert that price channel reference id is replaced with key.
@@ -110,7 +110,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceVariantsReferenceIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceSomeKeys() {
+    void replaceVariantsReferenceIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceSomeKeys() {
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
 
         final Reference<Type> priceCustomTypeReference1 =
@@ -155,8 +155,8 @@ public class VariantReferenceReplacementUtilsTest {
 
         assertThat(variantDrafts).hasSize(2);
         assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
-        final Reference<Channel> channel1ReferenceAfterReplacement = variantDrafts.get(0).getPrices().get(0)
-                                                                                  .getChannel();
+        final ResourceIdentifier<Channel> channel1ReferenceAfterReplacement =
+            variantDrafts.get(0).getPrices().get(0).getChannel();
         assertThat(channel1ReferenceAfterReplacement).isNotNull();
         assertThat(channel1ReferenceAfterReplacement.getId()).isEqualTo(channelKey1);
 
@@ -175,8 +175,8 @@ public class VariantReferenceReplacementUtilsTest {
         assertThat(asset1CustomType.getId()).isEqualTo(customType.getKey());
 
         assertThat(variantDrafts.get(1).getPrices()).hasSize(1);
-        final Reference<Channel> channel2ReferenceAfterReplacement = variantDrafts.get(1).getPrices().get(0)
-                                                                                  .getChannel();
+        final ResourceIdentifier<Channel> channel2ReferenceAfterReplacement =
+            variantDrafts.get(1).getPrices().get(0).getChannel();
         assertThat(channel2ReferenceAfterReplacement).isNotNull();
         // Asset price channel reference id is not replaced.
         assertThat(channel2ReferenceAfterReplacement.getId()).isEqualTo(channelReference2.getId());
@@ -209,7 +209,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceVariantsReferenceIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
+    void replaceVariantsReferenceIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
         final Reference<Channel> channelReference = Channel.referenceOfId(UUID.randomUUID().toString());
         final Reference<Type> customTypeReference = Type.referenceOfId(UUID.randomUUID().toString());
 
@@ -224,8 +224,8 @@ public class VariantReferenceReplacementUtilsTest {
 
         assertThat(variantDrafts).hasSize(1);
         assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
-        final Reference<Channel> channelReferenceAfterReplacement = variantDrafts.get(0).getPrices().get(0)
-                                                                                 .getChannel();
+        final ResourceIdentifier<Channel> channelReferenceAfterReplacement =
+            variantDrafts.get(0).getPrices().get(0).getChannel();
         assertThat(channelReferenceAfterReplacement).isNotNull();
         // Assert price channel reference id is not replaced.
         assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
@@ -247,7 +247,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replacePricesReferencesIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
+    void replacePricesReferencesIdsWithKeys_WithNoExpandedReferences_ShouldNotReplaceIds() {
         final Reference<Channel> channelReference = Channel.referenceOfId(UUID.randomUUID().toString());
         final Reference<Type> typeReference = Type.referenceOfId(UUID.randomUUID().toString());
 
@@ -259,7 +259,7 @@ public class VariantReferenceReplacementUtilsTest {
         assertThat(priceDrafts).hasSize(1);
         final PriceDraft priceDraftAfterReplacement = priceDrafts.get(0);
 
-        final Reference<Channel> channelReferenceAfterReplacement = priceDraftAfterReplacement.getChannel();;
+        final ResourceIdentifier<Channel> channelReferenceAfterReplacement = priceDraftAfterReplacement.getChannel();;
         assertThat(channelReferenceAfterReplacement).isNotNull();
         // Assert Id is not replaced with key.
         assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
@@ -274,7 +274,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replacePricesReferencesIdsWithKeys_WithAllExpandedReferences_ShouldReplaceIds() {
+    void replacePricesReferencesIdsWithKeys_WithAllExpandedReferences_ShouldReplaceIds() {
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
 
         final String channelKey1 = "channelKey1";
@@ -300,7 +300,7 @@ public class VariantReferenceReplacementUtilsTest {
         assertThat(priceDrafts).hasSize(2);
 
         final PriceDraft priceDraft1AfterReplacement = priceDrafts.get(0);
-        final Reference<Channel> channelReference1AfterReplacement = priceDraft1AfterReplacement.getChannel();
+        final ResourceIdentifier<Channel> channelReference1AfterReplacement = priceDraft1AfterReplacement.getChannel();
         assertThat(channelReference1AfterReplacement).isNotNull();
         // Assert id is replaced with key.
         assertThat(channelReference1AfterReplacement.getId()).isEqualTo(channelKey1);
@@ -314,7 +314,7 @@ public class VariantReferenceReplacementUtilsTest {
 
 
         final PriceDraft priceDraft2AfterReplacement = priceDrafts.get(1);
-        final Reference<Channel> channelReference2AfterReplacement = priceDraft2AfterReplacement.getChannel();
+        final ResourceIdentifier<Channel> channelReference2AfterReplacement = priceDraft2AfterReplacement.getChannel();
         assertThat(channelReference2AfterReplacement).isNotNull();
         // Assert id is replaced with key.
         assertThat(channelReference2AfterReplacement.getId()).isEqualTo(channelKey2);
@@ -328,7 +328,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replacePricesReferencesIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedIds() {
+    void replacePricesReferencesIdsWithKeys_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedIds() {
         final Type customType = getTypeMock(UUID.randomUUID().toString(), "customTypeKey");
         final String channelKey1 = "channelKey1";
 
@@ -350,12 +350,12 @@ public class VariantReferenceReplacementUtilsTest {
 
         assertThat(priceDrafts).hasSize(2);
 
-        final Reference<Channel> channelReference1AfterReplacement = priceDrafts.get(0).getChannel();
+        final ResourceIdentifier<Channel> channelReference1AfterReplacement = priceDrafts.get(0).getChannel();
         assertThat(channelReference1AfterReplacement).isNotNull();
         // Assert expanded reference has id replaced with key.
         assertThat(channelReference1AfterReplacement.getId()).isEqualTo(channelKey1);
 
-        final Reference<Channel> channelReference2AfterReplacement = priceDrafts.get(1).getChannel();
+        final ResourceIdentifier<Channel> channelReference2AfterReplacement = priceDrafts.get(1).getChannel();
         assertThat(channelReference2AfterReplacement).isNotNull();
         // Assert non expanded reference has id not replaced.
         assertThat(channelReference2AfterReplacement.getId()).isEqualTo(channelReference2.getId());
@@ -374,7 +374,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
+    void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
         final String channelId = UUID.randomUUID().toString();
         final Reference<Channel> channelReference = Channel.referenceOfId(channelId);
         final Price price = getPriceMockWithReferences(channelReference, null);
@@ -386,7 +386,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
+    void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
         final String channelKey = "channelKey";
         final Channel channel = getChannelMock(channelKey);
 
@@ -402,7 +402,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceChannelReferenceIdWithKey_WithNullChannelReference_ShouldReturnNull() {
+    void replaceChannelReferenceIdWithKey_WithNullChannelReference_ShouldReturnNull() {
         final Price price = getPriceMockWithReferences(null, null);
 
         final Reference<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(price);
@@ -411,7 +411,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributeReferenceIdWithKey_WithTextAttribute_ShouldReturnEmptyOptional() {
+    void replaceAttributeReferenceIdWithKey_WithTextAttribute_ShouldReturnEmptyOptional() {
         final Attribute attribute = Attribute.of("attrName", AttributeAccess.ofText(), "value");
         final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
 
@@ -419,7 +419,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributeReferenceIdWithKey_WithProductReferenceSetAttribute_ShouldReturnEmptyOptional() {
+    void replaceAttributeReferenceIdWithKey_WithProductReferenceSetAttribute_ShouldReturnEmptyOptional() {
         final Attribute attribute =
             Attribute.of("attrName", AttributeAccess.ofProductReferenceSet(), new HashSet<>());
         final Optional<Reference<Product>> attributeReferenceIdWithKey = replaceAttributeReferenceIdWithKey(attribute);
@@ -428,7 +428,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributeReferenceIdWithKey_WithNonExpandedProductReferenceAttribute_ShouldNotReplaceId() {
+    void replaceAttributeReferenceIdWithKey_WithNonExpandedProductReferenceAttribute_ShouldNotReplaceId() {
         final Reference<Product> nonExpandedReference = Product.referenceOfId(UUID.randomUUID().toString());
         final Attribute attribute =
             Attribute.of("attrName", AttributeAccess.ofProductReference(), nonExpandedReference);
@@ -438,7 +438,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributeReferenceIdWithKey_WithExpandedProductReferenceAttribute_ShouldReplaceId() {
+    void replaceAttributeReferenceIdWithKey_WithExpandedProductReferenceAttribute_ShouldReplaceId() {
         final Product product = readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
         final Reference<Product> expandedReference =
             Reference.ofResourceTypeIdAndIdAndObj(Product.referenceTypeId(), UUID.randomUUID().toString(), product);
@@ -449,7 +449,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributeReferenceSetIdsWithKeys_WithTextAttribute_ShouldReturnEmptyOptional() {
+    void replaceAttributeReferenceSetIdsWithKeys_WithTextAttribute_ShouldReturnEmptyOptional() {
         final Attribute attribute = Attribute.of("attrName", AttributeAccess.ofText(), "value");
         final Optional<Set<Reference<Product>>> attributeReferenceSetIdsWithKeys =
             replaceAttributeReferenceSetIdsWithKeys(attribute);
@@ -458,7 +458,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributesReferencesIdsWithKeys_WithNoAttributes_ShouldNotReplaceIds() {
+    void replaceAttributesReferencesIdsWithKeys_WithNoAttributes_ShouldNotReplaceIds() {
         final ProductVariant variant = mock(ProductVariant.class);
         when(variant.getAttributes()).thenReturn(new ArrayList<>());
         final List<AttributeDraft> replacedDrafts = replaceAttributesReferencesIdsWithKeys(variant);
@@ -466,7 +466,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void replaceAttributesReferencesIdsWithKeys_WithAttributesWithNoReferences_ShouldNotChangeAttributes() {
+    void replaceAttributesReferencesIdsWithKeys_WithAttributesWithNoReferences_ShouldNotChangeAttributes() {
         final Product product = readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
         final ProductVariant masterVariant = product.getMasterData().getStaged().getMasterVariant();
         final List<AttributeDraft> replacedDrafts = replaceAttributesReferencesIdsWithKeys(masterVariant);
@@ -479,7 +479,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void isProductReference_WithDifferentAttributeTypes_ShouldBeTrueForProductReferenceAttributeOnly() {
+    void isProductReference_WithDifferentAttributeTypes_ShouldBeTrueForProductReferenceAttributeOnly() {
         assertThat(isProductReference(BOOLEAN_ATTRIBUTE_TRUE)).isFalse();
         assertThat(isProductReference(TEXT_ATTRIBUTE_BAR)).isFalse();
         assertThat(isProductReference(LTEXT_ATTRIBUTE_EN_BAR)).isFalse();
@@ -498,7 +498,7 @@ public class VariantReferenceReplacementUtilsTest {
     }
 
     @Test
-    public void isProductReferenceSet_WithDifferentAttributeTypes_ShouldBeTrueForProductReferenceSetAttributeOnly() {
+    void isProductReferenceSet_WithDifferentAttributeTypes_ShouldBeTrueForProductReferenceSetAttributeOnly() {
         assertThat(isProductReferenceSet(BOOLEAN_ATTRIBUTE_TRUE)).isFalse();
         assertThat(isProductReferenceSet(TEXT_ATTRIBUTE_BAR)).isFalse();
         assertThat(isProductReferenceSet(LTEXT_ATTRIBUTE_EN_BAR)).isFalse();

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildAddToCategoryUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildAddToCategoryUpdateActionsTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.AddToCategory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildAddToCategoryUpdateActionsTest {
+class BuildAddToCategoryUpdateActionsTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildAddToCategoryUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildAddToCategoryUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final Category category = readObjectFromResource(CATEGORY_KEY_1_RESOURCE_PATH, Category.class);
         final Set<ResourceIdentifier<Category>> newProductCategories = new HashSet<>();
         newProductCategories.add(category.toResourceIdentifier());
@@ -41,7 +41,7 @@ public class BuildAddToCategoryUpdateActionsTest {
     }
 
     @Test
-    public void buildAddToCategoryUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildAddToCategoryUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final List<UpdateAction<Product>> addToCategoryUpdateAction =
             getAddToCategoryUpdateActions(MOCK_OLD_PUBLISHED_PRODUCT, Collections.emptySet());
 

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildChangeNameUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildChangeNameUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
@@ -18,12 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildChangeNameUpdateActionTest {
+class BuildChangeNameUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildChangeNameUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newName = LocalizedString.of(Locale.GERMAN, "newName");
         final UpdateAction<Product> changeNameUpdateAction =
             getChangeNameUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newName).orElse(null);
@@ -34,7 +34,7 @@ public class BuildChangeNameUpdateActionTest {
     }
 
     @Test
-    public void buildChangeNameUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildChangeNameUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final LocalizedString newName = LocalizedString.of(Locale.ENGLISH, "english name");
         final Optional<UpdateAction<Product>> changeNameUpdateAction =
             getChangeNameUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newName);

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildChangeSlugUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildChangeSlugUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.ChangeSlug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
@@ -18,12 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildChangeSlugUpdateActionTest {
+class BuildChangeSlugUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildChangeSlugUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newSlug = LocalizedString.of(Locale.GERMAN, "newSlug");
         final UpdateAction<Product> changeSlugUpdateAction =
             getChangeSlugUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newSlug).orElse(null);
@@ -34,7 +34,7 @@ public class BuildChangeSlugUpdateActionTest {
     }
 
     @Test
-    public void buildChangeSlugUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildChangeSlugUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final LocalizedString newSlug = LocalizedString.of(Locale.ENGLISH, "english-slug");
         final Optional<UpdateAction<Product>> changeSlugUpdateAction =
             getChangeSlugUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newSlug);

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildRemoveFromCategoryUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildRemoveFromCategoryUpdateActionsTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -20,12 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildRemoveFromCategoryUpdateActionsTest {
+class BuildRemoveFromCategoryUpdateActionsTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildRemoveFromCategoryUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildRemoveFromCategoryUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final List<UpdateAction<Product>> removeFromCategoryUpdateActions =
             getRemoveFromCategoryUpdateActions(MOCK_OLD_PUBLISHED_PRODUCT, Collections.emptySet());
 
@@ -35,7 +35,7 @@ public class BuildRemoveFromCategoryUpdateActionsTest {
     }
 
     @Test
-    public void buildRemoveFromCategoryUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildRemoveFromCategoryUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Set<ResourceIdentifier<Category>> newProductCategories = new HashSet<>();
         newProductCategories.add(Category.referenceOfId("1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f"));
         newProductCategories.add(Category.referenceOfId("2dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f"));

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetCategoryOrderHintUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetCategoryOrderHintUpdateActionsTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.products.CategoryOrderHints;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetCategoryOrderHint;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetCategoryOrderHintUpdateActionsTest {
+class BuildSetCategoryOrderHintUpdateActionsTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetCategoryOrderHintUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetCategoryOrderHintUpdateActions_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final Map<String, String> categoryOrderHintsMap = new HashMap<>();
         categoryOrderHintsMap.put("1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f", "0.33");
         final CategoryOrderHints newProductCategoryOrderHints = CategoryOrderHints.of(categoryOrderHintsMap);
@@ -38,7 +38,7 @@ public class BuildSetCategoryOrderHintUpdateActionsTest {
     }
 
     @Test
-    public void buildSetCategoryOrderHintUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetCategoryOrderHintUpdateActions_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Map<String, String> categoryOrderHintsMap = new HashMap<>();
         categoryOrderHintsMap.put("1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f", "0.43");
         categoryOrderHintsMap.put("2dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f", "0.53");

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetDescriptionUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetDescriptionUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetDescription;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
@@ -18,12 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetDescriptionUpdateActionTest {
+class BuildSetDescriptionUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newDescription = LocalizedString.of(Locale.GERMAN, "newDescription");
         final UpdateAction<Product> setDescriptionUpdateAction =
             getSetDescriptionUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newDescription).orElse(null);
@@ -34,7 +34,7 @@ public class BuildSetDescriptionUpdateActionTest {
     }
 
     @Test
-    public void buildSetDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final LocalizedString newDescription = LocalizedString.of(Locale.ENGLISH, "english description.");
         final Optional<UpdateAction<Product>> setDescriptionUpdateAction =
             getSetDescriptionUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newDescription);

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaDescriptionUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaDescriptionUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetMetaDescription;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetMetaDescriptionUpdateActionTest {
+class BuildSetMetaDescriptionUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newDescription = LocalizedString.of(Locale.GERMAN, "newDescription");
         final UpdateAction<Product> setMetaDescriptionUpdateAction =
             getSetMetaDescriptionUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newDescription).orElse(null);
@@ -36,7 +36,7 @@ public class BuildSetMetaDescriptionUpdateActionTest {
     }
 
     @Test
-    public void buildSetMetaDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaDescriptionUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Product>> setMetaDescriptionUpdateAction =
             getSetMetaDescriptionUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, null);
 

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaKeywordsUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaKeywordsUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetMetaKeywords;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetMetaKeywordsUpdateActionTest {
+class BuildSetMetaKeywordsUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newKeywords = LocalizedString.of(Locale.GERMAN, "newKeywords");
         final UpdateAction<Product> setMetaKeywordsUpdateAction =
             getSetMetaKeywordsUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newKeywords).orElse(null);
@@ -35,7 +35,7 @@ public class BuildSetMetaKeywordsUpdateActionTest {
     }
 
     @Test
-    public void buildSetMetaKeywordsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaKeywordsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Product>> setMetaKeywordsUpdateAction =
             getSetMetaKeywordsUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, null);
 

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaTitleUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetMetaTitleUpdateActionTest.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetMetaTitle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,12 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetMetaTitleUpdateActionTest {
+class BuildSetMetaTitleUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final LocalizedString newTitle = LocalizedString.of(Locale.GERMAN, "newTitle");
         final UpdateAction<Product> setMetaTitleUpdateAction =
             getSetMetaTitleUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newTitle).orElse(null);
@@ -35,7 +35,7 @@ public class BuildSetMetaTitleUpdateActionTest {
     }
 
     @Test
-    public void buildSetMetaTitleUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetMetaTitleUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Product>> setMetaTitleUpdateAction =
             getSetMetaTitleUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, null);
 

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetSearchKeywordsUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetSearchKeywordsUpdateActionTest.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetSearchKeywords;
 import io.sphere.sdk.search.SearchKeyword;
 import io.sphere.sdk.search.SearchKeywords;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -20,12 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildSetSearchKeywordsUpdateActionTest {
+class BuildSetSearchKeywordsUpdateActionTest {
     private static final Product MOCK_OLD_PUBLISHED_PRODUCT = readObjectFromResource(
         PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
 
     @Test
-    public void buildSetSearchKeywordsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildSetSearchKeywordsUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final SearchKeywords newProductSearchKeywords = SearchKeywords.of(Locale.ENGLISH,
             Arrays.asList(SearchKeyword.of("searchKeyword1"), SearchKeyword.of("searchKeyword2")));
         final UpdateAction<Product> setSearchKeywordsUpdateAction =
@@ -39,7 +39,7 @@ public class BuildSetSearchKeywordsUpdateActionTest {
     }
 
     @Test
-    public void buildSetSearchKeywordsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildSetSearchKeywordsUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final SearchKeywords newProductSearchKeywords = SearchKeywords.of();
         final Optional<UpdateAction<Product>> setSearchKeywordsUpdateAction =
             getSetSearchKeywordsUpdateAction(MOCK_OLD_PUBLISHED_PRODUCT, newProductSearchKeywords);

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetTaxCategoryUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildSetTaxCategoryUpdateActionTest.java
@@ -5,18 +5,18 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.SetTaxCategory;
 import io.sphere.sdk.taxcategories.TaxCategory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildSetTaxCategoryUpdateAction;
 import static io.sphere.sdk.json.SphereJsonUtils.readObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class BuildSetTaxCategoryUpdateActionTest {
+@ExtendWith(MockitoExtension.class)
+class BuildSetTaxCategoryUpdateActionTest {
 
     @Mock
     private Product oldProduct;
@@ -37,7 +37,7 @@ public class BuildSetTaxCategoryUpdateActionTest {
         "{\"typeId\": \"tax-category\",\"id\": \"22222222-2222-2222-2222-222222222222\"}", Reference.class);
 
     @Test
-    public void buildSetTaxCategoryUpdateAction_withEmptyOld_containsNewCategory() throws Exception {
+    void buildSetTaxCategoryUpdateAction_withEmptyOld_containsNewCategory() {
         assertThat(buildSetTaxCategoryUpdateAction(oldProduct, newProduct)).isEmpty();
 
         when(newProduct.getTaxCategory()).thenReturn(newSameTaxCategory);
@@ -46,7 +46,7 @@ public class BuildSetTaxCategoryUpdateActionTest {
     }
 
     @Test
-    public void buildSetTaxCategoryUpdateAction_withEmptyNew_ShouldUnset() throws Exception {
+    void buildSetTaxCategoryUpdateAction_withEmptyNew_ShouldUnset() {
         assertThat(buildSetTaxCategoryUpdateAction(oldProduct, newProduct)).isEmpty();
 
         when(oldProduct.getTaxCategory()).thenReturn(oldTaxCategory);
@@ -54,14 +54,14 @@ public class BuildSetTaxCategoryUpdateActionTest {
     }
 
     @Test
-    public void buildSetTaxCategoryUpdateAction_withEqual_isEmpty() throws Exception {
+    void buildSetTaxCategoryUpdateAction_withEqual_isEmpty() {
         when(oldProduct.getTaxCategory()).thenReturn(oldTaxCategory);
         when(newProduct.getTaxCategory()).thenReturn(newSameTaxCategory);
         assertThat(buildSetTaxCategoryUpdateAction(oldProduct, newProduct)).isEmpty();
     }
 
     @Test
-    public void buildSetTaxCategoryUpdateAction_withDifferent_containsNew() throws Exception {
+    void buildSetTaxCategoryUpdateAction_withDifferent_containsNew() {
         when(oldProduct.getTaxCategory()).thenReturn(oldTaxCategory);
         when(newProduct.getTaxCategory()).thenReturn(newChangedTaxCategory);
         assertThat(buildSetTaxCategoryUpdateAction(oldProduct, newProduct))

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildTransitionStateUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildTransitionStateUpdateActionTest.java
@@ -5,18 +5,18 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.updateactions.TransitionState;
 import io.sphere.sdk.states.State;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildTransitionStateUpdateAction;
 import static io.sphere.sdk.json.SphereJsonUtils.readObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class BuildTransitionStateUpdateActionTest {
+@ExtendWith(MockitoExtension.class)
+class BuildTransitionStateUpdateActionTest {
 
     @Mock
     private Product oldProduct;
@@ -37,7 +37,7 @@ public class BuildTransitionStateUpdateActionTest {
         "{\"typeId\": \"state\",\"id\": \"22222222-2222-2222-2222-222222222222\"}", Reference.class);
 
     @Test
-    public void buildTransitionStateUpdateAction_withEmptyOld() throws Exception {
+    void buildTransitionStateUpdateAction_withEmptyOld() {
         assertThat(buildTransitionStateUpdateAction(oldProduct, newProduct)).isEmpty();
 
         when(newProduct.getState()).thenReturn(newState);
@@ -46,19 +46,19 @@ public class BuildTransitionStateUpdateActionTest {
     }
 
     @Test
-    public void buildTransitionStateUpdateAction_withEmptyNewShouldReturnEmpty() throws Exception {
+    void buildTransitionStateUpdateAction_withEmptyNewShouldReturnEmpty() {
         assertThat(buildTransitionStateUpdateAction(oldProduct, newProduct)).isEmpty();
     }
 
     @Test
-    public void buildTransitionStateUpdateAction_withEqual() throws Exception {
+    void buildTransitionStateUpdateAction_withEqual() {
         when(oldProduct.getState()).thenReturn(oldState);
         when(newProduct.getState()).thenReturn(newState);
         assertThat(buildTransitionStateUpdateAction(oldProduct, newProduct)).isEmpty();
     }
 
     @Test
-    public void buildTransitionStateUpdateAction_withEmptyOldShouldReturnNew() throws Exception {
+    void buildTransitionStateUpdateAction_withEmptyOldShouldReturnNew() {
         when(newProduct.getState()).thenReturn(newChangedState);
         assertThat(buildTransitionStateUpdateAction(oldProduct, newProduct))
             .contains(TransitionState.of(newChangedState, true));
@@ -66,7 +66,7 @@ public class BuildTransitionStateUpdateActionTest {
 
 
     @Test
-    public void buildTransitionStateUpdateAction_withDifferent() throws Exception {
+    void buildTransitionStateUpdateAction_withDifferent() {
         when(oldProduct.getState()).thenReturn(oldState);
         when(newProduct.getState()).thenReturn(newChangedState);
         assertThat(buildTransitionStateUpdateAction(oldProduct, newProduct))

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/BuildProductVariantImagesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/BuildProductVariantImagesUpdateActionsTest.java
@@ -9,7 +9,7 @@ import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.commands.updateactions.AddExternalImage;
 import io.sphere.sdk.products.commands.updateactions.MoveImageToPosition;
 import io.sphere.sdk.products.commands.updateactions.RemoveImage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +23,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildProductVariantImagesUpdateActionsTest {
+class BuildProductVariantImagesUpdateActionsTest {
     @Test
-    public void buildProductVariantImagesUpdateActions_WithNullImageLists_ShouldNotBuildUpdateActions() {
+    void buildProductVariantImagesUpdateActions_WithNullImageLists_ShouldNotBuildUpdateActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -35,7 +35,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithNullNewImageList_ShouldBuildRemoveImageUpdateActions() {
+    void buildProductVariantImagesUpdateActions_WithNullNewImageList_ShouldBuildRemoveImageUpdateActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -56,7 +56,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithNullOldImageList_ShouldBuildAddExternalImageActions() {
+    void buildProductVariantImagesUpdateActions_WithNullOldImageList_ShouldBuildAddExternalImageActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -77,7 +77,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithIdenticalImageLists_ShouldNotBuildUpdateActions() {
+    void buildProductVariantImagesUpdateActions_WithIdenticalImageLists_ShouldNotBuildUpdateActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -97,7 +97,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildAddExternalImageAction() {
+    void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildAddExternalImageAction() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -122,7 +122,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildRemoveImageAction() {
+    void buildProductVariantImagesUpdateActions_WithDifferentImageLists_ShouldBuildRemoveImageAction() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -147,7 +147,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferentOrderImageLists_ShouldBuildMovePositionActions() {
+    void buildProductVariantImagesUpdateActions_WithDifferentOrderImageLists_ShouldBuildMovePositionActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -183,7 +183,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantImagesUpdateActions_WithDifferentOrderAndImages_ShouldBuildActions() {
+    void buildProductVariantImagesUpdateActions_WithDifferentOrderAndImages_ShouldBuildActions() {
         final ProductVariant oldVariant = mock(ProductVariant.class);
         final ProductVariantDraft newVariantDraft = mock(ProductVariantDraft.class);
 
@@ -241,7 +241,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildMoveImageToPositionUpdateActions_WithDifferentOrder_ShouldBuildActions() {
+    void buildMoveImageToPositionUpdateActions_WithDifferentOrder_ShouldBuildActions() {
         final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
         final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
         final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
@@ -270,7 +270,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildMoveImageToPositionUpdateActions_WithSameOrder_ShouldNotBuildActions() {
+    void buildMoveImageToPositionUpdateActions_WithSameOrder_ShouldNotBuildActions() {
         final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
         final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
         final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");
@@ -294,7 +294,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildMoveImageToPositionUpdateActions_WitEmptyArrays_ShouldNotBuildActions() {
+    void buildMoveImageToPositionUpdateActions_WitEmptyArrays_ShouldNotBuildActions() {
         final List<Image> oldImages = new ArrayList<>();
         final List<Image> newImages = new ArrayList<>();
 
@@ -304,7 +304,7 @@ public class BuildProductVariantImagesUpdateActionsTest {
     }
 
     @Test
-    public void buildMoveImageToPositionUpdateActions_WithDifferentImages_ShouldThrowException() {
+    void buildMoveImageToPositionUpdateActions_WithDifferentImages_ShouldThrowException() {
         final Image image2 = Image.of("https://image2.url.com", ImageDimensions.of(2, 2), "image2Label");
         final Image image3 = Image.of("https://image3.url.com", ImageDimensions.of(2, 2), "image3Label");
         final Image image4 = Image.of("https://image4.url.com", ImageDimensions.of(2, 2), "image4Label");

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/BuildVariantAssetsUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/BuildVariantAssetsUpdateActionsTest.java
@@ -19,7 +19,7 @@ import io.sphere.sdk.products.commands.updateactions.ChangeAssetOrder;
 import io.sphere.sdk.products.commands.updateactions.RemoveAsset;
 import io.sphere.sdk.products.commands.updateactions.SetAssetSources;
 import io.sphere.sdk.products.commands.updateactions.SetAssetTags;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildVariantAssetsUpdateActionsTest {
+class BuildVariantAssetsUpdateActionsTest {
 
     private static final String RES_ROOT =
         "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/assets/";
@@ -59,7 +59,7 @@ public class BuildVariantAssetsUpdateActionsTest {
                                                                                     .build();
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithNullNewAssetsAndExistingAssets_ShouldBuild3RemoveActions() {
+    void buildProductVariantAssetsUpdateActions_WithNullNewAssetsAndExistingAssets_ShouldBuild3RemoveActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
 
         final ProductVariant oldMasterVariant = oldProduct.getMasterData().getStaged().getMasterVariant();
@@ -75,7 +75,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithNullNewAssetsAndNoOldAssets_ShouldNotBuildActions() {
+    void buildProductVariantAssetsUpdateActions_WithNullNewAssetsAndNoOldAssets_ShouldNotBuildActions() {
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getAssets()).thenReturn(emptyList());
 
@@ -87,7 +87,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithNewAssetsAndNoOldAssets_ShouldBuild3AddActions() {
+    void buildProductVariantAssetsUpdateActions_WithNewAssetsAndNoOldAssets_ShouldBuild3AddActions() {
         final ProductVariant productVariant = mock(ProductVariant.class);
         when(productVariant.getAssets()).thenReturn(emptyList());
 
@@ -110,7 +110,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithIdenticalAssets_ShouldNotBuildUpdateActions() {
+    void buildProductVariantAssetsUpdateActions_WithIdenticalAssets_ShouldNotBuildUpdateActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ABC, ProductDraft.class);
 
@@ -126,7 +126,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithDuplicateAssetKeys_ShouldNotBuildActionsAndTriggerErrorCb() {
+    void buildProductVariantAssetsUpdateActions_WithDuplicateAssetKeys_ShouldNotBuildActionsAndTriggerErrorCb() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ABB, ProductDraft.class);
 
@@ -160,7 +160,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithSameAssetPositionButChangesWithin_ShouldBuildUpdateActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ABC_WITH_CHANGES,
@@ -191,7 +191,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithOneMissingAsset_ShouldBuildRemoveAssetAction() {
+    void buildProductVariantAssetsUpdateActions_WithOneMissingAsset_ShouldBuildRemoveAssetAction() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_AB, ProductDraft.class);
 
@@ -209,7 +209,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithOneExtraAsset_ShouldBuildAddAssetAction() {
+    void buildProductVariantAssetsUpdateActions_WithOneExtraAsset_ShouldBuildAddAssetAction() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ABCD, ProductDraft.class);
 
@@ -229,7 +229,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithOneAssetSwitch_ShouldBuildRemoveAndAddAssetActions() {
+    void buildProductVariantAssetsUpdateActions_WithOneAssetSwitch_ShouldBuildRemoveAndAddAssetActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ABD, ProductDraft.class);
 
@@ -251,7 +251,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void buildProductVariantAssetsUpdateActions_WithDifferent_ShouldBuildChangeAssetOrderAction() {
+    void buildProductVariantAssetsUpdateActions_WithDifferent_ShouldBuildChangeAssetOrderAction() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_CAB, ProductDraft.class);
 
@@ -269,7 +269,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_CB, ProductDraft.class);
@@ -289,7 +289,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ACBD, ProductDraft.class);
@@ -311,7 +311,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithAddedAssetInBetween_ShouldBuildAddWithCorrectPositionActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_ADBC, ProductDraft.class);
@@ -332,7 +332,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAssetActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_CBD, ProductDraft.class);
@@ -355,7 +355,7 @@ public class BuildVariantAssetsUpdateActionsTest {
     }
 
     @Test
-    public void
+    void
         buildProductVariantAssetsUpdateActions_WithAddedRemovedAndDifOrderAndNewName_ShouldBuildAllDiffAssetActions() {
         final Product oldProduct = readObjectFromResource(PRODUCT_WITH_ASSETS_ABC, Product.class);
         final ProductDraft newProductDraft = readObjectFromResource(PRODUCT_DRAFT_WITH_ASSETS_CBD_WITH_CHANGES,

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/ProductVariantUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/ProductVariantUpdateActionUtilsTest.java
@@ -3,17 +3,17 @@ package com.commercetools.sync.products.utils.productvariantupdateactionutils;
 import io.sphere.sdk.products.ProductVariant;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.commands.updateactions.SetSku;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.commercetools.sync.products.utils.ProductVariantUpdateActionUtils.buildProductVariantSkuUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProductVariantUpdateActionUtilsTest {
+class ProductVariantUpdateActionUtilsTest {
 
     @Test
-    public void buildProductVariantSkuUpdateAction_WithBothNullSkus_ShouldNotBuildAction() {
+    void buildProductVariantSkuUpdateAction_WithBothNullSkus_ShouldNotBuildAction() {
         final ProductVariant variantOld = mock(ProductVariant.class);
         final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 
@@ -21,7 +21,7 @@ public class ProductVariantUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildProductVariantSkuUpdateAction_WithNullNewSku_ShouldBuildUpdateAction() {
+    void buildProductVariantSkuUpdateAction_WithNullNewSku_ShouldBuildUpdateAction() {
         final ProductVariant variantOld = mock(ProductVariant.class);
         final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 
@@ -33,7 +33,7 @@ public class ProductVariantUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildProductVariantSkuUpdateAction_WithNewSku_ShouldBuildUpdateAction() {
+    void buildProductVariantSkuUpdateAction_WithNewSku_ShouldBuildUpdateAction() {
         final ProductVariant variantOld = mock(ProductVariant.class);
         final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 
@@ -47,7 +47,7 @@ public class ProductVariantUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildProductVariantSkuUpdateAction_WithSameSku_ShouldNotBuildUpdateAction() {
+    void buildProductVariantSkuUpdateAction_WithSameSku_ShouldNotBuildUpdateAction() {
         final ProductVariant variantOld = mock(ProductVariant.class);
         final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 
@@ -58,7 +58,7 @@ public class ProductVariantUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildProductVariantSkuUpdateAction_WithNullOldSku_ShouldBuildUpdateAction() {
+    void buildProductVariantSkuUpdateAction_WithNullOldSku_ShouldBuildUpdateAction() {
         final ProductVariant variantOld = mock(ProductVariant.class);
         final ProductVariantDraft variantDraftNew = mock(ProductVariantDraft.class);
 

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/attributes/BuildProductVariantAttributeUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/attributes/BuildProductVariantAttributeUpdateActionsTest.java
@@ -13,7 +13,7 @@ import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.products.commands.updateactions.SetAttribute;
 import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,10 +26,10 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildProductVariantAttributeUpdateActionsTest {
+class BuildProductVariantAttributeUpdateActionsTest {
 
     @Test
-    public void withNullOldAndNonNullNew_ShouldBuildSetAction() throws BuildUpdateActionException {
+    void withNullOldAndNonNullNew_ShouldBuildSetAction() throws BuildUpdateActionException {
 
         // Preparation
         final int variantId = 1;
@@ -51,7 +51,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withNullOldAndNonNullNew_WithSameForAllAttribute_ShouldBuildSetAllAction()
+    void withNullOldAndNonNullNew_WithSameForAllAttribute_ShouldBuildSetAllAction()
         throws BuildUpdateActionException {
 
         // Preparation
@@ -74,7 +74,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withNullOldAndNonNullNew_WithNoExistingAttributeInMetaData_ShouldThrowException() {
+    void withNullOldAndNonNullNew_WithNoExistingAttributeInMetaData_ShouldThrowException() {
 
         // Preparation
         final Attribute oldAttribute = null;
@@ -89,7 +89,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withDifferentValues_ShouldBuildSetAction() throws BuildUpdateActionException {
+    void withDifferentValues_ShouldBuildSetAction() throws BuildUpdateActionException {
         // Preparation
         final Integer variantId = 1;
         final Attribute oldAttribute = Attribute.of("foo", JsonNodeFactory.instance.textNode("bar"));
@@ -110,7 +110,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withSameValues_ShouldNotBuildAction() throws BuildUpdateActionException {
+    void withSameValues_ShouldNotBuildAction() throws BuildUpdateActionException {
         // Preparation
         final Attribute oldAttribute = Attribute.of("foo", JsonNodeFactory.instance.textNode("foo"));
         final AttributeDraft newAttribute = AttributeDraft.of("foo", JsonNodeFactory.instance.textNode("foo"));
@@ -129,7 +129,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withDifferentValues_WithNoExistingAttributeInMetaData_ShouldThrowException() {
+    void withDifferentValues_WithNoExistingAttributeInMetaData_ShouldThrowException() {
         // Preparation
         final Attribute oldAttribute = Attribute.of("foo", JsonNodeFactory.instance.textNode("bar"));
         final AttributeDraft newAttribute = AttributeDraft.of("foo", JsonNodeFactory.instance.textNode("other-bar"));
@@ -143,7 +143,7 @@ public class BuildProductVariantAttributeUpdateActionsTest {
     }
 
     @Test
-    public void withSameValues_WithNoExistingAttributeInMetaData_ShouldThrowException() {
+    void withSameValues_WithNoExistingAttributeInMetaData_ShouldThrowException() {
         // Preparation
         final Attribute oldAttribute = Attribute.of("foo", JsonNodeFactory.instance.textNode("foo"));
         final AttributeDraft newAttribute = AttributeDraft.of("foo", JsonNodeFactory.instance.textNode("foo"));

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/attributes/BuildProductVariantAttributesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/attributes/BuildProductVariantAttributesUpdateActionsTest.java
@@ -19,8 +19,8 @@ import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.products.attributes.TimeAttributeType;
 import io.sphere.sdk.products.commands.updateactions.SetAttribute;
 import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildProductVariantAttributesUpdateActionsTest {
+class BuildProductVariantAttributesUpdateActionsTest {
 
     private final ProductVariant oldProductVariant = mock(ProductVariant.class);
     private final ProductVariantDraft newProductVariant = mock(ProductVariantDraft.class);
@@ -54,13 +54,13 @@ public class BuildProductVariantAttributesUpdateActionsTest {
                                                                                 errorMessages.add(msg))
                                                                             .build();
 
-    @Before
-    public void setupMethod() {
+    @BeforeEach
+    void setupMethod() {
         errorMessages = new ArrayList<>();
     }
 
     @Test
-    public void withNullNewAttributesAndEmptyExistingAttributes_ShouldNotBuildActions() {
+    void withNullNewAttributesAndEmptyExistingAttributes_ShouldNotBuildActions() {
         // Preparation
         when(newProductVariant.getAttributes()).thenReturn(null);
         when(oldProductVariant.getAttributes()).thenReturn(emptyList());
@@ -74,7 +74,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeNullNewAttributesAndExistingAttributes_ShouldBuildActionsAndTriggerErrorCallback() {
+    void withSomeNullNewAttributesAndExistingAttributes_ShouldBuildActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -109,7 +109,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withEmptyNewAttributesAndEmptyExistingAttributes_ShouldNotBuildActions() {
+    void withEmptyNewAttributesAndEmptyExistingAttributes_ShouldNotBuildActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -127,7 +127,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withAllMatchingAttributes_ShouldNotBuildActions() {
+    void withAllMatchingAttributes_ShouldNotBuildActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -160,7 +160,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNonEmptyNewAttributesButEmptyExistingAttributes_ShouldBuildSetAttributeActions() {
+    void withNonEmptyNewAttributesButEmptyExistingAttributes_ShouldBuildSetAttributeActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -196,7 +196,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeNonChangedMatchingAttributesAndNewAttributes_ShouldBuildSetAttributeActions()  {
+    void withSomeNonChangedMatchingAttributesAndNewAttributes_ShouldBuildSetAttributeActions()  {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -236,7 +236,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNullNewAttributes_ShouldBuildUnSetAttributeActions() {
+    void withNullNewAttributes_ShouldBuildUnSetAttributeActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -269,7 +269,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNullNewAttributes_WithSameForAllAttributes_ShouldBuildUnSetAllAttributeActions() {
+    void withNullNewAttributes_WithSameForAllAttributes_ShouldBuildUnSetAllAttributeActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -305,7 +305,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withEmptyNewAttributes_ShouldBuildUnSetAttributeActions() {
+    void withEmptyNewAttributes_ShouldBuildUnSetAttributeActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -338,7 +338,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withEmptyNewAttributes_WithNoExistingAttributeInMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
+    void withEmptyNewAttributes_WithNoExistingAttributeInMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -365,7 +365,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeNonChangedMatchingAttributesAndNoNewAttributes_ShouldBuildUnSetAttributeActions() {
+    void withSomeNonChangedMatchingAttributesAndNoNewAttributes_ShouldBuildUnSetAttributeActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -399,7 +399,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNoMatchingAttributes_ShouldBuildUnsetAndSetActions() {
+    void withNoMatchingAttributes_ShouldBuildUnsetAndSetActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -434,7 +434,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNoMatchingAttributes_WithSomeNoExistingMetaData_ShouldBuildSomeActionsAndTriggerErrorCallback() {
+    void withNoMatchingAttributes_WithSomeNoExistingMetaData_ShouldBuildSomeActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -467,7 +467,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNoMatchingAttributes_WithNoExistingMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
+    void withNoMatchingAttributes_WithNoExistingMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -496,7 +496,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withAllChangedMatchingAttributes_ShouldBuildSetActions() {
+    void withAllChangedMatchingAttributes_ShouldBuildSetActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -532,7 +532,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withAllChangedMatchingAttrs_WithSomeNoExistingMetaData_ShouldBuildSomeActionsAndTriggerErrorCallback() {
+    void withAllChangedMatchingAttrs_WithSomeNoExistingMetaData_ShouldBuildSomeActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -566,7 +566,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeChangedMatchingAttributes_ShouldBuildSetActions() {
+    void withSomeChangedMatchingAttributes_ShouldBuildSetActions() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -601,7 +601,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeChangedMatchingAttrs_WithNoExistingMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
+    void withSomeChangedMatchingAttrs_WithNoExistingMetaData_ShouldBuildNoActionsAndTriggerErrorCallback() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";
@@ -631,7 +631,7 @@ public class BuildProductVariantAttributesUpdateActionsTest {
     }
 
     @Test
-    public void withNoMatchingAttributes_ShouldBuildUnsetAndSetActionsInCorrectOrder() {
+    void withNoMatchingAttributes_ShouldBuildUnsetAndSetActionsInCorrectOrder() {
         // Preparation
         final String productKey = "foo";
         final String variantKey = "foo";

--- a/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productvariantupdateactionutils/prices/BuildProductVariantPricesUpdateActionsTest.java
@@ -14,8 +14,8 @@ import io.sphere.sdk.products.commands.updateactions.ChangePrice;
 import io.sphere.sdk.products.commands.updateactions.RemovePrice;
 import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomField;
 import io.sphere.sdk.products.commands.updateactions.SetProductPriceCustomType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildProductVariantPricesUpdateActionsTest {
+class BuildProductVariantPricesUpdateActionsTest {
 
     private final ProductVariant oldProductVariant = mock(ProductVariant.class);
     private final ProductVariantDraft newProductVariant = mock(ProductVariantDraft.class);
@@ -41,13 +41,14 @@ public class BuildProductVariantPricesUpdateActionsTest {
                                                                                        errorMessages.add(msg))
                                                                                    .build();
 
-    @Before
-    public void setupMethod() {
+    @BeforeEach
+    void setupMethod() {
         errorMessages = new ArrayList<>();
     }
 
+    
     @Test
-    public void withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+    void withNullNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
         // Preparation
         when(newProductVariant.getPrices()).thenReturn(null);
         when(oldProductVariant.getPrices()).thenReturn(emptyList());
@@ -61,7 +62,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeNullNewPricesAndExistingPrices_ShouldBuildActionsAndTriggerErrorCallback() {
+    void withSomeNullNewPricesAndExistingPrices_ShouldBuildActionsAndTriggerErrorCallback() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_US_111_USD,
@@ -88,7 +89,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withEmptyNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
+    void withEmptyNewPricesAndEmptyExistingPrices_ShouldNotBuildActions() {
         // Preparation
         when(oldProductVariant.getPrices()).thenReturn(emptyList());
         when(newProductVariant.getPrices()).thenReturn(emptyList());
@@ -102,7 +103,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withAllMatchingPrices_ShouldNotBuildActions() {
+    void withAllMatchingPrices_ShouldNotBuildActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_US_111_USD,
@@ -127,7 +128,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withNonEmptyNewPricesButEmptyExistingPrices_ShouldBuildAddPriceActions()  {
+    void withNonEmptyNewPricesButEmptyExistingPrices_ShouldBuildAddPriceActions()  {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_US_111_USD,
@@ -154,7 +155,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
     
     @Test
-    public void withSomeNonChangedMatchingPricesAndNewPrices_ShouldBuildAddPriceActions() {
+    void withSomeNonChangedMatchingPricesAndNewPrices_ShouldBuildAddPriceActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR,
@@ -182,7 +183,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withNullNewPrices_ShouldBuildRemovePricesAction() {
+    void withNullNewPrices_ShouldBuildRemovePricesAction() {
         // Preparation
         when(newProductVariant.getPrices()).thenReturn(null);
         final List<Price> prices = asList(
@@ -205,7 +206,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withEmptyNewPrices_ShouldBuildRemovePricesAction() {
+    void withEmptyNewPrices_ShouldBuildRemovePricesAction() {
         // Preparation
         when(newProductVariant.getPrices()).thenReturn(emptyList());
         final List<Price> prices = asList(
@@ -228,7 +229,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeNonChangedMatchingPricesAndNoNewPrices_ShouldBuildRemovePriceActions() {
+    void withSomeNonChangedMatchingPricesAndNoNewPrices_ShouldBuildRemovePriceActions() {
         // Preparation
         final List<PriceDraft> newPrices = singletonList(DRAFT_US_111_USD);
         when(newProductVariant.getPrices()).thenReturn(newPrices);
@@ -252,7 +253,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withNoMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
+    void withNoMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR,
@@ -281,7 +282,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withSomeChangedMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
+    void withSomeChangedMatchingPrices_ShouldBuildRemoveAndAddPricesActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR,
@@ -314,7 +315,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withPricesWithOverlappingValidityDates_ShouldBuildRemoveAndAddPricesActions() {
+    void withPricesWithOverlappingValidityDates_ShouldBuildRemoveAndAddPricesActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR_01_02,
@@ -362,7 +363,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withAllMatchingChangedPrices_ShouldBuildChangePriceActions() {
+    void withAllMatchingChangedPrices_ShouldBuildChangePriceActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR,
@@ -414,7 +415,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withDifferentPriceActions_ShouldBuildActionsInCorrectOrder() {
+    void withDifferentPriceActions_ShouldBuildActionsInCorrectOrder() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR_01_02,
@@ -440,7 +441,7 @@ public class BuildProductVariantPricesUpdateActionsTest {
     }
 
     @Test
-    public void withMixedCasesOfPriceMatches_ShouldBuildActions() {
+    void withMixedCasesOfPriceMatches_ShouldBuildActions() {
         // Preparation
         final List<PriceDraft> newPrices = asList(
             DRAFT_DE_111_EUR,

--- a/src/test/java/com/commercetools/sync/producttypes/ProductTypeSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/ProductTypeSyncOptionsBuilderTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,18 +25,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeSyncOptionsBuilderTest {
+class ProductTypeSyncOptionsBuilderTest {
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private ProductTypeSyncOptionsBuilder productTypeSyncOptionsBuilder = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT);
 
     @Test
-    public void of_WithClient_ShouldCreateProductTypeSyncOptionsBuilder() {
+    void of_WithClient_ShouldCreateProductTypeSyncOptionsBuilder() {
         final ProductTypeSyncOptionsBuilder builder = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT);
         assertThat(builder).isNotNull();
     }
 
     @Test
-    public void build_WithClient_ShouldBuildProductSyncOptions() {
+    void build_WithClient_ShouldBuildProductSyncOptions() {
         final ProductTypeSyncOptions productTypeSyncOptions = productTypeSyncOptionsBuilder.build();
         assertThat(productTypeSyncOptions).isNotNull();
         assertThat(productTypeSyncOptions.getBeforeUpdateCallback()).isNull();
@@ -48,7 +48,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
         final TriFunction<List<UpdateAction<ProductType>>,
                 ProductTypeDraft, ProductType, List<UpdateAction<ProductType>>>
             beforeUpdateCallback = (updateActions, newProductType, oldProductType) -> Collections.emptyList();
@@ -59,7 +59,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
         productTypeSyncOptionsBuilder.beforeCreateCallback((newProductType) -> null);
 
         final ProductTypeSyncOptions productTypeSyncOptions = productTypeSyncOptionsBuilder.build();
@@ -67,7 +67,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void errorCallBack_WithCallBack_ShouldSetCallBack() {
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final BiConsumer<String, Throwable> mockErrorCallBack = (errorMessage, errorException) -> {
         };
         productTypeSyncOptionsBuilder.errorCallback(mockErrorCallBack);
@@ -77,7 +77,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void warningCallBack_WithCallBack_ShouldSetCallBack() {
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final Consumer<String> mockWarningCallBack = (warningMessage) -> {
         };
         productTypeSyncOptionsBuilder.warningCallback(mockWarningCallBack);
@@ -87,7 +87,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void getThis_ShouldReturnCorrectInstance() {
+    void getThis_ShouldReturnCorrectInstance() {
         final ProductTypeSyncOptionsBuilder instance = productTypeSyncOptionsBuilder.getThis();
         assertThat(instance).isNotNull();
         assertThat(instance).isInstanceOf(ProductTypeSyncOptionsBuilder.class);
@@ -95,7 +95,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void productTypeSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+    void productTypeSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
         final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder
             .of(CTP_CLIENT)
             .batchSize(30)
@@ -106,7 +106,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
         final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT)
                                                                                .batchSize(10)
                                                                                .build();
@@ -114,7 +114,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
         final ProductTypeSyncOptions productTypeSyncOptionsWithZeroBatchSize =
                 ProductTypeSyncOptionsBuilder.of(CTP_CLIENT)
                     .batchSize(0)
@@ -134,7 +134,7 @@ public class ProductTypeSyncOptionsBuilderTest {
 
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
         final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .build();
         assertThat(productTypeSyncOptions.getBeforeUpdateCallback()).isNull();
@@ -146,7 +146,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<ProductType>>,
                 ProductTypeDraft, ProductType, List<UpdateAction<ProductType>>>
                 beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
@@ -169,7 +169,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
         final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
 
         final ProductTypeSyncOptions productTypeSyncOptions =
@@ -189,7 +189,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
         final TriFunction<List<UpdateAction<ProductType>>,
                 ProductTypeDraft, ProductType, List<UpdateAction<ProductType>>>
                 beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> Collections.emptyList();
@@ -208,7 +208,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
         final Function<ProductTypeDraft, ProductTypeDraft> draftFunction = productTypeDraft ->
                 ProductTypeDraftBuilder.of(productTypeDraft).key(productTypeDraft.getKey() + "_filteredKey").build();
 
@@ -230,7 +230,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
         final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT).build();
         assertThat(productTypeSyncOptions.getBeforeCreateCallback()).isNull();
 
@@ -242,7 +242,7 @@ public class ProductTypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
+    void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
         final Function<ProductTypeDraft, ProductTypeDraft> draftFunction = productDraft -> null;
         final ProductTypeSyncOptions productTypeSyncOptions = ProductTypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .beforeCreateCallback(draftFunction)

--- a/src/test/java/com/commercetools/sync/producttypes/ProductTypeSyncTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/ProductTypeSyncTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,9 +30,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeSyncTest {
+class ProductTypeSyncTest {
+
     @Test
-    public void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraft.ofAttributeDefinitionDrafts(
             "foo",
@@ -83,7 +84,7 @@ public class ProductTypeSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraftBuilder
             .of("newProductType", "productType", "a cool type", emptyList())
@@ -109,7 +110,7 @@ public class ProductTypeSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
         final ProductTypeDraft newProductTypeDraft = ProductTypeDraftBuilder
             .of("newProductType", "productType", "a cool type", emptyList())

--- a/src/test/java/com/commercetools/sync/producttypes/helpers/ProductTypeSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/helpers/ProductTypeSyncStatisticsTest.java
@@ -1,20 +1,20 @@
 package com.commercetools.sync.producttypes.helpers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProductTypeSyncStatisticsTest {
+class ProductTypeSyncStatisticsTest {
     private ProductTypeSyncStatistics productTypeSyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         productTypeSyncStatistics = new ProductTypeSyncStatistics();
     }
 
     @Test
-    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
         productTypeSyncStatistics.incrementCreated(1);
         productTypeSyncStatistics.incrementFailed(2);
         productTypeSyncStatistics.incrementUpdated(3);

--- a/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -26,8 +26,8 @@ import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValu
 import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
 import io.sphere.sdk.producttypes.commands.updateactions.SetInputTip;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +44,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AttributeDefinitionUpdateActionUtilsTest {
+class AttributeDefinitionUpdateActionUtilsTest {
     private static AttributeDefinition old;
     private static AttributeDefinitionDraft newSame;
     private static AttributeDefinitionDraft newDifferent;
@@ -58,8 +58,8 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         old = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), StringAttributeType.of())
             .isRequired(false)
@@ -83,7 +83,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -101,7 +101,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -119,7 +119,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
+    void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -139,7 +139,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -159,7 +159,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
+    void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -179,7 +179,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
+    void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -199,7 +199,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -219,7 +219,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -239,7 +239,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldBuildAction() {
+    void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -259,7 +259,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotBuildAction() {
+    void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -279,7 +279,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -298,7 +298,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -317,7 +317,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldBuildAction() {
+    void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -336,7 +336,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldNotBuildAction() {
+    void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldNotBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -355,7 +355,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldBuildAction() {
+    void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -376,7 +376,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -396,7 +396,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndDefaultTarget_ShouldNotBuildAction() {
+    void buildChangeAttributeConstraintAction_WithSourceNullValuesAndDefaultTarget_ShouldNotBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -416,7 +416,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldBuildAction() {
+    void buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldBuildAction() {
         // Preparation
         final AttributeDefinitionDraft draft = AttributeDefinitionDraftBuilder
             .of(null, "foo", ofEnglish("x"), null)
@@ -436,7 +436,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNullOptionalsAndDefaultValues_ShouldBuildNoActions() {
+    void buildActions_WithNullOptionalsAndDefaultValues_ShouldBuildNoActions() {
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(StringAttributeType.of(), "attributeName1", ofEnglish("label2"), true)
             .attributeConstraint(null)
@@ -456,7 +456,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNonDefaultValuesForOptionalFields_ShouldBuildActions() {
+    void buildActions_WithNonDefaultValuesForOptionalFields_ShouldBuildActions() {
         final AttributeDefinitionDraft attributeDefinitionDraft = AttributeDefinitionDraftBuilder
             .of(StringAttributeType.of(), "attributeName1", ofEnglish("label2"), true)
             .attributeConstraint(AttributeConstraint.SAME_FOR_ALL)
@@ -480,7 +480,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNewDifferentValues_ShouldReturnActions() {
+    void buildActions_WithNewDifferentValues_ShouldReturnActions() {
         final List<UpdateAction<ProductType>> result = buildActions(old, newDifferent);
 
         assertThat(result).containsExactlyInAnyOrder(
@@ -493,14 +493,14 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameValues_ShouldReturnEmpty() {
+    void buildActions_WithSameValues_ShouldReturnEmpty() {
         final List<UpdateAction<ProductType>> result = buildActions(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildActions_WithStringAttributeTypesWithLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithStringAttributeTypesWithLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), StringAttributeType.of())
             .build();
@@ -517,7 +517,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSetOfStringAttributeTypesWithDefinitionLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSetOfStringAttributeTypesWithDefinitionLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(StringAttributeType.of()))
             .build();
@@ -534,7 +534,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSetOfSetOfStringAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSetOfSetOfStringAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"),
                 SetAttributeType.of(SetAttributeType.of(StringAttributeType.of())))
@@ -553,7 +553,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameSetOfEnumsAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSameSetOfEnumsAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(
                 EnumAttributeType.of(emptyList())))
@@ -572,7 +572,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfEnumAttributeTypes_ShouldBuildEnumActions() {
+    void buildActions_WithChangedSetOfEnumAttributeTypes_ShouldBuildEnumActions() {
         // preparation
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(
@@ -618,7 +618,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameSetOfLEnumAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSameSetOfLEnumAttributeTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(
                 LocalizedEnumAttributeType.of(emptyList())))
@@ -637,7 +637,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfLocalizedEnumAttributeTypes_ShouldBuildEnumActions() {
+    void buildActions_WithChangedSetOfLocalizedEnumAttributeTypes_ShouldBuildEnumActions() {
         // preparation
         final AttributeDefinition oldDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), SetAttributeType.of(
@@ -646,7 +646,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
                         LocalizedEnumValue.of("c", ofEnglish("c")),
                         LOCALIZED_ENUM_VALUE_B,
                         LocalizedEnumValue.of("d", ofEnglish("d"))
-                ))))
+                    ))))
             .build();
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
@@ -656,7 +656,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
                         LOCALIZED_ENUM_VALUE_A,
                         LocalizedEnumValue.of(LOCALIZED_ENUM_VALUE_B.getKey(), ofEnglish("newLabel")),
                         LocalizedEnumValue.of("c", ofEnglish("c"))
-                ))),
+                    ))),
                 "attributeName1", ofEnglish("label1"), false)
             .build();
 
@@ -678,7 +678,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
+    void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
             .build();
@@ -701,7 +701,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutOldPlainEnum_ShouldReturnRemoveEnumValueAction() {
+    void buildActions_WithoutOldPlainEnum_ShouldReturnRemoveEnumValueAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
             .build();
@@ -723,7 +723,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WitDifferentPlainEnumValueLabel_ShouldReturnChangeEnumValueLabelAction() {
+    void buildActions_WitDifferentPlainEnumValueLabel_ShouldReturnChangeEnumValueLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"), EnumAttributeType.of(ENUM_VALUE_A))
             .build();
@@ -746,7 +746,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
+    void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of(
                 "attributeName1",
@@ -772,7 +772,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutOldLocalizedEnum_ShouldReturnRemoveLocalizedEnumValueAction() {
+    void buildActions_WithoutOldLocalizedEnum_ShouldReturnRemoveLocalizedEnumValueAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of(
                 "attributeName1",
@@ -797,7 +797,7 @@ public class AttributeDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
+    void buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
             .of("attributeName1", ofEnglish("label1"),
                 LocalizedEnumAttributeType.of(LOCALIZED_ENUM_VALUE_A))

--- a/src/test/java/com/commercetools/sync/producttypes/utils/LocalizedEnumValueUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/LocalizedEnumValueUpdateActionUtilsTest.java
@@ -5,21 +5,20 @@ import io.sphere.sdk.models.LocalizedEnumValue;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
-
 
 import static com.commercetools.sync.producttypes.utils.LocalizedEnumValueUpdateActionUtils.buildChangeLabelAction;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalizedEnumValueUpdateActionUtilsTest {
+class LocalizedEnumValueUpdateActionUtilsTest {
     private static LocalizedEnumValue old = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label1"));
     private static LocalizedEnumValue newSame = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label1"));
     private static LocalizedEnumValue newDifferent = LocalizedEnumValue.of("key1", LocalizedString.ofEnglish("label2"));
 
     @Test
-    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
             "attribute_definition_name_1",
             old,
@@ -30,7 +29,7 @@ public class LocalizedEnumValueUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
             "attribute_definition_name_1",
             old,

--- a/src/test/java/com/commercetools/sync/producttypes/utils/PlainEnumValueUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/PlainEnumValueUpdateActionUtilsTest.java
@@ -4,15 +4,15 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.EnumValue;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static com.commercetools.sync.producttypes.utils.PlainEnumValueUpdateActionUtils.buildChangeLabelAction;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PlainEnumValueUpdateActionUtilsTest {
+class PlainEnumValueUpdateActionUtilsTest {
     private static EnumValue old;
     private static EnumValue newSame;
     private static EnumValue newDifferent;
@@ -20,15 +20,15 @@ public class PlainEnumValueUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         old = EnumValue.of("key1", "label1");
         newSame = EnumValue.of("key1", "label1");
         newDifferent = EnumValue.of("key1", "label2");
     }
 
     @Test
-    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
             "attribute_definition_name_1",
             old,
@@ -40,7 +40,7 @@ public class PlainEnumValueUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<ProductType>> result = buildChangeLabelAction(
             "attribute_definition_name_1",
             old,

--- a/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
@@ -8,6 +8,15 @@ import io.sphere.sdk.products.attributes.AttributeDefinitionDraft;
 import io.sphere.sdk.products.attributes.AttributeDefinitionDraftBuilder;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.ProductTypeDraft;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeDescription;
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeDescriptionAction;
 import static com.commercetools.sync.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeNameAction;
@@ -16,17 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.sphere.sdk.producttypes.ProductTypeDraft;
-import io.sphere.sdk.producttypes.commands.updateactions.ChangeDescription;
-import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-
-public class ProductTypeUpdateActionUtilsTest {
+class ProductTypeUpdateActionUtilsTest {
     private static ProductType old;
     private static ProductTypeDraft newSame;
     private static ProductTypeDraft newDifferent;
@@ -34,17 +33,17 @@ public class ProductTypeUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         final LocalizedString label = LocalizedString.of(Locale.ENGLISH, "label1");
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
-                .of("attributeName1", label, StringAttributeType.of())
-                .build();
+            .of("attributeName1", label, StringAttributeType.of())
+            .build();
 
         final List<AttributeDefinition> oldAttributeDefinitions = singletonList(attributeDefinition);
 
         final List<AttributeDefinitionDraft> sameAttributeDefinitionDrafts = singletonList(
-                AttributeDefinitionDraftBuilder.of(attributeDefinition).build());
+            AttributeDefinitionDraftBuilder.of(attributeDefinition).build());
 
         old = mock(ProductType.class);
         when(old.getKey()).thenReturn("key1");
@@ -53,22 +52,22 @@ public class ProductTypeUpdateActionUtilsTest {
         when(old.getAttributes()).thenReturn(oldAttributeDefinitions);
 
         newSame = ProductTypeDraft.ofAttributeDefinitionDrafts(
-                "key1",
-                "name1",
-                "description 1",
-                sameAttributeDefinitionDrafts
+            "key1",
+            "name1",
+            "description 1",
+            sameAttributeDefinitionDrafts
         );
 
         newDifferent = ProductTypeDraft.ofAttributeDefinitionDrafts(
-                "key2",
-                "name2",
-                "description 2",
-                sameAttributeDefinitionDrafts
+            "key2",
+            "name2",
+            "description 2",
+            sameAttributeDefinitionDrafts
         );
     }
 
     @Test
-    public void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newDifferent);
 
         assertThat(result).containsInstanceOf(ChangeName.class);
@@ -76,14 +75,14 @@ public class ProductTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<ProductType>> result = buildChangeNameAction(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildChangeDescriptionAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeDescriptionAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newDifferent);
 
         assertThat(result).containsInstanceOf(ChangeDescription.class);
@@ -91,7 +90,7 @@ public class ProductTypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<ProductType>> result = buildChangeDescriptionAction(old, newSame);
 
         assertThat(result).isEmpty();

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -37,7 +37,7 @@ import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValu
 import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveAttributeDefinition;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildAttributeDefinitionUpdateActionsTest {
+class BuildAttributeDefinitionUpdateActionsTest {
     private static final String RES_ROOT =
         "com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/";
 
@@ -105,7 +105,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         .build();
 
     @Test
-    public void buildAttributesUpdateActions_WithNullNewAttributesAndExistingAttributes_ShouldBuild3RemoveActions() {
+    void buildAttributesUpdateActions_WithNullNewAttributesAndExistingAttributes_ShouldBuild3RemoveActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(
@@ -122,7 +122,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithNullNewAttributesAndNoOldAttributes_ShouldNotBuildActions() {
+    void buildAttributesUpdateActions_WithNullNewAttributesAndNoOldAttributes_ShouldNotBuildActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes()).thenReturn(emptyList());
         when(oldProductType.getKey()).thenReturn("product_type_key_1");
@@ -137,7 +137,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithNewAttributesAndNoOldAttributes_ShouldBuild3AddActions() {
+    void buildAttributesUpdateActions_WithNewAttributesAndNoOldAttributes_ShouldBuild3AddActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes()).thenReturn(emptyList());
         when(oldProductType.getKey()).thenReturn("product_type_key_1");
@@ -163,7 +163,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithIdenticalAttributes_ShouldNotBuildUpdateActions() {
+    void buildAttributesUpdateActions_WithIdenticalAttributes_ShouldNotBuildUpdateActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes())
             .thenReturn(asList(ATTRIBUTE_DEFINITION_A, ATTRIBUTE_DEFINITION_B, ATTRIBUTE_DEFINITION_C));
@@ -198,7 +198,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithChangedAttributes_ShouldBuildUpdateActions() {
+    void buildAttributesUpdateActions_WithChangedAttributes_ShouldBuildUpdateActions() {
         final ProductType oldProductType = mock(ProductType.class);
         when(oldProductType.getAttributes())
             .thenReturn(asList(ATTRIBUTE_DEFINITION_A, ATTRIBUTE_DEFINITION_B, ATTRIBUTE_DEFINITION_C));
@@ -241,7 +241,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithDuplicateAttributeNames_ShouldNotBuildActionsAndTriggerErrorCb() {
+    void buildAttributesUpdateActions_WithDuplicateAttributeNames_ShouldNotBuildActionsAndTriggerErrorCb() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -252,11 +252,12 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         final List<String> errorMessages = new ArrayList<>();
         final List<Throwable> exceptions = new ArrayList<>();
         final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder.of(mock(SphereClient.class))
-            .errorCallback((errorMessage, exception) -> {
-                errorMessages.add(errorMessage);
-                exceptions.add(exception);
-            })
-            .build();
+                                                                                .errorCallback(
+                                                                                    (errorMessage, exception) -> {
+                                                                                        errorMessages.add(errorMessage);
+                                                                                        exceptions.add(exception);
+                                                                                    })
+                                                                                .build();
 
         final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(
             oldProductType,
@@ -273,13 +274,13 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         assertThat(exceptions).hasSize(1);
         assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
         assertThat(exceptions.get(0).getMessage()).contains("Attribute definitions drafts have duplicated names. "
-                + "Duplicated attribute definition name: 'b'. Attribute definitions names are expected to be unique "
-                + "inside their product type.");
+            + "Duplicated attribute definition name: 'b'. Attribute definitions names are expected to be unique "
+            + "inside their product type.");
         assertThat(exceptions.get(0).getCause()).isExactlyInstanceOf(DuplicateNameException.class);
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithOneMissingAttribute_ShouldBuildRemoveAttributeAction() {
+    void buildAttributesUpdateActions_WithOneMissingAttribute_ShouldBuildRemoveAttributeAction() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -288,16 +289,16 @@ public class BuildAttributeDefinitionUpdateActionsTest {
         );
 
         final List<UpdateAction<ProductType>> updateActions = buildAttributesUpdateActions(
-                oldProductType,
-                newProductTypeDraft,
-                SYNC_OPTIONS
+            oldProductType,
+            newProductTypeDraft,
+            SYNC_OPTIONS
         );
 
         assertThat(updateActions).containsExactly(RemoveAttributeDefinition.of("c"));
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithOneExtraAttribute_ShouldBuildAddAttributesAction() {
+    void buildAttributesUpdateActions_WithOneExtraAttribute_ShouldBuildAddAttributesAction() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -321,7 +322,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithOneAttributeSwitch_ShouldBuildRemoveAndAddAttributesActions() {
+    void buildAttributesUpdateActions_WithOneAttributeSwitch_ShouldBuildRemoveAndAddAttributesActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -347,7 +348,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithDifferentOrder_ShouldBuildChangeAttributeOrderAction() {
+    void buildAttributesUpdateActions_WithDifferentOrder_ShouldBuildChangeAttributeOrderAction() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -372,7 +373,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    void buildAttributesUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -399,7 +400,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildAttributesUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -434,7 +435,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithAddedAttributeInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildAttributesUpdateActions_WithAddedAttributeInBetween_ShouldBuildChangeOrderAndAddActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -467,7 +468,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAttributeActions() {
+    void buildAttributesUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAttributeActions() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -499,7 +500,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithDifferentAttributeType_ShouldRemoveOldAttributeAndAddNewAttribute() {
+    void buildAttributesUpdateActions_WithDifferentAttributeType_ShouldRemoveOldAttributeAndAddNewAttribute() {
         final ProductType oldProductType = readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
 
         final ProductTypeDraft newProductTypeDraft = readObjectFromResource(
@@ -529,7 +530,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithANullAttributeDefinitionDraft_ShouldSkipNullAttributes() {
+    void buildAttributesUpdateActions_WithANullAttributeDefinitionDraft_ShouldSkipNullAttributes() {
         // preparation
         final ProductType oldProductType = mock(ProductType.class);
         final AttributeDefinition attributeDefinition = AttributeDefinitionBuilder
@@ -577,7 +578,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfText_ShouldBuildActions() {
+    void buildAttributesUpdateActions_WithSetOfText_ShouldBuildActions() {
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
             .of(SetAttributeType.of(StringAttributeType.of()), "a", ofEnglish("new_label"), true)
@@ -601,7 +602,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
+    void buildAttributesUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
 
         final AttributeDefinitionDraft newDefinition = AttributeDefinitionDraftBuilder
             .of(SetAttributeType.of(SetAttributeType.of(StringAttributeType.of())), "a", ofEnglish("new_label"), true)
@@ -625,7 +626,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
+    void buildAttributesUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfEnumType = SetAttributeType.of(
             EnumAttributeType.of(
@@ -673,7 +674,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
+    void buildAttributesUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
         // preparation
         final SetAttributeType newSetOfEnumType = SetAttributeType.of(
             EnumAttributeType.of(singletonList(EnumValue.of("foo", "bar"))));
@@ -702,7 +703,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
+    void buildAttributesUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfLenumType = SetAttributeType.of(
             LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
@@ -733,7 +734,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfIdenticalLEnums_ShouldBuildNoActions() {
+    void buildAttributesUpdateActions_WithSetOfIdenticalLEnums_ShouldBuildNoActions() {
         // preparation
         final SetAttributeType newSetOfLenumType = SetAttributeType.of(
             LocalizedEnumAttributeType.of(singletonList(LocalizedEnumValue.of("foo", ofEnglish("bar")))));
@@ -763,7 +764,7 @@ public class BuildAttributeDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefLabelChange_ShouldBuildCorrectActions() {
+    void buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefLabelChange_ShouldBuildCorrectActions() {
         // preparation
         final SetAttributeType newSetOfLenumType = SetAttributeType.of(
             LocalizedEnumAttributeType.of(

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -91,10 +91,11 @@ class BuildLocalizedEnumUpdateActionsTest {
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        )).isInstanceOf(DuplicateKeyException.class)
-          .hasMessage("Enum Values have duplicated keys. Definition name: "
-              + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
-              + "Enum Values are expected to be unique inside their definition.");
+        ))
+            .isInstanceOf(DuplicateKeyException.class)
+            .hasMessage("Enum Values have duplicated keys. Definition name: "
+                + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
+                + "Enum Values are expected to be unique inside their definition.");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -7,9 +7,7 @@ import io.sphere.sdk.producttypes.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeLocalizedEnumValueOrder;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -20,11 +18,12 @@ import static com.commercetools.sync.producttypes.utils.LocalizedEnumValueUpdate
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildLocalizedEnumUpdateActionsTest {
+class BuildLocalizedEnumUpdateActionsTest {
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+    void buildLocalizedEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -37,7 +36,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+    void buildLocalizedEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -50,7 +49,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
+    void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),
@@ -61,7 +60,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+    void buildLocalizedEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),
@@ -76,7 +75,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+    void buildLocalizedEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -86,25 +85,20 @@ public class BuildLocalizedEnumUpdateActionsTest {
         assertThat(updateActions).isEmpty();
     }
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
-        expectedException.expect(DuplicateKeyException.class);
-        expectedException.expectMessage("Enum Values have duplicated keys. Definition name: "
-            + "'attribute_definition_name_1', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
-            + "their definition.");
-
-        buildLocalizedEnumValuesUpdateActions(
+    void buildLocalizedEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
+        assertThatThrownBy(() -> buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        );
+        )).isInstanceOf(DuplicateKeyException.class)
+          .hasMessage("Enum Values have duplicated keys. Definition name: "
+              + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
+              + "Enum Values are expected to be unique inside their definition.");
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
+    void buildLocalizedEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -117,7 +111,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+    void buildLocalizedEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -130,7 +124,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
+    void buildLocalizedEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -144,7 +138,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
+    void buildLocalizedEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -161,7 +155,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithMixedCase_ShouldBuildChangeEnumValueOrderAction() {
+    void buildPlainEnumUpdateActions_WithMixedCase_ShouldBuildChangeEnumValueOrderAction() {
         final String attributeDefinitionName = "attribute_definition_name_1";
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             attributeDefinitionName,
@@ -180,7 +174,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    void buildLocalizedEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -197,7 +191,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -216,7 +210,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -235,7 +229,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -254,7 +248,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDifferentLabels_ShouldReturnChangeLabelAction() {
+    void buildLocalizedEnumUpdateActions_WithDifferentLabels_ShouldReturnChangeLabelAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValueUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUE_A,
@@ -267,7 +261,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithSameLabels_ShouldNotReturnChangeLabelAction() {
+    void buildLocalizedEnumUpdateActions_WithSameLabels_ShouldNotReturnChangeLabelAction() {
         final List<UpdateAction<ProductType>> updateActions = buildLocalizedEnumValueUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUE_A,

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
@@ -91,10 +91,11 @@ class BuildPlainEnumUpdateActionsTest {
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        )).isInstanceOf(DuplicateKeyException.class)
-          .hasMessage("Enum Values have duplicated keys. Definition name: "
-              + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
-              + "Enum Values are expected to be unique inside their definition.");
+        ))
+            .isInstanceOf(DuplicateKeyException.class)
+            .hasMessage("Enum Values have duplicated keys. Definition name: "
+                + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
+                + "Enum Values are expected to be unique inside their definition.");
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildPlainEnumUpdateActionsTest.java
@@ -7,9 +7,7 @@ import io.sphere.sdk.producttypes.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.producttypes.commands.updateactions.ChangePlainEnumValueLabel;
 import io.sphere.sdk.producttypes.commands.updateactions.RemoveEnumValues;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -20,11 +18,12 @@ import static com.commercetools.sync.producttypes.utils.PlainEnumValueUpdateActi
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildPlainEnumUpdateActionsTest {
+class BuildPlainEnumUpdateActionsTest {
 
     @Test
-    public void buildPlainEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+    void buildPlainEnumUpdateActions_WithNullNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -37,7 +36,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
+    void buildPlainEnumUpdateActions_WithEmptyNewEnumValuesAndExistingEnumValues_ShouldBuildRemoveAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -50,7 +49,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
+    void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),
@@ -61,7 +60,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+    void buildPlainEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             Collections.emptyList(),
@@ -76,7 +75,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+    void buildPlainEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -86,25 +85,20 @@ public class BuildPlainEnumUpdateActionsTest {
         assertThat(updateActions).isEmpty();
     }
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void buildPlainEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
-        expectedException.expect(DuplicateKeyException.class);
-        expectedException.expectMessage("Enum Values have duplicated keys. Definition name: "
-            + "'attribute_definition_name_1', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
-            + "their definition.");
-
-        buildEnumValuesUpdateActions(
+    void buildPlainEnumUpdateActions_WithDuplicatePlainEnumValues_ShouldTriggerDuplicateKeyError() {
+        assertThatThrownBy(() -> buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        );
+        )).isInstanceOf(DuplicateKeyException.class)
+          .hasMessage("Enum Values have duplicated keys. Definition name: "
+              + "'attribute_definition_name_1', Duplicated enum value: 'b'. "
+              + "Enum Values are expected to be unique inside their definition.");
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
+    void buildPlainEnumUpdateActions_WithOneMissingPlainEnumValue_ShouldBuildRemoveEnumValueAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -117,7 +111,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+    void buildPlainEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -130,7 +124,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
+    void buildPlainEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildRemoveAndAddEnumValueActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -144,7 +138,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
+    void buildPlainEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -161,7 +155,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithMixedCase_ShouldBuildChangeEnumValueOrderAction() {
+    void buildPlainEnumUpdateActions_WithMixedCase_ShouldBuildChangeEnumValueOrderAction() {
         final String attributeDefinitionName = "attribute_definition_name_1";
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             attributeDefinitionName,
@@ -180,7 +174,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    void buildPlainEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -197,7 +191,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildPlainEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -216,7 +210,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildPlainEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -235,7 +229,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
+    void buildPlainEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveEnumValueActions() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValuesUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUES_ABC,
@@ -254,7 +248,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithDifferentLabels_ShouldReturnChangeLabelAction() {
+    void buildPlainEnumUpdateActions_WithDifferentLabels_ShouldReturnChangeLabelAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValueUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUE_A,
@@ -267,7 +261,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithSameLabels_ShouldNotReturnChangeLabelAction() {
+    void buildPlainEnumUpdateActions_WithSameLabels_ShouldNotReturnChangeLabelAction() {
         final List<UpdateAction<ProductType>> updateActions = buildEnumValueUpdateActions(
             "attribute_definition_name_1",
             ENUM_VALUE_A,

--- a/src/test/java/com/commercetools/sync/services/impl/ProductServiceTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/ProductServiceTest.java
@@ -13,8 +13,8 @@ import io.sphere.sdk.products.commands.ProductUpdateCommand;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
 import io.sphere.sdk.queries.QueryPredicate;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -31,15 +31,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductServiceTest {
+class ProductServiceTest {
 
     private ProductServiceImpl service;
     private ProductSyncOptions productSyncOptions;
     private List<String> errorMessages;
     private List<Throwable> errorExceptions;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         errorMessages = new ArrayList<>();
         errorExceptions = new ArrayList<>();
         productSyncOptions = ProductSyncOptionsBuilder.of(mock(SphereClient.class))
@@ -52,7 +52,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void createProduct_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
+    void createProduct_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
         final Product mock = mock(Product.class);
         when(mock.getId()).thenReturn("productId");
         when(mock.getKey()).thenReturn("productKey");
@@ -69,7 +69,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void createProduct_WithUnSuccessfulMockCtpResponse_ShouldNotCreateProduct() {
+    void createProduct_WithUnSuccessfulMockCtpResponse_ShouldNotCreateProduct() {
         // preparation
         final Product mock = mock(Product.class);
         when(mock.getId()).thenReturn("productId");
@@ -99,7 +99,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void createProduct_WithDraftWithoutKey_ShouldNotCreateProduct() {
+    void createProduct_WithDraftWithoutKey_ShouldNotCreateProduct() {
         final ProductDraft draft = mock(ProductDraft.class);
         final Optional<Product> productOptional = service.createProduct(draft).toCompletableFuture().join();
 
@@ -111,7 +111,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void updateProduct_WithMockCtpResponse_ShouldReturnMock() {
+    void updateProduct_WithMockCtpResponse_ShouldReturnMock() {
         final Product mock = mock(Product.class);
         when(productSyncOptions.getCtpClient().execute(any())).thenReturn(completedFuture(mock));
 
@@ -124,13 +124,13 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void buildProductKeysQueryPredicate_WithEmptyProductKeysSet_ShouldBuildCorrectQuery() {
+    void buildProductKeysQueryPredicate_WithEmptyProductKeysSet_ShouldBuildCorrectQuery() {
         final QueryPredicate<Product> queryPredicate = service.buildProductKeysQueryPredicate(new HashSet<>());
         assertThat(queryPredicate.toSphereQuery()).isEqualTo("key in ()");
     }
 
     @Test
-    public void buildProductKeysQueryPredicate_WithProductKeysSet_ShouldBuildCorrectQuery() {
+    void buildProductKeysQueryPredicate_WithProductKeysSet_ShouldBuildCorrectQuery() {
         final HashSet<String> productKeys = new HashSet<>();
         productKeys.add("key1");
         productKeys.add("key2");
@@ -139,7 +139,7 @@ public class ProductServiceTest {
     }
 
     @Test
-    public void buildProductKeysQueryPredicate_WithSomeBlankProductKeys_ShouldBuildCorrectQuery() {
+    void buildProductKeysQueryPredicate_WithSomeBlankProductKeys_ShouldBuildCorrectQuery() {
         final HashSet<String> productKeys = new HashSet<>();
         productKeys.add("key1");
         productKeys.add("key2");

--- a/src/test/java/com/commercetools/sync/services/impl/ProductTypeServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/ProductTypeServiceImplTest.java
@@ -8,7 +8,7 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ProductTypeServiceImplTest {
+class ProductTypeServiceImplTest {
 
     @Test
-    public void fetchProductType_WithEmptyKey_ShouldNotFetchProductType() {
+    void fetchProductType_WithEmptyKey_ShouldNotFetchProductType() {
         // preparation
         final SphereClient sphereClient = mock(SphereClient.class);
         final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
@@ -40,7 +40,7 @@ public class ProductTypeServiceImplTest {
     }
 
     @Test
-    public void fetchProductType_WithNullKey_ShouldNotFetchProductType() {
+    void fetchProductType_WithNullKey_ShouldNotFetchProductType() {
         // preparation
         final SphereClient sphereClient = mock(SphereClient.class);
         final ProductTypeSyncOptions syncOptions = ProductTypeSyncOptionsBuilder
@@ -57,7 +57,7 @@ public class ProductTypeServiceImplTest {
     }
 
     @Test
-    public void fetchProductType_WithBadGateWayException_ShouldCompleteExceptionally() {
+    void fetchProductType_WithBadGateWayException_ShouldCompleteExceptionally() {
         // preparation
         final SphereClient sphereClient = mock(SphereClient.class);
         when(sphereClient.execute(any(ProductTypeQuery.class)))

--- a/src/test/java/com/commercetools/sync/types/TypeSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/types/TypeSyncOptionsBuilderTest.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.updateactions.ChangeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,19 +25,19 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TypeSyncOptionsBuilderTest {
+class TypeSyncOptionsBuilderTest {
 
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private TypeSyncOptionsBuilder typeSyncOptionsBuilder = TypeSyncOptionsBuilder.of(CTP_CLIENT);
 
     @Test
-    public void of_WithClient_ShouldCreateTypeSyncOptionsBuilder() {
+    void of_WithClient_ShouldCreateTypeSyncOptionsBuilder() {
         final TypeSyncOptionsBuilder builder = TypeSyncOptionsBuilder.of(CTP_CLIENT);
         assertThat(builder).isNotNull();
     }
 
     @Test
-    public void build_WithClient_ShouldBuildSyncOptions() {
+    void build_WithClient_ShouldBuildSyncOptions() {
         final TypeSyncOptions typeSyncOptions = typeSyncOptionsBuilder.build();
         assertThat(typeSyncOptions).isNotNull();
         assertThat(typeSyncOptions.getBeforeUpdateCallback()).isNull();
@@ -49,7 +49,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
         final TriFunction<List<UpdateAction<Type>>, TypeDraft, Type, List<UpdateAction<Type>>>
                 beforeUpdateCallback = (updateActions, newType, oldType) -> emptyList();
 
@@ -60,7 +60,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
         typeSyncOptionsBuilder.beforeCreateCallback((newType) -> null);
 
         final TypeSyncOptions typeSyncOptions = typeSyncOptionsBuilder.build();
@@ -68,7 +68,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void errorCallBack_WithCallBack_ShouldSetCallBack() {
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final BiConsumer<String, Throwable> mockErrorCallBack = (errorMessage, errorException) -> {
         };
         typeSyncOptionsBuilder.errorCallback(mockErrorCallBack);
@@ -78,7 +78,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void warningCallBack_WithCallBack_ShouldSetCallBack() {
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final Consumer<String> mockWarningCallBack = (warningMessage) -> {
         };
         typeSyncOptionsBuilder.warningCallback(mockWarningCallBack);
@@ -88,7 +88,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void getThis_ShouldReturnCorrectInstance() {
+    void getThis_ShouldReturnCorrectInstance() {
         final TypeSyncOptionsBuilder instance = typeSyncOptionsBuilder.getThis();
         assertThat(instance).isNotNull();
         assertThat(instance).isInstanceOf(TypeSyncOptionsBuilder.class);
@@ -96,7 +96,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void typeSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+    void typeSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder
                 .of(CTP_CLIENT)
                 .batchSize(30)
@@ -107,7 +107,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .batchSize(10)
                 .build();
@@ -115,7 +115,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
         final TypeSyncOptions typeSyncOptionsWithZeroBatchSize = TypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .batchSize(0)
                 .build();
@@ -131,7 +131,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .build();
         assertThat(typeSyncOptions.getBeforeUpdateCallback()).isNull();
@@ -145,7 +145,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<Type>>, TypeDraft, Type, List<UpdateAction<Type>>>
                 beforeUpdateCallback = (updateActions, newType, oldType) -> null;
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder.of(CTP_CLIENT)
@@ -166,7 +166,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
         final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
 
         final TypeSyncOptions typeSyncOptions =
@@ -185,7 +185,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
         final TriFunction<List<UpdateAction<Type>>, TypeDraft, Type, List<UpdateAction<Type>>>
                 beforeUpdateCallback = (updateActions, newType, oldType) -> emptyList();
 
@@ -203,7 +203,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
         final Function<TypeDraft, TypeDraft> draftFunction =
             typeDraft -> TypeDraftBuilder.of(typeDraft).key(typeDraft.getKey() + "_filteredKey").build();
 
@@ -224,7 +224,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder.of(CTP_CLIENT).build();
         assertThat(typeSyncOptions.getBeforeCreateCallback()).isNull();
 
@@ -235,7 +235,7 @@ public class TypeSyncOptionsBuilderTest {
     }
 
     @Test
-    public void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
+    void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
         final Function<TypeDraft, TypeDraft> draftFunction = typeDraft -> null;
         final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder.of(CTP_CLIENT)
                 .beforeCreateCallback(draftFunction)

--- a/src/test/java/com/commercetools/sync/types/TypeSyncTest.java
+++ b/src/test/java/com/commercetools/sync/types/TypeSyncTest.java
@@ -8,7 +8,7 @@ import io.sphere.sdk.types.ResourceTypeIdsSetBuilder;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,9 +32,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TypeSyncTest {
+class TypeSyncTest {
     @Test
-    public void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
         // preparation
 
         final TypeDraft newTypeDraft = TypeDraftBuilder.of(
@@ -86,7 +86,7 @@ public class TypeSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder
             .of("newType", ofEnglish( "typeName"), ResourceTypeIdsSetBuilder.of().addChannels())
@@ -112,7 +112,7 @@ public class TypeSyncTest {
     }
 
     @Test
-    public void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
         final TypeDraft newTypeDraft = TypeDraftBuilder
             .of("newType", ofEnglish( "typeName"), ResourceTypeIdsSetBuilder.of().addChannels())

--- a/src/test/java/com/commercetools/sync/types/helpers/TypeSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/types/helpers/TypeSyncStatisticsTest.java
@@ -1,21 +1,21 @@
 package com.commercetools.sync.types.helpers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class TypeSyncStatisticsTest {
+class TypeSyncStatisticsTest {
     private TypeSyncStatistics typeSyncStatistics;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         typeSyncStatistics = new TypeSyncStatistics();
     }
 
     @Test
-    public void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
         typeSyncStatistics.incrementCreated(1);
         typeSyncStatistics.incrementFailed(2);
         typeSyncStatistics.incrementUpdated(3);

--- a/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildFieldDefinitionUpdateActionsTest.java
@@ -27,7 +27,7 @@ import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionLabel;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionOrder;
 import io.sphere.sdk.types.commands.updateactions.ChangeLocalizedEnumValueOrder;
 import io.sphere.sdk.types.commands.updateactions.RemoveFieldDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BuildFieldDefinitionUpdateActionsTest {
+class BuildFieldDefinitionUpdateActionsTest {
     private static final String TYPE_KEY = "key";
     private static final LocalizedString TYPE_NAME = ofEnglish("name");
     private static final LocalizedString TYPE_DESCRIPTION = ofEnglish("description");
@@ -61,7 +61,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
         .build();
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithNullNewFieldDefAndExistingFieldDefs_ShouldBuild3RemoveActions() {
+    void buildFieldDefinitionsUpdateActions_WithNullNewFieldDefAndExistingFieldDefs_ShouldBuild3RemoveActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final List<UpdateAction<Type>> updateActions = buildFieldDefinitionsUpdateActions(
@@ -78,7 +78,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithNullNewFieldDefsAndNoOldFieldDefs_ShouldNotBuildActions() {
+    void buildFieldDefinitionsUpdateActions_WithNullNewFieldDefsAndNoOldFieldDefs_ShouldNotBuildActions() {
         final Type oldType = mock(Type.class);
         when(oldType.getFieldDefinitions()).thenReturn(emptyList());
         when(oldType.getKey()).thenReturn("type_key_1");
@@ -93,7 +93,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithNewFieldDefsAndNoOldFieldDefinitions_ShouldBuild3AddActions() {
+    void buildFieldDefinitionsUpdateActions_WithNewFieldDefsAndNoOldFieldDefinitions_ShouldBuild3AddActions() {
         final Type oldType = mock(Type.class);
         when(oldType.getFieldDefinitions()).thenReturn(emptyList());
         when(oldType.getKey()).thenReturn("type_key_1");
@@ -117,7 +117,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithIdenticalFieldDefinitions_ShouldNotBuildUpdateActions() {
+    void buildFieldDefinitionsUpdateActions_WithIdenticalFieldDefinitions_ShouldNotBuildUpdateActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -135,7 +135,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithDuplicateFieldDefNames_ShouldNotBuildActionsAndTriggerErrorCb() {
+    void buildFieldDefinitionsUpdateActions_WithDuplicateFieldDefNames_ShouldNotBuildActionsAndTriggerErrorCb() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -173,7 +173,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithOneMissingFieldDefinition_ShouldBuildRemoveFieldDefAction() {
+    void buildFieldDefinitionsUpdateActions_WithOneMissingFieldDefinition_ShouldBuildRemoveFieldDefAction() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -191,7 +191,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithOneExtraFieldDef_ShouldBuildAddFieldDefinitionAction() {
+    void buildFieldDefinitionsUpdateActions_WithOneExtraFieldDef_ShouldBuildAddFieldDefinitionAction() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -211,7 +211,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithOneFieldDefSwitch_ShouldBuildRemoveAndAddFieldDefActions() {
+    void buildFieldDefinitionsUpdateActions_WithOneFieldDefSwitch_ShouldBuildRemoveAndAddFieldDefActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -232,7 +232,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithDifferent_ShouldBuildChangeFieldDefinitionOrderAction() {
+    void buildFieldDefinitionsUpdateActions_WithDifferent_ShouldBuildChangeFieldDefinitionOrderAction() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -258,7 +258,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithRemovedAndDiffOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    void buildFieldDefinitionsUpdateActions_WithRemovedAndDiffOrder_ShouldBuildChangeOrderAndRemoveActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -284,7 +284,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildFieldDefinitionsUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -312,7 +312,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithAddedFieldDefInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildFieldDefinitionsUpdateActions_WithAddedFieldDefInBetween_ShouldBuildChangeOrderAndAddActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -340,7 +340,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithMixedFields_ShouldBuildAllThreeMoveFieldDefActions() {
+    void buildFieldDefinitionsUpdateActions_WithMixedFields_ShouldBuildAllThreeMoveFieldDefActions() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -367,7 +367,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithDifferentType_ShouldRemoveOldFieldDefAndAddNewFieldDef() {
+    void buildFieldDefinitionsUpdateActions_WithDifferentType_ShouldRemoveOldFieldDefAndAddNewFieldDef() {
         final Type oldType = readObjectFromResource(TYPE_WITH_FIELDS_ABC, Type.class);
 
         final TypeDraft newTypeDraft = readObjectFromResource(
@@ -387,7 +387,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithNullNewFieldDef_ShouldSkipNullFieldDefs() {
+    void buildFieldDefinitionsUpdateActions_WithNullNewFieldDef_ShouldSkipNullFieldDefs() {
         // preparation
         final Type oldType = mock(Type.class);
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
@@ -425,7 +425,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithDefWithNullName_ShouldBuildChangeFieldDefOrderAction() {
+    void buildFieldDefinitionsUpdateActions_WithDefWithNullName_ShouldBuildChangeFieldDefOrderAction() {
         // preparation
         final Type oldType = mock(Type.class);
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
@@ -464,7 +464,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldDefinitionsUpdateActions_WithDefWithNullType_ShouldBuildChangeFieldDefOrderAction() {
+    void buildFieldDefinitionsUpdateActions_WithDefWithNullType_ShouldBuildChangeFieldDefOrderAction() {
         // preparation
         final Type oldType = mock(Type.class);
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
@@ -501,7 +501,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfText_ShouldBuildActions() {
+    void buildFieldsUpdateActions_WithSetOfText_ShouldBuildActions() {
         final FieldDefinition newDefinition = FieldDefinition
             .of(SetFieldType.of(StringFieldType.of()), "a", ofEnglish("new_label"), true);
 
@@ -524,7 +524,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
+    void buildFieldsUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
 
         final FieldDefinition newDefinition = FieldDefinition
             .of(SetFieldType.of(SetFieldType.of(StringFieldType.of())), "a", ofEnglish("new_label"), true);
@@ -549,7 +549,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
+    void buildFieldsUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final FieldDefinition newDefinition = FieldDefinition
             .of(SetFieldType.of(
@@ -589,7 +589,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
+    void buildFieldsUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
         // preparation
         final FieldDefinition newDefinition = FieldDefinition
             .of(SetFieldType.of(EnumFieldType.of(emptyList())), "a", ofEnglish("new_label"), true);
@@ -615,7 +615,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
+    void buildFieldsUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(
             LocalizedEnumFieldType.of(
@@ -659,7 +659,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfIdenticalLEnums_ShouldNotBuildActions() {
+    void buildFieldsUpdateActions_WithSetOfIdenticalLEnums_ShouldNotBuildActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList())));
 
@@ -687,7 +687,7 @@ public class BuildFieldDefinitionUpdateActionsTest {
     }
 
     @Test
-    public void buildFieldsUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
+    void buildFieldsUpdateActions_WithSetOfLEnumsChangesAndDefinitionLabelChange_ShouldBuildCorrectActions() {
         // preparation
         final SetFieldType newSetFieldType = SetFieldType.of(
             LocalizedEnumFieldType.of(

--- a/src/test/java/com/commercetools/sync/types/utils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildLocalizedEnumUpdateActionsTest.java
@@ -93,11 +93,8 @@ class BuildLocalizedEnumUpdateActionsTest {
         );
 
         assertThat(updateActions).containsExactly(
-            ChangeLocalizedEnumValueOrder.of(FIELD_NAME_1, asList(
-                ENUM_VALUE_C.getKey(),
-                ENUM_VALUE_A.getKey(),
-                ENUM_VALUE_B.getKey()
-            ))
+            ChangeLocalizedEnumValueOrder.of(FIELD_NAME_1,
+                asList(ENUM_VALUE_C.getKey(), ENUM_VALUE_A.getKey(), ENUM_VALUE_B.getKey()))
         );
     }
 
@@ -111,10 +108,7 @@ class BuildLocalizedEnumUpdateActionsTest {
 
         // remove enum value actions not exists for type resources
         assertThat(updateActions).containsExactly(
-            ChangeLocalizedEnumValueOrder.of(FIELD_NAME_1, asList(
-                ENUM_VALUE_C.getKey(),
-                ENUM_VALUE_B.getKey()
-            ))
+            ChangeLocalizedEnumValueOrder.of(FIELD_NAME_1, asList(ENUM_VALUE_C.getKey(), ENUM_VALUE_B.getKey()))
         );
     }
 
@@ -176,12 +170,12 @@ class BuildLocalizedEnumUpdateActionsTest {
 
     @Test
     void buildLocalizedEnumUpdateActions_WithDuplicateEnumValues_ShouldTriggerDuplicateKeyError() {
-        assertThatThrownBy(() -> LocalizedEnumValueUpdateActionUtils.buildLocalizedEnumValuesUpdateActions(
+        assertThatThrownBy(() -> buildLocalizedEnumValuesUpdateActions(
             "field_definition_name",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
         )).isInstanceOf(DuplicateKeyException.class)
-          .hasMessage("Enum Values have duplicated keys. Definition name: "
+            .hasMessage("Enum Values have duplicated keys. Definition name: "
               + "'field_definition_name', Duplicated enum value: 'b'. "
               + "Enum Values are expected to be unique inside their definition.");
     }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildLocalizedEnumUpdateActionsTest.java
@@ -5,9 +5,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.types.commands.updateactions.ChangeLocalizedEnumValueOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -16,15 +14,14 @@ import static com.commercetools.sync.types.utils.LocalizedEnumValueUpdateActionU
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildLocalizedEnumUpdateActionsTest {
+class BuildLocalizedEnumUpdateActionsTest {
     private static final String FIELD_NAME_1 = "field1";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
+    void buildLocalizedEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             emptyList(),
@@ -35,7 +32,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+    void buildLocalizedEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             emptyList(),
@@ -50,7 +47,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+    void buildLocalizedEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -61,7 +58,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+    void buildLocalizedEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -74,7 +71,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildAddEnumValueActions() {
+    void buildLocalizedEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildAddEnumValueActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -88,7 +85,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
+    void buildLocalizedEnumUpdateActions_WithDifferent_ShouldBuildChangeEnumValueOrderAction() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -105,7 +102,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderActions() {
+    void buildLocalizedEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -122,7 +119,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -141,7 +138,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -160,7 +157,7 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAddAndOrderEnumValueActions() {
+    void buildLocalizedEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAddAndOrderEnumValueActions() {
         final List<UpdateAction<Type>> updateActions = buildLocalizedEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -178,16 +175,14 @@ public class BuildLocalizedEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDuplicateEnumValues_ShouldTriggerDuplicateKeyError() {
-        expectedException.expect(DuplicateKeyException.class);
-        expectedException.expectMessage("Enum Values have duplicated keys. Definition name: "
-                + "'field_definition_name', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
-                + "their definition.");
-
-        LocalizedEnumValueUpdateActionUtils.buildLocalizedEnumValuesUpdateActions(
-                "field_definition_name",
-                ENUM_VALUES_ABC,
-                ENUM_VALUES_ABB
-        );
+    void buildLocalizedEnumUpdateActions_WithDuplicateEnumValues_ShouldTriggerDuplicateKeyError() {
+        assertThatThrownBy(() -> LocalizedEnumValueUpdateActionUtils.buildLocalizedEnumValuesUpdateActions(
+            "field_definition_name",
+            ENUM_VALUES_ABC,
+            ENUM_VALUES_ABB
+        )).isInstanceOf(DuplicateKeyException.class)
+          .hasMessage("Enum Values have duplicated keys. Definition name: "
+              + "'field_definition_name', Duplicated enum value: 'b'. "
+              + "Enum Values are expected to be unique inside their definition.");
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildPlainEnumUpdateActionsTest.java
@@ -5,9 +5,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.commands.updateactions.AddEnumValue;
 import io.sphere.sdk.types.commands.updateactions.ChangeEnumValueOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -16,15 +14,13 @@ import static com.commercetools.sync.types.utils.PlainEnumValueUpdateActionUtils
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BuildPlainEnumUpdateActionsTest {
+class BuildPlainEnumUpdateActionsTest {
     private static final String FIELD_NAME_1 = "field1";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
+    void buildPlainEnumUpdateActions_WithEmptyPlainEnumValuesAndNoOldEnumValues_ShouldNotBuildActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             emptyList(),
@@ -35,7 +31,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
+    void buildPlainEnumUpdateActions_WithNewPlainEnumValuesAndNoOldPlainEnumValues_ShouldBuild3AddActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             emptyList(),
@@ -50,7 +46,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
+    void buildPlainEnumUpdateActions_WithIdenticalPlainEnum_ShouldNotBuildUpdateActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -61,7 +57,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
+    void buildPlainEnumUpdateActions_WithOnePlainEnumValue_ShouldBuildAddEnumValueAction() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -74,7 +70,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildAddEnumValueActions() {
+    void buildPlainEnumUpdateActions_WithOneEnumValueSwitch_ShouldBuildAddEnumValueActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -87,7 +83,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithDifferentOrder_ShouldBuildChangeEnumValueOrderAction() {
+    void buildPlainEnumUpdateActions_WithDifferentOrder_ShouldBuildChangeEnumValueOrderAction() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -104,7 +100,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAction() {
+    void buildPlainEnumUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAction() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -120,7 +116,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    void buildPlainEnumUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -139,7 +135,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
+    void buildPlainEnumUpdateActions_WithAddedEnumValueInBetween_ShouldBuildChangeOrderAndAddActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -158,7 +154,7 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildPlainEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAddAndChangeOrderActions() {
+    void buildPlainEnumUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAddAndChangeOrderActions() {
         final List<UpdateAction<Type>> updateActions = buildEnumValuesUpdateActions(
             FIELD_NAME_1,
             ENUM_VALUES_ABC,
@@ -176,16 +172,14 @@ public class BuildPlainEnumUpdateActionsTest {
     }
 
     @Test
-    public void buildLocalizedEnumUpdateActions_WithDuplicateEnumValues_ShouldTriggerDuplicateKeyError() {
-        expectedException.expect(DuplicateKeyException.class);
-        expectedException.expectMessage("Enum Values have duplicated keys. Definition name: "
-            + "'field_definition_name', Duplicated enum value: 'b'. Enum Values are expected to be unique inside "
-            + "their definition.");
-
-        buildEnumValuesUpdateActions(
+    void buildLocalizedEnumUpdateActions_WithDuplicateEnumValues_ShouldTriggerDuplicateKeyError() {
+        assertThatThrownBy(() -> buildEnumValuesUpdateActions(
             "field_definition_name",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        );
+        )).isInstanceOf(DuplicateKeyException.class)
+          .hasMessage("Enum Values have duplicated keys. Definition name: "
+              + "'field_definition_name', Duplicated enum value: 'b'. "
+              + "Enum Values are expected to be unique inside their definition.");
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/BuildPlainEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/BuildPlainEnumUpdateActionsTest.java
@@ -91,11 +91,12 @@ class BuildPlainEnumUpdateActionsTest {
         );
 
         assertThat(updateActions).containsExactly(
-            ChangeEnumValueOrder.of(FIELD_NAME_1, asList(
-                ENUM_VALUE_C.getKey(),
-                ENUM_VALUE_A.getKey(),
-                ENUM_VALUE_B.getKey()
-            ))
+            ChangeEnumValueOrder.of(FIELD_NAME_1,
+                asList(
+                    ENUM_VALUE_C.getKey(),
+                    ENUM_VALUE_A.getKey(),
+                    ENUM_VALUE_B.getKey()
+                ))
         );
     }
 
@@ -177,9 +178,10 @@ class BuildPlainEnumUpdateActionsTest {
             "field_definition_name",
             ENUM_VALUES_ABC,
             ENUM_VALUES_ABB
-        )).isInstanceOf(DuplicateKeyException.class)
-          .hasMessage("Enum Values have duplicated keys. Definition name: "
-              + "'field_definition_name', Duplicated enum value: 'b'. "
-              + "Enum Values are expected to be unique inside their definition.");
+        ))
+            .isInstanceOf(DuplicateKeyException.class)
+            .hasMessage("Enum Values have duplicated keys. Definition name: "
+                + "'field_definition_name', Duplicated enum value: 'b'. "
+                + "Enum Values are expected to be unique inside their definition.");
     }
 }

--- a/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/FieldDefinitionUpdateActionUtilsTest.java
@@ -16,8 +16,8 @@ import io.sphere.sdk.types.commands.updateactions.AddLocalizedEnumValue;
 import io.sphere.sdk.types.commands.updateactions.ChangeEnumValueOrder;
 import io.sphere.sdk.types.commands.updateactions.ChangeFieldDefinitionLabel;
 import io.sphere.sdk.types.commands.updateactions.ChangeLocalizedEnumValueOrder;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +31,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FieldDefinitionUpdateActionUtilsTest {
+class FieldDefinitionUpdateActionUtilsTest {
     private static final String FIELD_NAME_1 = "fieldName1";
     private static final String LABEL_1 = "label1";
     private static final String LABEL_2 = "label2";
@@ -50,29 +50,29 @@ public class FieldDefinitionUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         old = stringFieldDefinition(FIELD_NAME_1, LABEL_1, false, TextInputHint.SINGLE_LINE);
         newSame = stringFieldDefinition(FIELD_NAME_1, LABEL_1, false, TextInputHint.SINGLE_LINE);
         newDifferent = stringFieldDefinition(FIELD_NAME_1, LABEL_2, true, TextInputHint.MULTI_LINE);
     }
 
     @Test
-    public void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<Type>> result = buildChangeLabelUpdateAction(old, newDifferent);
 
         assertThat(result).contains(ChangeFieldDefinitionLabel.of(old.getName(), newDifferent.getLabel()));
     }
 
     @Test
-    public void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<Type>> result = buildChangeLabelUpdateAction(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildActions_WithNewDifferentValues_ShouldReturnActions() {
+    void buildActions_WithNewDifferentValues_ShouldReturnActions() {
         final List<UpdateAction<Type>> result = buildActions(old, newDifferent);
 
         assertThat(result).containsExactlyInAnyOrder(
@@ -81,14 +81,14 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameValues_ShouldReturnEmpty() {
+    void buildActions_WithSameValues_ShouldReturnEmpty() {
         final List<UpdateAction<Type>> result = buildActions(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
+    void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
                 EnumFieldType.of(singletonList(ENUM_VALUE_A)),
                 FIELD_NAME_1,
@@ -110,7 +110,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithoutOldPlainEnum_ShouldNotReturnAnyValueAction() {
+    void buildActions_WithoutOldPlainEnum_ShouldNotReturnAnyValueAction() {
 
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
                 EnumFieldType.of(singletonList(ENUM_VALUE_A)),
@@ -133,7 +133,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
+    void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
 
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
                 LocalizedEnumFieldType.of(singletonList(LOCALIZED_ENUM_VALUE_A)),
@@ -156,7 +156,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithStringFieldTypesWithLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithStringFieldTypesWithLabelChanges_ShouldBuildChangeLabelAction() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(StringFieldType.of(),"fieldName1",
             ofEnglish("label1"), false);
 
@@ -171,7 +171,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSetOfStringFieldTypesWithDefinitionLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSetOfStringFieldTypesWithDefinitionLabelChanges_ShouldBuildChangeLabelAction() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(StringFieldType.of()),
             "fieldName1", ofEnglish("label1"), false);
 
@@ -186,7 +186,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSetOfSetOfStringFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSetOfSetOfStringFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             SetFieldType.of(SetFieldType.of(StringFieldType.of())), "fieldName1", ofEnglish("label1"), false);
 
@@ -201,7 +201,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameSetOfEnumsFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSameSetOfEnumsFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(SetFieldType.of(EnumFieldType.of(emptyList())),
             "fieldName1", ofEnglish("label1"), false);
 
@@ -216,7 +216,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfEnumFieldTypes_ShouldBuildEnumActions() {
+    void buildActions_WithChangedSetOfEnumFieldTypes_ShouldBuildEnumActions() {
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             SetFieldType.of(EnumFieldType.of(
                 asList(
@@ -244,7 +244,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithSameSetOfLEnumFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
+    void buildActions_WithSameSetOfLEnumFieldTypesWithDefLabelChanges_ShouldBuildChangeLabelAction() {
         // preparation
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             SetFieldType.of(SetFieldType.of(LocalizedEnumFieldType.of(emptyList()))),
@@ -264,7 +264,7 @@ public class FieldDefinitionUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildActions_WithChangedSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
+    void buildActions_WithChangedSetOfLocalizedEnumFieldTypes_ShouldBuildEnumActions() {
         // preparation
         final FieldDefinition oldFieldDefinition = FieldDefinition.of(
             SetFieldType.of(LocalizedEnumFieldType.of(

--- a/src/test/java/com/commercetools/sync/types/utils/TypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/types/utils/TypeUpdateActionUtilsTest.java
@@ -8,8 +8,8 @@ import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.TypeDraftBuilder;
 import io.sphere.sdk.types.commands.updateactions.ChangeName;
 import io.sphere.sdk.types.commands.updateactions.SetDescription;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.Set;
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TypeUpdateActionUtilsTest {
+class TypeUpdateActionUtilsTest {
     private static Type old;
     private static TypeDraft newSame;
     private static TypeDraft newDifferent;
@@ -28,8 +28,8 @@ public class TypeUpdateActionUtilsTest {
     /**
      * Initialises test data.
      */
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         final String key = "category-custom-type-key";
         final LocalizedString name = LocalizedString.ofEnglish("type for standard categories");
         final LocalizedString desc = LocalizedString.ofEnglish("description for category custom type");
@@ -56,28 +56,28 @@ public class TypeUpdateActionUtilsTest {
     }
 
     @Test
-    public void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
+    void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<Type>> result = buildChangeNameUpdateAction(old, newDifferent);
 
         assertThat(result).contains(ChangeName.of(newDifferent.getName()));
     }
 
     @Test
-    public void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<Type>> result = buildChangeNameUpdateAction(old, newSame);
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    public void buildSetDescriptionAction_WithDifferentValues_ShouldReturnAction() {
+    void buildSetDescriptionAction_WithDifferentValues_ShouldReturnAction() {
         final Optional<UpdateAction<Type>> result = buildSetDescriptionUpdateAction(old, newDifferent);
 
         assertThat(result).contains(SetDescription.of(newDifferent.getDescription()));
     }
 
     @Test
-    public void buildSetDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
+    void buildSetDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
         final Optional<UpdateAction<Type>> result = buildSetDescriptionUpdateAction(old, newSame);
 
         assertThat(result).isEmpty();


### PR DESCRIPTION
#### Summary
Migrate junit4 to junit5 completely.

#### Description
Since we don't use the junit4 dependency and was depending on the junit4 dependncy from the JVM SDK. Now that that the JVM SDK limites its scope to test only. We migrate to junit5 completely.

#### Hints for Review
The changes are mostly:

- Make tests not public as its not required anymore by junit5
- Instead of `@BeforeClass` use `@BeforeAll`
- Instead of `@Before` use @BeforeEach`
- Instead of `@AfterClass` use `@AfterAll`
- Instead of `@After` use `@AfterEach`
- Use `@ExtendWith(MockitoExtension.class)` instead of `@RunWith(MockitoRunner.class)`
- Use `@Disabled` instead of `@Ignore`
- All changes are in the test, integration-test and benchmarks source sets.
