### PR TITLE
417 sync tax categories

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/TaxCategoryITUtils.java
@@ -20,11 +20,15 @@ import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static java.util.Collections.singletonList;
 
 public final class TaxCategoryITUtils {
-    private static final String TAXCATEGORY_KEY = "old_tax_category_key";
+    public static final String TAXCATEGORY_KEY = "old_tax_category_key";
     private static final String TAXCATEGORY_NAME = "old_tax_category_name";
     private static final String TAXCATEGORY_DESCRIPTION = "old_tax_category_desc";
     private static final String TAXCATEGORY_TAXRATE_NAME = "old_tax_rate_name";
     private static final double TAXCATEGORY_TAXRATE_AMOUNT = 0.2;
+
+    public static final String TAXCATEGORY_KEY_1 = "key_1";
+    public static final String TAXCATEGORY_NAME_1 = "name_1";
+    public static final String TAXCATEGORY_DESCRIPTION_1 = "description_1";
 
     /**
      * Deletes all Tax categories from CTP projects defined by the {@code CTP_SOURCE_CLIENT} and
@@ -74,4 +78,5 @@ public final class TaxCategoryITUtils {
 
     private TaxCategoryITUtils() {
     }
+
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/TaxCategoryServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/TaxCategoryServiceImplIT.java
@@ -1,46 +1,80 @@
 package com.commercetools.sync.integration.services.impl;
 
-import com.commercetools.sync.products.ProductSyncOptions;
-import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.services.TaxCategoryService;
 import com.commercetools.sync.services.impl.TaxCategoryServiceImpl;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptionsBuilder;
+import io.sphere.sdk.client.BadGatewayException;
+import io.sphere.sdk.client.ErrorResponseException;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.taxcategories.TaxCategoryDraft;
 import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
 import io.sphere.sdk.taxcategories.commands.TaxCategoryCreateCommand;
+import io.sphere.sdk.taxcategories.commands.updateactions.ChangeName;
+import io.sphere.sdk.taxcategories.commands.updateactions.SetKey;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import io.sphere.sdk.utils.CompletableFutureUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.TAXCATEGORY_DESCRIPTION_1;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.TAXCATEGORY_KEY;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.TAXCATEGORY_KEY_1;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.TAXCATEGORY_NAME_1;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxCategory;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxRateDraft;
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.deleteTaxCategories;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static java.lang.String.format;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TaxCategoryServiceImplIT {
     private TaxCategoryService taxCategoryService;
     private TaxCategory oldTaxCategory;
     private ArrayList<String> warnings;
 
+    private List<String> errorCallBackMessages;
+    private List<Throwable> errorCallBackExceptions;
+
     /**
      * Deletes tax categories from the target CTP projects, then it populates target CTP project with test data.
      */
     @BeforeEach
     void setup() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+
         deleteTaxCategories(CTP_TARGET_CLIENT);
         warnings = new ArrayList<>();
         oldTaxCategory = createTaxCategory(CTP_TARGET_CLIENT);
-        final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
-                                                                               .warningCallback(warnings::add)
-                                                                               .build();
-        taxCategoryService = new TaxCategoryServiceImpl(productSyncOptions);
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+            .warningCallback(warnings::add)
+            .errorCallback((errorMessage, exception) -> {
+                errorCallBackMessages.add(errorMessage);
+                errorCallBackExceptions.add(exception);
+            })
+            .build();
+        taxCategoryService = new TaxCategoryServiceImpl(taxCategorySyncOptions);
     }
 
     /**
@@ -54,8 +88,8 @@ class TaxCategoryServiceImplIT {
     @Test
     void fetchCachedTaxCategoryId_WithNonExistingTaxCategory_ShouldNotFetchATaxCategory() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId("non-existing-key")
-                                                                 .toCompletableFuture()
-                                                                 .join();
+            .toCompletableFuture()
+            .join();
         assertThat(taxCategoryId).isEmpty();
         assertThat(warnings).isEmpty();
     }
@@ -63,8 +97,8 @@ class TaxCategoryServiceImplIT {
     @Test
     void fetchCachedTaxCategoryId_WithExistingTaxCategory_ShouldFetchProductTypeAndCache() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(oldTaxCategory.getKey())
-                                                                 .toCompletableFuture()
-                                                                 .join();
+            .toCompletableFuture()
+            .join();
         assertThat(taxCategoryId).isNotEmpty();
         assertThat(warnings).isEmpty();
     }
@@ -84,8 +118,8 @@ class TaxCategoryServiceImplIT {
 
 
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(newTaxCategoryKey)
-                                                                 .toCompletableFuture()
-                                                                 .join();
+            .toCompletableFuture()
+            .join();
 
         assertThat(taxCategoryId).isEmpty();
         assertThat(warnings).isEmpty();
@@ -101,20 +135,321 @@ class TaxCategoryServiceImplIT {
             CTP_TARGET_CLIENT.execute(TaxCategoryCreateCommand.of(taxCategoryDraft)));
 
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(oldTaxCategory.getKey())
-                                                                 .toCompletableFuture()
-                                                                 .join();
+            .toCompletableFuture()
+            .join();
 
         assertThat(taxCategoryId).isNotEmpty();
         assertThat(warnings).contains(format("TaxCategory with id: '%s' has no key"
-            + " set. Keys are required for taxCategory matching.", newTaxCategory.getId()));
+            + " set. Keys are required for resource matching.", newTaxCategory.getId()));
     }
 
     @Test
-    void fetchCachedTaxCategoryId_WithWithNullKey_ShouldReturnFutureWithEmptyOptional() {
+    void fetchCachedTaxCategoryId_WithNullKey_ShouldReturnFutureWithEmptyOptional() {
         final Optional<String> taxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(null)
-                                                                 .toCompletableFuture()
-                                                                 .join();
+            .toCompletableFuture()
+            .join();
         assertThat(taxCategoryId).isEmpty();
         assertThat(warnings).isEmpty();
     }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithEmptySetOfKeys_ShouldReturnEmptySet() {
+        final Set<String> taxCategoryKeys = new HashSet<>();
+        final Set<TaxCategory> matchingTaxCategories = taxCategoryService
+            .fetchMatchingTaxCategoriesByKeys(taxCategoryKeys)
+            .toCompletableFuture()
+            .join();
+
+        assertThat(matchingTaxCategories).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithNonExistingKeys_ShouldReturnEmptySet() {
+        final Set<String> taxCategoryKeys = new HashSet<>();
+        taxCategoryKeys.add("taxCategory_key_1");
+        taxCategoryKeys.add("taxCategory_key_2");
+
+        final Set<TaxCategory> matchingTaxCategories = taxCategoryService
+            .fetchMatchingTaxCategoriesByKeys(taxCategoryKeys)
+            .toCompletableFuture()
+            .join();
+
+        assertThat(matchingTaxCategories).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithAnyExistingKeys_ShouldReturnASetOfTaxCategories() {
+        final Set<String> taxCategoryKeys = new HashSet<>();
+        taxCategoryKeys.add(TAXCATEGORY_KEY);
+
+        final Set<TaxCategory> matchingTaxCategories = taxCategoryService
+            .fetchMatchingTaxCategoriesByKeys(taxCategoryKeys)
+            .toCompletableFuture()
+            .join();
+
+        assertThat(matchingTaxCategories).hasSize(1);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithBadGateWayExceptionAlways_ShouldFail() {
+        // Mock sphere client to return BadGatewayException on any request.
+        final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
+        when(spyClient.execute(any(TaxCategoryQuery.class)))
+            .thenReturn(CompletableFutureUtils.exceptionallyCompletedFuture(new BadGatewayException()))
+            .thenCallRealMethod();
+
+        final TaxCategorySyncOptions spyOptions =
+            TaxCategorySyncOptionsBuilder.of(spyClient)
+                .errorCallback((errorMessage, exception) -> {
+                    errorCallBackMessages.add(errorMessage);
+                    errorCallBackExceptions.add(exception);
+                })
+                .build();
+
+        final TaxCategoryService spyTaxCategoryService = new TaxCategoryServiceImpl(spyOptions);
+
+
+        final Set<String> keys = new HashSet<>();
+        keys.add(TAXCATEGORY_KEY);
+
+        // test and assert
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(spyTaxCategoryService.fetchMatchingTaxCategoriesByKeys(keys))
+            .hasFailedWithThrowableThat()
+            .isExactlyInstanceOf(BadGatewayException.class);
+    }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithAllExistingSetOfKeys_ShouldCacheFetchedTaxCategoryIds() {
+        final Set<TaxCategory> fetchedTaxCategories = taxCategoryService.fetchMatchingTaxCategoriesByKeys(
+            singleton(TAXCATEGORY_KEY))
+            .toCompletableFuture().join();
+        assertThat(fetchedTaxCategories).hasSize(1);
+
+        final Optional<TaxCategory> taxCategoryOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of().withPredicates(queryModel -> queryModel.key().is(TAXCATEGORY_KEY)))
+            .toCompletableFuture()
+            .join()
+            .head();
+
+        assertThat(taxCategoryOptional).isNotNull();
+
+        // Change taxCategory old_taxCategory_key on ctp
+        final String newKey = "new_taxCategory_key";
+        taxCategoryService.updateTaxCategory(taxCategoryOptional.get(), Collections.singletonList(SetKey.of(newKey)))
+            .toCompletableFuture()
+            .join();
+
+        // Fetch cached id by old key
+        final Optional<String> cachedTaxCategoryId = taxCategoryService.fetchCachedTaxCategoryId(TAXCATEGORY_KEY)
+            .toCompletableFuture()
+            .join();
+
+        assertThat(cachedTaxCategoryId).isNotEmpty();
+        assertThat(cachedTaxCategoryId).contains(taxCategoryOptional.get().getId());
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void createTaxCategory_WithValidTaxCategory_ShouldCreateTaxCategoryAndCacheId() {
+        final TaxCategoryDraft newTaxCategoryDraft = TaxCategoryDraftBuilder.of(
+            TAXCATEGORY_NAME_1,
+            singletonList(createTaxRateDraft()),
+            TAXCATEGORY_DESCRIPTION_1)
+            .key(TAXCATEGORY_KEY_1)
+            .build();
+
+        final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
+        final TaxCategorySyncOptions spyOptions = TaxCategorySyncOptionsBuilder
+            .of(spyClient)
+            .errorCallback((errorMessage, exception) -> {
+                errorCallBackMessages.add(errorMessage);
+                errorCallBackExceptions.add(exception);
+            })
+            .build();
+
+        final TaxCategoryService spyTaxCategoryService = new TaxCategoryServiceImpl(spyOptions);
+
+        //test
+        final Optional<TaxCategory> createdTaxCategory = spyTaxCategoryService
+            .createTaxCategory(newTaxCategoryDraft)
+            .toCompletableFuture().join();
+
+        final Optional<TaxCategory> queriedOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of().withPredicates(taxCategoryQueryModel ->
+                taxCategoryQueryModel.key().is(TAXCATEGORY_KEY_1)))
+            .toCompletableFuture().join().head();
+
+        assertThat(queriedOptional).hasValueSatisfying(queried ->
+            assertThat(createdTaxCategory).hasValueSatisfying(created -> {
+                assertThat(created.getKey()).isEqualTo(queried.getKey());
+                assertThat(created.getDescription()).isEqualTo(queried.getDescription());
+                assertThat(created.getName()).isEqualTo(queried.getName());
+            }));
+
+        // Assert that the created taxCategory is cached
+        final Optional<String> taxCategoryId =
+            spyTaxCategoryService.fetchCachedTaxCategoryId(TAXCATEGORY_KEY_1).toCompletableFuture().join();
+        assertThat(taxCategoryId).isPresent();
+        verify(spyClient, times(0)).execute(any(TaxCategoryQuery.class));
+    }
+
+    @Test
+    void createTaxCategory_WithInvalidTaxCategory_ShouldHaveEmptyOptionalAsAResult() {
+        //preparation
+        final TaxCategoryDraft newTaxCategoryDraft = TaxCategoryDraftBuilder.of(
+            TAXCATEGORY_NAME_1,
+            singletonList(createTaxRateDraft()),
+            TAXCATEGORY_DESCRIPTION_1)
+            .key("")
+            .build();
+
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder
+            .of(CTP_TARGET_CLIENT)
+            .errorCallback((errorMessage, exception) -> {
+                errorCallBackMessages.add(errorMessage);
+                errorCallBackExceptions.add(exception);
+            })
+            .build();
+
+        final TaxCategoryService taxCategoryService = new TaxCategoryServiceImpl(options);
+
+        // test
+        final Optional<TaxCategory> result =
+            taxCategoryService.createTaxCategory(newTaxCategoryDraft).toCompletableFuture().join();
+
+        // assertion
+        assertThat(result).isEmpty();
+        assertThat(errorCallBackMessages)
+            .containsExactly("Failed to create draft with key: ''. Reason: Draft key is blank!");
+    }
+
+    @Test
+    void createTaxCategory_WithDuplicateKey_ShouldHaveEmptyOptionalAsAResult() {
+        //preparation
+        final TaxCategoryDraft newTaxCategoryDraft = TaxCategoryDraftBuilder.of(
+            TAXCATEGORY_NAME_1,
+            singletonList(createTaxRateDraft()),
+            TAXCATEGORY_DESCRIPTION_1)
+            .key(TAXCATEGORY_KEY)
+            .build();
+
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder
+            .of(CTP_TARGET_CLIENT)
+            .errorCallback((errorMessage, exception) -> {
+                errorCallBackMessages.add(errorMessage);
+                errorCallBackExceptions.add(exception);
+            })
+            .build();
+
+        final TaxCategoryService taxCategoryService = new TaxCategoryServiceImpl(options);
+
+        // test
+        final Optional<TaxCategory> result =
+            taxCategoryService.createTaxCategory(newTaxCategoryDraft).toCompletableFuture().join();
+
+        // assertion
+        assertThat(result).isEmpty();
+        assertThat(errorCallBackMessages)
+            .hasSize(1)
+            .hasOnlyOneElementSatisfying(msg -> assertThat(msg).contains("A duplicate value"));
+
+        assertThat(errorCallBackExceptions)
+            .hasSize(1)
+            .hasOnlyOneElementSatisfying(exception -> {
+                assertThat(exception).isExactlyInstanceOf(ErrorResponseException.class);
+                final ErrorResponseException errorResponseException = (ErrorResponseException) exception;
+
+                final List<DuplicateFieldError> fieldErrors = errorResponseException
+                    .getErrors()
+                    .stream()
+                    .map(sphereError -> {
+                        assertThat(sphereError.getCode()).isEqualTo(DuplicateFieldError.CODE);
+                        return sphereError.as(DuplicateFieldError.class);
+                    })
+                    .collect(toList());
+                assertThat(fieldErrors).hasSize(1);
+            });
+    }
+
+    @Test
+    void updateTaxCategory_WithValidChanges_ShouldUpdateTaxCategoryCorrectly() {
+        final Optional<TaxCategory> taxCategoryOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of()
+                .withPredicates(taxCategoryQueryModel -> taxCategoryQueryModel.key().is(TAXCATEGORY_KEY)))
+            .toCompletableFuture().join().head();
+        assertThat(taxCategoryOptional).isNotNull();
+
+        final ChangeName changeNameUpdateAction = ChangeName.of("new_taxCategory_name");
+
+        final TaxCategory updatedTaxCategory = taxCategoryService.updateTaxCategory(taxCategoryOptional.get(),
+            singletonList(changeNameUpdateAction))
+            .toCompletableFuture().join();
+        assertThat(updatedTaxCategory).isNotNull();
+
+        final Optional<TaxCategory> updatedTaxCategoryOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of()
+                .withPredicates(taxCategoryQueryModel -> taxCategoryQueryModel.key().is(TAXCATEGORY_KEY)))
+            .toCompletableFuture().join().head();
+
+        assertThat(taxCategoryOptional).isNotEmpty();
+        final TaxCategory fetchedTaxCategory = updatedTaxCategoryOptional.get();
+        assertThat(fetchedTaxCategory.getKey()).isEqualTo(updatedTaxCategory.getKey());
+        assertThat(fetchedTaxCategory.getDescription()).isEqualTo(updatedTaxCategory.getDescription());
+        assertThat(fetchedTaxCategory.getName()).isEqualTo(updatedTaxCategory.getName());
+    }
+
+    @Test
+    void updateTaxCategory_WithInvalidChanges_ShouldCompleteExceptionally() {
+        final Optional<TaxCategory> taxCategoryOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of()
+                .withPredicates(taxCategoryQueryModel -> taxCategoryQueryModel.key().is(TAXCATEGORY_KEY)))
+            .toCompletableFuture().join().head();
+        assertThat(taxCategoryOptional).isNotNull();
+
+        final ChangeName changeNameUpdateAction = ChangeName.of(null);
+        taxCategoryService.updateTaxCategory(taxCategoryOptional.get(), singletonList(changeNameUpdateAction))
+            .exceptionally(exception -> {
+                assertThat(exception).isNotNull();
+                assertThat(exception.getMessage()).contains("Request body does not contain valid JSON.");
+                return null;
+            })
+            .toCompletableFuture().join();
+    }
+
+    @Test
+    void fetchTaxCategory_WithExistingTaxCategoryKey_ShouldFetchTaxCategory() {
+        final Optional<TaxCategory> taxCategoryOptional = CTP_TARGET_CLIENT
+            .execute(TaxCategoryQuery.of()
+                .withPredicates(taxCategoryQueryModel -> taxCategoryQueryModel.key().is(TAXCATEGORY_KEY)))
+            .toCompletableFuture().join().head();
+        assertThat(taxCategoryOptional).isNotNull();
+
+        final Optional<TaxCategory> fetchedTaxCategoryOptional =
+            executeBlocking(taxCategoryService.fetchTaxCategory(TAXCATEGORY_KEY));
+        assertThat(fetchedTaxCategoryOptional).isEqualTo(taxCategoryOptional);
+    }
+
+    @Test
+    void fetchTaxCategory_WithBlankKey_ShouldNotFetchTaxCategory() {
+        final Optional<TaxCategory> fetchedTaxCategoryOptional =
+            executeBlocking(taxCategoryService.fetchTaxCategory(StringUtils.EMPTY));
+        assertThat(fetchedTaxCategoryOptional).isEmpty();
+    }
+
+    @Test
+    void fetchTaxCategory_WithNullKey_ShouldNotFetchTaxCategory() {
+        final Optional<TaxCategory> fetchedTaxCategoryOptional =
+            executeBlocking(taxCategoryService.fetchTaxCategory(null));
+        assertThat(fetchedTaxCategoryOptional).isEmpty();
+    }
+
 }

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -21,6 +21,7 @@ import com.commercetools.sync.services.impl.ProductTypeServiceImpl;
 import com.commercetools.sync.services.impl.StateServiceImpl;
 import com.commercetools.sync.services.impl.TaxCategoryServiceImpl;
 import com.commercetools.sync.services.impl.TypeServiceImpl;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptionsBuilder;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
@@ -81,7 +82,8 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                 new TypeServiceImpl(productSyncOptions),
                 new ChannelServiceImpl(productSyncOptions),
                 new CustomerGroupServiceImpl(productSyncOptions),
-                new TaxCategoryServiceImpl(productSyncOptions),
+                new TaxCategoryServiceImpl(TaxCategorySyncOptionsBuilder.of(productSyncOptions.getCtpClient())
+                    .warningCallback(productSyncOptions.getWarningCallBack()).build()),
                 new StateServiceImpl(productSyncOptions, PRODUCT_STATE));
     }
 

--- a/src/main/java/com/commercetools/sync/services/TaxCategoryService.java
+++ b/src/main/java/com/commercetools/sync/services/TaxCategoryService.java
@@ -1,13 +1,20 @@
 package com.commercetools.sync.services;
 
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 public interface TaxCategoryService {
+
     /**
      * Given a {@code key}, this method first checks if a cached map of TaxCategory keys -&gt; ids is not empty.
      * If not, it returns a completed future that contains an optional that contains what this key maps to in
@@ -27,4 +34,70 @@ public interface TaxCategoryService {
      */
     @Nonnull
     CompletionStage<Optional<String>> fetchCachedTaxCategoryId(@Nullable final String key);
