### PR TITLE
#447: Add unit tests for product sync statistics.

### DIFF
--- a/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
@@ -5,11 +5,11 @@ import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static io.sphere.sdk.utils.SphereInternalUtils.asSet;
 import static java.lang.String.format;
 
 public class ProductSyncStatistics extends BaseSyncStatistics {
@@ -68,16 +68,10 @@ public class ProductSyncStatistics extends BaseSyncStatistics {
      * @param childKey  the key of the product with a missing parent.
      */
     public void addMissingDependency(@Nonnull final String parentKey, @Nonnull final String childKey) {
-
-        final Set<String> missingParentProductChildrenKeys =
-            productKeysWithMissingParents.get(parentKey);
-        if (missingParentProductChildrenKeys != null) {
-            missingParentProductChildrenKeys.add(childKey);
-        } else {
-            final Set<String> newChildProductKeys = new HashSet<>();
-            newChildProductKeys.add(childKey);
-            productKeysWithMissingParents.put(parentKey, newChildProductKeys);
-        }
+        productKeysWithMissingParents.merge(parentKey, asSet(childKey), (existingSet, newChildAsSet) -> {
+            existingSet.addAll(newChildAsSet);
+            return existingSet;
+        });
     }
 
     @Nullable

--- a/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
@@ -4,6 +4,7 @@ import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -44,16 +45,17 @@ public class ProductSyncStatistics extends BaseSyncStatistics {
     }
 
     /**
-     * Returns the total number of categories with missing parents.
+     * Returns the total number of products with missing parents.
      *
-     * @return the total number of categories with missing parents.
+     * @return the total number of products with missing parents.
      */
     public int getNumberOfProductsWithMissingParents() {
-        return productKeysWithMissingParents
+        return (int) productKeysWithMissingParents
             .values()
             .stream()
-            .mapToInt(Set::size)
-            .sum();
+            .flatMap(Collection::stream)
+            .distinct()
+            .count();
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/helpers/CategorySyncStatisticsTest.java
@@ -91,7 +91,7 @@ class CategorySyncStatisticsTest {
         categoryKeysWithMissingParents.put("parent2", emptySet());
 
         categorySyncStatistics.setCategoryKeysWithMissingParents(categoryKeysWithMissingParents);
-        assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isEqualTo(0);
+        assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isZero();
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/products/helpers/ProductSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/products/helpers/ProductSyncStatisticsTest.java
@@ -3,6 +3,8 @@ package com.commercetools.sync.products.helpers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ProductSyncStatisticsTest {
@@ -23,4 +25,112 @@ class ProductSyncStatisticsTest {
         assertThat(productSyncStatistics.getReportMessage()).isEqualTo("Summary: 3 product(s) were processed in total "
             + "(1 created, 1 updated, 1 failed to sync and 0 product(s) with missing reference(s)).");
     }
+
+    @Test
+    void getNumberOfProductsWithMissingParents_WithEmptyMap_ShouldReturn0() {
+        final int result = productSyncStatistics.getNumberOfProductsWithMissingParents();
+
+        assertThat(result).isZero();
+    }
+
+    @Test
+    void getNumberOfCategoriesWithMissingParents_WithNonEmptyNonDuplicateKeyMap_ShouldReturnCorrectValue() {
+        // preparation
+        productSyncStatistics.addMissingDependency("parent1", "key1");
+        productSyncStatistics.addMissingDependency("parent1", "key2");
+
+        productSyncStatistics.addMissingDependency("parent1", "key3");
+        productSyncStatistics.addMissingDependency("parent2", "key4");
+
+        // test
+        final int result = productSyncStatistics.getNumberOfProductsWithMissingParents();
+
+        // assert
+        assertThat(result).isEqualTo(4);
+    }
+
+    @Test
+    void getNumberOfCategoriesWithMissingParents_WithNonEmptyDuplicateKeyMap_ShouldReturnCorrectValue() {
+        // preparation
+        productSyncStatistics.addMissingDependency("parent1", "key1");
+        productSyncStatistics.addMissingDependency("parent1", "key2");
+
+        productSyncStatistics.addMissingDependency("parent1", "key3");
+        productSyncStatistics.addMissingDependency("parent2", "key1");
+
+        // test
+        final int result = productSyncStatistics.getNumberOfProductsWithMissingParents();
+
+        // assert
+        assertThat(result).isEqualTo(3);
+    }
+
+    @Test
+    void addMissingDependency_WithEmptyParentsAndChildren_ShouldAddKeys() {
+        // preparation
+        productSyncStatistics.addMissingDependency("", "");
+        productSyncStatistics.addMissingDependency("foo", "");
+        productSyncStatistics.addMissingDependency("", "");
+
+        // test
+        final int result = productSyncStatistics.getNumberOfProductsWithMissingParents();
+
+        // assert
+        assertThat(result).isOne();
+    }
+
+    @Test
+    void removeAndGetReferencingKeys_WithEmptyMap_ShouldGetNull() {
+        // test
+        final Set<String> result = productSyncStatistics.removeAndGetReferencingKeys("foo");
+
+        // assert
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void removeAndGetReferencingKeys_WithNonExistingKey_ShouldGetAndRemoveNoKey() {
+        // preparation
+        productSyncStatistics.addMissingDependency("bar", "a");
+        productSyncStatistics.addMissingDependency("foo", "b");
+
+        // test
+        final Set<String> result = productSyncStatistics.removeAndGetReferencingKeys("x");
+
+        // assert
+        assertThat(result).isNull();
+        assertThat(productSyncStatistics.getNumberOfProductsWithMissingParents()).isEqualTo(2);
+    }
+
+    @Test
+    void removeAndGetReferencingKeys_WithExistingKey_ShouldGetAndRemoveKey() {
+        // preparation
+        productSyncStatistics.addMissingDependency("bar", "a");
+        productSyncStatistics.addMissingDependency("foo", "b");
+
+        // test
+        final Set<String> result = productSyncStatistics.removeAndGetReferencingKeys("foo");
+
+        // assert
+        assertThat(result).containsExactly("b");
+        assertThat(productSyncStatistics.getNumberOfProductsWithMissingParents()).isEqualTo(1);
+    }
+
+    @Test
+    void removeAndGetReferencingKeys_WithExistingKey_ShouldGetAndRemoveAllKeys() {
+        // preparation
+        productSyncStatistics.addMissingDependency("bar", "a");
+        productSyncStatistics.addMissingDependency("foo", "b");
+        productSyncStatistics.addMissingDependency("foo", "c");
+
+        // test
+        final Set<String> result = productSyncStatistics.removeAndGetReferencingKeys("foo");
+
+        // assert
+        assertThat(result).containsExactly("b", "c");
+        assertThat(productSyncStatistics.getNumberOfProductsWithMissingParents()).isEqualTo(1);
+    }
+
+
+
 }


### PR DESCRIPTION
#### Summary

1. Makes sure the count is distinct from the product statistics.
2. Adds unit tests to the change.
