### PR TITLE
update benchmark triggering flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark
-      if: branch = master AND commit_message =~ /^(Prepare for release .*)/
-      script: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+      if: branch = master
+      script: ./gradlew clean setLibraryVersion benchmark
     - stage: full build
       script: ./gradlew clean dependencyUpdates setLibraryVersion build
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ before_install:
 install: true # skips travis' default installation step which executes gradle assemble.
 jobs:
   include:
+    - stage: build
+      script: ./gradlew clean dependencyUpdates setLibraryVersion build
     - stage: benchmark
       if: branch = benchmark-commit
       script: ./gradlew clean setLibraryVersion benchmark
-    - stage: full build
-      script: ./gradlew clean dependencyUpdates setLibraryVersion build
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ before_install:
 install: true # skips travis' default installation step which executes gradle assemble.
 jobs:
   include:
-    - stage: build
-      script: ./gradlew clean dependencyUpdates setLibraryVersion build
     - stage: benchmark
+      if: branch = master
       script: ./gradlew clean setLibraryVersion benchmark
+    - stage: full build
+      script: ./gradlew clean dependencyUpdates setLibraryVersion build
       after_success:
       - bash <(curl -s https://codecov.io/bash)
       - ./travis-publish.sh || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install: true # skips travis' default installation step which executes gradle as
 jobs:
   include:
     - stage: benchmark
-      if: branch = master
+      if: branch = benchmark-commit
       script: ./gradlew clean setLibraryVersion benchmark
     - stage: full build
       script: ./gradlew clean dependencyUpdates setLibraryVersion build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ jobs:
     - stage: build
       script: ./gradlew clean dependencyUpdates setLibraryVersion build
     - stage: benchmark
-      if: branch = benchmark-commit
       script: ./gradlew clean setLibraryVersion benchmark
       after_success:
       - bash <(curl -s https://codecov.io/bash)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -12,10 +12,7 @@ the gh-pages branch of the repo.
 3. Every time a release is made or the build has a git tag, the benchmarks are run and the results are added to 
 [benchmarks.json](https://commercetools.github.io/commercetools-sync-java/benchmarks/benchmarks.json).
 
-4. Using Travis stages, each benchmark is run 5 times, producing 5 results in which the averages of the results is 
-calculated for more accurate results.
-
-5. The average results in [benchmarks.json](https://commercetools.github.io/commercetools-sync-java/benchmarks/benchmarks.json)
+4. The average results in [benchmarks.json](https://commercetools.github.io/commercetools-sync-java/benchmarks/benchmarks.json)
 are used to display the results in the form of this [graph](https://commercetools.github.io/commercetools-sync-java/benchmarks/). 
 
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -13,8 +13,7 @@
 
 # Release workflow
 
-The main goal of the build process is to publish the artifacts to public repositories, 
-like [JCenter](https://bintray.com/commercetools/maven/commercetools-sync-java) and [Maven Central](https://mvnrepository.com/artifact/com.commercetools/commercetools-sync-java).
+The main goal of the build process is to publish the artifacts to public repositories [JCenter](https://bintray.com/commercetools/maven/commercetools-sync-java) and [Maven Central](https://mvnrepository.com/artifact/com.commercetools/commercetools-sync-java).
      
 ## Step 1: Release
 
@@ -38,14 +37,14 @@ For example, define the link to the release notes pointing to a released version
 - [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.2/)
 ```
 
-> Additionally define important changes like breaking changes or important new features into the description.
+> Additionally define important changes, breaking changes or important new features into the description.
 
 After the release build status is **success** follow the next steps below. Check [here](https://travis-ci.org/commercetools/commercetools-sync-java) for Travis build status.
 
 ## Step 2: Publish
 
 - Go to [https://bintray.com/commercetools/maven/commercetools-sync-java](https://bintray.com/commercetools/maven/commercetools-sync-java)
-- You will see a notice like _Notice: You have 24 unpublished item(s) for this package (expiring in 6 days and 22 hours)_
+- You will see a notice _Notice: You have 24 unpublished item(s) for this package (expiring in 6 days and 22 hours)_
 - Click the _Publish_ button.
 
 ## Step 3: Sync

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,148 +1,54 @@
-# Build and release workflow
-
-The main goal of the build process is to publish the artifacts to public repositories, 
-like [JCenter](https://jcenter.bintray.com/) and [Maven Central](https://search.maven.org/).
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents** 
 
-
-- [Release a new version](#release-a-new-version)
-- [Publish workflow](#publish-workflow)
-  - [Full build with tests, documentation publishing and Bintray upload](#full-build-with-tests-documentation-publishing-and-bintray-upload)
-  - [Publish to local maven repo](#publish-to-local-maven-repo)
-  - [Publish snapshots to oss.sonatype.org](#publish-snapshots-to-osssonatypeorg)
-  - [Publish to Bintray](#publish-to-bintray)
-  - [Publish to Maven](#publish-to-maven)
+- [Release workflow](#release-workflow)
+  - [Step 1: Prepare Release](#step-1-prepare-release)
+  - [Step 2: Publish](#step-2-publish)
+  - [Step 3: Sync](#step-3-sync)
+  - [Final Step](#final-step)
+    - [Checklist](#checklist)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Release a new version
+# Release workflow
 
-### Before Release
+The main goal of the build process is to publish the artifacts to public repositories, 
+like [JCenter](https://bintray.com/commercetools/maven/commercetools-sync-java) and [Maven Central](https://mvnrepository.com/artifact/com.commercetools/commercetools-sync-java).
+     
+## Step 1: Prepare Release
 
-Before making a new release make sure to:
- - Create a new PR to prepare for the new release. In this PR, you should make sure all
- the dependencies are up-to-date and make sure the new release's version is updated 
- everywhere in the docs and the project files where needed.
- - Make sure the squashed commit message when merging this PR to master contains the words 
- `"Prepare for release "`. For example, before releasing version `1.10.0`, this commit message should be
-  `"Prepare for release 1.10.0"`. This is important to trigger and publish new benchmarks
- for the library.
+Create a new PR for the new release: 
+- Increment the release version to the new library version, please follow the [semantic versioning](https://semver.org/) for finding the new version.
+- Make sure all the dependencies are up-to-date everywhere in the documentation files and the project files where needed.
+- Make sure to add a section for the release in the [release notes](/docs/RELEASE_NOTES.md). 
+- Ask for review for this PR and then "squash and merge" to master.
+
+For example PR, see: https://github.com/commercetools/commercetools-sync-java/pull/412
     
-### Release
-    
-To release the library, you need to create a new git commit tag.
+To release the library, you need to ["create a new release"](https://github.com/commercetools/commercetools-sync-java/releases/new) with Github, 
+describe the new release and publish it. 
 
-This will trigger a new Travis build. The tag can be created via the command line
+## Step 2: Publish
 
-```bash
-git tag -a {version} -m "Minor text adjustments."
-git push --tags
-```
+- Go to [https://bintray.com/commercetools/maven/commercetools-sync-java](https://bintray.com/commercetools/maven/commercetools-sync-java)
+- You will see a notice like _Notice: You have 24 unpublished item(s) for this package (expiring in 6 days and 22 hours)_
+- Click the _Publish_ button.
 
-or github UI "Draft new Release":
-https://github.com/commercetools/commercetools-sync-java/releases
+## Step 3: Sync
 
-Having a tag in the commit will cause Travis to call the `bintrayUpload` task specified in the Gradle build scripts, which uploads
-the artifacts to Bintray. The artifacts have to be then promoted/published from Bintray to _JCenter_ and/or 
-_Maven Central_. See [Publish workflow](#publish-workflow) below for more details.
+- Click to the Maven Central tab.
+- Enter the commercetools Sonatype Maven Central API Key and password (into User token key and User token password fields)
+- Click the _Sync_ button and check the `Sync Status`. 
 
-Please make sure to add a section for the release in the [release notes](/docs/RELEASE_NOTES.md). 
+<img width="600" alt="Screenshot 2020-07-02 at 09 48 57" src="https://user-images.githubusercontent.com/3469524/86331559-906e3e80-bc49-11ea-9390-e813bc12c163.png">
 
-# Publish workflow
+## Final Step
 
-## Full build with tests, documentation publishing and Bintray upload
+Ensure the new version is publicly available at [JCenter](https://bintray.com/commercetools/maven/commercetools-sync-java) and [Maven Central](https://mvnrepository.com/artifact/com.commercetools/commercetools-sync-java). 
 
-```
-./gradlew clean build gitPublishPush bintrayUpload -Dbuild.version={version}
-```
+### Checklist 
 
-## Publish to local maven repo
- 
-This step may be used for local test versions:
-```
-./gradlew clean install -Dbuild.version={version}
-```
-
-If you want to review full generated `pom.xml` (with license, scm, developers) like it will be published, then use:
-```
-./gradlew clean publishToMavenLocal -Dbuild.version={version}
-```
-
-where `publishToMavenLocal` is a task from 
-[`maven-publish`](https://docs.gradle.org/3.3/userguide/publishing_maven.html#publishing_maven:install)
-plugin.
-
-## Publish snapshots to oss.sonatype.org
-
-To publish to [OSS Sonatype snapshots](https://oss.sonatype.org/content/repositories/snapshots/com/commercetools/)
-repo the following command is used:
-
-```bash
-./gradlew clean build uploadArchives -Dbuild.version={version}-SNAPSHOT
-```
-
-The `-SNAPSHOT` suffix is mandatory. 
-
-**Note**: for publishing to OSS Sonatype you need to specify **API** User/Key (not login credentials) for  
-`OSS_USER`/`OSS_KEY` environment variables or `ossUser`/`ossKey` Gradle build properties 
-(the properties have precedence over environment variables). 
-
-See more configuration details of the oss uploading in [oss-publish.gradle](/gradle-scripts/oss-publish.gradle) file.
-
-
-## Publish to Bintray
-
-[Bintray documentation about the publishing process](https://blog.bintray.com/2014/02/11/bintray-as-pain-free-gateway-to-maven-central/)
-
-Bintray publish is performed by [`gradle-bintray-plugin`](https://github.com/bintray/gradle-bintray-plugin). 
-The artifacts are published to [bintray commercetools maven repo](https://bintray.com/commercetools/maven/commercetools-sync-java).
-
-If you are a new developer in the project - update contributors list in 
-[`maven-publish.gradle`](/gradle-scripts/maven-publish.gradle)`-> pomConfig -> developers`.
-
-To initiate publish call:
-```
-./gradlew clean build bintrayUpload -Dbuild.version={version}
-```
-
-**NOTE**: Bintray does not allow to publish snapshots thus `{version}` should not contain _SNAPSHOT_.
-If you wish to use snapshots, https://oss.jfrog.com account should be configured.
-See https://blog.bintray.com/2014/02/11/bintray-as-pain-free-gateway-to-maven-central/ for more info.
-
-To publish the artifacts to Bintray:
-1. Go to https://bintray.com/commercetools/maven/commercetools-sync-java
-2. Make sure you are logged in with the commercetools account.
-3. You will see a notice _Notice: You have 24 unpublished item(s) for this package (expiring in 6 days and 22 hours)_
-4. Click _Publish_
-
-After publishing to Bintray artifacts are available in [Bintray Download](http://dl.bintray.com/commercetools/maven/com/commercetools/commercetools-sync-java/)
-but still not available in [JCenter](https://jcenter.bintray.com/com/commercetools/commercetools-sync-java/). 
-
-To publish the artifacts to JCenter do the next:
-  1. On the version page go to the Maven Central tab.
-  2. Enter the commercetools Sonatype Maven Central API Key and password.
-  3. Click _Sync_ and you’re done! 
-  
-Your package should now be available in [JCenter commercetools-sync-java](https://jcenter.bintray.com/com/commercetools/commercetools-sync-java/) 
-and will be synced to Maven Central (and they usually take their time). In case of a sync problem, Bintray will automatically take care of any needed cleanup. 
-
-## Publish to Maven
-
-Publishing to Maven Central requires the following steps:
-
- 1. Build the app and upload to Bintray (see the steps above for integration tests)
- 1. [Signing up the app with PGP key](https://blog.bintray.com/2013/08/06/fight-crime-with-gpg/): for now we use Bintray's 
-    "a stock built-in key-pair so that it can auto-sign every file you upload"
- 1. [Manually release from Bintray web page to Maven Central](https://blog.bintray.com/2015/09/17/publishing-your-maven-project-to-bintray/)
- 
-**Note**: Maven Central has much stricter requirements to published artifacts, e.g. it should have mandatory POM fields 
-(like developers list, SCM references; this is configured in the [build script](/maven-publish.gradle)) 
-and mandatory signed by GPG key (could be performed by Bintray settings). For more info about Maven Central 
-requirements see [Requirements](http://central.sonatype.org/pages/requirements.html) page.
-
-As soon as artifacts are synced you will be able to find them in the Maven Central repo and mirrors:
-
-https://repo1.maven.org/maven2/com/commercetools/commercetools-sync-java/
-http://repo2.maven.org/maven2/com/commercetools/commercetools-sync-java/
+- [Publish](#step-2-publish) and [Sync](#step-3-sync) completed without an issue.
+- The new version is available in the bintray: [https://dl.bintray.com/commercetools/maven/com/commercetools/commercetools-sync-java/](https://dl.bintray.com/commercetools/maven/com/commercetools/commercetools-sync-java/)
+- The new version is available in the maven: [https://repo1.maven.org/maven2/com/commercetools/commercetools-sync-java/](https://repo1.maven.org/maven2/com/commercetools/commercetools-sync-java/)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -3,7 +3,7 @@
 **Table of Contents** 
 
 - [Release workflow](#release-workflow)
-  - [Step 1: Prepare Release](#step-1-prepare-release)
+  - [Step 1: Release](#step-1-release)
   - [Step 2: Publish](#step-2-publish)
   - [Step 3: Sync](#step-3-sync)
   - [Final Step](#final-step)
@@ -16,7 +16,7 @@
 The main goal of the build process is to publish the artifacts to public repositories, 
 like [JCenter](https://bintray.com/commercetools/maven/commercetools-sync-java) and [Maven Central](https://mvnrepository.com/artifact/com.commercetools/commercetools-sync-java).
      
-## Step 1: Prepare Release
+## Step 1: Release
 
 Create a new PR for the new release: 
 - Increment the release version to the new library version, please follow the [semantic versioning](https://semver.org/) for finding the new version.
@@ -28,6 +28,8 @@ For example PR, see: https://github.com/commercetools/commercetools-sync-java/pu
     
 To release the library, you need to ["create a new release"](https://github.com/commercetools/commercetools-sync-java/releases/new) with Github, 
 describe the new release and publish it. 
+
+After the release build status is **success** follow the next steps below. Check [here](https://travis-ci.org/commercetools/commercetools-sync-java) for Travis build status.
 
 ## Step 2: Publish
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -25,9 +25,20 @@ Create a new PR for the new release:
 - Ask for review for this PR and then "squash and merge" to master.
 
 For example PR, see: https://github.com/commercetools/commercetools-sync-java/pull/412
+
+------
     
 To release the library, you need to ["create a new release"](https://github.com/commercetools/commercetools-sync-java/releases/new) with Github, 
-describe the new release and publish it. 
+describe the new release as below and publish it. 
+
+For example, define the link to the release notes pointing to a released version:
+```markdown
+#### 1.8.2
+- [Release notes](https://github.com/commercetools/commercetools-sync-java/blob/master/docs/RELEASE_NOTES.md#182----april-30-2020)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.2/)
+```
+
+> Additionally define important changes like breaking changes or important new features into the description.
 
 After the release build status is **success** follow the next steps below. Check [here](https://travis-ci.org/commercetools/commercetools-sync-java) for Travis build status.
 

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -20,17 +20,17 @@
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-models</artifactId>
-  <version>1.47.0</version>
+  <version>1.51.0</version>
 </dependency>
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-java-client</artifactId>
-  <version>1.47.0</version>
+  <version>1.51.0</version>
 </dependency>
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-convenience</artifactId>
-  <version>1.47.0</version>
+  <version>1.51.0</version>
 </dependency>
 
 <!-- Add commercetools-sync-java dependency. -->
@@ -43,9 +43,9 @@
 - For Gradle users:
 ````groovy
 // Add commercetools-jvm-sdk dependencies.
-implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.37.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.37.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.37.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.51.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.51.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.51.0'
 
 // Add commercetools-sync-java dependency.
 implementation 'com.commercetools:commercetools-sync-java:1.8.2'

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeSyncIT.java
@@ -79,6 +79,12 @@ class ProductTypeSyncIT {
     @BeforeEach
     void setup() {
         deleteProductTypes(CTP_TARGET_CLIENT);
+        try {
+            // The removal of the attributes is eventually consistent.
+            // Here with one second break we are slowing down the ITs a little bit so CTP could remove the attributes.
+            // see: SUPPORT-8408
+            Thread.sleep(1000);
+        } catch (InterruptedException expected) { }
         populateTargetProject();
     }
 

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -7,6 +7,7 @@ export TAG=`if [ "$TRAVIS_PULL_REQUEST" = "false" -a -n "$TRAVIS_TAG" ] ; then e
 
 if [ "$TAG" ]; then
   echo "Build is tagged. Uploading artifact $TAG to Bintray."
+  ./gradlew --info -Dbuild.version="$TAG" benchmarkCommit || exit 1
   ./gradlew --info -Dbuild.version="$TAG" mkdocsPublish || exit 1
   ./gradlew --info -Dbuild.version="$TAG" bintrayUpload
   if [[ $? != 0 ]]; then


### PR DESCRIPTION
Before to able to trigger a benchmark test, we would need to push a commit into master like `Prepare for release v1.8.2`, This is not easy to do manage, also when this is designed in the first place benchmarks were running with 10.000 thresholds, now it's 1000. so it should not be an issue for the platform. In this PR also there is a change related to benchmarkCommit task (`gh-pages/benchmarks.json` commit changes should be trigger only with a release tag)

Todo:
- [ ] It's tested locally but not in Travis and with a release tag, those tests could be done when the PR is merged to master branch, then we could try a temporary/pre-release.

- [x] Update all dependency references in documentations.
- [x] Update build & release documentation.