### PR TITLE
494 improve CartDiscountSync handling of javax.money.MonetaryAmount

### DIFF
--- a/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtils.java
@@ -123,10 +123,12 @@ public final class CartDiscountUpdateActionUtils {
             return Optional.of(ChangeValue.of(newValue));
         }
 
-        final boolean areEqual = oldValue.getMoney().containsAll(newValue.getMoney())
-            && newValue.getMoney().containsAll(oldValue.getMoney());
+        final boolean allOldValuesFoundInNewValues = oldValue.getMoney().stream().allMatch(oldAmount -> 
+                newValue.getMoney().stream()
+                        .filter(newAmount -> newAmount.getCurrency().equals(oldAmount.getCurrency()))
+                        .anyMatch(newAmount -> newAmount.isEqualTo(oldAmount)));
 
-        return areEqual ? empty() : Optional.of(ChangeValue.of(newValue));
+        return allOldValuesFoundInNewValues ? empty() : Optional.of(ChangeValue.of(newValue));
     }
 
     /**

--- a/src/test/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtilsTest.java
@@ -308,7 +308,7 @@ class CartDiscountUpdateActionUtilsTest {
     }
 
     @Test
-    void buildChangeValueUpdateAction_WithSameAbsoluteValuesUsingDifferentMonetaryAmountImplementation_ShouldNotBuildUpdateAction() {
+    void buildChangeValueUpdateAction_WithSameValuesUsingDifferentMonetaryAmount_ShouldNotBuildUpdateAction() {
         final CartDiscountValue values =
                 CartDiscountValue.ofAbsolute(asList(MoneyImpl.of(10, EUR), MoneyImpl.of(10, USD)));
         final CartDiscountValue values2 =

--- a/src/test/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/cartdiscounts/utils/CartDiscountUpdateActionUtilsTest.java
@@ -31,6 +31,7 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.utils.MoneyImpl;
+import org.javamoney.moneta.Money;
 import org.junit.jupiter.api.Test;
 
 import javax.money.MonetaryAmount;
@@ -293,6 +294,25 @@ class CartDiscountUpdateActionUtilsTest {
                 CartDiscountValue.ofAbsolute(asList(MoneyImpl.of(10, EUR), MoneyImpl.of(10, USD)));
         final CartDiscountValue values2 =
                 CartDiscountValue.ofAbsolute(asList(MoneyImpl.of(10, EUR), MoneyImpl.of(10, USD)));
+
+        final CartDiscount oldCartDiscount = mock(CartDiscount.class);
+        when(oldCartDiscount.getValue()).thenReturn(values);
+
+        final CartDiscountDraft newCartDiscountDraft = mock(CartDiscountDraft.class);
+        when(newCartDiscountDraft.getValue()).thenReturn(values2);
+
+        final Optional<UpdateAction<CartDiscount>> changeValueUpdateAction =
+                buildChangeValueUpdateAction(oldCartDiscount, newCartDiscountDraft);
+
+        assertThat(changeValueUpdateAction).isNotPresent();
+    }
+
+    @Test
+    void buildChangeValueUpdateAction_WithSameAbsoluteValuesUsingDifferentMonetaryAmountImplementation_ShouldNotBuildUpdateAction() {
+        final CartDiscountValue values =
+                CartDiscountValue.ofAbsolute(asList(MoneyImpl.of(10, EUR), MoneyImpl.of(10, USD)));
+        final CartDiscountValue values2 =
+                CartDiscountValue.ofAbsolute(asList(Money.of(10, EUR), Money.of(10, USD)));
 
         final CartDiscount oldCartDiscount = mock(CartDiscount.class);
         when(oldCartDiscount.getValue()).thenReturn(values);


### PR DESCRIPTION
#### Summary
Compare AbsoluteCartDiscountValue list elements using `isEqualTo` instead of (implicitly) `equals`.

#### Description
CartDiscountSync generated a setValue action if the CartDiscountDraft values were built using a different `javax.money.MonetaryAmount` implementation. This meant that a sync would generate setValue actions that made commercetools throw an InvalidOperation error saying "'value' has no changes."

The JSR 354 spec for [MonetaryAmount](https://javamoney.github.io/apidocs/javax/money/MonetaryAmount.html) explicitly states that the `equals` method should not consider instances from two different implementation to be equal, and the `isEqualTo` method is the appropriate comparison in this case.
`io.sphere.sdk.utils.MoneyImpl` is actually not compliant with the spec in this regard, since its `equals` method is more permissive, but `org.javamoney.moneta.Money` is compliant and hence we get some surprising behaviour. It's probably not desirable to change the implementation of `io.sphere.sdk.utils.MoneyImpl` as people may be relying on it with its current behaviour, so better to fix here in CartDiscountUpdateActionUtils.

#### Relevant Issues
#494 
JavaMoney/jsr354-ri#328

#### Todo

- Tests
    - [x] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->
