### PR TITLE
#449: ensurePriceChannels in ProductSyncOptions does not create a missing channel

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
@@ -7,6 +7,9 @@ import com.commercetools.sync.products.helpers.ProductSyncStatistics;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
+import io.sphere.sdk.channels.Channel;
+import io.sphere.sdk.channels.ChannelRole;
+import io.sphere.sdk.channels.queries.ChannelByIdGet;
 import io.sphere.sdk.client.BadGatewayException;
 import io.sphere.sdk.client.ConcurrentModificationException;
 import io.sphere.sdk.client.ErrorResponseException;
@@ -17,11 +20,15 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.products.CategoryOrderHints;
+import io.sphere.sdk.products.Price;
+import io.sphere.sdk.products.PriceDraftBuilder;
+import io.sphere.sdk.products.PriceDraftDsl;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.products.ProductVariantDraft;
 import io.sphere.sdk.products.ProductVariantDraftBuilder;
+import io.sphere.sdk.products.ProductVariantDraftDsl;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.ProductUpdateCommand;
@@ -29,6 +36,7 @@ import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.SetAttribute;
 import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
 import io.sphere.sdk.products.commands.updateactions.SetTaxCategory;
+import io.sphere.sdk.products.queries.ProductByKeyGet;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.queries.PagedQueryResult;
@@ -37,6 +45,7 @@ import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateType;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.utils.CompletableFutureUtils;
+import io.sphere.sdk.utils.MoneyImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,9 +53,11 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -177,6 +188,52 @@ class ProductSyncIT {
         assertThat(errorCallBackExceptions).isEmpty();
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void sync_withMissingPriceChannel_shouldCreateProductDistributionPriceChannel() {
+        PriceDraftDsl priceDraftWithMissingChannelRef = PriceDraftBuilder.of(MoneyImpl.of("20", "EUR"))
+                .channel(ResourceIdentifier.ofId("missingId")).build();
+
+        ProductVariantDraftDsl masterVariantDraft = ProductVariantDraftBuilder.of(
+                ProductVariantDraftDsl.of()
+                        .withKey("v2")
+                        .withSku("1065833")
+                        .withPrices(Collections.singletonList(priceDraftWithMissingChannelRef)))
+                .build();
+
+        final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_RESOURCE_PATH,
+                ProductType.referenceOfId(productType.getKey()))
+                .masterVariant(masterVariantDraft)
+                .taxCategory(null)
+                .state(null)
+                .build();
+
+
+        final Consumer<String> warningCallBack = warningMessage -> warningCallBackMessages.add(warningMessage);
+
+        ProductSyncOptions syncOptions = ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                .errorCallback(this::collectErrors)
+                .warningCallback(warningCallBack)
+                .ensurePriceChannels(true)
+                .build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics = executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(warningCallBackMessages).isEmpty();
+
+        Product productFromTargetProject = executeBlocking(
+                CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(productDraft.getKey())));
+        List<Price> prices = productFromTargetProject.getMasterData().getStaged().getMasterVariant().getPrices();
+        assertThat(prices.size()).isEqualTo(1);
+
+        Channel channel = executeBlocking(CTP_TARGET_CLIENT.execute(ChannelByIdGet.of(
+                Objects.requireNonNull(Objects.requireNonNull(prices.get(0).getChannel()).getId()))));
+        assertThat(channel.getRoles()).containsOnly(ChannelRole.PRODUCT_DISTRIBUTION);
     }
 
     @Test

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -26,6 +26,7 @@ import com.commercetools.sync.services.impl.TaxCategoryServiceImpl;
 import com.commercetools.sync.services.impl.TypeServiceImpl;
 import com.commercetools.sync.services.impl.UnresolvedReferencesServiceImpl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.sphere.sdk.channels.ChannelRole;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
@@ -34,6 +35,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +87,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
             new ProductTypeServiceImpl(productSyncOptions),
             new CategoryServiceImpl(CategorySyncOptionsBuilder.of(productSyncOptions.getCtpClient()).build()),
             new TypeServiceImpl(productSyncOptions),
-            new ChannelServiceImpl(productSyncOptions),
+            new ChannelServiceImpl(productSyncOptions, Collections.singleton(ChannelRole.PRODUCT_DISTRIBUTION)),
             new CustomerGroupServiceImpl(productSyncOptions),
             new TaxCategoryServiceImpl(productSyncOptions),
             new StateServiceImpl(productSyncOptions),

--- a/src/main/java/com/commercetools/sync/services/impl/ChannelServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ChannelServiceImpl.java
@@ -13,7 +13,6 @@ import io.sphere.sdk.channels.queries.ChannelQueryBuilder;
 import io.sphere.sdk.channels.queries.ChannelQueryModel;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -30,11 +29,6 @@ public final class ChannelServiceImpl extends BaseServiceWithKey<ChannelDraft, C
         @Nonnull final Set<ChannelRole> channelRoles) {
         super(syncOptions);
         this.channelRoles = channelRoles;
-    }
-
-    public ChannelServiceImpl(@Nonnull final BaseSyncOptions syncOptions) {
-        super(syncOptions);
-        this.channelRoles = Collections.emptySet();
     }
 
     @Nonnull


### PR DESCRIPTION
## Note:
## Why this PR?
There was a problem with this previous PR created for the same issue. https://github.com/commercetools/commercetools-sync-java/pull/507
If you open the commits on that PR, the first commit is not related to the PR and it should not be merged to `master` branch. 

#### Summary
<!-- Provide a short summary of your changes -->
ensurePriceChannels in ProductSyncOptions does not create a missing channel

#### Description
<!-- Describe the changes in this PR here and provide some context -->
It was reported that we are submitting an invalid http request to CTP platform with roles: []. This happens when `ensureChannel` enabled in syncOptions, we are using ProductSync having a variant which has a price channel which cannot be resolved.

#### Relevant Issues
<!-- What are the relevant issues? Make sure there is an issue that this PR addresses here:
 https://github.com/commercetools/commercetools-sync-java/issues and add the number(s) here please.-->
https://github.com/commercetools/commercetools-sync-java/issues/499
#### Todo

- Tests
    - [ ] Unit 
    - [x] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
<!-- Where should the reviewer start? Most important files to review.-->
https://github.com/commercetools/commercetools-sync-java/blob/b152aa945df1a868ef7477ad2b6316c296120090/src/main/java/com/commercetools/sync/products/ProductSync.java#L88