### PR TITLE
Use ResourceIdentifier's key field for InventoryEntry supplyChannel reference resolution instead of using id field as a workaround.

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
@@ -53,7 +53,7 @@ import static com.commercetools.sync.integration.inventories.utils.InventoryITUt
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.getInventoryEntryBySkuAndSupplyChannel;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.populateSourceProject;
 import static com.commercetools.sync.integration.inventories.utils.InventoryITUtils.populateTargetProject;
-import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.replaceInventoriesReferenceIdsWithKeys;
+import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.mapToInventoryEntryDrafts;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,9 +149,8 @@ class InventorySyncIT {
 
         /*
          * Prepare InventoryEntryDraft of sku SKU_1 and reference to supply channel of key SUPPLY_CHANNEL_KEY_1.
-         * Please note that the key is provided in place of Referenced id.
          */
-        final ResourceIdentifier<Channel> supplyChannelReference = ResourceIdentifier.ofId(SUPPLY_CHANNEL_KEY_1);
+        final ResourceIdentifier<Channel> supplyChannelReference = ResourceIdentifier.ofKey(SUPPLY_CHANNEL_KEY_1);
 
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraftBuilder
             .of(SKU_1, QUANTITY_ON_STOCK_2, EXPECTED_DELIVERY_2, RESTOCKABLE_IN_DAYS_2, supplyChannelReference).build();
@@ -184,7 +183,7 @@ class InventorySyncIT {
         assertThat(oldSupplyChannelBeforeSync).isEmpty();
 
         //Prepare sync data.
-        final ResourceIdentifier<Channel> newSupplyChannelReference = ResourceIdentifier.ofId(SUPPLY_CHANNEL_KEY_2);
+        final ResourceIdentifier<Channel> newSupplyChannelReference = ResourceIdentifier.ofKey(SUPPLY_CHANNEL_KEY_2);
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraftBuilder
             .of(SKU_1, QUANTITY_ON_STOCK_2, EXPECTED_DELIVERY_2, RESTOCKABLE_IN_DAYS_2, newSupplyChannelReference)
             .build();
@@ -216,7 +215,7 @@ class InventorySyncIT {
         //Prepare InventoryEntryDraft of sku SKU_1 and reference to above supply channel key.
         final InventoryEntryDraft newInventoryDraft = InventoryEntryDraftBuilder
             .of(SKU_1, QUANTITY_ON_STOCK_2, EXPECTED_DELIVERY_2, RESTOCKABLE_IN_DAYS_2,
-                ResourceIdentifier.ofId(SUPPLY_CHANNEL_KEY_1)).build();
+                ResourceIdentifier.ofKey(SUPPLY_CHANNEL_KEY_1)).build();
 
         //Fetch existing Channel of key SUPPLY_CHANNEL_KEY_1 from target project.
         final Optional<Channel> targetSupplyChannel = getChannelByKey(CTP_TARGET_CLIENT, SUPPLY_CHANNEL_KEY_1);
@@ -263,7 +262,7 @@ class InventorySyncIT {
                                                                        .join()
                                                                        .getResults();
 
-        final List<InventoryEntryDraft> newInventories = replaceInventoriesReferenceIdsWithKeys(inventoryEntries);
+        final List<InventoryEntryDraft> newInventories = mapToInventoryEntryDrafts(inventoryEntries);
 
         //Prepare sync options and perform sync of draft to target project.
         final InventorySyncOptions inventorySyncOptions = InventorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -285,7 +284,7 @@ class InventorySyncIT {
                                         .plusExpansionPaths(ExpansionPath.of("custom.type")))
             .toCompletableFuture().join().getResults();
 
-        final List<InventoryEntryDraft> newInventories = replaceInventoriesReferenceIdsWithKeys(inventoryEntries);
+        final List<InventoryEntryDraft> newInventories = mapToInventoryEntryDrafts(inventoryEntries);
 
         //Prepare sync options and perform sync of draft to target project.
         final InventorySyncOptions inventorySyncOptions = InventorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -333,7 +332,7 @@ class InventorySyncIT {
                                         .plusExpansionPaths(ExpansionPath.of("custom.type")))
             .toCompletableFuture().join().getResults();
 
-        final List<InventoryEntryDraft> newInventories = replaceInventoriesReferenceIdsWithKeys(inventoryEntries);
+        final List<InventoryEntryDraft> newInventories = mapToInventoryEntryDrafts(inventoryEntries);
 
         //Prepare sync options and perform sync of draft to target project.
         final InventorySyncOptions inventorySyncOptions = InventorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
@@ -354,7 +353,7 @@ class InventorySyncIT {
                                         .plusExpansionPaths(ExpansionPath.of("custom.type")))
             .toCompletableFuture().join().getResults();
 
-        final List<InventoryEntryDraft> newInventories = replaceInventoriesReferenceIdsWithKeys(inventoryEntries);
+        final List<InventoryEntryDraft> newInventories = mapToInventoryEntryDrafts(inventoryEntries);
 
         //Prepare sync options and perform sync of draft to target project.
         final AtomicInteger invocationCounter = new AtomicInteger(0);

--- a/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceReplacementUtils.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 import static com.commercetools.sync.commons.utils.AssetReferenceReplacementUtils.mapToAssetDrafts;
 import static com.commercetools.sync.commons.utils.CustomTypeReferenceReplacementUtils.mapToCustomFieldsDraft;
-import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKeyReplaced;
+import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKey;
 
 /**
  * Util class which provides utilities that can be used when syncing resources from a source commercetools project
@@ -45,7 +45,7 @@ public final class CategoryReferenceReplacementUtils {
             .map(category -> {
                 final CustomFieldsDraft customTypeWithKeysInReference = mapToCustomFieldsDraft(category);
                 @SuppressWarnings("ConstantConditions") // NPE checked in replaceReferenceIdWithKey
-                final ResourceIdentifier<Category> parentWithKeyInReference = getResourceIdentifierWithKeyReplaced(
+                final ResourceIdentifier<Category> parentWithKeyInReference = getResourceIdentifierWithKey(
                     category.getParent(), () -> ResourceIdentifier.ofId(category.getParent().getObj().getKey()));
                 final List<AssetDraft> assetDraftsWithKeyInReference = mapToAssetDrafts(category.getAssets());
 

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
@@ -73,7 +73,7 @@ public final class SyncUtils {
      *         Otherwise, it returns the supplied reference as is.
      */
     @Nullable
-    public static <T> ResourceIdentifier<T> getResourceIdentifierWithKeyReplaced(
+    public static <T> ResourceIdentifier<T> getResourceIdentifierWithKey(
         @Nullable final Reference<T> reference,
         @Nonnull final Supplier<ResourceIdentifier<T>> keyInReferenceSupplier) {
 

--- a/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtils.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.commercetools.sync.commons.utils.CustomTypeReferenceReplacementUtils.mapToCustomFieldsDraft;
-import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKeyReplaced;
+import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKey;
 
 /**
  * Util class which provides utilities that can be used when syncing resources from a source commercetools project
@@ -24,23 +24,22 @@ public final class InventoryReferenceReplacementUtils {
 
     /**
      * Takes a list of inventoryEntries that are supposed to have their custom type and supply channel reference
-     * expanded in order to be able to fetch the keys and replace the reference ids with the corresponding keys and then
-     * return a new list of inventory entry drafts with their references containing keys instead of the ids.  Note that
-     * if the references are not expanded for an inventory entry, the reference ids will not be replaced with keys and
-     * will still have their ids in place.
+     * expanded in order to be able to fetch the keys and then return a new list of inventory entry drafts with
+     * their references containing keys.
+     * Note that if the references are not expanded for an inventory entry, the references will not have keys.
      *
-     * @param inventoryEntries the inventory entries to replace their reference ids with keys
-     * @return a list of inventoryEntry drafts with keys instead of ids for references.
+     * @param inventoryEntries the inventory entries expanded with keys
+     * @return a list of inventoryEntry drafts with keys for references.
      */
     @Nonnull
-    public static List<InventoryEntryDraft> replaceInventoriesReferenceIdsWithKeys(
+    public static List<InventoryEntryDraft> mapToInventoryEntryDrafts(
         @Nonnull final List<InventoryEntry> inventoryEntries) {
         return inventoryEntries
             .stream()
             .map(inventoryEntry -> {
                 final CustomFieldsDraft customTypeWithKeysInReference = mapToCustomFieldsDraft(inventoryEntry);
                 final ResourceIdentifier<Channel> channelReferenceWithKeysInReference =
-                    replaceChannelReferenceIdWithKey(inventoryEntry);
+                    mapToChannelResourceIdentifier(inventoryEntry);
                 return InventoryEntryDraftBuilder.of(inventoryEntry)
                                                  .custom(customTypeWithKeysInReference)
                                                  .supplyChannel(channelReferenceWithKeysInReference)
@@ -52,23 +51,22 @@ public final class InventoryReferenceReplacementUtils {
 
     /**
      * Takes an inventoryEntry that is supposed to have its channel reference expanded in order to be able to fetch the
-     * key and replace the reference id with the corresponding key and then return a new {@link Channel}
-     * {@link ResourceIdentifier} containing the key in the id field.
+     * key and return a new {@link Channel} {@link ResourceIdentifier} containing the key field.
      *
      * <p><b>Note:</b> The Channel reference should be expanded for the {@code inventoryEntry}, otherwise the reference
-     * id will not be replaced with the key and will still have the id in place.
+     * will not have a key in place.
      *
-     * @param inventoryEntry the inventoryEntry to replace its channel reference id with the key.
+     * @param inventoryEntry the inventoryEntry with {@link Channel} {@link ResourceIdentifier} containing the key.
      *
-     * @return a new {@link Channel} {@link ResourceIdentifier} containing the key in the id field.
+     * @return a new {@link Channel} {@link ResourceIdentifier} containing the key field.
      */
     @Nullable
     @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
-    static ResourceIdentifier<Channel> replaceChannelReferenceIdWithKey(@Nonnull final InventoryEntry inventoryEntry) {
+    static ResourceIdentifier<Channel> mapToChannelResourceIdentifier(@Nonnull final InventoryEntry inventoryEntry) {
 
         final Reference<Channel> inventoryEntrySupplyChannel = inventoryEntry.getSupplyChannel();
-        return getResourceIdentifierWithKeyReplaced(inventoryEntrySupplyChannel,
-            () -> ResourceIdentifier.ofId(inventoryEntrySupplyChannel.getObj().getKey()));
+        return getResourceIdentifierWithKey(inventoryEntrySupplyChannel,
+            () -> ResourceIdentifier.ofKey(inventoryEntrySupplyChannel.getObj().getKey()));
     }
 
 

--- a/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductReferenceReplacementUtils.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.commercetools.sync.commons.utils.SyncUtils.getReferenceWithKeyReplaced;
-import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKeyReplaced;
+import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKey;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -137,7 +137,7 @@ public final class ProductReferenceReplacementUtils {
     @SuppressWarnings("ConstantConditions") // NPE cannot occur due to being checked in replaceReferenceIdWithKey
     static ResourceIdentifier<ProductType> replaceProductTypeReferenceIdWithKey(@Nonnull final Product product) {
         final Reference<ProductType> productType = product.getProductType();
-        return getResourceIdentifierWithKeyReplaced(productType,
+        return getResourceIdentifierWithKey(productType,
             () -> ResourceIdentifier.ofId(productType.getObj().getKey()));
     }
 
@@ -158,7 +158,7 @@ public final class ProductReferenceReplacementUtils {
     static ResourceIdentifier<TaxCategory> replaceTaxCategoryReferenceIdWithKey(@Nonnull final Product product) {
 
         final Reference<TaxCategory> productTaxCategory = product.getTaxCategory();
-        return getResourceIdentifierWithKeyReplaced(productTaxCategory,
+        return getResourceIdentifierWithKey(productTaxCategory,
             () -> ResourceIdentifier.ofId(productTaxCategory.getObj().getKey()));
     }
 
@@ -208,7 +208,7 @@ public final class ProductReferenceReplacementUtils {
 
         categoryReferences.forEach(categoryReference ->
             categoryResourceIdentifiers.add(
-                getResourceIdentifierWithKeyReplaced(categoryReference, () -> {
+                getResourceIdentifierWithKey(categoryReference, () -> {
                     final String categoryId = categoryReference.getId();
                     @SuppressWarnings("ConstantConditions") // NPE is checked in replaceReferenceIdWithKey.
                     final String categoryKey = categoryReference.getObj().getKey();

--- a/src/main/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/VariantReferenceReplacementUtils.java
@@ -31,7 +31,7 @@ import static com.commercetools.sync.commons.utils.AssetReferenceReplacementUtil
 import static com.commercetools.sync.commons.utils.CustomTypeReferenceReplacementUtils.mapToCustomFieldsDraft;
 import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.REFERENCE_TYPE_ID_FIELD;
 import static com.commercetools.sync.commons.utils.SyncUtils.getReferenceWithKeyReplaced;
-import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKeyReplaced;
+import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKey;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -116,7 +116,7 @@ public final class VariantReferenceReplacementUtils {
     static ResourceIdentifier<Channel> replaceChannelReferenceIdWithKey(@Nonnull final Price price) {
 
         final Reference<Channel> priceChannel = price.getChannel();
-        return getResourceIdentifierWithKeyReplaced(priceChannel,
+        return getResourceIdentifierWithKey(priceChannel,
             () -> ResourceIdentifier.ofId(priceChannel.getObj().getKey()));
     }
 

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
@@ -20,7 +20,7 @@ import java.util.stream.IntStream;
 import static com.commercetools.sync.categories.CategorySyncMockUtils.getMockCategoryDraft;
 import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static com.commercetools.sync.commons.utils.SyncUtils.getReferenceWithKeyReplaced;
-import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKeyReplaced;
+import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifierWithKey;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -136,13 +136,13 @@ class SyncUtilsTest {
 
         final Reference<Category> keyReplacedReference = getReferenceWithKeyReplaced(categoryReference,
             () -> Category.referenceOfId(categoryReference.getObj().getKey()));
-        
+
         assertThat(keyReplacedReference).isNotNull();
         assertThat(keyReplacedReference.getId()).isEqualTo(categoryKey);
     }
 
     @Test
-    void getResourceIdentifierWithKeyReplaced_WithExpandedReference_ShouldReturnCategoryResourceIdentifierWithKey() {
+    void getResourceIdentifierWithKey_WithExpandedReference_ShouldReturnCategoryResourceIdentifierWithKey() {
         final String categoryKey = "categoryKey";
         final Category mockCategory = mock(Category.class);
         when(mockCategory.getKey()).thenReturn(categoryKey);
@@ -151,7 +151,7 @@ class SyncUtilsTest {
             mockCategory);
 
         final ResourceIdentifier<Category> keyReplacedReference =
-            getResourceIdentifierWithKeyReplaced(categoryReference,
+            getResourceIdentifierWithKey(categoryReference,
                 () -> ResourceIdentifier.ofId(categoryReference.getObj().getKey()));
 
         assertThat(keyReplacedReference).isNotNull();
@@ -159,7 +159,7 @@ class SyncUtilsTest {
     }
 
     @Test
-    void getReferenceWithKeyReplaced_WithNonExpandedCategoryReference_ShouldReturnReferenceWithoutReplacedKey() {
+    void getReferenceWithKey_WithNonExpandedCategoryReference_ShouldReturnReferenceWithoutKey() {
         final String categoryUuid = UUID.randomUUID().toString();
         final Reference<Category> categoryReference = Reference.ofResourceTypeIdAndId(Category.referenceTypeId(),
             categoryUuid);
@@ -172,13 +172,13 @@ class SyncUtilsTest {
     }
 
     @Test
-    void getResourceIdentifierWithKeyReplaced_WithNonExpandedReference_ShouldReturnResIdentifierWithoutReplacedKey() {
+    void getResourceIdentifierWithKey_WithNonExpandedReference_ShouldReturnResIdentifierWithoutKey() {
         final String categoryUuid = UUID.randomUUID().toString();
         final Reference<Category> categoryReference = Reference.ofResourceTypeIdAndId(Category.referenceTypeId(),
             categoryUuid);
 
         final ResourceIdentifier<Category> keyReplacedReference =
-            getResourceIdentifierWithKeyReplaced(categoryReference,
+            getResourceIdentifierWithKey(categoryReference,
                 () -> ResourceIdentifier.ofId(categoryReference.getObj().getKey()));
 
         assertThat(keyReplacedReference).isNotNull();

--- a/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/InventorySyncTest.java
@@ -85,10 +85,6 @@ class InventorySyncTest {
      */
     @BeforeEach
     void setup() {
-        final Channel channel1 = getMockSupplyChannel(REF_1, KEY_1);
-
-        final Reference<Channel> expandedReference1 = Channel.referenceOfId(REF_1).filled(channel1);
-
         final Reference<Channel> reference1 = Channel.referenceOfId(REF_1);
         final Reference<Channel> reference2 = Channel.referenceOfId(REF_2);
 
@@ -105,25 +101,22 @@ class InventorySyncTest {
                 .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, null)
                 .build(),
             InventoryEntryDraftBuilder
-                .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofId(KEY_2))
+                .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_2))
                 .build(),
             InventoryEntryDraftBuilder
                 .of(SKU_2, QUANTITY_2, DATE_2, RESTOCKABLE_2, null)
                 .build(),
             InventoryEntryDraftBuilder
-                .of(SKU_2, QUANTITY_2, DATE_2, RESTOCKABLE_2, ResourceIdentifier.ofId(KEY_1))
+                .of(SKU_2, QUANTITY_2, DATE_2, RESTOCKABLE_2, ResourceIdentifier.ofKey(KEY_1))
                 .build(),
             InventoryEntryDraftBuilder
-                .of(SKU_2, QUANTITY_2, DATE_2, RESTOCKABLE_2, ResourceIdentifier.ofId(KEY_2))
+                .of(SKU_2, QUANTITY_2, DATE_2, RESTOCKABLE_2, ResourceIdentifier.ofKey(KEY_2))
                 .build(),
             InventoryEntryDraftBuilder
                 .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, null)
                 .build(),
             InventoryEntryDraftBuilder
-                .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, expandedReference1)
-                .build(),
-            InventoryEntryDraftBuilder
-                .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofId(KEY_2))
+                .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_2))
                 .build()
         );
 
@@ -144,7 +137,7 @@ class InventorySyncTest {
         final InventorySyncStatistics stats = inventorySync.getStatistics();
 
         // assertion
-        assertThat(stats).hasValues(8, 3, 3, 0);
+        assertThat(stats).hasValues(7, 2, 3, 0);
         assertThat(errorCallBackMessages).hasSize(0);
         assertThat(errorCallBackExceptions).hasSize(0);
     }
@@ -163,8 +156,9 @@ class InventorySyncTest {
 
     @Test
     void sync_WithEnsuredChannels_ShouldCreateEntriesWithUnknownChannels() {
-        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraft.of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1,
-                Channel.referenceOfId(KEY_3));
+        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraftBuilder
+            .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_3))
+            .build();
         final InventorySync inventorySync = getInventorySync(30, true);
         final InventorySyncStatistics stats = inventorySync.sync(singletonList(draftWithNewChannel))
                 .toCompletableFuture()
@@ -177,8 +171,9 @@ class InventorySyncTest {
 
     @Test
     void sync_WithNoNewCreatedInventory_ShouldIncrementFailedStatic() {
-        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraft.of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1,
-            Channel.referenceOfId(KEY_3));
+        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraftBuilder
+            .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_3))
+            .build();
         final InventorySyncOptions options = getInventorySyncOptions(30, true);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
             null,  mock(InventoryEntry.class));
@@ -196,8 +191,9 @@ class InventorySyncTest {
 
     @Test
     void sync_WithNotEnsuredChannels_ShouldNotSyncEntriesWithUnknownChannels() {
-        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraft.of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1,
-                Channel.referenceOfId(KEY_3));
+        final InventoryEntryDraft draftWithNewChannel = InventoryEntryDraftBuilder
+            .of(SKU_3, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_3))
+            .build();
 
         final InventorySyncOptions options = getInventorySyncOptions(30, false);
         final InventoryService inventoryService = getMockInventoryService(existingInventories,
@@ -272,7 +268,7 @@ class InventorySyncTest {
                 .toCompletableFuture()
                 .join();
 
-        assertThat(stats).hasValues(8, 5, 1, 2);
+        assertThat(stats).hasValues(7, 4, 1, 2);
         assertThat(errorCallBackMessages).hasSize(2);
         assertThat(errorCallBackExceptions).hasSize(2);
     }
@@ -293,9 +289,9 @@ class InventorySyncTest {
                 .toCompletableFuture()
                 .join();
 
-        assertThat(stats).hasValues(8, 0, 0, 6);
-        assertThat(errorCallBackMessages).hasSize(6);
-        assertThat(errorCallBackExceptions).hasSize(6);
+        assertThat(stats).hasValues(7, 0, 0, 5);
+        assertThat(errorCallBackMessages).hasSize(5);
+        assertThat(errorCallBackExceptions).hasSize(5);
     }
 
     @Test
@@ -311,7 +307,8 @@ class InventorySyncTest {
             mock(TypeService.class));
 
         final InventoryEntryDraft inventoryEntryDraft = InventoryEntryDraftBuilder
-            .of(SKU_2, QUANTITY_2, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofId(KEY_2)).build();
+            .of(SKU_2, QUANTITY_2, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_2))
+            .build();
 
         final InventorySyncStatistics stats = inventorySync.sync(Collections.singletonList(inventoryEntryDraft))
                                                            .toCompletableFuture()
@@ -367,8 +364,9 @@ class InventorySyncTest {
         when(channelService.fetchCachedChannelId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft
-            .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, Channel.referenceOfId(KEY_3));
+        final InventoryEntryDraft newInventoryDraft = InventoryEntryDraftBuilder
+            .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_3))
+            .build();
         final InventorySync inventorySync = new InventorySync(options, inventoryService, channelService,
             mock(TypeService.class));
 
@@ -392,8 +390,9 @@ class InventorySyncTest {
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
         when(channelService.createAndCacheChannel(anyString())).thenReturn(failed(new SphereException()));
 
-        final InventoryEntryDraft newInventoryDraft = InventoryEntryDraft
-            .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, Channel.referenceOfId(KEY_3));
+        final InventoryEntryDraft newInventoryDraft = InventoryEntryDraftBuilder
+            .of(SKU_1, QUANTITY_1, DATE_1, RESTOCKABLE_1, ResourceIdentifier.ofKey(KEY_3))
+            .build();
         final InventorySync inventorySync = new InventorySync(options, inventoryService, channelService,
             mock(TypeService.class));
 

--- a/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/helpers/InventoryReferenceResolverTest.java
@@ -12,6 +12,7 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.inventory.InventoryEntryDraft;
 import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.models.SphereException;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.utils.CompletableFutureUtils;
@@ -64,9 +65,10 @@ class InventoryReferenceResolverTest {
         when(channelService.fetchCachedChannelId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final InventoryEntryDraft draft = InventoryEntryDraft
-            .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
-            .withCustom(CustomFieldsDraft.ofTypeKeyAndJson(CUSTOM_TYPE_KEY, new HashMap<>()));
+        final InventoryEntryDraft draft = InventoryEntryDraftBuilder
+            .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, ResourceIdentifier.ofKey(CHANNEL_KEY))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(CUSTOM_TYPE_KEY, new HashMap<>()))
+            .build();
 
         final InventoryReferenceResolver referenceResolver =
             new InventoryReferenceResolver(syncOptions, typeService, channelService);
@@ -93,9 +95,10 @@ class InventoryReferenceResolverTest {
         when(channelService.fetchCachedChannelId(anyString()))
             .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final InventoryEntryDraft draft = InventoryEntryDraft
-            .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, Channel.referenceOfId(CHANNEL_KEY))
-            .withCustom(CustomFieldsDraft.ofTypeKeyAndJson(CUSTOM_TYPE_KEY, new HashMap<>()));
+        final InventoryEntryDraft draft = InventoryEntryDraftBuilder
+            .of(SKU, QUANTITY, DATE_1, RESTOCKABLE_IN_DAYS, ResourceIdentifier.ofKey(CHANNEL_KEY))
+            .custom(CustomFieldsDraft.ofTypeKeyAndJson(CUSTOM_TYPE_KEY, new HashMap<>()))
+            .build();
 
         final InventoryReferenceResolver referenceResolver =
             new InventoryReferenceResolver(optionsWithEnsureChannels, typeService, channelService);

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceReplacementUtilsTest.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.replaceChannelReferenceIdWithKey;
-import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.replaceInventoriesReferenceIdsWithKeys;
+import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.mapToChannelResourceIdentifier;
+import static com.commercetools.sync.inventories.utils.InventoryReferenceReplacementUtils.mapToInventoryEntryDrafts;
 import static com.commercetools.sync.products.ProductSyncMockUtils.getChannelMock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -23,8 +23,7 @@ import static org.mockito.Mockito.when;
 class InventoryReferenceReplacementUtilsTest {
 
     @Test
-    void
-        replaceInventoriesReferenceIdsWithKeys_WithAllExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    void mapToInventoryEntryDrafts_WithAllExpandedReferences_ShouldReturnResourceIdentifiersWithKeys() {
         //preparation
         final String customTypeId = UUID.randomUUID().toString();
         final String customTypeKey = "customTypeKey";
@@ -53,18 +52,17 @@ class InventoryReferenceReplacementUtilsTest {
 
         //test
         final List<InventoryEntryDraft> referenceReplacedDrafts =
-            replaceInventoriesReferenceIdsWithKeys(mockInventoryEntries);
+            mapToInventoryEntryDrafts(mockInventoryEntries);
 
         //assertion
         for (InventoryEntryDraft referenceReplacedDraft : referenceReplacedDrafts) {
             assertThat(referenceReplacedDraft.getCustom().getType().getKey()).isEqualTo(customTypeKey);
-            assertThat(referenceReplacedDraft.getSupplyChannel().getId()).isEqualTo(channelKey);
+            assertThat(referenceReplacedDraft.getSupplyChannel().getKey()).isEqualTo(channelKey);
         }
     }
 
     @Test
-    void
-        replaceInventoriesReferenceIdsWithKeys_WithNonExpandedReferences_ShouldReturnReferencesWithoutReplacedKeys() {
+    void mapToInventoryEntryDrafts_WithNonExpandedReferences_ShouldReturnResourceIdentifiersWithoutKeys() {
         //preparation
         final String customTypeId = UUID.randomUUID().toString();
         final List<InventoryEntry> mockInventoryEntries = new ArrayList<>();
@@ -86,7 +84,7 @@ class InventoryReferenceReplacementUtilsTest {
 
         //test
         final List<InventoryEntryDraft> referenceReplacedDrafts =
-            replaceInventoriesReferenceIdsWithKeys(mockInventoryEntries);
+            mapToInventoryEntryDrafts(mockInventoryEntries);
 
         //assertion
         for (InventoryEntryDraft referenceReplacedDraft : referenceReplacedDrafts) {
@@ -97,7 +95,7 @@ class InventoryReferenceReplacementUtilsTest {
 
 
     @Test
-    void replaceChannelReferenceIdWithKey_WithNonExpandedReferences_ShouldReturnReferenceWithoutReplacedKeys() {
+    void mapToChannelResourceIdentifier_WithNonExpandedReferences_ShouldReturnResourceIdentifiersWithoutKeys() {
         //preparation
         final String channelId = UUID.randomUUID().toString();
         final Reference<Channel> channelReference = Channel.referenceOfId(channelId);
@@ -105,7 +103,7 @@ class InventoryReferenceReplacementUtilsTest {
         when(inventoryEntry.getSupplyChannel()).thenReturn(channelReference);
 
         //test
-        final ResourceIdentifier<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(inventoryEntry);
+        final ResourceIdentifier<Channel> channelReferenceWithKey = mapToChannelResourceIdentifier(inventoryEntry);
 
         //assertion
         assertThat(channelReferenceWithKey).isNotNull();
@@ -113,7 +111,7 @@ class InventoryReferenceReplacementUtilsTest {
     }
 
     @Test
-    void replaceChannelReferenceIdWithKey_WithExpandedReferences_ShouldReturnReplaceReferenceIdsWithKey() {
+    void mapToChannelResourceIdentifier_WithExpandedReferences_ShouldReturnResourceIdentifierWithKey() {
         //preparation
         final String channelKey = "channelKey";
         final Channel channel = getChannelMock(channelKey);
@@ -123,18 +121,18 @@ class InventoryReferenceReplacementUtilsTest {
         when(inventoryEntry.getSupplyChannel()).thenReturn(channelReference);
 
         //test
-        final ResourceIdentifier<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(inventoryEntry);
+        final ResourceIdentifier<Channel> channelReferenceWithKey = mapToChannelResourceIdentifier(inventoryEntry);
 
         //assertion
         assertThat(channelReferenceWithKey).isNotNull();
-        assertThat(channelReferenceWithKey.getId()).isEqualTo(channelKey);
+        assertThat(channelReferenceWithKey.getKey()).isEqualTo(channelKey);
     }
 
     @Test
-    void replaceChannelReferenceIdWithKey_WithNullChannelReference_ShouldReturnNull() {
+    void mapToChannelResourceIdentifier_WithNullChannelReference_ShouldReturnNull() {
         final InventoryEntry inventoryEntry = mock(InventoryEntry.class);
 
-        final ResourceIdentifier<Channel> channelReferenceWithKey = replaceChannelReferenceIdWithKey(inventoryEntry);
+        final ResourceIdentifier<Channel> channelReferenceWithKey = mapToChannelResourceIdentifier(inventoryEntry);
 
         assertThat(channelReferenceWithKey).isNull();
     }


### PR DESCRIPTION
#### Description
For reference resolution, the library user needs to replace Id with Key for Reference and ResourceIdentifier types **(or the user could use our exposed utilities like replaceInventoriesReferenceIdsWithKeys)** 
For the Channel of field type (ResourceIdentifier), it's not needed anymore because ResourceIdentifier has a key field already so that confusing replacement is not needed anymore as a workaround for most of the types. 

This PR is targeting to change only the supply channel of the InventoryEnty, custom type reference is changed with the base branch. 

For more details refer to the ticket: #138 also check the https://github.com/commercetools/commercetools-sync-java/issues/138#issuecomment-680761023 for the latest map.

#### Todo

- Tests
    - [x] Unit 
    - [x] Integration
- [ ] Documentation
    - [ ] Ensure javadocs are clear.
    - [ ] Prepare the migration guide/update docs for the breaking changes. 
- [ ] Add Release Notes entry.
- [ ] Complete the parts commented with `todo (ahmetoz)`
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
exposed `replaceInventoriesReferenceIdsWithKeys` renamed to `mapToInventoryEntryDrafts`, also some parts related to CategorySync refactoring is not merged into this branch and noted as todos.
