### PR TITLE
Fix the ProductSync's publish/unpublish build actions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 1.9.0](https://img.shields.io/badge/Benchmarks-1.9.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Benchmarks 1.9.1](https://img.shields.io/badge/Benchmarks-1.9.1-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/)
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
@@ -36,7 +36,7 @@ The library supports synchronising the following entities in commercetools
     - [Ivy](#ivy)
 - [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -78,26 +78,26 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:1.9.0'
+implementation 'com.commercetools:commercetools-sync-java:1.9.1'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.9.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.9.1"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.9.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.9.1"/>
 ````
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sync-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sync-java)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 1.9.0](https://img.shields.io/badge/Benchmarks-1.9.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Benchmarks 1.9.1](https://img.shields.io/badge/Benchmarks-1.9.1-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 [![Download](https://api.bintray.com/packages/commercetools/maven/commercetools-sync-java/images/download.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/)
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
  
@@ -55,18 +55,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:1.9.0'
+implementation 'com.commercetools:commercetools-sync-java:1.9.1'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.9.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "1.9.1"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.9.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="1.9.1"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -35,6 +35,16 @@
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.9.0)
 -->
 
+### 1.9.1 -  Aug 5, 2020
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.9.0...1.9.1) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/) | 
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.9.1)
+
+- 🐞 **Bug Fixes** (1)
+    - **Product Sync** - Fixed a bug in the `ProductSync` related to publish/unpublish of the product update actions,
+    when a new product draft has publish flag set to true and the existing product is published already then no publish action will be created 
+    which was not correct [#530](https://github.com/commercetools/commercetools-sync-java/issues/530)
+
 ### 1.9.0 -  July 27, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.8.2...1.9.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/) | 

--- a/docs/usage/CART_DISCOUNT_SYNC.md
+++ b/docs/usage/CART_DISCOUNT_SYNC.md
@@ -36,7 +36,7 @@ Therefore, in order for the sync to resolve the actual ids of those references i
     reference should return its `key`.
 
    **Note**: When syncing from a source commercetools project, you can use this util which this library provides:
-    [`replaceCartDiscountsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountReferenceReplacementUtils.html#replaceCartDiscountsReferenceIdsWithKeys-java.util.List-)
+    [`replaceCartDiscountsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/cartdiscounts/utils/CartDiscountReferenceReplacementUtils.html#replaceCartDiscountsReferenceIdsWithKeys-java.util.List-)
     that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
     ````java
     // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -37,7 +37,7 @@ otherwise they won't be matched.
     reference would return its `key`.  
 
    **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-    [`replaceCategoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.html#replaceCategoriesReferenceIdsWithKeys-java.util.List-)
+    [`replaceCategoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.html#replaceCategoriesReferenceIdsWithKeys-java.util.List-)
     that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
     ````java
     // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/IMPORTANT_USAGE_TIPS.md
+++ b/docs/usage/IMPORTANT_USAGE_TIPS.md
@@ -31,7 +31,7 @@ productSync.sync(batch1)
 By design, scaling the sync process should **not** be done by executing the batches themselves in parallel. However, it can be done either by:
  
  - Changing the number of [max parallel requests](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L116) within the `sphereClient` configuration. It defines how many requests the client can execute in parallel.
- - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contain.
+ - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contain.
  
 The current overridable default [configuration](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) of the `sphereClient` 
 is the recommended good balance for stability and performance for the sync process.

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -35,7 +35,7 @@ against a [InventoryEntryDraft](https://docs.commercetools.com/http-api-projects
    reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceInventoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.html#replaceInventoriesReferenceIdsWithKeys-java.util.List-)
+         [`replaceInventoriesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.html#replaceInventoriesReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -42,7 +42,7 @@ order for the sync to resolve the actual ids of those references, those `key`s h
     reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceProductsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.html#replaceProductsReferenceIdsWithKeys-java.util.List-)
+         [`replaceProductsReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.html#replaceProductsReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -39,7 +39,7 @@ references, those `key`s have to be supplied in the following way:
     reference would return its `key`. 
      
         **Note**: When syncing from a source commercetools project, you can use this util which this library provides: 
-         [`replaceProductTypesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/com/commercetools/sync/producttypes/utils/ProductTypeReferenceReplacementUtils.html#replaceProductTypesReferenceIdsWithKeys-java.util.List-)
+         [`replaceProductTypesReferenceIdsWithKeys`](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/com/commercetools/sync/producttypes/utils/ProductTypeReferenceReplacementUtils.html#replaceProductTypesReferenceIdsWithKeys-java.util.List-)
          that replaces the references id fields with keys, in order to make them ready for reference resolution by the sync:
          ````java
          // Puts the keys in the reference id fields to prepare for reference resolution

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -20,35 +20,35 @@
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-models</artifactId>
-  <version>1.51.0</version>
+  <version>1.52.0</version>
 </dependency>
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-java-client</artifactId>
-  <version>1.51.0</version>
+  <version>1.52.0</version>
 </dependency>
 <dependency>
   <groupId>com.commercetools.sdk.jvm.core</groupId>
   <artifactId>commercetools-convenience</artifactId>
-  <version>1.51.0</version>
+  <version>1.52.0</version>
 </dependency>
 
 <!-- Add commercetools-sync-java dependency. -->
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
 </dependency>
 ````
 - For Gradle users:
 ````groovy
 // Add commercetools-jvm-sdk dependencies.
-implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.51.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.51.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.51.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.52.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.52.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.52.0'
 
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:1.9.0'
+implementation 'com.commercetools:commercetools-sync-java:1.9.1'
 ````
 
 ### 2. Setup Syncing Options
@@ -86,4 +86,4 @@ implementation 'com.commercetools:commercetools-sync-java:1.9.0'
 *[Product Sync](PRODUCT_SYNC.md), [ProductType Sync](PRODUCT_TYPE_SYNC.md), 
 [Category Sync](CATEGORY_SYNC.md), [Inventory Sync](INVENTORY_SYNC.md), 
 [Type Sync](TYPE_SYNC.md), [CartDiscount Sync](CART_DISCOUNT_SYNC.md),
-[TaxCategory Sync](/docs/usage/TAX_CATEGORY_SYNC.md)*
+[TaxCategory Sync](/docs/usage/TAX_CATEGORY_SYNC.md), [State Sync](/docs/usage/STATE_SYNC.md)*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
       - Advanced:
         - Sync Options: usage/SYNC_OPTIONS.md
         - Usage Tips: usage/IMPORTANT_USAGE_TIPS.md
-  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/1.9.0/
+  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/1.9.1/
   - Release notes: RELEASE_NOTES.md
   - Roadmap: https://github.com/commercetools/commercetools-sync-java/milestones
   - Issues: https://github.com/commercetools/commercetools-sync-java/issues

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/ProductSyncIT.java
@@ -445,7 +445,8 @@ class ProductSyncIT {
 
         assertThat(updateActions).containsExactlyInAnyOrder(
             SetAttributeInAllVariants.of(targetProductRefAttr.getName(), targetProductRefAttr.getValue(), true),
-            SetAttributeInAllVariants.of(targetProductSetRefAttr.getName(), targetProductSetRefAttr.getValue(), true)
+            SetAttributeInAllVariants.of(targetProductSetRefAttr.getName(), targetProductSetRefAttr.getValue(), true),
+            Publish.of()
         );
     }
 
@@ -512,7 +513,8 @@ class ProductSyncIT {
             SetAttributeInAllVariants.ofUnsetAttribute("verpackung", true),
             SetAttributeInAllVariants.ofUnsetAttribute("anlieferung", true),
             SetAttributeInAllVariants.ofUnsetAttribute("zubereitung", true),
-            SetAttribute.ofUnsetAttribute(1, "localisedText", true)
+            SetAttribute.ofUnsetAttribute(1, "localisedText", true),
+            Publish.of()
         );
     }
 
@@ -616,9 +618,9 @@ class ProductSyncIT {
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(errorCallBackExceptions).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();
-        assertThat(updateActions)
-            .containsExactly(SetAttributeInAllVariants
-                .of(productSetRefAttr.getName(), JsonNodeFactory.instance.arrayNode(), true));
+        assertThat(updateActions).containsExactly(
+            SetAttributeInAllVariants.of(productSetRefAttr.getName(), JsonNodeFactory.instance.arrayNode(), true),
+            Publish.of());
 
         final Product targetProduct = CTP_TARGET_CLIENT.execute(ProductByKeyGet.of(sourceProductDraft.getKey()))
                                                        .toCompletableFuture()

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/templates/beforeupdatecallback/KeepOtherVariantsSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/products/templates/beforeupdatecallback/KeepOtherVariantsSyncIT.java
@@ -129,6 +129,6 @@ class KeepOtherVariantsSyncIT {
 
         assertThat(productOptional).isNotEmpty();
         final Product fetchedProduct = productOptional.get();
-        assertThat(fetchedProduct.getMasterData().getCurrent().getVariants()).hasSize(1);
+        assertThat(fetchedProduct.getMasterData().getCurrent().getVariants()).hasSize(2);
     }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncFilterIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncFilterIT.java
@@ -15,6 +15,7 @@ import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.updateactions.AddToCategory;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
+import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.SetCategoryOrderHint;
 import io.sphere.sdk.producttypes.ProductType;
@@ -171,11 +172,13 @@ class ProductSyncFilterIT {
                 executeBlocking(productSync.sync(singletonList(productDraft)));
 
         assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
-        assertThat(updateActionsFromSync).hasSize(1);
+        assertThat(updateActionsFromSync).hasSize(2);
         final UpdateAction<Product> updateAction = updateActionsFromSync.get(0);
         assertThat(updateAction.getAction()).isEqualTo("changeName");
         assertThat(updateAction).isExactlyInstanceOf(ChangeName.class);
         assertThat(((ChangeName) updateAction).getName()).isEqualTo(LocalizedString.of(Locale.ENGLISH, "new name"));
+        final UpdateAction<Product> updateAction2 = updateActionsFromSync.get(1);
+        assertThat(updateAction2).isEqualTo(Publish.of());
         assertThat(errorCallBackExceptions).isEmpty();
         assertThat(errorCallBackMessages).isEmpty();
         assertThat(warningCallBackMessages).isEmpty();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
@@ -32,6 +32,7 @@ import io.sphere.sdk.products.ProductVariantDraftDsl;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.ProductUpdateCommand;
+import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.SetAttribute;
 import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
@@ -913,7 +914,8 @@ class ProductSyncIT {
                 SetAttributeInAllVariants.ofUnsetAttribute("verpackung", true),
                 SetAttributeInAllVariants.ofUnsetAttribute("anlieferung", true),
                 SetAttributeInAllVariants.ofUnsetAttribute("zubereitung", true),
-                SetAttribute.ofUnsetAttribute(1, "localisedText", true)
+                SetAttribute.ofUnsetAttribute(1, "localisedText", true),
+                Publish.of()
             );
     }
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
@@ -112,7 +112,8 @@ public final class ProductSyncUtils {
         updateActions.addAll(buildVariantsUpdateActions(oldProduct, newProduct, syncOptions, attributesMetaData));
 
         // lastly publish/unpublish product
-        buildPublishOrUnpublishUpdateAction(oldProduct, newProduct).ifPresent(updateActions::add);
+        final boolean hasNewUpdateActions = updateActions.size() > 0;
+        buildPublishOrUnpublishUpdateAction(oldProduct, newProduct, hasNewUpdateActions).ifPresent(updateActions::add);
 
         return prioritizeUpdateActions(updateActions,
                 oldProduct.getMasterData().getStaged().getMasterVariant().getId());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductSyncUtils.java
@@ -23,7 +23,7 @@ import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.bui
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildAddToCategoryUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeNameUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeSlugUpdateAction;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildPublishUpdateAction;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildPublishOrUnpublishUpdateAction;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildRemoveFromCategoryUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildSetCategoryOrderHintUpdateActions;
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildSetDescriptionUpdateAction;
@@ -112,7 +112,7 @@ public final class ProductSyncUtils {
         updateActions.addAll(buildVariantsUpdateActions(oldProduct, newProduct, syncOptions, attributesMetaData));
 
         // lastly publish/unpublish product
-        buildPublishUpdateAction(oldProduct, newProduct).ifPresent(updateActions::add);
+        buildPublishOrUnpublishUpdateAction(oldProduct, newProduct).ifPresent(updateActions::add);
 
         return prioritizeUpdateActions(updateActions,
                 oldProduct.getMasterData().getStaged().getMasterVariant().getId());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -24,13 +24,13 @@ import io.sphere.sdk.products.commands.updateactions.ChangeSlug;
 import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.RemoveVariant;
+import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
 import io.sphere.sdk.products.commands.updateactions.SetCategoryOrderHint;
 import io.sphere.sdk.products.commands.updateactions.SetDescription;
 import io.sphere.sdk.products.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.products.commands.updateactions.SetMetaKeywords;
 import io.sphere.sdk.products.commands.updateactions.SetMetaTitle;
 import io.sphere.sdk.products.commands.updateactions.SetSearchKeywords;
-import io.sphere.sdk.products.commands.updateactions.SetAttributeInAllVariants;
 import io.sphere.sdk.products.commands.updateactions.SetTaxCategory;
 import io.sphere.sdk.products.commands.updateactions.TransitionState;
 import io.sphere.sdk.products.commands.updateactions.Unpublish;
@@ -508,27 +508,180 @@ public final class ProductUpdateActionUtils {
     }
 
     /**
-     * Compares the 'published' field of a {@link ProductDraft} and a {@link Product} and accordingly returns
-     * a {@link Publish} or {@link Unpublish} update action as a result in an {@link Optional}. If the new product's
-     * 'published' field is null, then the default false value is assumed.
+     * Compares the 'published' field of a {@link ProductDraft} and a {@link Product} with the new update actions
+     * and hasStagedChanges of the old product accordingly returns a {@link Publish} or {@link Unpublish} update action
+     * as a result in an {@link Optional}.
+     * Check the calculation table below for all different combinations named as states.
      *
-     * <p>If both the {@link Product} and the {@link ProductDraft} have the same 'published' flag value, then no update
-     * action is needed and hence an empty {@link Optional} is returned.
+     * <p>
+     * <table summary="Mapping of product publish/unpublish update action calculation">
+     * <thead>
+     * <tr>
+     * <th align="center">State</th>
+     * <th align="center">New draft publish</th>
+     * <th align="center">Old product publish</th>
+     * <th align="center">New update actions</th>
+     * <th align="center">Old product hasStagedChanges</th>
+     * <th align="center">Action</th>
+     * </tr>
+     * </thead>
+     * <tbody>
+     * <tr>
+     * <td>State 1</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">-</td>
+     * </tr>
+     * <tr>
+     * <td>State 2</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">-</td>
+     * </tr>
+     * <tr>
+     * <td>State 3</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">-</td>
+     * </tr>
+     * <tr>
+     * <td>State 4</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">-</td>
+     * </tr>
+     * <tr>
+     * <td>State 5</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">unpublish</td>
+     * </tr>
+     * <tr>
+     * <td>State 6</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">unpublish</td>
+     * </tr>
+     * <tr>
+     * <td>State 7</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">unpublish</td>
+     * </tr>
+     * <tr>
+     * <td>State 8</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">unpublish</td>
+     * </tr>
+     * <tr>
+     * <td>State 9</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 10</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 11</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 12</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 13</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">false</td>
+     * <td align="center">-</td>
+     * </tr>
+     * <tr>
+     * <td>State 14</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">true</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 15</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">false</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * <tr>
+     * <td>State 16</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">true</td>
+     * <td align="center">publish</td>
+     * </tr>
+     * </tbody>
+     * </table>
+     * </p>
      *
-     * <p>NOTE: Comparison is done against the staged projection of the old product.
+     * <p>NOTE: Comparison is done against the staged projection of the old product. If the new product's 'published'
+     * field is null, then the default false value is assumed. </p>
      *
      * @param oldProduct the product which should be updated.
      * @param newProduct the product draft where we get the new published field value.
+     * @param hasNewUpdateActions the product draft has other update actions set.
      * @return A filled optional with the update action or an empty optional if the flag values are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<Product>> buildPublishOrUnpublishUpdateAction(
         @Nonnull final Product oldProduct,
-        @Nonnull final ProductDraft newProduct) {
+        @Nonnull final ProductDraft newProduct,
+        final boolean hasNewUpdateActions) {
 
         final Boolean isNewProductPublished = toBoolean(newProduct.isPublish());
         final Boolean isOldProductPublished = toBoolean(oldProduct.getMasterData().isPublished());
+
         if (Boolean.TRUE.equals(isNewProductPublished)) {
+            if (Boolean.TRUE.equals(isOldProductPublished)
+                && (hasNewUpdateActions || oldProduct.getMasterData().hasStagedChanges())) {
+
+                // covers the state 14, state 15 and state 16.
+                return Optional.of(Publish.of());
+            }
             return buildUpdateAction(isOldProductPublished, isNewProductPublished, Publish::of);
         }
         return buildUpdateAction(isOldProductPublished, isNewProductPublished, Unpublish::of);

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -522,8 +522,8 @@ public final class ProductUpdateActionUtils {
      * @return A filled optional with the update action or an empty optional if the flag values are identical.
      */
     @Nonnull
-    public static Optional<UpdateAction<Product>> buildPublishUpdateAction(@Nonnull final Product oldProduct,
-                                                                           @Nonnull final ProductDraft newProduct) {
+    public static Optional<UpdateAction<Product>> buildPublishOrUnpublishUpdateAction(@Nonnull final Product oldProduct,
+                                                                                      @Nonnull final ProductDraft newProduct) {
         final Boolean isNewProductPublished = toBoolean(newProduct.isPublish());
         final Boolean isOldProductPublished = toBoolean(oldProduct.getMasterData().isPublished());
         if (Boolean.TRUE.equals(isNewProductPublished)) {

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -672,19 +672,17 @@ public final class ProductUpdateActionUtils {
         @Nonnull final ProductDraft newProduct,
         final boolean hasNewUpdateActions) {
 
-        final Boolean isNewProductPublished = toBoolean(newProduct.isPublish());
-        final Boolean isOldProductPublished = toBoolean(oldProduct.getMasterData().isPublished());
+        final boolean isNewProductPublished = toBoolean(newProduct.isPublish());
+        final boolean isOldProductPublished = toBoolean(oldProduct.getMasterData().isPublished());
 
-        if (Boolean.TRUE.equals(isNewProductPublished)) {
-            if (Boolean.TRUE.equals(isOldProductPublished)
-                && (hasNewUpdateActions || oldProduct.getMasterData().hasStagedChanges())) {
-
+        if (isNewProductPublished) {
+            if (isOldProductPublished && (hasNewUpdateActions || oldProduct.getMasterData().hasStagedChanges())) {
                 // covers the state 14, state 15 and state 16.
                 return Optional.of(Publish.of());
             }
-            return buildUpdateAction(isOldProductPublished, isNewProductPublished, Publish::of);
+            return buildUpdateAction(isOldProductPublished, true, Publish::of);
         }
-        return buildUpdateAction(isOldProductPublished, isNewProductPublished, Unpublish::of);
+        return buildUpdateAction(isOldProductPublished, false, Unpublish::of);
     }
 
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -522,8 +522,10 @@ public final class ProductUpdateActionUtils {
      * @return A filled optional with the update action or an empty optional if the flag values are identical.
      */
     @Nonnull
-    public static Optional<UpdateAction<Product>> buildPublishOrUnpublishUpdateAction(@Nonnull final Product oldProduct,
-                                                                                      @Nonnull final ProductDraft newProduct) {
+    public static Optional<UpdateAction<Product>> buildPublishOrUnpublishUpdateAction(
+        @Nonnull final Product oldProduct,
+        @Nonnull final ProductDraft newProduct) {
+
         final Boolean isNewProductPublished = toBoolean(newProduct.isPublish());
         final Boolean isOldProductPublished = toBoolean(oldProduct.getMasterData().isPublished());
         if (Boolean.TRUE.equals(isNewProductPublished)) {

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -509,8 +509,8 @@ public final class ProductUpdateActionUtils {
 
     /**
      * Compares the 'published' field of a {@link ProductDraft} and a {@link Product} with the new update actions
-     * and hasStagedChanges of the old product accordingly returns a {@link Publish} or {@link Unpublish} update action
-     * as a result in an {@link Optional}.
+     * and hasStagedChanges of the old product. Accordingly it returns a {@link Publish} or {@link Unpublish}
+     * update action as a result in an {@link Optional}.
      * Check the calculation table below for all different combinations named as states.
      *
      * <p>

--- a/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
@@ -32,6 +32,7 @@ import io.sphere.sdk.products.commands.updateactions.AddVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeMasterVariant;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
 import io.sphere.sdk.products.commands.updateactions.ChangeSlug;
+import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.RemoveFromCategory;
 import io.sphere.sdk.products.commands.updateactions.RemoveImage;
 import io.sphere.sdk.products.commands.updateactions.RemovePrice;
@@ -102,7 +103,7 @@ class ProductSyncUtilsTest {
             ProductSyncUtils.buildActions(oldProduct, newProductDraft, productSyncOptions, new HashMap<>());
 
 
-        assertThat(updateActions).containsExactly(ChangeName.of(newName, true));
+        assertThat(updateActions).containsExactly(ChangeName.of(newName, true), Publish.of());
     }
 
     @Test
@@ -172,7 +173,8 @@ class ProductSyncUtilsTest {
                 PriceDraft.of(MoneyImpl.ofCents(100, createCurrencyByCode("EGP")))
                           .withChannel(Channel.referenceOfId("channel-key_1")), true),
             AddAsset.ofVariantId(1, assetDraft).withPosition(0).withStaged(true),
-            SetSku.of(1, "3065831", true)
+            SetSku.of(1, "3065831", true),
+            Publish.of()
         );
     }
 
@@ -279,7 +281,7 @@ class ProductSyncUtilsTest {
 
         // check that we only have one generated action for all the variants and no duplicates
         // and is ordered correctly before addVariant action
-        assertThat(updateActions.size()).isEqualTo(2);
+        assertThat(updateActions.size()).isEqualTo(3);
         assertThat(updateActions).containsOnlyOnce(SetAttributeInAllVariants.of(
                 AttributeDraft.of("brandName", "sameForAllBrand"), true));
         assertThat(updateActions.get(0)).isEqualTo(SetAttributeInAllVariants.of(
@@ -287,6 +289,7 @@ class ProductSyncUtilsTest {
         assertThat(updateActions.get(1)).isEqualTo(AddVariant.of(Arrays.asList(
                 AttributeDraft.of("brandName", "sameForAllBrand")),
                 null, "3065834", true).withKey("v2"));
+        assertThat(updateActions.get(2)).isEqualTo(Publish.of());
     }
 
     @Test
@@ -332,7 +335,7 @@ class ProductSyncUtilsTest {
                 ProductSyncUtils.buildActions(oldProduct, newProductDraft, productSyncOptions, attributesMetaData);
 
         // check the generated attribute update actions
-        assertThat(updateActions.size()).isEqualTo(8);
+        assertThat(updateActions.size()).isEqualTo(9);
         assertThat(updateActions).containsSequence(
                 RemoveVariant.ofVariantId(5, true),
                 AddVariant.of(Arrays.asList(AttributeDraft.of("priceInfo", "64,90/kg"),
@@ -343,6 +346,7 @@ class ProductSyncUtilsTest {
                 SetAttribute.of(2, AttributeDraft.of("size", null), true),
                 SetAttribute.of(2, AttributeDraft.of("orderLimit", "5"), true),
                 SetAttribute.of(2, AttributeDraft.of("priceInfo", "80,20/kg"), true),
-                SetAttribute.of(2, AttributeDraft.of("brandName", "myBrand"), true));
+                SetAttribute.of(2, AttributeDraft.of("brandName", "myBrand"), true),
+                Publish.of());
     }
 }

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 
 class BuildPublishOrUnpublishUpdateActionTest {
     @Test
-    void buildPublishUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildPublishOrUnpublishUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
         final UpdateAction<Product> action =
             getPublishOrUnpublishUpdateAction(true, false).orElse(null);
 
@@ -25,7 +25,7 @@ class BuildPublishOrUnpublishUpdateActionTest {
     }
 
     @Test
-    void buildPublishUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildPublishOrUnpublishUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Product>> action =
             getPublishOrUnpublishUpdateAction(false, false);
 

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
@@ -1,0 +1,50 @@
+package com.commercetools.sync.products.utils.productupdateactionutils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductCatalogData;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.commands.updateactions.Unpublish;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildPublishOrUnpublishUpdateAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BuildPublishOrUnpublishUpdateActionTest {
+    @Test
+    void buildPublishUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, false).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Unpublish.of());
+    }
+
+    @Test
+    void buildPublishUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(false, false);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    private Optional<UpdateAction<Product>> getPublishOrUnpublishUpdateAction(
+        final boolean isOldProductPublished, final boolean isNewProductPublished) {
+
+        final ProductCatalogData productCatalogData = mock(ProductCatalogData.class);
+        when(productCatalogData.isPublished()).thenReturn(isOldProductPublished);
+        final Product oldProduct = mock(Product.class);
+        when(oldProduct.getMasterData()).thenReturn(productCatalogData);
+
+        final ProductDraft newProductDraft = mock(ProductDraft.class);
+        when(newProductDraft.isPublish()).thenReturn(isNewProductPublished);
+        return buildPublishOrUnpublishUpdateAction(oldProduct, newProductDraft);
+    }
+
+
+}

--- a/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/productupdateactionutils/BuildPublishOrUnpublishUpdateActionTest.java
@@ -4,9 +4,11 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductCatalogData;
 import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.commands.updateactions.Publish;
 import io.sphere.sdk.products.commands.updateactions.Unpublish;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildPublishOrUnpublishUpdateAction;
@@ -16,34 +18,174 @@ import static org.mockito.Mockito.when;
 
 class BuildPublishOrUnpublishUpdateActionTest {
     @Test
-    void buildPublishOrUnpublishUpdateAction_WithDifferentStagedValues_ShouldBuildUpdateAction() {
+    void buildPublishOrUnpublishUpdateAction_State_1_ShouldNotBuildUpdateAction() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(false, false, false, false);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_2_ShouldNotBuildUpdateAction() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(false, false, false, true);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_3_ShouldNotBuildUpdateAction() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(false, false, true, false);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_4_ShouldNotBuildUpdateAction() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(false, false, true, true);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_5_ShouldBuildUnpublishUpdateAction() {
         final UpdateAction<Product> action =
-            getPublishOrUnpublishUpdateAction(true, false).orElse(null);
+            getPublishOrUnpublishUpdateAction(false, true, false, false).orElse(null);
 
         assertThat(action).isNotNull();
         assertThat(action).isEqualTo(Unpublish.of());
     }
 
     @Test
-    void buildPublishOrUnpublishUpdateAction_WithSameStagedValues_ShouldNotBuildUpdateAction() {
+    void buildPublishOrUnpublishUpdateAction_State_6_ShouldBuildUnpublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(false, true, false, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Unpublish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_7_ShouldBuildUnpublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(false, true, true, false).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Unpublish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_8_ShouldBuildUnpublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(false, true, true, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Unpublish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_9_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, false, false, false).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_10_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, false, false, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_11_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, false, true, false).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_12_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, false, true, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_13_ShouldNotBuildUpdateAction() {
         final Optional<UpdateAction<Product>> action =
-            getPublishOrUnpublishUpdateAction(false, false);
+            getPublishOrUnpublishUpdateAction(true, true, false, false);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isNotPresent();
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_14_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, true, false, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_15_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, true, true, false).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_State_16_ShouldBuildPublishUpdateAction() {
+        final UpdateAction<Product> action =
+            getPublishOrUnpublishUpdateAction(true, true, true, true).orElse(null);
+
+        assertThat(action).isNotNull();
+        assertThat(action).isEqualTo(Publish.of());
+    }
+
+    @Test
+    void buildPublishOrUnpublishUpdateAction_WithNullIsPublishedValues_ShouldAssumeTheValuesAsFalse() {
+        final Optional<UpdateAction<Product>> action =
+            getPublishOrUnpublishUpdateAction(null, null, true, true);
 
         assertThat(action).isNotNull();
         assertThat(action).isNotPresent();
     }
 
     private Optional<UpdateAction<Product>> getPublishOrUnpublishUpdateAction(
-        final boolean isOldProductPublished, final boolean isNewProductPublished) {
+        @Nullable final Boolean isNewProductDraftPublished,
+        @Nullable final Boolean isOldProductPublished,
+        final boolean hasNewUpdateActions,
+        final boolean hasOldProductStagedChanges) {
 
         final ProductCatalogData productCatalogData = mock(ProductCatalogData.class);
         when(productCatalogData.isPublished()).thenReturn(isOldProductPublished);
+        when(productCatalogData.hasStagedChanges()).thenReturn(hasOldProductStagedChanges);
+
         final Product oldProduct = mock(Product.class);
         when(oldProduct.getMasterData()).thenReturn(productCatalogData);
 
         final ProductDraft newProductDraft = mock(ProductDraft.class);
-        when(newProductDraft.isPublish()).thenReturn(isNewProductPublished);
-        return buildPublishOrUnpublishUpdateAction(oldProduct, newProductDraft);
+        when(newProductDraft.isPublish()).thenReturn(isNewProductDraftPublished);
+        return buildPublishOrUnpublishUpdateAction(oldProduct, newProductDraft, hasNewUpdateActions);
     }
 
 

--- a/src/test/resources/product-key-1-with-prices.json
+++ b/src/test/resources/product-key-1-with-prices.json
@@ -123,7 +123,7 @@
       "searchKeywords": {}
     },
     "published": true,
-    "hasStagedChanges": true
+    "hasStagedChanges": false
   },
   "catalogData": {},
   "taxCategory": {


### PR DESCRIPTION
#### Summary
Check the task for the bug, #530 
#### Todo

- Tests
    - [X] Unit 
    - [X] Integration
- [-] Documentation
- [x] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
<!-- Where should the reviewer start? Most important files to review.-->
Check the fix first with following the cases in `BuildPublishOrUnpublishUpdateActionTest`
Some tests are adjusted, as some conditions before (state 13,14,15,16) was missing/bug.