### PR TITLE
Use JUnit engines in benchmarks source sets

### DIFF
--- a/gradle-scripts/benchmark.gradle
+++ b/gradle-scripts/benchmark.gradle
@@ -11,11 +11,15 @@ sourceSets {
 
 configurations {
     benchmarkImplementation.extendsFrom implementation, testImplementation
+    benchmarkRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 task benchmark(type: Test) {
     doFirst{
         grgit.clone(dir: 'tmp_git_dir/', uri: scmProjectUrl, checkout: true, refToCheckout: 'gh-pages')
+    }
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter', 'junit-vintage'
     }
     testClassesDirs = sourceSets.benchmark.output.classesDirs
     classpath = sourceSets.benchmark.runtimeClasspath


### PR DESCRIPTION
#### Summary
Benchmarks weren't running before: https://travis-ci.org/commercetools/commercetools-sync-java/jobs/553671170#L634

After updating to the new Junit. This was due to missing configuration in the benchmark gradle task. 
This PR fixes it.


