### PR TITLE
Prepare for release 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 1.5.0](https://img.shields.io/badge/Benchmarks-1.5.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Benchmarks 1.6.0](https://img.shields.io/badge/Benchmarks-1.6.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/)
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
@@ -34,7 +34,7 @@ The library supports synchronising the following entities in commercetools
     - [Ivy](#ivy)
 - [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -74,26 +74,26 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:1.5.0'
+implementation 'com.commercetools:commercetools-sync-java:1.6.0'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.5.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.6.0"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.5.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.6.0"/>
 ````
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 1.6.0](https://img.shields.io/badge/Benchmarks-1.5.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Benchmarks 1.6.0](https://img.shields.io/badge/Benchmarks-1.6.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
 [![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 1.5.0](https://img.shields.io/badge/Benchmarks-1.5.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Benchmarks 1.6.0](https://img.shields.io/badge/Benchmarks-1.5.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/)
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
  
@@ -51,18 +51,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:1.5.0'
+implementation 'com.commercetools:commercetools-sync-java:1.6.0'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.5.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.6.0"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.5.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.6.0"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,9 +27,14 @@
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 
 -->
-
 <!--
-### 1.6.0 -  Oct 8, 2019
+### 1.7.0 -  Oct 17, 2019
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.6.0...1.7.0) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.7.0/) | 
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.7.0)
+-->
+
+### 1.6.0 -  Oct 10, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.5.0...1.6.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.6.0)
@@ -37,7 +42,8 @@
 - 🎉 **New Features** (1)
     - **Product Sync** - Introduced support for syncing products with other product references as attributes in any order. [#447](https://github.com/commercetools/commercetools-sync-java/issues/447)
 
--->
+- 🛠️ **Dependency Updates** (1)
+    - `com.adarshr.test-logger` to 1.7.0 -> 1.7.1 [#456](https://github.com/commercetools/commercetools-sync-java/pull/456)
 
 ### 1.5.0 -  Sept 13, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.4.1...1.5.0) |

--- a/docs/usage/CART_DISCOUNT_SYNC.md
+++ b/docs/usage/CART_DISCOUNT_SYNC.md
@@ -36,7 +36,7 @@ Therefore, in order for the sync to resolve the actual ids of those references i
     reference should return its `key`.
 
    **Note**: When syncing from a source commercetools project, you can use this util which this library provides:
-    [`replaceCartDiscountsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountReferenceReplacementUtils.html#replaceCartDiscountsReferenceIdsWithKeys-java.util.List-)
+    [`replaceCartDiscountsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountReferenceReplacementUtils.html#replaceCartDiscountsReferenceIdsWithKeys-java.util.List-)
     that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
     ````java
     // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -37,7 +37,7 @@ otherwise they won't be matched.
     reference would return its `key`.  
 
    **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-    [`replaceCategoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.html#replaceCategoriesReferenceIdsWithKeys-java.util.List-)
+    [`replaceCategoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.html#replaceCategoriesReferenceIdsWithKeys-java.util.List-)
     that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
     ````java
     // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/IMPORTANT_USAGE_TIPS.md
+++ b/docs/usage/IMPORTANT_USAGE_TIPS.md
@@ -29,7 +29,7 @@ productSync.sync(batch1)
 By design, scaling the sync process should **not** be done by executing the batches themselves in parallel. However, it can be done either by:
  
  - Changing the number of [max parallel requests](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L116) within the `sphereClient` configuration. It defines how many requests the client can execute in parallel.
- - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contain.
+ - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contain.
  
 The current overridable default [configuration](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) of the `sphereClient` 
 is the recommended good balance for stability and performance for the sync process.

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -35,7 +35,7 @@ against a [InventoryEntryDraft](https://docs.commercetools.com/http-api-projects
    reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceInventoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.html#replaceInventoriesReferenceIdsWithKeys-java.util.List-)
+         [`replaceInventoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.html#replaceInventoriesReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -42,7 +42,7 @@ order for the sync to resolve the actual ids of those references, those `key`s h
     reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceProductsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.html#replaceProductsReferenceIdsWithKeys-java.util.List-)
+         [`replaceProductsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.html#replaceProductsReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -39,7 +39,7 @@ references, those `key`s have to be supplied in the following way:
     reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceProductTypesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/com/commercetools/sync/producttypes/utils/ProductTypeReferenceReplacementUtils.html#replaceProductTypesReferenceIdsWithKeys-java.util.List-)
+         [`replaceProductTypesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/com/commercetools/sync/producttypes/utils/ProductTypeReferenceReplacementUtils.html#replaceProductTypesReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -37,7 +37,7 @@
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ````
 - For Gradle users:
@@ -48,7 +48,7 @@ implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.37.0'
 implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.37.0'
 
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:1.5.0'
+implementation 'com.commercetools:commercetools-sync-java:1.6.0'
 ````
 
 ### 2. Setup Syncing Options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
       - Advanced:
         - Sync Options: usage/SYNC_OPTIONS.md
         - Usage Tips: usage/IMPORTANT_USAGE_TIPS.md
-  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/1.5.0/
+  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/1.6.0/
   - Release notes: RELEASE_NOTES.md
   - Roadmap: https://github.com/commercetools/commercetools-sync-java/milestones
   - Issues: https://github.com/commercetools/commercetools-sync-java/issues


### PR DESCRIPTION
#### Description

Prepare for release 1.6:

- Bumps the new version in the docs.
- Uncomments the new release notes.