+
+    /**
+     * Given a {@link Set} of tax category keys, this method fetches a set of all the taxCategories, matching
+     * given set of keys in the CTP project, defined in an injected {@link SphereClient}. A mapping of the key to
+     * the id of the fetched taxCategories is persisted in an in-memory map.
+     * <br>
+     * One must remember key is not required to create TaxCategory but is required to synchronize tax categories.
+     *
+     * @param taxCategoryKeys set of tax category keys to fetch matching taxCategories by.
+     * @return {@link CompletionStage}&lt;{@link Map}&gt; in which the result of it's completion contains a {@link Set}
+     *         of all matching taxCategories.
+     */
+    @Nonnull
+    CompletionStage<Set<TaxCategory>> fetchMatchingTaxCategoriesByKeys(@Nonnull final Set<String> taxCategoryKeys);
+
+    /**
+     * Given a tax category key, this method fetches a tax category that matches given key in the CTP project
+     * defined in a potentially injected {@link SphereClient}. If there is no matching tax category an empty
+     * {@link Optional} will be returned in the returned future. A mapping of the key to the id of the fetched category
+     * is persisted in an in-memory map.
+     *
+     * @param key the key of the tax category to fetch.
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
+     *         {@link Optional} that contains the matching {@link TaxCategory} if exists, otherwise empty.
+     */
+    @Nonnull
+    CompletionStage<Optional<TaxCategory>> fetchTaxCategory(@Nullable final String key);
+
+    /**
+     * Given a resource draft of type {@link TaxCategoryDraft}, this method attempts to create a resource
+     * {@link TaxCategory} based on it in the CTP project defined by the sync options.
+     *
+     * <p>A completion stage containing an empty option and the error callback will be triggered in those cases:
+     * <ul>
+     * <li>the draft has a blank key</li>
+     * <li>the create request fails on CTP</li>
+     * </ul>
+     *
+     * <p>On the other hand, if the resource gets created successfully on CTP, then the created resource's id and
+     * key are cached and the method returns a {@link CompletionStage} in which the result of it's completion
+     * contains an instance {@link Optional} of the resource which was created.
+     *
+     * @param taxCategoryDraft the resource draft to create a resource based off of.
+     * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
+     *         empty optional.
+     */
+    @Nonnull
+    CompletionStage<Optional<TaxCategory>> createTaxCategory(@Nonnull final TaxCategoryDraft taxCategoryDraft);
+
+    /**
+     * Given a {@link TaxCategory} and a {@link List}&lt;{@link UpdateAction}&lt;{@link TaxCategory}&gt;&gt;, this
+     * method issues an update request with these update actions on this {@link TaxCategory} in the CTP project defined
+     * in a potentially injected {@link io.sphere.sdk.client.SphereClient}. This method returns
+     * {@link CompletionStage}&lt;{@link TaxCategory}&gt; in which the result of it's completion contains an instance
+     * of the {@link TaxCategory} which was updated in the CTP project.
+     *
+     * @param taxCategory   the {@link TaxCategory} to update.
+     * @param updateActions the update actions to update the {@link TaxCategory} with.
+     * @return {@link CompletionStage}&lt;{@link TaxCategory}&gt; containing as a result of it's completion an instance
+     *         of the {@link TaxCategory} which was updated in the CTP project or a
+     *         {@link io.sphere.sdk.models.SphereException}.
+     */
+    @Nonnull
+    CompletionStage<TaxCategory> updateTaxCategory(@Nonnull final TaxCategory taxCategory,
+                                                   @Nonnull final List<UpdateAction<TaxCategory>> updateActions);
+
 }

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -1,20 +1,31 @@
 package com.commercetools.sync.services.impl;
 
 import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.CtpQueryUtils;
+import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.DraftBasedCreateCommand;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.commands.UpdateCommand;
 import io.sphere.sdk.models.Resource;
