### PR TITLE
#424: Bring the thresholds back down.

### DIFF
--- a/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/ProductTypeSyncBenchmark.java
@@ -92,8 +92,8 @@ class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~43 seconds)
-        final int threshold = 43000; // double of the highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~12 seconds)
+        final int threshold = 24000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -138,8 +138,8 @@ class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~43 seconds)
-        final int threshold = 43000; // double of the highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 
@@ -198,8 +198,8 @@ class ProductTypeSyncBenchmark {
         final ProductTypeSyncStatistics syncStatistics = executeBlocking(productTypeSync.sync(productTypeDrafts));
         final long totalTime = System.currentTimeMillis() - beforeSyncTime;
 
-        // assert on threshold (based on history of benchmarks; highest was ~43 seconds)
-        final int threshold = 43000; // double of the highest benchmark
+        // assert on threshold (based on history of benchmarks; highest was ~13 seconds)
+        final int threshold = 26000; // double of the highest benchmark
         assertThat(totalTime).withFailMessage(format(THRESHOLD_EXCEEDED_ERROR, totalTime, threshold))
                              .isLessThan(threshold);
 


### PR DESCRIPTION
#### Summary
This PR adjusts the benchmarks thresholds for the productType sync back to their normal values.

#### Relevant Issues
#424