+import io.sphere.sdk.queries.MetaModelQueryDsl;
+import io.sphere.sdk.queries.QueryPredicate;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static java.lang.String.format;
@@ -22,11 +33,18 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * @param <T> Resource Draft (e.g. {@link io.sphere.sdk.products.ProductDraft},
- *  {@link io.sphere.sdk.categories.CategoryDraft}, etc..
+ *            {@link io.sphere.sdk.categories.CategoryDraft}, etc..
  * @param <U> Resource (e.g. {@link io.sphere.sdk.products.Product}, {@link io.sphere.sdk.categories.Category}, etc..
  * @param <S> Subclass of {@link BaseSyncOptions}
+ * @param <Q> Query (e.g. {@link io.sphere.sdk.products.queries.ProductQuery},
+ *            {@link io.sphere.sdk.categories.queries.CategoryQuery}, etc..
+ * @param <M> Query Model (e.g. {@link io.sphere.sdk.products.queries.ProductQueryModel},
+ *            {@link io.sphere.sdk.categories.queries.CategoryQueryModel}, etc..
+ * @param <E> Expansion Model (e.g. {@link io.sphere.sdk.products.expansion.ProductExpansionModel},
+ *            {@link io.sphere.sdk.categories.expansion.CategoryExpansionModel}, etc..
  */
-class BaseService<T, U extends Resource<U>, S extends BaseSyncOptions> {
+abstract class BaseService<T, U extends Resource<U>, S extends BaseSyncOptions,
+    Q extends MetaModelQueryDsl<U, Q, M, E>, M, E> {
 
     final S syncOptions;
     boolean isCached = false;
@@ -93,16 +111,16 @@ class BaseService<T, U extends Resource<U>, S extends BaseSyncOptions> {
      *
      * <p>A completion stage containing an empty option and the error callback will be triggered in those cases:
      * <ul>
-     *     <li>the draft has a blank key</li>
-     *     <li>the create request fails on CTP</li>
+     * <li>the draft has a blank key</li>
+     * <li>the create request fails on CTP</li>
      * </ul>
      *
      * <p>On the other hand, if the resource gets created successfully on CTP, then the created resource's id and
      * key are cached and the method returns a {@link CompletionStage} in which the result of it's completion
      * contains an instance {@link Optional} of the resource which was created.
      *
-     * @param draft the resource draft to create a resource based off of.
-     * @param keyMapper a function to get the key from the supplied draft.
+     * @param draft         the resource draft to create a resource based off of.
+     * @param keyMapper     a function to get the key from the supplied draft.
      * @param createCommand a function to get the create command using the supplied draft.
      * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
      *         empty optional.
@@ -135,4 +153,156 @@ class BaseService<T, U extends Resource<U>, S extends BaseSyncOptions> {
         }
 
     }
+
+    /**
+     * Given a {@code key}, if it is blank (null/empty), a completed future with an empty optional is returned.
+     * This method then checks if the cached map of resource keys -&gt; ids contains the key. If it does, then an
+     * optional containing the mapped id is returned. If the cache doesn't contain the key; this method attempts to
+     * fetch the id of the key from the CTP project, caches it and returns a
+     * {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's completion
+     * could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no resource
+     * was found in the CTP project with this key.
+     *
+     * @param key the key by which a resource id should be fetched from the CTP project.
+     * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
+     *         completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     *         resource was found in the CTP project with this key.
+     */
+    @Nonnull
+    CompletionStage<Optional<String>> fetchCachedResourceId(@Nullable final String key) {
+        if (isBlank(key)) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        if (keyToIdCache.isEmpty()) {
+            return fetchAndCache(key);
+        }
+        return CompletableFuture.completedFuture(Optional.ofNullable(keyToIdCache.get(key)));
+    }
+
+    /**
+     * Given a {@code key}, this method queries a CTP project and fetches all available resource of given type.
+     * Next it stores key - id pair in the {@code keyToIdCache}.
+     *
+     * @param key the key by which a resource id should be fetched from the CTP project
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
+     *         {@link Optional} that contains the matching id if exists, otherwise empty.
+     */
+    abstract CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key);
+
+    /**
+     * The default implementation of the {@link #fetchAndCache(String)} abstract method.
+     *
+     * @param key       the key by which a resource id should be fetched from the CTP project
+     * @param query     a function to get a query
+     * @param keyMapper a function to get the key from the returned resource
+     * @param typeName  a resource type name, f.e.: <i>ProductType</i>
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
+     *         {@link Optional} that contains the matching id if exists, otherwise empty.
+     */
+    CompletionStage<Optional<String>> fetchAndCache(@Nullable final String key,
+                                                    @Nonnull final Supplier<Q> query,
+                                                    @Nonnull final Function<U, String> keyMapper,
+                                                    @Nonnull final String typeName) {
+        final Consumer<List<U>> resourcePageConsumer = resourcePage ->
+            resourcePage.forEach(resource -> {
+                final String fetchedResourceKey = keyMapper.apply(resource);
+                final String id = resource.getId();
+                if (StringUtils.isNotBlank(fetchedResourceKey)) {
+                    keyToIdCache.put(fetchedResourceKey, id);
+                } else {
+                    syncOptions.applyWarningCallback(format("%s with id: '%s' has no key set. Keys are"
+                        + " required for resource matching.", typeName, id));
+                }
+            });
+
+        return CtpQueryUtils
+            .queryAll(syncOptions.getCtpClient(), query.get(), resourcePageConsumer)
+            .thenApply(result -> Optional.ofNullable(keyToIdCache.get(key)));
+    }
+
+    /**
+     * Given a {@link Set} of resource keys, this method fetches a set of all the resources, matching this given set of
+     * keys in the CTP project, defined in an injected {@link SphereClient}. A mapping of the key to the id
+     * of the fetched resources is persisted in an in-memory map.
+     *
+     * @param resourceKeys set of state keys to fetch matching states by
+     * @param query        a function to get query
+     * @param keyMapper    a function to get the key from the returned resource
+     * @return {@link CompletionStage}&lt;{@link Set}&lt;{@code U}&gt;&gt; in which the result of it's completion
+     *         contains a {@link Set} of all matching resources.
+     */
+    @Nonnull
+    CompletionStage<Set<U>> fetchMatchingResources(@Nonnull final Set<String> resourceKeys,
+                                                   @Nonnull final Supplier<Q> query,
+                                                   @Nonnull final Function<U, String> keyMapper) {
+        if (resourceKeys.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptySet());
+        }
+
+        return CtpQueryUtils
+            .queryAll(syncOptions.getCtpClient(), query.get(), Function.identity())
+            .thenApply(fetchedResources -> fetchedResources
+                .stream()
+                .flatMap(List::stream)
+                .peek(resource -> keyToIdCache.put(keyMapper.apply(resource), resource.getId()))
+                .collect(Collectors.toSet()));
+    }
+
+    /**
+     * Given a resource key, this method fetches a resource that matches this given key in the CTP project defined in a
+     * potentially injected {@link SphereClient}. If there is no matching resource an empty {@link Optional} will be
+     * returned in the returned future. A mapping of the key to the id of the fetched category is persisted in an in
+     * -memory map.
+     *
+     * @param key       the key of the resource to fetch
+     * @param query     a function to get query
+     * @param keyMapper a function to get the key from the returned resource
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
+     *         {@link Optional} that contains the matching {@code T} if exists, otherwise empty.
+     */
+    @Nonnull
+    CompletionStage<Optional<U>> fetchResource(@Nullable final String key,
+                                               @Nonnull final Supplier<Q> query,
+                                               @Nonnull final Function<U, String> keyMapper) {
+        if (isBlank(key)) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        return syncOptions
+            .getCtpClient()
+            .execute(query.get())
+            .thenApply(pagedQueryResult -> pagedQueryResult
+                .head()
+                .map(resource -> {
+                    keyToIdCache.put(keyMapper.apply(resource), resource.getId());
+                    return resource;
+                }));
+    }
+
+    /**
+     * Builds query predicate based on provided set of keys.
+     *
+     * @param resourceKeys set of resource keys
+     * @return the query predicate with set of keys transformed into string
+     */
+    QueryPredicate<U> buildResourceKeysQueryPredicate(@Nonnull final Set<String> resourceKeys) {
+        return buildResourceQueryPredicate(resourceKeys, "key");
+    }
+
+    /**
+     * Builds query predicate based on provided set of values and property name.
+     *
+     * @param propertyValues set of resource property values
+     * @param propertyName   name of the property to create query for
+     * @return the query predicate with set of keys transformed into string
+     */
+    QueryPredicate<U> buildResourceQueryPredicate(@Nonnull final Set<String> propertyValues,
+                                                  @Nonnull final String propertyName) {
+        final String keysQueryString = propertyValues.stream()
+            .filter(StringUtils::isNotBlank)
+            .map(resourceKey -> format("\"%s\"", resourceKey))
+            .collect(Collectors.joining(", "));
+        return QueryPredicate.of(format("%s in (%s)", propertyName, keysQueryString));
+    }
+
 }

--- a/src/main/java/com/commercetools/sync/services/impl/CartDiscountServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CartDiscountServiceImpl.java
@@ -7,8 +7,10 @@ import io.sphere.sdk.cartdiscounts.CartDiscount;
 import io.sphere.sdk.cartdiscounts.CartDiscountDraft;
 import io.sphere.sdk.cartdiscounts.commands.CartDiscountCreateCommand;
 import io.sphere.sdk.cartdiscounts.commands.CartDiscountUpdateCommand;
+import io.sphere.sdk.cartdiscounts.expansion.CartDiscountExpansionModel;
 import io.sphere.sdk.cartdiscounts.queries.CartDiscountQuery;
 import io.sphere.sdk.cartdiscounts.queries.CartDiscountQueryBuilder;
+import io.sphere.sdk.cartdiscounts.queries.CartDiscountQueryModel;
 import io.sphere.sdk.commands.UpdateAction;
 
 import javax.annotation.Nonnull;
@@ -24,11 +26,17 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class CartDiscountServiceImpl extends BaseService<CartDiscountDraft, CartDiscount, CartDiscountSyncOptions>
+public class CartDiscountServiceImpl extends BaseService<CartDiscountDraft, CartDiscount, CartDiscountSyncOptions,
+    CartDiscountQuery, CartDiscountQueryModel, CartDiscountExpansionModel<CartDiscount>>
     implements CartDiscountService {
 
     public CartDiscountServiceImpl(@Nonnull final CartDiscountSyncOptions syncOptions) {
         super(syncOptions);
+    }
+
+    @Nonnull
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+        return CompletableFuture.completedFuture(Optional.empty());
     }
 
     @Nonnull

--- a/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
@@ -8,7 +8,9 @@ import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.commands.CategoryCreateCommand;
 import io.sphere.sdk.categories.commands.CategoryUpdateCommand;
+import io.sphere.sdk.categories.expansion.CategoryExpansionModel;
 import io.sphere.sdk.categories.queries.CategoryQuery;
+import io.sphere.sdk.categories.queries.CategoryQueryModel;
 import io.sphere.sdk.commands.UpdateAction;
 
 import javax.annotation.Nonnull;
@@ -32,8 +34,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  * Implementation of CategoryService interface.
  * TODO: USE graphQL to get only keys. GITHUB ISSUE#84
  */
-public final class CategoryServiceImpl extends BaseService<CategoryDraft, Category, CategorySyncOptions>
-    implements CategoryService {
+public final class CategoryServiceImpl extends BaseService<CategoryDraft, Category, CategorySyncOptions,
+    CategoryQuery, CategoryQueryModel, CategoryExpansionModel<Category>> implements CategoryService {
 
     private static final String CATEGORY_KEY_NOT_SET = "Category with id: '%s' has no key set. Keys are required for "
         + "category matching.";
@@ -120,7 +122,7 @@ public final class CategoryServiceImpl extends BaseService<CategoryDraft, Catego
         return fetchAndCache(key);
     }
 
-    private CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
         return cacheKeysToIds()
             .thenApply(result -> Optional.ofNullable(keyToIdCache.get(key)));
     }

--- a/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
@@ -8,7 +8,9 @@ import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.ProductUpdateCommand;
+import io.sphere.sdk.products.expansion.ProductExpansionModel;
 import io.sphere.sdk.products.queries.ProductQuery;
+import io.sphere.sdk.products.queries.ProductQueryModel;
 import io.sphere.sdk.queries.QueryPredicate;
 import org.apache.commons.lang3.StringUtils;
 
@@ -29,8 +31,8 @@ import static java.util.Collections.singleton;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 
-public final class ProductServiceImpl
-    extends BaseService<ProductDraft, Product, ProductSyncOptions> implements ProductService {
+public final class ProductServiceImpl extends BaseService<ProductDraft, Product, ProductSyncOptions, ProductQuery,
+    ProductQueryModel, ProductExpansionModel<Product>> implements ProductService {
 
     public ProductServiceImpl(@Nonnull final ProductSyncOptions syncOptions) {
         super(syncOptions);
@@ -49,7 +51,7 @@ public final class ProductServiceImpl
     }
 
     @Nonnull
-    private CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
         return cacheKeysToIds(singleton(key)).thenApply(result -> Optional.ofNullable(keyToIdCache.get(key)));
     }
 

--- a/src/main/java/com/commercetools/sync/services/impl/ProductTypeServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductTypeServiceImpl.java
@@ -9,8 +9,10 @@ import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
 import io.sphere.sdk.producttypes.commands.ProductTypeUpdateCommand;
+import io.sphere.sdk.producttypes.expansion.ProductTypeExpansionModel;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.producttypes.queries.ProductTypeQueryBuilder;
+import io.sphere.sdk.producttypes.queries.ProductTypeQueryModel;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nonnull;
@@ -31,8 +33,8 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public final class ProductTypeServiceImpl
-    extends BaseService<ProductTypeDraft, ProductType, BaseSyncOptions> implements ProductTypeService {
+public final class ProductTypeServiceImpl extends BaseService<ProductTypeDraft, ProductType, BaseSyncOptions,
+    ProductTypeQuery, ProductTypeQueryModel, ProductTypeExpansionModel<ProductType>> implements ProductTypeService {
 
     private final Map<String, Map<String, AttributeMetaData>> productsAttributesMetaData = new ConcurrentHashMap<>();
 
@@ -51,7 +53,7 @@ public final class ProductTypeServiceImpl
     }
 
     @Nonnull
-    private CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
 
         final Consumer<List<ProductType>> productTypePageConsumer = productTypePage ->
                 productTypePage.forEach(type -> {

--- a/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
@@ -1,60 +1,78 @@
 package com.commercetools.sync.services.impl;
 
-import com.commercetools.sync.commons.utils.CtpQueryUtils;
-import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.commons.BaseSyncOptions;
 import com.commercetools.sync.services.TaxCategoryService;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.commands.TaxCategoryCreateCommand;
+import io.sphere.sdk.taxcategories.commands.TaxCategoryUpdateCommand;
+import io.sphere.sdk.taxcategories.expansion.TaxCategoryExpansionModel;
 import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
-import org.apache.commons.lang3.StringUtils;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQueryModel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static java.util.Collections.singleton;
 
-public final class TaxCategoryServiceImpl implements TaxCategoryService {
-    private final ProductSyncOptions syncOptions;
-    private final Map<String, String> keyToIdCache = new ConcurrentHashMap<>();
+public final class TaxCategoryServiceImpl extends BaseService<TaxCategoryDraft, TaxCategory, BaseSyncOptions,
+    TaxCategoryQuery, TaxCategoryQueryModel, TaxCategoryExpansionModel<TaxCategory>>
+    implements TaxCategoryService {
 
-    public TaxCategoryServiceImpl(@Nonnull final ProductSyncOptions syncOptions) {
-        this.syncOptions = syncOptions;
+    public TaxCategoryServiceImpl(@Nonnull final TaxCategorySyncOptions syncOptions) {
+        super(syncOptions);
     }
 
     @Nonnull
     @Override
     public CompletionStage<Optional<String>> fetchCachedTaxCategoryId(@Nullable final String key) {
-        if (isBlank(key)) {
-            return CompletableFuture.completedFuture(Optional.empty());
-        }
-        if (keyToIdCache.isEmpty()) {
-            return fetchAndCache(key);
-        }
-        return CompletableFuture.completedFuture(Optional.ofNullable(keyToIdCache.get(key)));
+        return fetchCachedResourceId(key);
     }
 
     @Nonnull
-    private CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
-        final Consumer<List<TaxCategory>> taxCategoryPageConsumer = taxCategoryPage ->
-            taxCategoryPage.forEach(taxCategory -> {
-                final String fetchedTaxCategoryKey = taxCategory.getKey();
-                final String id = taxCategory.getId();
-                if (StringUtils.isNotBlank(fetchedTaxCategoryKey)) {
-                    keyToIdCache.put(fetchedTaxCategoryKey, id);
-                } else {
-                    syncOptions.applyWarningCallback(format("TaxCategory with id: '%s' has no key set. Keys are"
-                        + " required for taxCategory matching.", id));
-                }
-            });
-
-        return CtpQueryUtils.queryAll(syncOptions.getCtpClient(), TaxCategoryQuery.of(), taxCategoryPageConsumer)
-                            .thenApply(result -> Optional.ofNullable(keyToIdCache.get(key)));
+    @Override
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+        return fetchAndCache(key, TaxCategoryQuery::of, TaxCategory::getKey, "TaxCategory");
     }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Set<TaxCategory>> fetchMatchingTaxCategoriesByKeys(
+        @Nonnull final Set<String> taxCategoryNames) {
+        return fetchMatchingResources(
+            taxCategoryNames,
+            () -> TaxCategoryQuery.of().withPredicates(
+                buildResourceQueryPredicate(taxCategoryNames, "key")),
+            TaxCategory::getKey);
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Optional<TaxCategory>> fetchTaxCategory(@Nullable final String name) {
+        return fetchResource(name,
+            () -> TaxCategoryQuery.of().withPredicates(
+                buildResourceQueryPredicate(singleton(name), "key")),
+            TaxCategory::getKey);
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Optional<TaxCategory>> createTaxCategory(@Nonnull final TaxCategoryDraft stateDraft) {
+        return createResource(stateDraft, TaxCategoryDraft::getKey, TaxCategoryCreateCommand::of);
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<TaxCategory> updateTaxCategory(
+        @Nonnull final TaxCategory state,
+        @Nonnull final List<UpdateAction<TaxCategory>> updateActions) {
+        return updateResource(state, TaxCategoryUpdateCommand::of, updateActions);
+    }
+
 }

--- a/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
@@ -8,8 +8,10 @@ import io.sphere.sdk.types.Type;
 import io.sphere.sdk.types.TypeDraft;
 import io.sphere.sdk.types.commands.TypeCreateCommand;
 import io.sphere.sdk.types.commands.TypeUpdateCommand;
+import io.sphere.sdk.types.expansion.TypeExpansionModel;
 import io.sphere.sdk.types.queries.TypeQuery;
 import io.sphere.sdk.types.queries.TypeQueryBuilder;
+import io.sphere.sdk.types.queries.TypeQueryModel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,7 +31,8 @@ import static org.apache.http.util.TextUtils.isBlank;
  * Implementation of TypeService interface.
  * TODO: USE graphQL to get only keys. GITHUB ISSUE#84
  */
-public final class TypeServiceImpl extends BaseService<TypeDraft, Type, BaseSyncOptions> implements TypeService {
+public final class TypeServiceImpl extends BaseService<TypeDraft, Type, BaseSyncOptions, TypeQuery, TypeQueryModel,
+    TypeExpansionModel<Type>> implements TypeService {
 
     public TypeServiceImpl(@Nonnull final BaseSyncOptions syncOptions) {
         super(syncOptions);
@@ -46,7 +49,7 @@ public final class TypeServiceImpl extends BaseService<TypeDraft, Type, BaseSync
     }
 
     @Nonnull
-    private CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+    CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
 
         final Consumer<List<Type>> typePageConsumer = typePage ->
             typePage.forEach(type -> keyToIdCache.put(type.getKey(), type.getId()));

--- a/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySync.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySync.java
@@ -1,0 +1,282 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.taxcategories.helpers.TaxCategorySyncStatistics;
+import com.commercetools.sync.commons.BaseSync;
+import com.commercetools.sync.services.TaxCategoryService;
+import com.commercetools.sync.services.impl.TaxCategoryServiceImpl;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static com.commercetools.sync.taxcategories.utils.TaxCategorySyncUtils.buildActions;
+import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class TaxCategorySync extends BaseSync<TaxCategoryDraft, TaxCategorySyncStatistics, TaxCategorySyncOptions> {
+
+    private static final String CTP_STATE_UPDATE_FAILED = "Failed to update tax category with key: '%s'. Reason: %s";
+
+    private final TaxCategoryService taxCategoryService;
+
+    public TaxCategorySync(@Nonnull final TaxCategorySyncOptions taxCategorySyncOptions) {
+        this(taxCategorySyncOptions, new TaxCategoryServiceImpl(taxCategorySyncOptions));
+    }
+
+    /**
+     * Takes a {@link TaxCategorySyncOptions} and a {@link TaxCategorySync} instances to instantiate
+     * a new {@link TaxCategorySync} instance that could be used to sync tax category drafts in the CTP project
+     * specified in the injected {@link TaxCategorySyncOptions} instance.
+     *
+     * <p>NOTE: This constructor is mainly to be used for tests where the services can be mocked and passed to.
+     *
+     * @param taxCategorySyncOptions the container of all the options of the sync process including the CTP project
+     *                               client and/or configuration and other sync-specific options.
+     * @param taxCategoryService     the type service which is responsible for fetching/caching the Types from the CTP
+     *                               project.
+     */
+    TaxCategorySync(@Nonnull final TaxCategorySyncOptions taxCategorySyncOptions,
+                    @Nonnull final TaxCategoryService taxCategoryService) {
+        super(new TaxCategorySyncStatistics(), taxCategorySyncOptions);
+        this.taxCategoryService = taxCategoryService;
+    }
+
+    @Override
+    protected CompletionStage<TaxCategorySyncStatistics> process(@Nonnull final List<TaxCategoryDraft> resourceDrafts) {
+        List<List<TaxCategoryDraft>> batches = batchElements(resourceDrafts, syncOptions.getBatchSize());
+        return syncBatches(batches, completedFuture(statistics));
+    }
+
+    @Override
+    protected CompletionStage<TaxCategorySyncStatistics> processBatch(@Nonnull final List<TaxCategoryDraft> batch) {
+        final Set<TaxCategoryDraft> validTaxCategoryDrafts = batch.stream()
+            .filter(this::validateDraft)
+            .collect(toSet());
+
+        if (validTaxCategoryDrafts.isEmpty()) {
+            statistics.incrementProcessed(batch.size());
+            return completedFuture(statistics);
+        } else {
+            final Set<String> keys = validTaxCategoryDrafts.stream().map(TaxCategoryDraft::getKey).collect(toSet());
+            return taxCategoryService
+                .fetchMatchingTaxCategoriesByKeys(keys)
+                .handle(ImmutablePair::new)
+                .thenCompose(fetchResponse -> {
+                    Set<TaxCategory> fetchedTaxCategorys = fetchResponse.getKey();
+                    final Throwable exception = fetchResponse.getValue();
+
+                    if (exception != null) {
+                        final String errorMessage = format(
+                            "Failed to fetch existing taxCategories with keys: '%s'.",
+                            keys);
+                        handleError(errorMessage, exception, keys.size());
+                        return completedFuture(null);
+                    } else {
+                        return syncBatch(fetchedTaxCategorys, validTaxCategoryDrafts);
+                    }
+                })
+                .thenApply(ignored -> {
+                    statistics.incrementProcessed(batch.size());
+                    return statistics;
+                });
+        }
+    }
+
+    /**
+     * Checks if a draft is valid for further processing. If so, then returns {@code true}. Otherwise handles an error
+     * and returns {@code false}. A valid draft is a {@link TaxCategoryDraft} object that is not {@code null} and its
+     * key is not empty.
+     *
+     * @param draft nullable draft
+     * @return boolean that indicate if given {@code draft} is valid for sync
+     */
+    private boolean validateDraft(@Nullable final TaxCategoryDraft draft) {
+        if (draft == null) {
+            handleError("Failed to process null tax category draft.", null, 1);
+        } else if (isBlank(draft.getKey())) {
+            handleError("Failed to process tax category draft without key.", null, 1);
+        } else {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this method calls the
+     * optional error callback specified in the {@code syncOptions} and updates the {@code statistics} instance by
+     * incrementing the total number of failed tax categories to sync.
+     *
+     * @param errorMessage The error message describing the reason(s) of failure.
+     * @param exception    The exception that called caused the failure, if any.
+     * @param failedTimes  The number of times that the failed tax categories counter is incremented.
+     */
+    private void handleError(@Nonnull final String errorMessage, @Nullable final Throwable exception,
+                             final int failedTimes) {
+        syncOptions.applyErrorCallback(errorMessage, exception);
+        statistics.incrementFailed(failedTimes);
+    }
+
+    /**
+     * Given a set of tax category drafts, attempts to sync the drafts with the existing tax categories in the CTP
+     * project. The tax category and the draft are considered to match if they have the same key. When there will be no
+     * error it will attempt to sync the drafts transactions.
+     *
+     * @param oldTaxCategorys old tax categories.
+     * @param newTaxCategorys drafts that need to be synced.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the update
+     */
+    @Nonnull
+    private CompletionStage<Void> syncBatch(@Nonnull final Set<TaxCategory> oldTaxCategorys,
+                                            @Nonnull final Set<TaxCategoryDraft> newTaxCategorys) {
+        final Map<String, TaxCategory> oldTaxCategoryMap = oldTaxCategorys.stream()
+            .collect(toMap(TaxCategory::getKey, identity()));
+
+        return allOf(newTaxCategorys
+            .stream()
+            .map(newTaxCategory -> {
+                final TaxCategory oldTaxCategory = oldTaxCategoryMap.get(newTaxCategory.getKey());
+                return ofNullable(oldTaxCategory)
+                    .map(taxCategory -> buildActionsAndUpdate(oldTaxCategory, newTaxCategory))
+                    .orElseGet(() -> applyCallbackAndCreate(newTaxCategory));
+            })
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * Given a tax category draft, this method applies the beforeCreateCallback and then issues a create request to the
+     * CTP project to create the corresponding TaxCategory.
+     *
+     * @param taxCategoryDraft the tax category draft to create the tax category from.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the create.
+     */
+    @Nonnull
+    private CompletionStage<Optional<TaxCategory>> applyCallbackAndCreate(
+        @Nonnull final TaxCategoryDraft taxCategoryDraft) {
+        return syncOptions
+            .applyBeforeCreateCallBack(taxCategoryDraft)
+            .map(draft -> taxCategoryService
+                .createTaxCategory(draft)
+                .thenApply(taxCategoryOptional -> {
+                    if (taxCategoryOptional.isPresent()) {
+                        statistics.incrementCreated();
+                    } else {
+                        statistics.incrementFailed();
+                    }
+                    return taxCategoryOptional;
+                })
+            )
+            .orElse(completedFuture(Optional.empty()));
+    }
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
+    @Nonnull
+    private CompletionStage<Optional<TaxCategory>> buildActionsAndUpdate(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory) {
+        final List<UpdateAction<TaxCategory>> updateActions = buildActions(oldTaxCategory, newTaxCategory, syncOptions);
+        List<UpdateAction<TaxCategory>> updateActionsAfterCallback =
+            syncOptions.applyBeforeUpdateCallBack(updateActions, newTaxCategory, oldTaxCategory);
+
+        if (!updateActionsAfterCallback.isEmpty()) {
+            return updateTaxCategory(oldTaxCategory, newTaxCategory, updateActionsAfterCallback);
+        }
+
+        return completedFuture(null);
+    }
+
+    /**
+     * Given an existing {@link TaxCategory} and a new {@link TaxCategoryDraft}, the method calculates all the
+     * update actions required to synchronize the existing tax category to be the same as the new one. If there are
+     * update actions found, a request is made to CTP to update the existing tax category, otherwise it doesn't issue a
+     * request.
+     *
+     * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was carried
+     * out successfully or not. If an exception was thrown on executing the request to CTP, the error handling method
+     * is called.
+     *
+     * @param oldTaxCategory existing tax category that could be updated.
+     * @param newTaxCategory draft containing data that could differ from data in {@code oldTaxCategory}.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the update.
+     */
+    @Nonnull
+    private CompletionStage<Optional<TaxCategory>> updateTaxCategory(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory,
+        @Nonnull final List<UpdateAction<TaxCategory>> updateActions) {
+
+        return taxCategoryService
+            .updateTaxCategory(oldTaxCategory, updateActions)
+            .handle(ImmutablePair::new)
+            .thenCompose(updateResponse -> {
+                final TaxCategory updatedTaxCategory = updateResponse.getKey();
+                final Throwable sphereException = updateResponse.getValue();
+
+                if (sphereException != null) {
+                    return executeSupplierIfConcurrentModificationException(
+                        sphereException,
+                        () -> fetchAndUpdate(oldTaxCategory, newTaxCategory),
+                        () -> {
+                            final String errorMessage =
+                                format(CTP_STATE_UPDATE_FAILED, newTaxCategory.getKey(),
+                                    sphereException.getMessage());
+                            handleError(errorMessage, sphereException, 1);
+                            return completedFuture(Optional.empty());
+                        });
+                } else {
+                    statistics.incrementUpdated();
+                    return completedFuture(Optional.of(updatedTaxCategory));
+                }
+            });
+    }
+
+    @Nonnull
+    private CompletionStage<Optional<TaxCategory>> fetchAndUpdate(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory) {
+        final String key = oldTaxCategory.getKey();
+        return taxCategoryService
+            .fetchTaxCategory(key)
+            .handle(ImmutablePair::new)
+            .thenCompose(fetchResponse -> {
+                Optional<TaxCategory> fetchedTaxCategoryOptional = fetchResponse.getKey();
+                final Throwable exception = fetchResponse.getValue();
+
+                if (exception != null) {
+                    final String errorMessage = format(CTP_STATE_UPDATE_FAILED, key,
+                        "Failed to fetch from CTP while retrying after concurrency modification.");
+                    handleError(errorMessage, exception, 1);
+                    return completedFuture(null);
+                }
+
+                return fetchedTaxCategoryOptional
+                    .map(fetchedTaxCategory -> buildActionsAndUpdate(fetchedTaxCategory, newTaxCategory))
+                    .orElseGet(() -> {
+                        final String errorMessage = format(CTP_STATE_UPDATE_FAILED, key,
+                            "Not found when attempting to fetch while retrying "
+                                + "after concurrency modification.");
+                        handleError(errorMessage, null, 1);
+                        return completedFuture(null);
+                    });
+            });
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptions.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptions.java
@@ -1,0 +1,36 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class TaxCategorySyncOptions extends BaseSyncOptions<TaxCategory, TaxCategoryDraft> {
+
+    TaxCategorySyncOptions(
+        @Nonnull final SphereClient ctpClient,
+        @Nullable final BiConsumer<String, Throwable> errorCallBack,
+        @Nullable final Consumer<String> warningCallBack,
+        final int batchSize,
+        @Nullable final TriFunction<List<UpdateAction<TaxCategory>>, TaxCategoryDraft, TaxCategory,
+            List<UpdateAction<TaxCategory>>> beforeUpdateCallback,
+        @Nullable final Function<TaxCategoryDraft, TaxCategoryDraft> beforeCreateCallback) {
+        super(
+            ctpClient,
+            errorCallBack,
+            warningCallBack,
+            batchSize,
+            beforeUpdateCallback,
+            beforeCreateCallback);
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsBuilder.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsBuilder.java
@@ -1,0 +1,59 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.commons.BaseSyncOptionsBuilder;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+
+import javax.annotation.Nonnull;
+
+public final class TaxCategorySyncOptionsBuilder extends BaseSyncOptionsBuilder<TaxCategorySyncOptionsBuilder,
+    TaxCategorySyncOptions, TaxCategory, TaxCategoryDraft> {
+
+    public static final int BATCH_SIZE_DEFAULT = 50;
+
+    private TaxCategorySyncOptionsBuilder(@Nonnull final SphereClient ctpClient) {
+        this.ctpClient = ctpClient;
+    }
+
+    /**
+     * Creates a new instance of {@link TaxCategorySyncOptionsBuilder} given a {@link SphereClient} responsible for
+     * interaction with the target CTP project, with the default batch size ({@code BATCH_SIZE_DEFAULT} = 50).
+     *
+     * @param ctpClient instance of the {@link SphereClient} responsible for interaction with the target CTP project.
+     * @return new instance of {@link TaxCategorySyncOptionsBuilder}
+     */
+    public static TaxCategorySyncOptionsBuilder of(@Nonnull final SphereClient ctpClient) {
+        return new TaxCategorySyncOptionsBuilder(ctpClient).batchSize(BATCH_SIZE_DEFAULT);
+    }
+
+    /**
+     * Creates new instance of {@link TaxCategorySyncOptions} enriched with all attributes provided to {@code this}
+     * builder.
+     *
+     * @return new instance of {@link TaxCategorySyncOptions}
+     */
+    @Override
+    public TaxCategorySyncOptions build() {
+        return new TaxCategorySyncOptions(
+            ctpClient,
+            errorCallback,
+            warningCallback,
+            batchSize,
+            beforeUpdateCallback,
+            beforeCreateCallback
+        );
+    }
+
+    /**
+     * Returns an instance of this class to be used in the superclass's generic methods. Please see the JavaDoc in the
+     * overridden method for further details.
+     *
+     * @return an instance of this class.
+     */
+    @Override
+    protected TaxCategorySyncOptionsBuilder getThis() {
+        return this;
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategoryDraftBuilderHelper.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategoryDraftBuilderHelper.java
@@ -1,0 +1,30 @@
+package com.commercetools.sync.taxcategories.helpers;
+
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TaxCategoryDraftBuilderHelper {
+
+    /**
+     * Convenient method to create the {@link TaxCategoryDraft} instance out of the {@link TaxCategory} instance.
+     *
+     * @param taxCategory the taxCategory to be converted
+     * @return an instance of the taxCategory draft
+     */
+    public static TaxCategoryDraft of(@Nonnull final TaxCategory taxCategory) {
+        final List<TaxRateDraft> taxRateDrafts = taxCategory.getTaxRates().stream()
+            .map(taxRate -> TaxRateDraftBuilder.of(taxRate).build())
+            .collect(Collectors.toList());
+        return TaxCategoryDraftBuilder.of(taxCategory.getName(), taxRateDrafts, taxCategory.getDescription())
+            .key(taxCategory.getKey())
+            .build();
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatistics.java
@@ -1,0 +1,28 @@
+package com.commercetools.sync.taxcategories.helpers;
+
+import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
+
+import static java.lang.String.format;
+
+/**
+ * Tax category sync statistics.
+ * Keeps track of processed, created, updated and failed states through whole sync process.
+ */
+public final class TaxCategorySyncStatistics extends BaseSyncStatistics {
+
+    /**
+     * Builds a summary of the tax category sync statistics instance that looks like the following example:
+     *
+     * <p>"Summary: 2 tax categories were processed in total (0 created, 0 updated and 0 failed to sync)."
+     *
+     * @return a summary message of the tax category sync statistics instance.
+     */
+    @Override
+    public String getReportMessage() {
+        reportMessage = format(
+            "Summary: %s tax categories were processed in total (%s created, %s updated and %s failed to sync).",
+            getProcessed(), getCreated(), getUpdated(), getFailed());
+        return reportMessage;
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtils.java
@@ -1,0 +1,55 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildChangeNameAction;
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildTaxRateUpdateActions;
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildSetDescriptionAction;
+import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
+
+public final class TaxCategorySyncUtils {
+
+    private TaxCategorySyncUtils() {
+    }
+
+    /**
+     * Compares all the fields (including the tax rates see
+     * {@link TaxRatesUpdateActionUtils#buildTaxRatesUpdateActions(List, List)}) of a {@link TaxCategory} and a
+     * {@link TaxCategoryDraft}. It returns a {@link List} of {@link UpdateAction}&lt;{@link TaxCategory}&gt; as a
+     * result. If no update action is needed, for example in case where both the {@link TaxCategory} and the
+     * {@link TaxCategoryDraft} have the same fields, an empty {@link List} is returned.
+     *
+     * @param oldTaxCategory the {@link TaxCategory} which should be updated.
+     * @param newTaxCategory the {@link TaxCategoryDraft} where we get the new data.
+     * @param syncOptions    the sync options wrapper which contains options related to the sync process supplied
+     *                       by the user. For example, custom callbacks to call in case of warnings or errors occurring
+     *                       on the build update action process. And other options (See {@link TaxCategorySyncOptions}
+     *                       for more info.
+     * @return A list of tax category-specific update actions.
+     */
+    @Nonnull
+    public static List<UpdateAction<TaxCategory>> buildActions(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory,
+        @Nonnull final TaxCategorySyncOptions syncOptions) {
+
+        final List<UpdateAction<TaxCategory>> updateActions = new ArrayList<>(
+            filterEmptyOptionals(
+                buildChangeNameAction(oldTaxCategory, newTaxCategory),
+                buildSetDescriptionAction(oldTaxCategory, newTaxCategory)
+            )
+        );
+
+        updateActions.addAll(buildTaxRateUpdateActions(oldTaxCategory, newTaxCategory, syncOptions));
+
+        return updateActions;
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtils.java
@@ -1,0 +1,90 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.commands.updateactions.ChangeName;
+import io.sphere.sdk.taxcategories.commands.updateactions.SetDescription;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+
+import static com.commercetools.sync.taxcategories.utils.TaxRatesUpdateActionUtils.buildTaxRatesUpdateActions;
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+public final class TaxCategoryUpdateActionUtils {
+
+    /**
+     * Compares the {@code name} values of a {@link TaxCategory} and a {@link TaxCategoryDraft}
+     * and returns an {@link Optional} of update action, which would contain the {@code "changeName"}
+     * {@link UpdateAction}. If both {@link TaxCategory} and {@link TaxCategoryDraft} have the same
+     * {@code name} values, then no update action is needed and empty optional will be returned.
+     *
+     * @param oldTaxCategory the tax category that should be updated.
+     * @param newTaxCategory the tax category draft which contains the new name.
+     * @return optional containing update action or empty optional if names are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<TaxCategory>> buildChangeNameAction(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory) {
+        return buildUpdateAction(oldTaxCategory.getName(), newTaxCategory.getName(),
+            () -> ChangeName.of(newTaxCategory.getName()));
+    }
+
+    /**
+     * Compares the {@code description} values of a {@link TaxCategory} and a {@link TaxCategoryDraft}
+     * and returns an {@link Optional} of update action, which would contain the {@code "setDescription"}
+     * {@link UpdateAction}. If both {@link TaxCategory} and {@link TaxCategoryDraft} have the same
+     * {@code description} values, then no update action is needed and empty optional will be returned.
+     *
+     * @param oldTaxCategory the tax category that should be updated.
+     * @param newTaxCategory the tax category draft which contains the new description.
+     * @return optional containing update action or empty optional if descriptions are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<TaxCategory>> buildSetDescriptionAction(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory) {
+        return buildUpdateAction(oldTaxCategory.getDescription(), newTaxCategory.getDescription(),
+            () -> SetDescription.of(newTaxCategory.getDescription()));
+    }
+
+    /**
+     * Compares the tax rates of a {@link TaxCategory} and a {@link TaxCategoryDraft} and returns a list of
+     * {@link UpdateAction}&lt;{@link TaxCategory}&gt; as a result. If both the {@link TaxCategory} and
+     * the {@link TaxCategoryDraft} have identical tax rates, then no update action is needed and hence an empty
+     * {@link List} is returned. In case, the new product type draft has a list of attributes in which a duplicate name
+     * exists, the error callback is triggered and an empty list is returned.
+     *
+     * @param oldTaxCategory the tax category which should be updated.
+     * @param newTaxCategory the tax category draft where we get the key.
+     * @param syncOptions    responsible for supplying the sync options to the sync utility method.
+     *                       It is used for triggering the error callback within the utility, in case of
+     *                       errors.
+     * @return A list with the update actions or an empty list if the tax rates are identical.
+     */
+    @Nonnull
+    public static List<UpdateAction<TaxCategory>> buildTaxRateUpdateActions(
+        @Nonnull final TaxCategory oldTaxCategory,
+        @Nonnull final TaxCategoryDraft newTaxCategory,
+        @Nonnull final TaxCategorySyncOptions syncOptions) {
+        try {
+            return buildTaxRatesUpdateActions(
+                oldTaxCategory.getTaxRates(),
+                newTaxCategory.getTaxRates()
+            );
+        } catch (final BuildUpdateActionException exception) {
+            syncOptions.applyErrorCallback(format("Failed to build update actions for the tax rates "
+                    + "of the tax category with the key '%s'. Reason: %s", oldTaxCategory.getKey(), exception),
+                exception);
+            return emptyList();
+        }
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtils.java
@@ -19,6 +19,9 @@ import static java.util.Collections.emptyList;
 
 public final class TaxCategoryUpdateActionUtils {
 
+    private TaxCategoryUpdateActionUtils() {
+    }
+
     /**
      * Compares the {@code name} values of a {@link TaxCategory} and a {@link TaxCategoryDraft}
      * and returns an {@link Optional} of update action, which would contain the {@code "changeName"}
@@ -33,6 +36,7 @@ public final class TaxCategoryUpdateActionUtils {
     public static Optional<UpdateAction<TaxCategory>> buildChangeNameAction(
         @Nonnull final TaxCategory oldTaxCategory,
         @Nonnull final TaxCategoryDraft newTaxCategory) {
+
         return buildUpdateAction(oldTaxCategory.getName(), newTaxCategory.getName(),
             () -> ChangeName.of(newTaxCategory.getName()));
     }
@@ -51,6 +55,7 @@ public final class TaxCategoryUpdateActionUtils {
     public static Optional<UpdateAction<TaxCategory>> buildSetDescriptionAction(
         @Nonnull final TaxCategory oldTaxCategory,
         @Nonnull final TaxCategoryDraft newTaxCategory) {
+
         return buildUpdateAction(oldTaxCategory.getDescription(), newTaxCategory.getDescription(),
             () -> SetDescription.of(newTaxCategory.getDescription()));
     }
@@ -59,7 +64,7 @@ public final class TaxCategoryUpdateActionUtils {
      * Compares the tax rates of a {@link TaxCategory} and a {@link TaxCategoryDraft} and returns a list of
      * {@link UpdateAction}&lt;{@link TaxCategory}&gt; as a result. If both the {@link TaxCategory} and
      * the {@link TaxCategoryDraft} have identical tax rates, then no update action is needed and hence an empty
-     * {@link List} is returned. In case, the new product type draft has a list of attributes in which a duplicate name
+     * {@link List} is returned. In case, the new tax category draft has a list of attributes in which a duplicate name
      * exists, the error callback is triggered and an empty list is returned.
      *
      * @param oldTaxCategory the tax category which should be updated.
@@ -74,6 +79,7 @@ public final class TaxCategoryUpdateActionUtils {
         @Nonnull final TaxCategory oldTaxCategory,
         @Nonnull final TaxCategoryDraft newTaxCategory,
         @Nonnull final TaxCategorySyncOptions syncOptions) {
+
         try {
             return buildTaxRatesUpdateActions(
                 oldTaxCategory.getTaxRates(),

--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
@@ -1,0 +1,212 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.commons.exceptions.DuplicateNameException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.SubRate;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxRate;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.commands.updateactions.AddTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.RemoveTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ReplaceTaxRate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+final class TaxRatesUpdateActionUtils {
+
+    /**
+     * Compares a list of {@link TaxRate}s with a list of {@link TaxRateDraft}s to
+     * returns a {@link List} of {@link UpdateAction}&lt;{@link TaxCategory}&gt;. If both lists have identical
+     * TaxRates, then no update actions are needed and hence an empty {@link List} is returned.
+     *
+     * <p>If the list of new {@link TaxRateDraft}s is {@code null}, then remove actions are built for
+     * every existing tax rate in the {@code oldTaxRates} list.
+     *
+     * <p>Note: The method will ignore/filter out {@code null} tax rates drafts from the passed
+     * {@code newTaxRateDrafts}.</p>
+     *
+     * @param oldTaxRates       the old list of tax rates.
+     * @param newTaxRatesDrafts the new list of tax rates drafts.
+     * @return a list of tax rates update actions if the list of tax rates are not identical.
+     *         Otherwise, if the tax rates are identical, an empty list is returned.
+     * @throws BuildUpdateActionException in case there are tax rates drafts with duplicate names or enums
+     *                                    duplicate keys.
+     */
+    @Nonnull
+    static List<UpdateAction<TaxCategory>> buildTaxRatesUpdateActions(
+        @Nonnull final List<TaxRate> oldTaxRates,
+        @Nullable final List<TaxRateDraft> newTaxRatesDrafts)
+        throws BuildUpdateActionException {
+        if (newTaxRatesDrafts != null) {
+            return buildUpdateActions(
+                oldTaxRates,
+                newTaxRatesDrafts.stream().filter(Objects::nonNull).collect(toList())
+            );
+        } else {
+            return oldTaxRates
+                .stream()
+                .map(TaxRate::getId)
+                .filter(Objects::nonNull)
+                .map(RemoveTaxRate::of)
+                .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Compares a list of {@link TaxRate}s with a list of {@link TaxRateDraft}s.
+     * The method serves as an implementation for tax rates syncing. The method takes in functions
+     * for building the required update actions (AddAttribute, RemoveAttribute, ChangeAttributeOrder and 1-1
+     * update actions on tax rates (e.g. changeAttributeName, changeAttributeLabel, etc..) for the required
+     * resource.
+     *
+     * @param oldTaxRates       the old list of tax rates.
+     * @param newTaxRatesDrafts the new list of tax rates drafts.
+     * @return a list of tax rates update actions if the list of tax rates is not identical.
+     *         Otherwise, if the tax rates are identical, an empty list is returned.
+     * @throws BuildUpdateActionException in case there are tax rates drafts with duplicate names.
+     */
+    @Nonnull
+    private static List<UpdateAction<TaxCategory>> buildUpdateActions(
+        @Nonnull final List<TaxRate> oldTaxRates,
+        @Nonnull final List<TaxRateDraft> newTaxRatesDrafts)
+        throws BuildUpdateActionException {
+
+        try {
+            final List<UpdateAction<TaxCategory>> updateActions =
+                buildRemoveTaxRateOrTaxRateUpdateActions(
+                    oldTaxRates,
+                    newTaxRatesDrafts
+                );
+
+            updateActions.addAll(
+                buildAddTaxRateUpdateActions(
+                    oldTaxRates,
+                    newTaxRatesDrafts
+                )
+            );
+
+            return updateActions;
+        } catch (final DuplicateNameException exception) {
+            throw new BuildUpdateActionException(exception);
+        }
+    }
+
+    /**
+     * Checks if there are any tax rates which are not existing in the {@code newTaxRatesDrafts}.
+     * If there are, then "remove" tax rate update actions are built.
+     * Otherwise, if the tax rate still exists in the new draft, then compare the tax rate
+     * fields (amount, country, state, etc..), and add the computed actions to the list of update actions.
+     *
+     * @param oldTaxRates       the list of old {@link TaxRate}s.
+     * @param newTaxRatesDrafts the list of new {@link TaxRateDraft}s.
+     * @return a list of tax rate update actions if there are tax rates that are not existing
+     *         in the new draft. If the tax rate still exists in the new draft, then compare the attribute
+     *         definition fields (name, label, etc..), and add the computed actions to the list of update actions.
+     *         Otherwise, if the tax rates are identical, an empty list is returned.
+     * @throws DuplicateNameException in case there are tax rates drafts with duplicate names.
+     */
+    @Nonnull
+    private static List<UpdateAction<TaxCategory>> buildRemoveTaxRateOrTaxRateUpdateActions(
+        @Nonnull final List<TaxRate> oldTaxRates,
+        @Nonnull final List<TaxRateDraft> newTaxRatesDrafts) {
+
+        final Map<String, TaxRateDraft> newTaxRatesDraftsNameMap =
+            newTaxRatesDrafts
+                .stream().collect(
+                toMap(TaxRateDraft::getName, taxRateDraft -> taxRateDraft,
+                    (taxRateDraftA, taxRateDraftB) -> {
+                        throw new DuplicateNameException(
+                            format("Tax rates drafts have duplicated names. Duplicated tax rate "
+                                    + "name: '%s'.  Tax rates names are expected to be unique "
+                                    + "inside their tax category.",
+                                taxRateDraftA.getName()));
+                    }
+                ));
+
+        return oldTaxRates
+            .stream()
+            .map(oldTaxRate -> {
+                final String oldTaxRateName = oldTaxRate.getName();
+                final TaxRateDraft matchingNewTaxRateDraft = newTaxRatesDraftsNameMap.get(oldTaxRateName);
+                return ofNullable(matchingNewTaxRateDraft)
+                    .map(taxRateDraft -> {
+                        if (!same(oldTaxRate, taxRateDraft)) {
+                            return singletonList(ReplaceTaxRate.of(oldTaxRate.getId(), taxRateDraft));
+                        } else {
+                            return new ArrayList<UpdateAction<TaxCategory>>();
+                        }
+                    })
+                    .orElseGet(() -> singletonList(RemoveTaxRate.of(oldTaxRate.getId())));
+            })
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if there are any new tax rate drafts which are not existing in the {@code oldTaxRates}.
+     * If there are, then "add" tax rate update actions are built.
+     * Otherwise, if there are no new tax rates, then an empty list is returned.
+     *
+     * @param oldTaxRates      the list of old {@link TaxRate}s.
+     * @param newTaxRateDrafts the list of new {@link TaxRateDraft}s.
+     * @return a list of tax rate update actions if there are new tax rate that should be added.
+     *         Otherwise, if the tax rates are identical, an empty list is returned.
+     */
+    @Nonnull
+    private static List<UpdateAction<TaxCategory>> buildAddTaxRateUpdateActions(
+        @Nonnull final List<TaxRate> oldTaxRates,
+        @Nonnull final List<TaxRateDraft> newTaxRateDrafts) {
+        final Map<String, TaxRate> oldTaxRateNameMap = oldTaxRates.stream()
+            .collect(toMap(TaxRate::getName, attributeDefinition -> attributeDefinition));
+
+        return newTaxRateDrafts
+            .stream()
+            .filter(attributeDefinitionDraft -> !oldTaxRateNameMap.containsKey(attributeDefinitionDraft.getName()))
+            .map(AddTaxRate::of)
+            .collect(Collectors.toList());
+    }
+
+    private static boolean same(@Nonnull final TaxRate oldTaxRate, @Nonnull final TaxRateDraft newTaxRate) {
+        return Objects.equals(oldTaxRate.getAmount(), newTaxRate.getAmount())
+            && Objects.equals(oldTaxRate.getCountry(), newTaxRate.getCountry())
+            && Objects.equals(oldTaxRate.getState(), newTaxRate.getState())
+            && Objects.equals(oldTaxRate.isIncludedInPrice(), newTaxRate.isIncludedInPrice())
+            && sameSubRates(oldTaxRate.getSubRates(), newTaxRate.getSubRates());
+    }
+
+    private static boolean sameSubRates(final List<SubRate> oldSubRates, final List<SubRate> newSubRates) {
+        boolean same = false;
+
+        if (Objects.nonNull(oldSubRates) && Objects.nonNull(newSubRates)) {
+            if (oldSubRates.size() == newSubRates.size()) {
+                Map<String, SubRate> osr = oldSubRates.stream().collect(toMap(SubRate::getName, subRate -> subRate));
+                Map<String, SubRate> nsr = newSubRates.stream().collect(toMap(SubRate::getName, subRate -> subRate));
+
+                same = true;
+                for (final Map.Entry<String, SubRate> entry : osr.entrySet()) {
+                    if (!Objects.equals(entry.getValue(), nsr.get(entry.getKey()))) {
+                        same = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return same;
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
@@ -1,0 +1,302 @@
+package com.commercetools.sync.services.impl;
+
+import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.expansion.ExpansionPathContainer;
+import io.sphere.sdk.models.Resource;
+import io.sphere.sdk.models.WithKey;
+import io.sphere.sdk.queries.MetaModelQueryDsl;
+import io.sphere.sdk.queries.PagedQueryResult;
+import io.sphere.sdk.queries.QueryPredicate;
+import io.sphere.sdk.queries.QuerySort;
+import io.sphere.sdk.queries.ResourceQueryModel;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BaseServiceImplTest {
+
+    private TestQuery query = mock(TestQuery.class);
+    private TestResource resource = mock(TestResource.class);
+    @SuppressWarnings("unchecked")
+    private Consumer<String> warningCallback = mock(Consumer.class);
+    private SphereClient client = mock(SphereClient.class);
+    private TestServiceImpl service;
+
+    class TestServiceImpl extends BaseService<TestDraft, TestResource, TestSyncOptions, TestQuery, TestQueryModel,
+        TestExpansionModel<TestResource>> {
+
+        TestServiceImpl(@Nonnull final TestSyncOptions syncOptions) {
+            super(syncOptions);
+        }
+
+        @Override
+        CompletionStage<Optional<String>> fetchAndCache(@Nonnull final String key) {
+            return fetchAndCache(key, () -> query, TestResource::getKey, "TestResource");
+        }
+
+        void cache(final String key, final String id) {
+            keyToIdCache.put(key, id);
+        }
+
+        void clearCached() {
+            keyToIdCache.clear();
+        }
+
+    }
+
+    interface TestResource extends Resource<TestResource>, WithKey {
+
+    }
+
+    interface TestDraft {
+
+    }
+
+    static class TestSyncOptions extends BaseSyncOptions<TestResource, TestDraft> {
+
+        TestSyncOptions(@Nonnull final SphereClient ctpClient,
+                        @Nullable final BiConsumer<String, Throwable> errorCallBack,
+                        @Nullable final Consumer<String> warningCallBack,
+                        int batchSize,
+                        @Nullable final TriFunction<List<UpdateAction<TestResource>>, TestDraft, TestResource,
+                            List<UpdateAction<TestResource>>> beforeUpdateCallback,
+                        @Nullable final Function<TestDraft, TestDraft> beforeCreateCallback) {
+            super(ctpClient, errorCallBack, warningCallBack, batchSize, beforeUpdateCallback, beforeCreateCallback);
+        }
+    }
+
+    interface TestQuery extends MetaModelQueryDsl<TestResource, TestQuery, TestQueryModel,
+        TestExpansionModel<TestResource>> {
+
+    }
+
+    interface TestQueryModel extends ResourceQueryModel<TestResource> {
+
+    }
+
+    interface TestExpansionModel<T> extends ExpansionPathContainer<T> {
+
+    }
+
+    private interface TestPagedQueryResult extends PagedQueryResult<TestResource> {
+    }
+
+    @BeforeEach
+    void setup() {
+        TestSyncOptions syncOptions = new TestSyncOptions(client, null, warningCallback, 20, null, null);
+        service = new TestServiceImpl(syncOptions);
+    }
+
+    @AfterEach
+    void cleanup() {
+        reset(client, query, resource, warningCallback);
+    }
+
+    @Test
+    void fetchCachedResourceId_WithEmptyKey_ShouldReturnEmpty() {
+        Optional<String> result = service.fetchCachedResourceId("").toCompletableFuture().join();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void fetchCachedResourceId_WithFetchReturnResourceWithoutKey_ShouldReturnEmptyAndTriggerWarningCallback() {
+        when(query.sort()).thenReturn(Collections.singletonList(QuerySort.of("id asc")));
+        when(query.withLimit(any())).thenReturn(query);
+
+        PagedQueryResult pagedQueryResult = mock(PagedQueryResult.class);
+        when(pagedQueryResult.getResults()).thenReturn(Collections.singletonList(resource));
+
+        when(resource.getKey()).thenReturn(null);
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(pagedQueryResult));
+
+        Optional<String> result = service.fetchCachedResourceId("testKey").toCompletableFuture().join();
+
+        assertThat(result).isEmpty();
+        verify(warningCallback).accept(any());
+    }
+
+    @Test
+    void fetchCachedResourceId_WithFetchReturnResource_ShouldReturnResourceId() {
+        when(query.sort()).thenReturn(Collections.singletonList(QuerySort.of("id asc")));
+        when(query.withLimit(any())).thenReturn(query);
+
+        PagedQueryResult pagedQueryResult = mock(PagedQueryResult.class);
+        when(pagedQueryResult.getResults()).thenReturn(Collections.singletonList(resource));
+
+        String key = "testKey";
+        String id = "testId";
+        when(resource.getKey()).thenReturn(key);
+        when(resource.getId()).thenReturn(id);
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(pagedQueryResult));
+
+        String result = service.fetchCachedResourceId(key).toCompletableFuture().join().orElse(null);
+
+        assertThat(result).isEqualTo(id);
+
+        service.clearCached();
+    }
+
+    @Test
+    void fetchCachedResourceId_WithCachedResource_ShouldReturnResourceId() {
+        String key = "testKey";
+        String id = "testId";
+        service.cache(key, id);
+
+        String result = service.fetchCachedResourceId(key).toCompletableFuture().join().orElse(null);
+
+        assertThat(result).isEqualTo(id);
+
+        service.clearCached();
+    }
+
+    @Test
+    void fetchMatchingResources_WithEmptyKeySet_ShouldFetchNothing() {
+        Set<TestResource> resources = service.fetchMatchingResources(new HashSet<>(),
+            () -> null, TestResource::getKey).toCompletableFuture().join();
+        assertAll(
+            () -> assertThat(resources).isEmpty(),
+            () -> assertThat(service.keyToIdCache).isEmpty()
+        );
+        verify(client, never()).execute(any(TestQuery.class));
+    }
+
+    @Test
+    void fetchMatchingResources_WithKeySet_ShouldFetchResources() {
+        String key1 = RandomStringUtils.random(15);
+        String key2 = RandomStringUtils.random(15);
+
+        HashSet<String> resourceKeys = new HashSet<>();
+        resourceKeys.add(key1);
+        resourceKeys.add(key2);
+
+        TestResource mock1 = mock(TestResource.class);
+        when(mock1.getId()).thenReturn(RandomStringUtils.random(15));
+        when(mock1.getKey()).thenReturn(key1);
+
+        TestResource mock2 = mock(TestResource.class);
+        when(mock2.getId()).thenReturn(RandomStringUtils.random(15));
+        when(mock2.getKey()).thenReturn(key2);
+
+        TestPagedQueryResult result = mock(TestPagedQueryResult.class);
+        when(result.getResults()).thenReturn(Arrays.asList(mock1, mock2));
+
+        when(client.execute(any())).thenReturn(completedFuture(result));
+
+        TestQuery testQuery = mock(TestQuery.class);
+        when(testQuery.sort()).thenReturn(Collections.singletonList(QuerySort.of("id asc")));
+        when(testQuery.withLimit(anyLong())).thenReturn(testQuery);
+
+        Set<TestResource> resources = service.fetchMatchingResources(resourceKeys,
+            () -> testQuery, TestResource::getKey).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(resources).isNotEmpty(),
+            () -> assertThat(resources).contains(mock1, mock2),
+            () -> assertThat(service.keyToIdCache).containsKeys(key1, key2)
+        );
+        verify(client).execute(any(TestQuery.class));
+    }
+
+    @Test
+    void fetchResource_WithNullKey_ShouldFetchNothing() {
+        Optional<TestResource> optional = service.fetchResource(null,
+            () -> null, TestResource::getKey).toCompletableFuture().join();
+        assertThat(optional).isEmpty();
+    }
+
+    @Test
+    void fetchResource_WithKey_ShouldFetchResource() {
+        String resourceId = RandomStringUtils.random(15);
+        String resourceKey = RandomStringUtils.random(15);
+
+        TestResource mock = mock(TestResource.class);
+        when(mock.getId()).thenReturn(resourceId);
+        when(mock.getKey()).thenReturn(resourceKey);
+        TestPagedQueryResult result = mock(TestPagedQueryResult.class);
+        when(result.head()).thenReturn(Optional.of(mock));
+
+        when(client.execute(any())).thenReturn(completedFuture(result));
+
+        Optional<TestResource> resourceOptional = service.fetchResource(resourceKey,
+            () -> mock(TestQuery.class), TestResource::getKey).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(resourceOptional).isNotEmpty(),
+            () -> assertThat(resourceOptional).containsSame(mock),
+            () -> assertThat(service.keyToIdCache.get(resourceKey)).isEqualTo(resourceId)
+        );
+        verify(client).execute(any(TestQuery.class));
+    }
+
+    @Test
+    void buildResourceKeysQueryPredicate_WithEmptyKeySet_ShouldBuildQueryPredicate() {
+        QueryPredicate<TestResource> queryPredicate = service.buildResourceKeysQueryPredicate(new HashSet<>());
+
+        assertThat(queryPredicate.toSphereQuery()).isEqualTo("key in ()");
+    }
+
+    @Test
+    void buildResourceKeysQueryPredicate_WithKeySet_ShouldBuildQueryPredicate() {
+        String key1 = RandomStringUtils.random(15);
+        String key2 = RandomStringUtils.random(15);
+
+        HashSet<String> stateKeys = new HashSet<>();
+        stateKeys.add(key1);
+        stateKeys.add(key2);
+
+        QueryPredicate<TestResource> queryPredicate = service.buildResourceKeysQueryPredicate(stateKeys);
+
+        assertThat(queryPredicate.toSphereQuery())
+            .isIn("key in (\"" + key1 + "\", \"" + key2 + "\")", "key in (\"" + key2 + "\", \"" + key1 + "\")");
+    }
+
+    @Test
+    void buildResourceKeysQueryPredicate_WithKeySetContainingInvalidKeys_ShouldBuildQueryPredicate() {
+        String key1 = RandomStringUtils.random(15);
+        String key2 = RandomStringUtils.random(15);
+
+        HashSet<String> stateKeys = new HashSet<>();
+        stateKeys.add(key1);
+        stateKeys.add(key2);
+        stateKeys.add("");
+        stateKeys.add(null);
+
+        QueryPredicate<TestResource> queryPredicate = service.buildResourceKeysQueryPredicate(stateKeys);
+
+        assertThat(queryPredicate.toSphereQuery())
+            .isIn("key in (\"" + key1 + "\", \"" + key2 + "\")", "key in (\"" + key2 + "\", \"" + key1 + "\")");
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/services/impl/TaxCategoryServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/TaxCategoryServiceImplTest.java
@@ -1,0 +1,215 @@
+package com.commercetools.sync.services.impl;
+
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptionsBuilder;
+import io.sphere.sdk.client.BadRequestException;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.queries.PagedQueryResult;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.commands.TaxCategoryCreateCommand;
+import io.sphere.sdk.taxcategories.commands.TaxCategoryUpdateCommand;
+import io.sphere.sdk.taxcategories.commands.updateactions.ChangeName;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import io.sphere.sdk.utils.CompletableFutureUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaxCategoryServiceImplTest {
+
+    private SphereClient client = mock(SphereClient.class);
+    private TaxCategoryServiceImpl service;
+    private List<String> errorMessages;
+    private List<Throwable> errorExceptions;
+
+    private String taxCategoryId;
+    private String taxCategoryName;
+    private String taxCategoryKey;
+
+    @BeforeEach
+    void setup() {
+        taxCategoryId = RandomStringUtils.random(15);
+        taxCategoryName = RandomStringUtils.random(15);
+        taxCategoryKey = RandomStringUtils.random(15);
+
+        errorMessages = new ArrayList<>();
+        errorExceptions = new ArrayList<>();
+        TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(client)
+            .errorCallback((errorMessage, errorException) -> {
+                errorMessages.add(errorMessage);
+                errorExceptions.add(errorException);
+            })
+            .build();
+        service = new TaxCategoryServiceImpl(taxCategorySyncOptions);
+    }
+
+    @AfterEach
+    void cleanup() {
+        reset(client);
+    }
+
+    private interface TaxCategoryPagedQueryResult extends PagedQueryResult<TaxCategory> {
+    }
+
+    @Test
+    void fetchCachedTaxCategoryId_WithKey_ShouldFetchTaxCategory() {
+        final String key = RandomStringUtils.random(15);
+        final String id = RandomStringUtils.random(15);
+
+        final TaxCategory mock = mock(TaxCategory.class);
+        when(mock.getId()).thenReturn(id);
+        when(mock.getKey()).thenReturn(key);
+
+        final TaxCategoryPagedQueryResult result = mock(TaxCategoryPagedQueryResult.class);
+        when(result.getResults()).thenReturn(Collections.singletonList(mock));
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
+
+        final Optional<String> fetchedId = service.fetchCachedTaxCategoryId(key).toCompletableFuture().join();
+
+        assertThat(fetchedId).contains(id);
+    }
+
+    @Test
+    void fetchMatchingTaxCategoriesByKeys_WithKeySet_ShouldFetchTaxCategories() {
+        final String key1 = RandomStringUtils.random(15);
+        final String key2 = RandomStringUtils.random(15);
+
+        final HashSet<String> taxCategoryKeys = new HashSet<>();
+        taxCategoryKeys.add(key1);
+        taxCategoryKeys.add(key2);
+
+        final TaxCategory mock1 = mock(TaxCategory.class);
+        when(mock1.getId()).thenReturn(RandomStringUtils.random(15));
+        when(mock1.getKey()).thenReturn(key1);
+
+        final TaxCategory mock2 = mock(TaxCategory.class);
+        when(mock2.getId()).thenReturn(RandomStringUtils.random(15));
+        when(mock2.getKey()).thenReturn(key2);
+
+        final TaxCategoryPagedQueryResult result = mock(TaxCategoryPagedQueryResult.class);
+        when(result.getResults()).thenReturn(Arrays.asList(mock1, mock2));
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
+
+        final Set<TaxCategory> taxCategories = service.fetchMatchingTaxCategoriesByKeys(taxCategoryKeys)
+            .toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(taxCategories).contains(mock1, mock2),
+            () -> assertThat(service.keyToIdCache).containsKeys(key1, key2)
+        );
+        verify(client).execute(any(TaxCategoryQuery.class));
+    }
+
+    @Test
+    void fetchTaxCategory_WithKey_ShouldFetchTaxCategory() {
+        final TaxCategory mock = mock(TaxCategory.class);
+        when(mock.getId()).thenReturn(taxCategoryId);
+        when(mock.getKey()).thenReturn(taxCategoryKey);
+        final TaxCategoryPagedQueryResult result = mock(TaxCategoryPagedQueryResult.class);
+        when(result.head()).thenReturn(Optional.of(mock));
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
+
+        final Optional<TaxCategory> taxCategoryOptional = service.fetchTaxCategory(taxCategoryKey)
+            .toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(taxCategoryOptional).containsSame(mock),
+            () -> assertThat(service.keyToIdCache.get(taxCategoryKey)).isEqualTo(taxCategoryId)
+        );
+        verify(client).execute(any(TaxCategoryQuery.class));
+    }
+
+    @Test
+    void createTaxCategory_WithDraft_ShouldCreateTaxCategory() {
+        final TaxCategory mock = mock(TaxCategory.class);
+        when(mock.getId()).thenReturn(taxCategoryId);
+        when(mock.getKey()).thenReturn(taxCategoryKey);
+
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(mock));
+
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder
+            .of(taxCategoryName, Collections.emptyList(), "description")
+            .key(taxCategoryKey)
+            .build();
+        final Optional<TaxCategory> taxCategoryOptional = service.createTaxCategory(draft).toCompletableFuture().join();
+
+        assertThat(taxCategoryOptional).containsSame(mock);
+        verify(client).execute(eq(TaxCategoryCreateCommand.of(draft)));
+    }
+
+    @Test
+    void createTaxCategory_WithRequestException_ShouldNotCreateTaxCategory() {
+        final TaxCategory mock = mock(TaxCategory.class);
+        when(mock.getId()).thenReturn(taxCategoryId);
+
+        when(client.execute(any())).thenReturn(CompletableFutureUtils.failed(new BadRequestException("bad request")));
+
+        final TaxCategoryDraft draft = mock(TaxCategoryDraft.class);
+        when(draft.getKey()).thenReturn(taxCategoryKey);
+
+        final Optional<TaxCategory> taxCategoryOptional = service.createTaxCategory(draft).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(taxCategoryOptional).isEmpty(),
+            () -> assertThat(errorMessages).hasOnlyOneElementSatisfying(message -> {
+                assertThat(message).contains("Failed to create draft with key: '" + taxCategoryKey + "'.");
+                assertThat(message).contains("BadRequestException");
+            }),
+            () -> assertThat(errorExceptions).hasOnlyOneElementSatisfying(exception ->
+                assertThat(exception).isExactlyInstanceOf(BadRequestException.class))
+        );
+    }
+
+    @Test
+    void createTaxCategory_WithDraftHasNoKey_ShouldNotCreateTaxCategory() {
+        final TaxCategoryDraft draft = mock(TaxCategoryDraft.class);
+
+        final Optional<TaxCategory> taxCategoryOptional = service.createTaxCategory(draft).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(taxCategoryOptional).isEmpty(),
+            () -> assertThat(errorMessages).hasSize(1),
+            () -> assertThat(errorExceptions).hasSize(1),
+            () -> assertThat(errorMessages)
+                .contains("Failed to create draft with key: 'null'. Reason: Draft key is blank!")
+        );
+    }
+
+    @Test
+    void updateTaxCategory_WithNoError_ShouldUpdateTaxCategory() {
+        final TaxCategory mock = mock(TaxCategory.class);
+        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(mock));
+        final List<UpdateAction<TaxCategory>> updateActions = Collections.singletonList(ChangeName.of("name"));
+
+        final TaxCategory taxCategory = service.updateTaxCategory(mock, updateActions).toCompletableFuture().join();
+
+        assertThat(taxCategory).isSameAs(mock);
+        verify(client).execute(eq(TaxCategoryUpdateCommand.of(mock, updateActions)));
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsBuilderTest.java
@@ -1,0 +1,128 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+
+class TaxCategorySyncOptionsBuilderTest {
+
+    private static SphereClient CTP_CLIENT = mock(SphereClient.class);
+    private TaxCategorySyncOptionsBuilder taxCategorySyncOptionsBuilder = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT);
+
+    @Test
+    void of_WithClient_ShouldCreateTaxCategorySyncOptionsBuilder() {
+        final TaxCategorySyncOptionsBuilder builder = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT);
+
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void getThis_ShouldReturnBuilderInstance() {
+        final TaxCategorySyncOptionsBuilder instance = taxCategorySyncOptionsBuilder.getThis();
+
+        assertThat(instance).isNotNull();
+        assertThat(instance).isInstanceOf(TaxCategorySyncOptionsBuilder.class);
+    }
+
+    @Test
+    void build_WithClient_ShouldBuildSyncOptions() {
+        final TaxCategorySyncOptions taxCategorySyncOptions = taxCategorySyncOptionsBuilder.build();
+
+        assertThat(taxCategorySyncOptions).isNotNull();
+        assertAll(
+            () -> assertThat(taxCategorySyncOptions.getBeforeUpdateCallback()).isNull(),
+            () -> assertThat(taxCategorySyncOptions.getBeforeCreateCallback()).isNull(),
+            () -> assertThat(taxCategorySyncOptions.getErrorCallBack()).isNull(),
+            () -> assertThat(taxCategorySyncOptions.getWarningCallBack()).isNull(),
+            () -> assertThat(taxCategorySyncOptions.getCtpClient()).isEqualTo(CTP_CLIENT),
+            () -> assertThat(taxCategorySyncOptions.getBatchSize())
+                .isEqualTo(TaxCategorySyncOptionsBuilder.BATCH_SIZE_DEFAULT)
+        );
+    }
+
+    @Test
+    void build_WithBeforeUpdateCallback_ShouldSetBeforeUpdateCallback() {
+        final TriFunction<List<UpdateAction<TaxCategory>>, TaxCategoryDraft, TaxCategory,
+            List<UpdateAction<TaxCategory>>> beforeUpdateCallback = (updateActions, newTaxCategory, oldTaxCategory) ->
+            emptyList();
+        taxCategorySyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
+
+        final TaxCategorySyncOptions taxCategorySyncOptions = taxCategorySyncOptionsBuilder.build();
+
+        assertThat(taxCategorySyncOptions.getBeforeUpdateCallback())
+            .isNotNull();
+    }
+
+    @Test
+    void build_WithBeforeCreateCallback_ShouldSetBeforeCreateCallback() {
+        taxCategorySyncOptionsBuilder.beforeCreateCallback((newTaxCategory) -> null);
+
+        final TaxCategorySyncOptions taxCategorySyncOptions = taxCategorySyncOptionsBuilder.build();
+
+        assertThat(taxCategorySyncOptions.getBeforeCreateCallback()).isNotNull();
+    }
+
+    @Test
+    void build_WithErrorCallback_ShouldSetErrorCallback() {
+        final BiConsumer<String, Throwable> mockErrorCallBack = (errorMessage, errorException) -> {
+        };
+        taxCategorySyncOptionsBuilder.errorCallback(mockErrorCallBack);
+
+        final TaxCategorySyncOptions taxCategorySyncOptions = taxCategorySyncOptionsBuilder.build();
+
+        assertThat(taxCategorySyncOptions.getErrorCallBack()).isNotNull();
+    }
+
+    @Test
+    void build_WithWarningCallback_ShouldSetWarningCallback() {
+        final Consumer<String> mockWarningCallBack = (warningMessage) -> {
+        };
+        taxCategorySyncOptionsBuilder.warningCallback(mockWarningCallBack);
+
+        final TaxCategorySyncOptions taxCategorySyncOptions = taxCategorySyncOptionsBuilder.build();
+
+        assertThat(taxCategorySyncOptions.getWarningCallBack()).isNotNull();
+    }
+
+
+    @Test
+    void build_WithBatchSize_ShouldSetBatchSize() {
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .batchSize(10)
+            .build();
+
+        assertThat(taxCategorySyncOptions.getBatchSize()).isEqualTo(10);
+    }
+
+    @Test
+    void build_WithInvalidBatchSize_ShouldBuildSyncOptions() {
+        final TaxCategorySyncOptions taxCategorySyncOptionsWithZeroBatchSize = TaxCategorySyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(0)
+            .build();
+
+        assertThat(taxCategorySyncOptionsWithZeroBatchSize.getBatchSize())
+            .isEqualTo(TaxCategorySyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+
+        final TaxCategorySyncOptions taxCategorySyncOptionsWithNegativeBatchSize = TaxCategorySyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(-100)
+            .build();
+
+        assertThat(taxCategorySyncOptionsWithNegativeBatchSize.getBatchSize())
+            .isEqualTo(TaxCategorySyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncOptionsTest.java
@@ -1,0 +1,132 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.commands.updateactions.SetKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaxCategorySyncOptionsTest {
+
+    private static SphereClient CTP_CLIENT = mock(SphereClient.class);
+
+    @Test
+    void applyBeforeUpdateCallback_WithNullCallback_ShouldReturnIdenticalList() {
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .build();
+        final List<UpdateAction<TaxCategory>> updateActions = singletonList(SetKey.of("key"));
+        final List<UpdateAction<TaxCategory>> filteredList = taxCategorySyncOptions
+            .applyBeforeUpdateCallBack(updateActions, mock(TaxCategoryDraft.class), mock(TaxCategory.class));
+
+        assertThat(filteredList).isSameAs(updateActions);
+    }
+
+    @Test
+    void applyBeforeUpdateCallback_WithNullReturnCallback_ShouldReturnEmptyList() {
+        final TriFunction<List<UpdateAction<TaxCategory>>, TaxCategoryDraft, TaxCategory,
+            List<UpdateAction<TaxCategory>>> beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        final List<UpdateAction<TaxCategory>> updateActions = singletonList(SetKey.of("key"));
+
+        final List<UpdateAction<TaxCategory>> filteredList = taxCategorySyncOptions
+            .applyBeforeUpdateCallBack(updateActions, mock(TaxCategoryDraft.class), mock(TaxCategory.class));
+
+        assertThat(filteredList).isEmpty();
+    }
+
+    private interface MockTriFunction extends
+        TriFunction<List<UpdateAction<TaxCategory>>, TaxCategoryDraft, TaxCategory, List<UpdateAction<TaxCategory>>> {
+    }
+
+    @Test
+    void applyBeforeUpdateCallback_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+        final TaxCategorySyncOptionsTest.MockTriFunction beforeUpdateCallback =
+            mock(TaxCategorySyncOptionsTest.MockTriFunction.class);
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        final List<UpdateAction<TaxCategory>> filteredList = taxCategorySyncOptions
+            .applyBeforeUpdateCallBack(emptyList(), mock(TaxCategoryDraft.class), mock(TaxCategory.class));
+
+        assertThat(filteredList).isEmpty();
+        verify(beforeUpdateCallback, never()).apply(any(), any(), any());
+    }
+
+    @Test
+    void applyBeforeUpdateCallback_WithCallback_ShouldReturnFilteredList() {
+        final TriFunction<List<UpdateAction<TaxCategory>>, TaxCategoryDraft, TaxCategory,
+            List<UpdateAction<TaxCategory>>> beforeUpdateCallback = (updateActions, newCategory, oldCategory) ->
+            emptyList();
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        final List<UpdateAction<TaxCategory>> updateActions = singletonList(SetKey.of("key"));
+
+        final List<UpdateAction<TaxCategory>> filteredList = taxCategorySyncOptions
+            .applyBeforeUpdateCallBack(updateActions, mock(TaxCategoryDraft.class), mock(TaxCategory.class));
+
+        assertThat(filteredList).isEmpty();
+    }
+
+    @Test
+    void applyBeforeCreateCallback_WithCallback_ShouldReturnFilteredDraft() {
+        final Function<TaxCategoryDraft, TaxCategoryDraft> draftFunction =
+            taxCategoryDraft -> TaxCategoryDraftBuilder.of(taxCategoryDraft)
+                .key(taxCategoryDraft.getKey() + "_filteredKey").build();
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .beforeCreateCallback(draftFunction)
+            .build();
+        final TaxCategoryDraft resourceDraft = mock(TaxCategoryDraft.class);
+        when(resourceDraft.getKey()).thenReturn("myKey");
+
+        final Optional<TaxCategoryDraft> filteredDraft = taxCategorySyncOptions
+            .applyBeforeCreateCallBack(resourceDraft);
+
+        assertThat(filteredDraft).hasValueSatisfying(taxCategoryDraft -> assertThat(taxCategoryDraft.getKey())
+            .isEqualTo("myKey_filteredKey"));
+    }
+
+    @Test
+    void applyBeforeCreateCallback_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT).build();
+        final TaxCategoryDraft resourceDraft = mock(TaxCategoryDraft.class);
+
+        final Optional<TaxCategoryDraft> filteredDraft = taxCategorySyncOptions
+            .applyBeforeCreateCallBack(resourceDraft);
+
+        assertThat(filteredDraft).containsSame(resourceDraft);
+    }
+
+    @Test
+    void applyBeforeCreateCallback_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
+        final Function<TaxCategoryDraft, TaxCategoryDraft> draftFunction = taxCategoryDraft -> null;
+        final TaxCategorySyncOptions taxCategorySyncOptions = TaxCategorySyncOptionsBuilder.of(CTP_CLIENT)
+            .beforeCreateCallback(draftFunction)
+            .build();
+        final TaxCategoryDraft resourceDraft = mock(TaxCategoryDraft.class);
+
+        final Optional<TaxCategoryDraft> filteredDraft = taxCategorySyncOptions
+            .applyBeforeCreateCallBack(resourceDraft);
+
+        assertThat(filteredDraft).isEmpty();
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/TaxCategorySyncTest.java
@@ -1,0 +1,316 @@
+package com.commercetools.sync.taxcategories;
+
+import com.commercetools.sync.services.TaxCategoryService;
+import com.commercetools.sync.taxcategories.helpers.TaxCategorySyncStatistics;
+import io.sphere.sdk.client.ConcurrentModificationException;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.models.SphereException;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class TaxCategorySyncTest {
+
+    private TaxCategoryService taxCategoryService = mock(TaxCategoryService.class);
+
+    @AfterEach
+    void cleanup() {
+        reset(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithInvalidDrafts_ShouldApplyErrorCallbackAndIncrementFailed() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft withoutKeyDraft = TaxCategoryDraftBuilder.of(null, emptyList(), null).build();
+
+        final TaxCategorySyncStatistics result = sync.sync(asList(null, withoutKeyDraft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(2),
+            () -> assertThat(result.getFailed().get()).isEqualTo(2),
+            () -> assertThat(errors).hasSize(2),
+            () -> assertThat(errors).contains("Failed to process null tax category draft.",
+                "Failed to process tax category draft without key.")
+        );
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithErrorFetchingExistingKeys_ShouldApplyErrorCallbackAndIncrementFailed() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), null).key("someKey").build();
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any())).thenReturn(supplyAsync(() -> {
+            throw new SphereException();
+        }));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(errors).hasSize(1),
+            () -> assertThat(errors).contains("Failed to fetch existing taxCategories with keys: '[someKey]'.")
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithErrorCreating_ShouldIncrementFailedButNotApplyErrorCallback() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), null).key("someKey").build();
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any())).thenReturn(completedFuture(emptySet()));
+        when(taxCategoryService.createTaxCategory(any())).thenReturn(completedFuture(empty()));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getFailed().get()).isEqualTo(1),
+            () -> assertThat(errors).isEmpty()
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).createTaxCategory(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithNoError_ShouldApplyBeforeCreateCallbackAndIncrementCreated() {
+        final AtomicBoolean callbackApplied = new AtomicBoolean(false);
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .beforeCreateCallback((draft) -> {
+                callbackApplied.set(true);
+                return draft;
+            })
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), null).key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any())).thenReturn(completedFuture(emptySet()));
+        when(taxCategoryService.createTaxCategory(any())).thenReturn(completedFuture(Optional.of(taxCategory)));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getCreated().get()).isEqualTo(1),
+            () -> assertThat(result.getFailed().get()).isEqualTo(0),
+            () -> assertThat(callbackApplied.get()).isTrue()
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).createTaxCategory(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithErrorUpdating_ShouldApplyErrorCallbackAndIncrementFailed() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), "changed")
+            .key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategory.getKey()).thenReturn("someKey");
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any()))
+            .thenReturn(completedFuture(new HashSet<>(singletonList(taxCategory))));
+        when(taxCategoryService.updateTaxCategory(any(), any())).thenReturn(supplyAsync(() -> {
+            throw new SphereException();
+        }));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(result.getFailed().get()).isEqualTo(1),
+            () -> assertThat(errors).hasSize(1)
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).updateTaxCategory(any(), any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithErrorUpdatingAndTryingToRecoverWithFetchException_ShouldApplyErrorCallbackAndIncrementFailed() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), "changed")
+            .key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategory.getKey()).thenReturn("someKey");
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any()))
+            .thenReturn(completedFuture(new HashSet<>(singletonList(taxCategory))));
+        when(taxCategoryService.updateTaxCategory(any(), any())).thenReturn(supplyAsync(() -> {
+            throw new io.sphere.sdk.client.ConcurrentModificationException();
+        }));
+        when(taxCategoryService.fetchTaxCategory(any())).thenReturn(supplyAsync(() -> {
+            throw new SphereException();
+        }));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(result.getFailed().get()).isEqualTo(1),
+            () -> assertThat(errors).hasSize(1),
+            () -> assertThat(errors).hasOnlyOneElementSatisfying(msg -> assertThat(msg)
+                .contains("Failed to fetch from CTP while retrying after concurrency modification."))
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).updateTaxCategory(any(), any());
+        verify(taxCategoryService, times(1)).fetchTaxCategory(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithErrorUpdatingAndTryingToRecoverWithEmptyResponse_ShouldApplyErrorCallbackAndIncrementFailed() {
+        final List<String> errors = new ArrayList<>();
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((msg, error) -> errors.add(msg))
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), "changed")
+            .key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategory.getKey()).thenReturn("someKey");
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any()))
+            .thenReturn(completedFuture(new HashSet<>(singletonList(taxCategory))));
+        when(taxCategoryService.updateTaxCategory(any(), any())).thenReturn(supplyAsync(() -> {
+            throw new ConcurrentModificationException();
+        }));
+        when(taxCategoryService.fetchTaxCategory(any())).thenReturn(completedFuture(Optional.empty()));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(result.getFailed().get()).isEqualTo(1),
+            () -> assertThat(errors).hasSize(1),
+            () -> assertThat(errors).hasOnlyOneElementSatisfying(msg -> assertThat(msg)
+                .contains("Not found when attempting to fetch while retrying after concurrency modification."))
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).updateTaxCategory(any(), any());
+        verify(taxCategoryService, times(1)).fetchTaxCategory(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithNoError_ShouldApplyBeforeUpdateCallbackAndIncrementUpdated() {
+        final AtomicBoolean callbackApplied = new AtomicBoolean(false);
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .beforeUpdateCallback((actions, draft, old) -> {
+                callbackApplied.set(true);
+                return actions;
+            })
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), "changed")
+            .key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategory.getId()).thenReturn("id");
+        when(taxCategory.getKey()).thenReturn("someKey");
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any()))
+            .thenReturn(completedFuture(new HashSet<>(singletonList(taxCategory))));
+        when(taxCategoryService.updateTaxCategory(any(), any())).thenReturn(completedFuture(taxCategory));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getUpdated().get()).isEqualTo(1),
+            () -> assertThat(result.getFailed().get()).isEqualTo(0),
+            () -> assertThat(callbackApplied.get()).isTrue()
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verify(taxCategoryService, times(1)).updateTaxCategory(any(), any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+    @Test
+    void sync_WithFilteredActions_ShouldApplyBeforeUpdateCallbackAndNotIncrementUpdated() {
+        final AtomicBoolean callbackApplied = new AtomicBoolean(false);
+        final TaxCategorySyncOptions options = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .beforeUpdateCallback((actions, draft, old) -> {
+                callbackApplied.set(true);
+                return emptyList();
+            })
+            .build();
+        final TaxCategorySync sync = new TaxCategorySync(options, taxCategoryService);
+        final TaxCategoryDraft draft = TaxCategoryDraftBuilder.of("someName", emptyList(), "changed")
+            .key("someKey").build();
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+
+        when(taxCategory.getId()).thenReturn("id");
+        when(taxCategory.getKey()).thenReturn("someKey");
+
+        when(taxCategoryService.fetchMatchingTaxCategoriesByKeys(any()))
+            .thenReturn(completedFuture(new HashSet<>(singletonList(taxCategory))));
+
+        final TaxCategorySyncStatistics result = sync.sync(singletonList(draft)).toCompletableFuture().join();
+
+        assertAll(
+            () -> assertThat(result.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(result.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(result.getFailed().get()).isEqualTo(0),
+            () -> assertThat(callbackApplied.get()).isTrue()
+        );
+        verify(taxCategoryService, times(1)).fetchMatchingTaxCategoriesByKeys(any());
+        verifyNoMoreInteractions(taxCategoryService);
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/helpers/TaxCategoryDraftBuilderHelperTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/helpers/TaxCategoryDraftBuilderHelperTest.java
@@ -1,0 +1,35 @@
+package com.commercetools.sync.taxcategories.helpers;
+
+import io.sphere.sdk.json.SphereJsonUtils;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class TaxCategoryDraftBuilderHelperTest {
+
+    @Test
+    void of_WithTaxCategory_ShouldBuildTaxCategoryDraft() {
+        TaxCategory resource = SphereJsonUtils.readObjectFromResource("tax-category.json", TaxCategory.class);
+        // convertion because of types
+        List<TaxRateDraft> resourcesDrafts = resource.getTaxRates().stream()
+            .map(taxRate -> TaxRateDraftBuilder.of(taxRate).build()).collect(Collectors.toList());
+
+        TaxCategoryDraft draft = TaxCategoryDraftBuilderHelper.of(resource);
+
+        assertAll(
+            () -> assertThat(draft.getKey()).isEqualTo(resource.getKey()),
+            () -> assertThat(draft.getName()).isEqualTo(resource.getName()),
+            () -> assertThat(draft.getDescription()).isEqualTo(resource.getDescription()),
+            () -> assertThat(draft.getTaxRates()).isEqualTo(resourcesDrafts)
+        );
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatisticsTest.java
@@ -1,0 +1,30 @@
+package com.commercetools.sync.taxcategories.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaxCategorySyncStatisticsTest {
+
+    @Test
+    void getReportMessage_WithRandomStats_ShouldGetCorrectMessage() {
+        Random random = new Random();
+
+        int created = random.nextInt();
+        int updated = random.nextInt();
+        int failed = random.nextInt();
+        int processed = created + updated + failed;
+
+        TaxCategorySyncStatistics statistics = new TaxCategorySyncStatistics();
+        statistics.incrementCreated(created);
+        statistics.incrementUpdated(updated);
+        statistics.incrementFailed(failed);
+        statistics.incrementProcessed(processed);
+
+        assertThat(statistics.getReportMessage()).isEqualTo("Summary: %s tax categories were processed in "
+            + "total (%s created, %s updated and %s failed to sync).", processed, created, updated, failed);
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtilsTest.java
@@ -1,0 +1,96 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.TaxRate;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import io.sphere.sdk.taxcategories.commands.updateactions.AddTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ChangeName;
+import io.sphere.sdk.taxcategories.commands.updateactions.RemoveTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ReplaceTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.SetDescription;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.commercetools.sync.taxcategories.utils.TaxCategorySyncUtils.buildActions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TaxCategorySyncUtilsTest {
+
+    private static String KEY = "key";
+
+    @Test
+    void buildActions_WithSameValues_ShouldNotBuildUpdateActions() {
+        final String name = "test name";
+        final String description = "test description";
+
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+        when(taxCategory.getName()).thenReturn(name);
+        when(taxCategory.getKey()).thenReturn(KEY);
+        when(taxCategory.getDescription()).thenReturn(description);
+
+        final TaxCategoryDraft taxCategoryDraft = TaxCategoryDraftBuilder.of(name, null, description)
+            .key(KEY)
+            .build();
+
+        final List<UpdateAction<TaxCategory>> result = buildActions(taxCategory, taxCategoryDraft,
+            mock(TaxCategorySyncOptions.class));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildActions_WithDifferentValues_ShouldBuildAllUpdateActions() {
+        final TaxCategory taxCategory = mock(TaxCategory.class);
+        when(taxCategory.getName()).thenReturn("name");
+        when(taxCategory.getKey()).thenReturn(KEY);
+        when(taxCategory.getDescription()).thenReturn("description");
+
+        final String removeId = "removeMe";
+        final String replaceId = "replaceMe";
+        final CountryCode countryCode = CountryCode.DE;
+
+        final TaxRate toBeRemovedTaxRate = mock(TaxRate.class);
+        when(toBeRemovedTaxRate.getId()).thenReturn(removeId);
+        when(toBeRemovedTaxRate.getName()).thenReturn(removeId);
+        final TaxRate toBeReplacedTaxRate = mock(TaxRate.class);
+        when(toBeReplacedTaxRate.getId()).thenReturn(replaceId);
+        when(toBeReplacedTaxRate.getName()).thenReturn(replaceId);
+
+        when(taxCategory.getTaxRates()).thenReturn(Arrays.asList(toBeRemovedTaxRate, toBeReplacedTaxRate));
+
+        final TaxRateDraft replaceTaxRateDraft = TaxRateDraftBuilder
+            .of(replaceId, 10, true, countryCode)
+            .build();
+        final TaxRateDraft addTaxRateDraft = TaxRateDraftBuilder
+            .of("addMe", 1, true, countryCode)
+            .build();
+
+        final TaxCategoryDraft taxCategoryDraft = TaxCategoryDraftBuilder
+            .of("different name", Arrays.asList(replaceTaxRateDraft, addTaxRateDraft), "different description")
+            .key(KEY)
+            .build();
+
+        final List<UpdateAction<TaxCategory>> result = buildActions(taxCategory, taxCategoryDraft,
+            mock(TaxCategorySyncOptions.class));
+
+        assertAll(
+            () -> assertThat(result).contains(ChangeName.of(taxCategoryDraft.getName())),
+            () -> assertThat(result).contains(SetDescription.of(taxCategoryDraft.getDescription())),
+            () -> assertThat(result).contains(ReplaceTaxRate.of(replaceId, replaceTaxRateDraft)),
+            () -> assertThat(result).contains(RemoveTaxRate.of(removeId)),
+            () -> assertThat(result).contains(AddTaxRate.of(addTaxRateDraft))
+        );
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategorySyncUtilsTest.java
@@ -17,6 +17,7 @@ import io.sphere.sdk.taxcategories.commands.updateactions.SetDescription;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.commercetools.sync.taxcategories.utils.TaxCategorySyncUtils.buildActions;
@@ -39,7 +40,7 @@ class TaxCategorySyncUtilsTest {
         when(taxCategory.getKey()).thenReturn(KEY);
         when(taxCategory.getDescription()).thenReturn(description);
 
-        final TaxCategoryDraft taxCategoryDraft = TaxCategoryDraftBuilder.of(name, null, description)
+        final TaxCategoryDraft taxCategoryDraft = TaxCategoryDraftBuilder.of(name, Collections.emptyList(), description)
             .key(KEY)
             .build();
 

--- a/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/utils/TaxCategoryUpdateActionUtilsTest.java
@@ -1,0 +1,173 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptionsBuilder;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.TaxRate;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import io.sphere.sdk.taxcategories.commands.updateactions.AddTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ChangeName;
+import io.sphere.sdk.taxcategories.commands.updateactions.RemoveTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ReplaceTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.SetDescription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildChangeNameAction;
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildTaxRateUpdateActions;
+import static com.commercetools.sync.taxcategories.utils.TaxCategoryUpdateActionUtils.buildSetDescriptionAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TaxCategoryUpdateActionUtilsTest {
+
+    private TaxCategory taxCategory;
+    private TaxCategoryDraft newSameTaxCategoryDraft;
+    private TaxCategoryDraft newDifferentTaxCategoryDraft;
+
+    @BeforeEach
+    void setup() {
+        final String name = "test name";
+        final String key = "test key";
+        final String description = "test description";
+
+        taxCategory = mock(TaxCategory.class);
+        when(taxCategory.getName()).thenReturn(name);
+        when(taxCategory.getKey()).thenReturn(key);
+        when(taxCategory.getDescription()).thenReturn(description);
+
+        final String taxRateName1 = "taxRateName1";
+        final String taxRateName2 = "taxRateName2";
+        final CountryCode countryCode = CountryCode.DE;
+
+        final TaxRate taxRate1 = mock(TaxRate.class);
+        when(taxRate1.getName()).thenReturn(taxRateName1);
+        when(taxRate1.getId()).thenReturn("taxRateId1");
+        when(taxRate1.getAmount()).thenReturn(1.0);
+        when(taxRate1.getCountry()).thenReturn(countryCode);
+        when(taxRate1.isIncludedInPrice()).thenReturn(false);
+        final TaxRate taxRate2 = mock(TaxRate.class);
+        when(taxRate2.getName()).thenReturn(taxRateName2);
+        when(taxRate2.getId()).thenReturn("taxRateId2");
+        when(taxRate2.getAmount()).thenReturn(2.0);
+        when(taxRate2.getCountry()).thenReturn(countryCode);
+        when(taxRate2.isIncludedInPrice()).thenReturn(false);
+
+        final List<TaxRate> oldTaxRates = Arrays.asList(taxRate1, taxRate2);
+
+        when(taxCategory.getTaxRates()).thenReturn(oldTaxRates);
+
+        newSameTaxCategoryDraft = TaxCategoryDraftBuilder.of(name, Arrays.asList(
+            TaxRateDraftBuilder
+                .of(taxRateName1, 1.0, false, countryCode)
+                .build(),
+            TaxRateDraftBuilder
+                .of(taxRateName2, 2.0, false, countryCode)
+                .build()
+        ), description).key(key).build();
+
+        newDifferentTaxCategoryDraft = TaxCategoryDraftBuilder.of("changedName", Arrays.asList(
+            // replace
+            TaxRateDraftBuilder
+                .of(taxRateName1, 2.0, false, countryCode)
+                .build(),
+            // remove - taxRateName2
+            // add
+            TaxRateDraftBuilder
+                .of("taxRateName3", 3.0, false, countryCode)
+                .build()
+        ), "desc")
+            .key(key)
+            .build();
+    }
+
+    @Test
+    void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<TaxCategory>> result = buildChangeNameAction(taxCategory,
+            newDifferentTaxCategoryDraft);
+
+        assertThat(result).contains(ChangeName.of(newDifferentTaxCategoryDraft.getName()));
+    }
+
+    @Test
+    void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<TaxCategory>> result = buildChangeNameAction(taxCategory, newSameTaxCategoryDraft);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildSetDescriptionAction_WithDifferentValues_ShouldReturnAction() {
+        final Optional<UpdateAction<TaxCategory>> result = buildSetDescriptionAction(taxCategory,
+            newDifferentTaxCategoryDraft);
+
+        assertThat(result).contains(SetDescription.of(newDifferentTaxCategoryDraft.getDescription()));
+    }
+
+    @Test
+    void buildSetDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
+        final Optional<UpdateAction<TaxCategory>> result = buildSetDescriptionAction(taxCategory,
+            newSameTaxCategoryDraft);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildRatesUpdateActions_WithSameValues_ShouldNotBuildAction() {
+        final List<UpdateAction<TaxCategory>> result = buildTaxRateUpdateActions(taxCategory, newSameTaxCategoryDraft,
+            mock(TaxCategorySyncOptions.class));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void buildRatesUpdateActions_WithDifferentValues_ShouldReturnAction() {
+        final List<UpdateAction<TaxCategory>> result = buildTaxRateUpdateActions(taxCategory,
+            newDifferentTaxCategoryDraft, mock(TaxCategorySyncOptions.class));
+
+        assertAll(
+            () -> assertThat(result)
+                .contains(AddTaxRate.of(newDifferentTaxCategoryDraft.getTaxRates().get(1))),
+            () -> assertThat(result)
+                .contains(ReplaceTaxRate.of("taxRateId1", newDifferentTaxCategoryDraft.getTaxRates().get(0))),
+            () -> assertThat(result).contains(RemoveTaxRate.of("taxRateId2"))
+        );
+    }
+
+    @Test
+    void buildRatesUpdateActions_WithDuplicatedValues_ShouldNotBuildActionAndTriggerErrorCallback() {
+        final String name = "DuplicatedName";
+        newDifferentTaxCategoryDraft = TaxCategoryDraftBuilder.of(name, Arrays.asList(
+            // replace
+            TaxRateDraftBuilder.of(name, 2.0, false, CountryCode.DE).build(),
+            TaxRateDraftBuilder.of(name, 3.0, false, CountryCode.DE).build()
+        ), "desc").build();
+
+        final AtomicReference<String> callback = new AtomicReference<>(null);
+
+        final TaxCategorySyncOptions syncOptions = TaxCategorySyncOptionsBuilder.of(mock(SphereClient.class))
+            .errorCallback((errorMsg, exception) -> callback.set(errorMsg))
+            .build();
+
+        final List<UpdateAction<TaxCategory>> result = buildTaxRateUpdateActions(taxCategory,
+            newDifferentTaxCategoryDraft, syncOptions);
+
+        assertAll(
+            () -> assertThat(result).isEmpty(),
+            () -> assertThat(callback.get()).contains(name)
+        );
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtilsTest.java
@@ -1,0 +1,140 @@
+package com.commercetools.sync.taxcategories.utils;
+
+import com.commercetools.sync.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.commons.exceptions.DuplicateNameException;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.taxcategories.SubRate;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxRate;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import io.sphere.sdk.taxcategories.commands.updateactions.AddTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.RemoveTaxRate;
+import io.sphere.sdk.taxcategories.commands.updateactions.ReplaceTaxRate;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TaxRatesUpdateActionUtilsTest {
+
+    private static final Random random = new Random();
+
+    private static final String NAME = "Test old category";
+    private static final String ID = RandomStringUtils.randomAlphabetic(15);
+    private static final Double AMOUNT = random.nextDouble();
+    private static final CountryCode COUNTRY_CODE = CountryCode.DE;
+    private static final String STATE = RandomStringUtils.randomAlphabetic(15);
+    private static final Boolean INCLUDED_IN_PRICE = random.nextBoolean();
+    private List<TaxRate> oldTaxRates;
+
+    private static final String SUB_RATE_NAME_1 = RandomStringUtils.randomAlphabetic(15);
+    private static final Double SUB_RATE_AMOUNT_1 = random.nextDouble();
+
+    private static final String SUB_RATE_NAME_2 = RandomStringUtils.randomAlphabetic(15);
+    private static final Double SUB_RATE_AMOUNT_2 = random.nextDouble();
+
+    @BeforeEach
+    void setup() {
+        final TaxRate oldTaxRate = mock(TaxRate.class);
+        when(oldTaxRate.getName()).thenReturn(NAME);
+        when(oldTaxRate.getId()).thenReturn(ID);
+        when(oldTaxRate.getAmount()).thenReturn(AMOUNT);
+        when(oldTaxRate.getCountry()).thenReturn(COUNTRY_CODE);
+        when(oldTaxRate.getState()).thenReturn(STATE);
+        when(oldTaxRate.isIncludedInPrice()).thenReturn(INCLUDED_IN_PRICE);
+
+        final SubRate rate1 = SubRate.of(SUB_RATE_NAME_1, SUB_RATE_AMOUNT_1);
+        final SubRate rate2 = SubRate.of(SUB_RATE_NAME_2, SUB_RATE_AMOUNT_2);
+        when(oldTaxRate.getSubRates()).thenReturn(Arrays.asList(rate1, rate2));
+
+        oldTaxRates = singletonList(oldTaxRate);
+    }
+
+    @Test
+    void buildTaxRatesUpdateActions_WithNewTaxRatesSetToNull_ShouldReturnOnlyRemovalActions()
+        throws BuildUpdateActionException {
+        final List<UpdateAction<TaxCategory>> updateActions = TaxRatesUpdateActionUtils
+            .buildTaxRatesUpdateActions(oldTaxRates, null);
+
+        assertAll(
+            () -> assertThat(updateActions).allMatch(ac -> ac instanceof RemoveTaxRate),
+            () -> assertThat(updateActions).contains(RemoveTaxRate.of(ID))
+        );
+    }
+
+    @Test
+    void buildTaxRatesUpdateActions_WithSameValues_ShouldNotBuildUpdateActions() throws BuildUpdateActionException {
+        final SubRate rate1 = SubRate.of(SUB_RATE_NAME_1, SUB_RATE_AMOUNT_1);
+        final SubRate rate2 = SubRate.of(SUB_RATE_NAME_2, SUB_RATE_AMOUNT_2);
+
+        final List<TaxRateDraft> newTaxRates = singletonList(
+            TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE)
+                .state(STATE)
+                .subRates(Arrays.asList(rate2, rate1)).build());
+
+        final List<UpdateAction<TaxCategory>> updateActions = TaxRatesUpdateActionUtils
+            .buildTaxRatesUpdateActions(oldTaxRates, newTaxRates);
+
+        assertThat(updateActions).isEmpty();
+    }
+
+    @Test
+    void buildTaxRatesUpdateActions_WithDuplicatedValues_ShouldThrowDuplicateNameException() {
+        final List<TaxRateDraft> newTaxRates = Arrays.asList(
+            TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE).build(),
+            TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE).build());
+
+        assertThatExceptionOfType(BuildUpdateActionException.class)
+            .isThrownBy(() -> TaxRatesUpdateActionUtils.buildTaxRatesUpdateActions(oldTaxRates, newTaxRates))
+            .withCauseInstanceOf(DuplicateNameException.class)
+            .withMessageContaining(NAME);
+    }
+
+    @Test
+    void buildTaxRatesUpdateActions_WithDifferentValues_ShouldReturnOnlyReplaceAction()
+        throws BuildUpdateActionException {
+        final SubRate rate1 = SubRate.of(SUB_RATE_NAME_1, SUB_RATE_AMOUNT_1);
+        final SubRate rate2 = SubRate.of(SUB_RATE_NAME_2, random.nextDouble());
+
+        final List<TaxRateDraft> newTaxRates = singletonList(
+            TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE)
+                .state(STATE)
+                .subRates(Arrays.asList(rate1, rate2)).build());
+
+        final List<UpdateAction<TaxCategory>> updateActions = TaxRatesUpdateActionUtils
+            .buildTaxRatesUpdateActions(oldTaxRates, newTaxRates);
+
+        assertAll(
+            () -> assertThat(updateActions).allMatch(ac -> ac instanceof ReplaceTaxRate),
+            () -> assertThat(updateActions).contains(ReplaceTaxRate.of(ID, newTaxRates.get(0)))
+        );
+    }
+
+    @Test
+    void buildTaxRatesUpdateActions_WithNewValues_ShouldReturnOnlyAddAction() throws BuildUpdateActionException {
+        final List<TaxRateDraft> newTaxRates = singletonList(
+            TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE).build());
+
+        final List<UpdateAction<TaxCategory>> updateActions = TaxRatesUpdateActionUtils
+            .buildTaxRatesUpdateActions(emptyList(), newTaxRates);
+
+        assertAll(
+            () -> assertThat(updateActions).allMatch(ac -> ac instanceof AddTaxRate),
+            () -> assertThat(updateActions).contains(AddTaxRate.of(newTaxRates.get(0)))
+        );
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtilsTest.java
@@ -58,16 +58,16 @@ class TaxRatesUpdateActionUtilsTest {
 
         final SubRate rate1 = SubRate.of(SUB_RATE_NAME_1, SUB_RATE_AMOUNT_1);
         final SubRate rate2 = SubRate.of(SUB_RATE_NAME_2, SUB_RATE_AMOUNT_2);
-        when(oldTaxRate.getSubRates()).thenReturn(Arrays.asList(rate1, rate2));
+        when(oldTaxRate.getSubRates()).thenReturn(Arrays.asList(rate1, rate2, null));
 
         oldTaxRates = singletonList(oldTaxRate);
     }
 
     @Test
-    void buildTaxRatesUpdateActions_WithNewTaxRatesSetToNull_ShouldReturnOnlyRemovalActions()
+    void buildTaxRatesUpdateActions_WithNewTaxRatesSetToEmptyList_ShouldReturnOnlyRemovalActions()
         throws BuildUpdateActionException {
         final List<UpdateAction<TaxCategory>> updateActions = TaxRatesUpdateActionUtils
-            .buildTaxRatesUpdateActions(oldTaxRates, null);
+            .buildTaxRatesUpdateActions(oldTaxRates, emptyList());
 
         assertAll(
             () -> assertThat(updateActions).allMatch(ac -> ac instanceof RemoveTaxRate),
@@ -80,7 +80,8 @@ class TaxRatesUpdateActionUtilsTest {
         final SubRate rate1 = SubRate.of(SUB_RATE_NAME_1, SUB_RATE_AMOUNT_1);
         final SubRate rate2 = SubRate.of(SUB_RATE_NAME_2, SUB_RATE_AMOUNT_2);
 
-        final List<TaxRateDraft> newTaxRates = singletonList(
+        final List<TaxRateDraft> newTaxRates = Arrays.asList(
+            null,
             TaxRateDraftBuilder.of(NAME, AMOUNT, INCLUDED_IN_PRICE, COUNTRY_CODE)
                 .state(STATE)
                 .subRates(Arrays.asList(rate2, rate1)).build());

--- a/src/test/resources/tax-category.json
+++ b/src/test/resources/tax-category.json
@@ -1,0 +1,24 @@
+{
+  "id": "44e5e889-0878-4c30-941f-767cebebeb7f",
+  "version": 18,
+  "name": "Standard tax category",
+  "key": "standard_tax_category",
+  "rates": [
+    {
+      "name": "5% US",
+      "amount": 0.051,
+      "includedInPrice": true,
+      "country": "US",
+      "id": "ak80m7Jk",
+      "subRates": []
+    },
+    {
+      "name": "19% MwSt test",
+      "amount": 0.19,
+      "includedInPrice": false,
+      "country": "DE",
+      "id": "IZV0fDOU",
+      "subRates": []
+    }
+  ]
+}


### PR DESCRIPTION
#### Summary
Synchronization of tax categories

#### Description
Added modules for tax category synchronization, contains breaking changes.
PR source code originates from [BaseService improvement](https://github.com/commercetools/commercetools-sync-java/pull/419)

#### Relevant Issues
[#417](https://github.com/commercetools/commercetools-sync-java/issues/417)

#### Hints for Review
As was decided in [discussion](https://github.com/commercetools/commercetools-sync-java/pull/415#issuecomment-511797104) - old PR splitted; I hope I addressed all requested changes 😄 