### PR TITLE
Add customobjects sync

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomObjectServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomObjectServiceImplIT.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.integration.services.impl;
 
-
 import com.commercetools.sync.customobjects.CustomObjectSyncOptions;
 import com.commercetools.sync.customobjects.CustomObjectSyncOptionsBuilder;
 import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
@@ -165,8 +164,6 @@ class CustomObjectServiceImplIT {
                 OLD_CUSTOM_OBJECT_KEY + "_2", OLD_CUSTOM_OBJECT_CONTAINER + "_2");
     }
 
-
-
     @Test
     void fetchMatchingCustomObjectsByCompositeIdentifiers_WithBadGateWayExceptionAlways_ShouldFail() {
         // Mock sphere client to return BadGatewayException on any request.
@@ -262,8 +259,6 @@ class CustomObjectServiceImplIT {
         verify(spyClient, times(0)).execute(any(CustomObjectQuery.class));
     }
 
-
-
     @Test
     void upsertCustomObject_WithDuplicateKeyAndContainerInCompositeIdentifier_ShouldUpdateValue() {
         //preparation
@@ -284,5 +279,4 @@ class CustomObjectServiceImplIT {
         assertThat(result.get().getKey()).isEqualTo(OLD_CUSTOM_OBJECT_KEY);
 
     }
-
 }

--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -180,7 +180,7 @@ public class BaseSyncOptions<U, V> {
      * function has been applied.
      *
      * @return the {@code beforeUpdateCallback} {@link Function}&lt;{@code V}, {@link Optional}&lt;{@code V}&gt;&gt;
-     * function set to {@code this} {@link BaseSyncOptions}.
+     *      function set to {@code this} {@link BaseSyncOptions}.
      */
     @Nullable
     public Function<V, V> getBeforeCreateCallback() {

--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -18,13 +18,13 @@ import static java.util.Optional.ofNullable;
 
 /**
  * @param <V> Resource Draft (e.g. {@link io.sphere.sdk.products.ProductDraft},
- *             {@link io.sphere.sdk.categories.CategoryDraft}, etc..
+ *            {@link io.sphere.sdk.categories.CategoryDraft}, etc..
  * @param <U> Resource (e.g. {@link io.sphere.sdk.products.Product}, {@link io.sphere.sdk.categories.Category}, etc..
  */
 public class BaseSyncOptions<U, V> {
     private final SphereClient ctpClient;
     private final QuadConsumer<SyncException, Optional<V>, Optional<U>, List<UpdateAction<U>>>
-            errorCallback;
+        errorCallback;
     private final TriConsumer<SyncException, Optional<V>, Optional<U>> warningCallback;
     private int batchSize;
     private final TriFunction<List<UpdateAction<U>>, V, U, List<UpdateAction<U>>> beforeUpdateCallback;
@@ -33,7 +33,7 @@ public class BaseSyncOptions<U, V> {
     protected BaseSyncOptions(
         @Nonnull final SphereClient ctpClient,
         @Nullable final QuadConsumer<SyncException, Optional<V>, Optional<U>, List<UpdateAction<U>>>
-                errorCallback,
+            errorCallback,
         @Nullable final TriConsumer<SyncException, Optional<V>, Optional<U>> warningCallback,
         final int batchSize,
         @Nullable final TriFunction<List<UpdateAction<U>>, V, U, List<UpdateAction<U>>>
@@ -64,9 +64,9 @@ public class BaseSyncOptions<U, V> {
      * the sync process that represents an error.
      *
      * @return the {@code errorCallback} {@link QuadConsumer}&lt;{@link SyncException},
-     *      {@link Optional}&lt;{@code V}&gt;, {@link Optional}&lt;{@code U}&gt;,
-     *      {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt; function set to
-     *      {@code this} {@link BaseSyncOptions}
+     * {@link Optional}&lt;{@code V}&gt;, {@link Optional}&lt;{@code U}&gt;,
+     * {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt; function set to
+     * {@code this} {@link BaseSyncOptions}
      */
     @Nullable
     public QuadConsumer<SyncException, Optional<V>, Optional<U>, List<UpdateAction<U>>> getErrorCallback() {
@@ -80,8 +80,8 @@ public class BaseSyncOptions<U, V> {
      * during the sync process that represents a warning.
      *
      * @return the {@code warningCallback} {@link TriConsumer}&lt;{@link SyncException},
-     *      {@link Optional}&lt;{@code V}&gt;, {@link Optional}&lt;{@code U}&gt;&gt; function set to {@code this}
-     *      {@link BaseSyncOptions}
+     * {@link Optional}&lt;{@code V}&gt;, {@link Optional}&lt;{@code U}&gt;&gt; function set to {@code this}
+     * {@link BaseSyncOptions}
      */
     @Nullable
     public TriConsumer<SyncException, Optional<V>, Optional<U>> getWarningCallback() {
@@ -94,12 +94,12 @@ public class BaseSyncOptions<U, V> {
      * {@link BaseSyncOptions}. If there {@code warningCallback} is null, this
      * method does nothing.
      *
-     * @param exception the exception to supply to the {@code warningCallback} function.
-     * @param oldResource the old resource that is being compared to the new draft.
+     * @param exception        the exception to supply to the {@code warningCallback} function.
+     * @param oldResource      the old resource that is being compared to the new draft.
      * @param newResourceDraft the new resource draft that is being compared to the old resource.
      */
     public void applyWarningCallback(@Nonnull final SyncException exception, @Nullable final U oldResource,
-        @Nullable final V newResourceDraft) {
+                                     @Nullable final V newResourceDraft) {
         if (this.warningCallback != null) {
             this.warningCallback.accept(exception, Optional.ofNullable(newResourceDraft),
                 Optional.ofNullable(oldResource));
@@ -111,13 +111,14 @@ public class BaseSyncOptions<U, V> {
      * which is set to {@code this} instance of the {@link BaseSyncOptions}. If there {@code errorCallback} is null,
      * this method does nothing.
      *
-     * @param exception {@link Throwable} instance to supply as first param to the {@code errorCallback} function.
-     * @param oldResource the old resource that is being compared to the new draft.
+     * @param exception        {@link Throwable} instance to supply as first param to the {@code errorCallback} function.
+     * @param oldResource      the old resource that is being compared to the new draft.
      * @param newResourceDraft the new resource draft that is being compared to the old resource.
-     * @param updateActions the list of update actions.
+     * @param updateActions    the list of update actions.
      */
     public void applyErrorCallback(@Nonnull final SyncException exception, @Nullable final U oldResource,
-        @Nullable final V newResourceDraft, @Nullable final List<UpdateAction<U>> updateActions) {
+                                   @Nullable final V newResourceDraft,
+                                   @Nullable final List<UpdateAction<U>> updateActions) {
         if (this.errorCallback != null) {
             this.errorCallback.accept(exception, Optional.ofNullable(newResourceDraft),
                 Optional.ofNullable(oldResource), updateActions);
@@ -125,7 +126,6 @@ public class BaseSyncOptions<U, V> {
     }
 
     /**
-     *
      * @param syncException {@link Throwable} instance to supply as first param to the {@code errorCallback} function.
      * @see #applyErrorCallback(SyncException exception, Object oldResource, Object newResource, List updateActions)
      */
@@ -134,7 +134,6 @@ public class BaseSyncOptions<U, V> {
     }
 
     /**
-     *
      * @param errorMessage the error message to supply as part of first param to the {@code errorCallback} function.
      * @see #applyErrorCallback(SyncException exception, Object oldResource, Object newResource, List updateActions)
      */
@@ -151,6 +150,7 @@ public class BaseSyncOptions<U, V> {
      * for fetching entries responding to them. Then comparision and sync are performed.
      *
      * <p>This batch size is set to 30 by default.
+     *
      * @return option that indicates capacity of batch of resources to process.
      */
     public int getBatchSize() {
@@ -164,8 +164,8 @@ public class BaseSyncOptions<U, V> {
      * generated list of update actions to produce a resultant list after the filter function has been applied.
      *
      * @return the {@code beforeUpdateCallback} {@link TriFunction}&lt;{@link List}&lt;{@link UpdateAction}&lt;
-     *         {@code U}&gt;&gt;, {@code V}, {@code U}, {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt;&gt;
-     *         function set to {@code this} {@link BaseSyncOptions}.
+     * {@code U}&gt;&gt;, {@code V}, {@code U}, {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt;&gt;
+     * function set to {@code this} {@link BaseSyncOptions}.
      */
     @Nullable
     public TriFunction<List<UpdateAction<U>>, V, U, List<UpdateAction<U>>> getBeforeUpdateCallback() {
@@ -179,7 +179,7 @@ public class BaseSyncOptions<U, V> {
      * function has been applied.
      *
      * @return the {@code beforeUpdateCallback} {@link Function}&lt;{@code V}, {@link Optional}&lt;{@code V}&gt;&gt;
-     *         function set to {@code this} {@link BaseSyncOptions}.
+     * function set to {@code this} {@link BaseSyncOptions}.
      */
     @Nullable
     public Function<V, V> getBeforeCreateCallback() {
@@ -193,13 +193,13 @@ public class BaseSyncOptions<U, V> {
      * is null or {@code updateActions} is empty, this method does nothing to the supplied list of {@code updateActions}
      * and returns the same list. If the result of the callback is null, an empty list is returned.
      *
-     * @param updateActions the list of update actions to apply the {@code beforeUpdateCallback} function on.
+     * @param updateActions    the list of update actions to apply the {@code beforeUpdateCallback} function on.
      * @param newResourceDraft the new resource draft that is being compared to the old resource.
-     * @param oldResource the old resource that is being compared to the new draft.
+     * @param oldResource      the old resource that is being compared to the new draft.
      * @return a list of update actions after applying the {@code beforeUpdateCallback} function on. If the
-     *         {@code beforeUpdateCallback} function is null or {@code updateActions} is empty, the supplied list of
-     *         {@code updateActions} is returned as is. If the return of the callback is null, an empty list is
-     *         returned.
+     * {@code beforeUpdateCallback} function is null or {@code updateActions} is empty, the supplied list of
+     * {@code updateActions} is returned as is. If the return of the callback is null, an empty list is
+     * returned.
      */
     @Nonnull
     public List<UpdateAction<U>> applyBeforeUpdateCallback(@Nonnull final List<UpdateAction<U>> updateActions,
@@ -224,12 +224,12 @@ public class BaseSyncOptions<U, V> {
      *
      * @param newResourceDraft the new resource draft that should be created.
      * @return an optional containing the resultant resource draft after applying the {@code beforeCreateCallback}
-     *         function on. If the {@code beforeCreateCallback} function is null, the supplied resource draft is
-     *         returned as is, wrapped in an optional.
+     * function on. If the {@code beforeCreateCallback} function is null, the supplied resource draft is
+     * returned as is, wrapped in an optional.
      */
     @Nonnull
     public Optional<V> applyBeforeCreateCallback(@Nonnull final V newResourceDraft) {
         return ofNullable(
-                beforeCreateCallback != null ? beforeCreateCallback.apply(newResourceDraft) : newResourceDraft);
+            beforeCreateCallback != null ? beforeCreateCallback.apply(newResourceDraft) : newResourceDraft);
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -111,7 +111,8 @@ public class BaseSyncOptions<U, V> {
      * which is set to {@code this} instance of the {@link BaseSyncOptions}. If there {@code errorCallback} is null,
      * this method does nothing.
      *
-     * @param exception        {@link Throwable} instance to supply as first param to the {@code errorCallback} function.
+     * @param exception        {@link Throwable} instance to supply as first param to the {@code errorCallback}
+     *                         function.
      * @param oldResource      the old resource that is being compared to the new draft.
      * @param newResourceDraft the new resource draft that is being compared to the old resource.
      * @param updateActions    the list of update actions.
@@ -147,7 +148,7 @@ public class BaseSyncOptions<U, V> {
      * batches and then processed. It allows to reduce the query size for fetching all resources processed in one
      * batch.
      * E.g. value of 30 means that 30 entries from input list would be accumulated and one API call will be performed
-     * for fetching entries responding to them. Then comparision and sync are performed.
+     * for fetching entries responding to them. Then comparison and sync are performed.
      *
      * <p>This batch size is set to 30 by default.
      *
@@ -164,8 +165,8 @@ public class BaseSyncOptions<U, V> {
      * generated list of update actions to produce a resultant list after the filter function has been applied.
      *
      * @return the {@code beforeUpdateCallback} {@link TriFunction}&lt;{@link List}&lt;{@link UpdateAction}&lt;
-     * {@code U}&gt;&gt;, {@code V}, {@code U}, {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt;&gt;
-     * function set to {@code this} {@link BaseSyncOptions}.
+     *     {@code U}&gt;&gt;, {@code V}, {@code U}, {@link List}&lt;{@link UpdateAction}&lt;{@code U}&gt;&gt;&gt;
+     *     function set to {@code this} {@link BaseSyncOptions}.
      */
     @Nullable
     public TriFunction<List<UpdateAction<U>>, V, U, List<UpdateAction<U>>> getBeforeUpdateCallback() {
@@ -197,9 +198,9 @@ public class BaseSyncOptions<U, V> {
      * @param newResourceDraft the new resource draft that is being compared to the old resource.
      * @param oldResource      the old resource that is being compared to the new draft.
      * @return a list of update actions after applying the {@code beforeUpdateCallback} function on. If the
-     * {@code beforeUpdateCallback} function is null or {@code updateActions} is empty, the supplied list of
-     * {@code updateActions} is returned as is. If the return of the callback is null, an empty list is
-     * returned.
+     *     {@code beforeUpdateCallback} function is null or {@code updateActions} is empty, the supplied list of
+     *     {@code updateActions} is returned as is. If the return of the callback is null, an empty list is
+     *     returned.
      */
     @Nonnull
     public List<UpdateAction<U>> applyBeforeUpdateCallback(@Nonnull final List<UpdateAction<U>> updateActions,
@@ -224,8 +225,8 @@ public class BaseSyncOptions<U, V> {
      *
      * @param newResourceDraft the new resource draft that should be created.
      * @return an optional containing the resultant resource draft after applying the {@code beforeCreateCallback}
-     * function on. If the {@code beforeCreateCallback} function is null, the supplied resource draft is
-     * returned as is, wrapped in an optional.
+     *     function on. If the {@code beforeCreateCallback} function is null, the supplied resource draft is
+     *     returned as is, wrapped in an optional.
      */
     @Nonnull
     public Optional<V> applyBeforeCreateCallback(@Nonnull final V newResourceDraft) {

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -1,0 +1,377 @@
+package com.commercetools.sync.customobjects;
+
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
+import com.commercetools.sync.customobjects.utils.CustomObjectSyncUtils;
+import com.commercetools.sync.services.CustomObjectService;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.client.ConcurrentModificationException;
+import io.sphere.sdk.customobjects.CustomObject;
+import io.sphere.sdk.customobjects.CustomObjectDraft;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import static com.commercetools.sync.customobjects.utils.CustomObjectSyncUtils.batchElements;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * This class syncs custom object drafts with the corresponding custom objects in the CTP project.
+ */
+public class CustomObjectSync {
+    private static final String CTP_CUSTOM_OBJECT_FETCH_FAILED =
+            "Failed to fetch existing customObjects with keys: '%s'.";
+    private static final String CTP_CUSTOM_OBJECT_UPSERT_FAILED =
+            "Failed to create/update customObjects with key: '%s'. Reason: %s";
+    private static final String CUSTOM_OBJECT_DRAFT_HAS_NO_KEY = "Failed to process customObject draft without key.";
+    private static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "Failed to process null customObject draft.";
+
+    private final CustomObjectSyncStatistics statistics;
+    private final CustomObjectSyncOptions syncOptions;
+    private final CustomObjectService customObjectService;
+
+    /**
+     * Takes a {@link CustomObjectSyncOptions} and a {@link CustomObjectService} instances to instantiate
+     * a new {@link CustomObjectSync} instance that could be used to sync customObject drafts in the CTP project
+     * specified in the injected {@link CustomObjectSyncOptions} instance.
+     *
+     * <p>NOTE: This constructor is mainly to be used for tests where the services can be mocked and passed to.
+     *
+     * @param syncOptions         the container of all the options of the sync process including the CTP project
+     *                            client and/or configuration and other sync-specific options.
+     * @param customObjectService the custom object service which is responsible for fetching/caching the
+     */
+    public CustomObjectSync(
+            @Nonnull final CustomObjectSyncOptions syncOptions,
+            @Nonnull final CustomObjectService customObjectService) {
+
+        this.statistics = new CustomObjectSyncStatistics();
+        this.syncOptions = syncOptions;
+        this.customObjectService = customObjectService;
+    }
+
+    private CompletionStage<CustomObjectSyncStatistics> syncBatches(
+            @Nonnull final List<List<CustomObjectDraft<JsonNode>>> batches,
+            @Nonnull final CompletionStage<CustomObjectSyncStatistics> result) {
+
+        if (batches.isEmpty()) {
+            return result;
+        }
+        final List<CustomObjectDraft<JsonNode>> firstBatch = batches.remove(0);
+        return syncBatches(batches, result.thenCompose(subResult -> processBatch(firstBatch)));
+    }
+
+
+    /**
+     * Iterates through the whole {@code customObjectDrafts} list and accumulates its valid drafts to batches.
+     * Every batch is then processed by {@link CustomObjectSync#processBatch(List)}.
+     *
+     * <p><strong>Inherited doc:</strong>
+     * {@inheritDoc}
+     *
+     * @param customObjectDrafts {@link List} of {@link CustomObjectDraft}'s that would be synced into CTP project.
+     * @return {@link CompletionStage} with {@link CustomObjectSyncStatistics} holding statistics of all sync
+     *     processes performed by this sync instance.
+     */
+    protected CompletionStage<CustomObjectSyncStatistics> process(
+            @Nonnull final List<CustomObjectDraft<JsonNode>> customObjectDrafts) {
+        final List<List<CustomObjectDraft<JsonNode>>> batches = batchElements(
+                customObjectDrafts, syncOptions.getBatchSize());
+        return syncBatches(batches, CompletableFuture.completedFuture(statistics));
+    }
+
+
+
+    /**
+     * This method first creates a new {@link Set} of valid {@link CustomObjectDraft} elements. For more on the rules of
+     * validation, check: {@link CustomObjectSync#validateDraft(CustomObjectDraft)}. Using the resulting set of
+     * {@code validCustomObjectDrafts}, the matching types in the target CTP project are fetched then the method
+     * {@link CustomObjectSync#syncBatch(Set, Set)} is called to perform the sync (<b>update</b> or <b>create</b>
+     * requests accordingly) on the target project.
+     *
+     * <p> In case of error during of fetching of existing custom objects, the error callback will be triggered.
+     * And the sync process would stop for the given batch.
+     * </p>
+     *
+     * @param batch batch of drafts that need to be synced
+     * @return a {@link CompletionStage} containing an instance
+     *     of {@link CustomObjectSyncStatistics} which contains information about the result of syncing the supplied
+     *     batch to the target project.
+     */
+
+    protected CompletionStage<CustomObjectSyncStatistics> processBatch(
+            @Nonnull final List<CustomObjectDraft<JsonNode>> batch) {
+
+        final Set<CustomObjectDraft<JsonNode>> validCustomObjectDrafts = batch.stream().filter(
+                this::validateDraft).collect(toSet());
+
+        if (validCustomObjectDrafts.isEmpty()) {
+            statistics.incrementProcessed(batch.size());
+            return completedFuture(statistics);
+        } else {
+            final Set<CustomObjectCompositeIdentifier> identifiers = validCustomObjectDrafts.stream().map(draft ->
+                    CustomObjectCompositeIdentifier.of(draft)).collect(toSet());
+
+            return customObjectService
+                    .fetchMatchingCustomObjects(identifiers)
+                    .handle(ImmutablePair::new)
+                    .thenCompose(fetchResponse -> {
+                        final Set<CustomObject<JsonNode>> fetchedCustomObjects = fetchResponse.getKey();
+                        final Throwable exception = fetchResponse.getValue();
+
+                        if (exception != null) {
+                            final String errorMessage = format(CTP_CUSTOM_OBJECT_FETCH_FAILED, identifiers);
+                            handleError(errorMessage, exception, identifiers.size());
+                            return CompletableFuture.completedFuture(null);
+                        } else {
+                            return syncBatch(fetchedCustomObjects, validCustomObjectDrafts);
+                        }
+                    })
+                    .thenApply(ignored -> {
+                        statistics.incrementProcessed(batch.size());
+                        return statistics;
+                    });
+        }
+    }
+
+    /**
+     * Checks if a draft is valid for further processing. If so, then returns {@code true}. Otherwise handles an error
+     * and returns {@code false}. A valid draft is a {@link CustomObjectDraft} object that is not {@code null} and its
+     * key is not empty.
+     *
+     * @param draft nullable draft
+     * @return boolean that indicate if given {@code draft} is valid for sync
+     */
+    private boolean validateDraft(@Nullable final CustomObjectDraft draft) {
+        if (draft == null) {
+            handleError(CUSTOM_OBJECT_DRAFT_IS_NULL, null, 1);
+        } else if (isBlank(draft.getKey())) {
+            handleError(CUSTOM_OBJECT_DRAFT_HAS_NO_KEY, null, 1);
+        } else {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this method calls the
+     * optional error callback specified in the {@code syncOptions} and updates the {@code statistics} instance by
+     * incrementing the total number of failed custom objects to sync.
+     *
+     * @param errorMessage The error message describing the reason(s) of failure.
+     * @param exception    The exception that called caused the failure, if any.
+     * @param failedTimes  The number of times that the failed types counter is incremented.
+     */
+    private void handleError(@Nonnull final String errorMessage, @Nullable final Throwable exception,
+                             final int failedTimes) {
+        SyncException syncException = exception != null ? new SyncException(errorMessage, exception)
+                : new SyncException(errorMessage);
+        syncOptions.applyErrorCallback(syncException);
+        statistics.incrementFailed(failedTimes);
+    }
+
+    /**
+     * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this method calls the
+     * optional error callback specified in the {@code syncOptions} and updates the {@code statistics} instance by
+     * incrementing the total number of failed custom objects to sync.
+     *
+     * @param errorMessage         The error message describing the reason(s) of failure.
+     * @param exception            The exception that called caused the failure, if any.
+     * @param failedTimes          The number of times that the failed types counter is incremented.
+     * @param oldCustomObject      existing type that could be updated.
+     * @param newCustomObjectDraft draft containing data that could differ from data in {@code oldCustomObject}.
+     */
+    private void handleError(@Nonnull final String errorMessage, @Nullable final Throwable exception,
+                             final int failedTimes, @Nullable final CustomObject<JsonNode> oldCustomObject,
+                             @Nullable final CustomObjectDraft<JsonNode> newCustomObjectDraft) {
+
+        SyncException syncException = exception != null ? new SyncException(errorMessage, exception)
+                : new SyncException(errorMessage);
+        syncOptions.applyErrorCallback(syncException, oldCustomObject, newCustomObjectDraft, null);
+        statistics.incrementFailed(failedTimes);
+    }
+
+    /**
+     * Given a set of custom object drafts, attempts to sync the drafts with the existing custom objects in the CTP
+     * project. The custom object and the draft are considered to match if they have the same key and container.
+     *
+     * @param oldCustomObjects      old custom objects.
+     * @param newCustomObjectDrafts drafts that need to be synced.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the update
+     */
+
+    @Nonnull
+    private CompletionStage<Void> syncBatch(
+            @Nonnull final Set<CustomObject<JsonNode>> oldCustomObjects,
+            @Nonnull final Set<CustomObjectDraft<JsonNode>> newCustomObjectDrafts) {
+
+        final Map<CustomObjectCompositeIdentifier, CustomObject<JsonNode>> oldCustomObjectMap =
+                oldCustomObjects.stream().collect(
+                        toMap(customObject -> CustomObjectCompositeIdentifier.of(
+                                customObject.getKey(), customObject.getContainer()), identity()));
+
+        return CompletableFuture.allOf(newCustomObjectDrafts
+                .stream()
+                .map(newCustomObjectDraft -> {
+                    final CustomObject<JsonNode> oldCustomObject = oldCustomObjectMap.get(
+                            CustomObjectCompositeIdentifier.of(newCustomObjectDraft));
+                    return ofNullable(oldCustomObject)
+                            .map(customObject -> updateCustomObject(oldCustomObject, newCustomObjectDraft))
+                            .orElseGet(() -> applyCallbackAndCreate(newCustomObjectDraft));
+                })
+                .map(CompletionStage::toCompletableFuture)
+                .toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * Given a custom object draft, this method applies the beforeCreateCallback and then issues a create request to the
+     * CTP project to create the corresponding CustomObject.
+     *
+     * @param customObjectDraft the custom object draft to create the custom object from.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the create.
+     */
+    @Nonnull
+    private CompletionStage<Optional<CustomObject<JsonNode>>> applyCallbackAndCreate(
+            @Nonnull final CustomObjectDraft<JsonNode> customObjectDraft) {
+
+        return syncOptions
+                .applyBeforeCreateCallback(customObjectDraft)
+                .map(draft -> customObjectService.upsertCustomObject(customObjectDraft)
+                        .thenApply(customObjectOptional -> {
+                            if (customObjectOptional.isPresent()) {
+                                statistics.incrementCreated();
+                            } else {
+                                statistics.incrementFailed();
+                            }
+                            return customObjectOptional;
+                        })
+                )
+                .orElse(CompletableFuture.completedFuture(Optional.empty()));
+    }
+
+
+    /**
+     * Given an existing {@link CustomObject} and a new {@link CustomObjectDraft}, the method verifies whether the JSON
+     * objects between {@link CustomObject#getValue()} and {@link CustomObjectDraft#getValue()} are identical. If so, a
+     * request is made to CTP to update the existing type, otherwise it doesn't issue a request.
+     *
+     * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was carried
+     * out successfully or not. If an exception was thrown on executing the request to CTP,the error handling method
+     * is called.
+     *
+     * @param oldCustomObject existing custom object that could be updated.
+     * @param newCustomObject draft containing data that could differ from data in {@code oldCustomObject}.
+     * @return a {@link CompletionStage} which contains an empty result after execution of the update.
+     */
+    @Nonnull
+    private CompletionStage<Optional<CustomObject<JsonNode>>> updateCustomObject(
+            @Nonnull final CustomObject<JsonNode> oldCustomObject,
+            @Nonnull final CustomObjectDraft<JsonNode> newCustomObject) {
+
+        if (CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObject)) {
+            return customObjectService
+                    .upsertCustomObject(newCustomObject)
+                    .handle(ImmutablePair::new)
+                    .thenCompose(updateResponse -> {
+                        final CustomObject<JsonNode> updatedCustomObject = updateResponse.getKey().get();
+                        final Throwable sphereException = updateResponse.getValue();
+                        if (sphereException != null) {
+                            return executeSupplierIfConcurrentModificationException(sphereException,
+                                () -> fetchAndUpdate(oldCustomObject, newCustomObject),
+                                () -> {
+                                    final String errorMessage =
+                                                format(CTP_CUSTOM_OBJECT_UPSERT_FAILED,
+                                                        CustomObjectCompositeIdentifier.of(newCustomObject).toString(),
+                                                        sphereException.getMessage());
+                                    handleError(errorMessage, sphereException, 1,
+                                                oldCustomObject, newCustomObject);
+                                    return CompletableFuture.completedFuture(Optional.empty());
+                                });
+                        } else {
+                            statistics.incrementUpdated();
+                            return CompletableFuture.completedFuture(Optional.of(updatedCustomObject));
+                        }
+
+                    });
+        }
+        return completedFuture(Optional.empty());
+    }
+
+    @Nonnull
+    private CompletionStage<Optional<CustomObject<JsonNode>>> fetchAndUpdate(
+            @Nonnull final CustomObject<JsonNode> oldCustomObject,
+            @Nonnull final CustomObjectDraft<JsonNode> customObjectDraft) {
+
+        final CustomObjectCompositeIdentifier identifier = CustomObjectCompositeIdentifier.of(oldCustomObject);
+
+        return customObjectService
+                .fetchCustomObject(identifier)
+                .handle(ImmutablePair::new)
+                .thenCompose(fetchResponse -> {
+                    final Optional<CustomObject<JsonNode>> fetchedCustomObjectOptional = fetchResponse.getKey();
+                    final Throwable exception = fetchResponse.getValue();
+
+                    if (exception != null) {
+                        final String errorMessage = format(CTP_CUSTOM_OBJECT_UPSERT_FAILED, identifier.toString(),
+                                "Failed to fetch from CTP while retrying after concurrency modification.");
+                        handleError(errorMessage, exception, 1, oldCustomObject, customObjectDraft);
+                        return CompletableFuture.completedFuture(Optional.empty());
+                    }
+                    return fetchedCustomObjectOptional
+                            .map(fetchedCustomObject -> updateCustomObject(fetchedCustomObject, customObjectDraft))
+                            .orElseGet(() -> {
+                                final String errorMessage =
+                                        format(CTP_CUSTOM_OBJECT_UPSERT_FAILED, identifier.toString(),
+                                                "Not found when attempting to fetch while retrying "
+                                                        + "after concurrency modification.");
+                                handleError(errorMessage, null, 1, oldCustomObject, customObjectDraft);
+                                return CompletableFuture.completedFuture(null);
+                            });
+
+                });
+    }
+
+    /**
+     * This method checks if the supplied {@code sphereException} is an instance of
+     * {@link io.sphere.sdk.client.ConcurrentModificationException}. If it is, then it executes the supplied
+     * {@code onConcurrentModificationSupplier} {@link Supplier}. Otherwise, if it is
+     * not an instance of a {@link io.sphere.sdk.client.ConcurrentModificationException} then it executes
+     * the other {@code onOtherExceptionSupplier} {@link Supplier}. Regardless, which supplier is executed the results
+     * of either is the result of this method.
+     *
+     * @param sphereException                  the sphere exception to check if is
+     *                                         {@link io.sphere.sdk.client.ConcurrentModificationException}.
+     * @param onConcurrentModificationSupplier the supplier to execute if the {@code sphereException} is a
+     *                                         {@link io.sphere.sdk.client.ConcurrentModificationException}.
+     * @param onOtherExceptionSupplier         the supplier to execute if the {@code sphereException} is not a
+     *                                         {@link io.sphere.sdk.client.ConcurrentModificationException}.
+     * @return the result of the executed supplier.
+     */
+    private static CompletionStage<Optional<CustomObject<JsonNode>>>  executeSupplierIfConcurrentModificationException(
+            @Nonnull final Throwable sphereException,
+            @Nonnull final Supplier<CompletionStage<Optional<CustomObject<JsonNode>>>> onConcurrentModificationSupplier,
+            @Nonnull final Supplier<CompletionStage<Optional<CustomObject<JsonNode>>>> onOtherExceptionSupplier) {
+        final Throwable completionExceptionCause = sphereException.getCause();
+        if (completionExceptionCause instanceof ConcurrentModificationException) {
+            return onConcurrentModificationSupplier.get();
+        }
+        return onOtherExceptionSupplier.get();
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -6,6 +6,7 @@ import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentif
 import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.customobjects.utils.CustomObjectSyncUtils;
 import com.commercetools.sync.services.CustomObjectService;
+import com.commercetools.sync.services.impl.CustomObjectServiceImpl;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
@@ -93,8 +94,8 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
      *
      * @param batch batch of drafts that need to be synced
      * @return a {@link CompletionStage} containing an instance
-     * of {@link CustomObjectSyncStatistics} which contains information about the result of syncing the supplied
-     * batch to the target project.
+     *      of {@link CustomObjectSyncStatistics} which contains information about the result of syncing the supplied
+     *      batch to the target project.
      */
 
     protected CompletionStage<CustomObjectSyncStatistics> processBatch(

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -44,6 +44,10 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
 
     private final CustomObjectService customObjectService;
 
+    public CustomObjectSync(@Nonnull final CustomObjectSyncOptions syncOptions) {
+        this(syncOptions, new CustomObjectServiceImpl(syncOptions));
+    }
+    
     /**
      * Takes a {@link CustomObjectSyncOptions} and a {@link CustomObjectService} instances to instantiate
      * a new {@link CustomObjectSync} instance that could be used to sync customObject drafts in the CTP project

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static com.commercetools.sync.customobjects.utils.CustomObjectSyncUtils.batchElements;
+import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.completedFuture;

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -111,8 +111,8 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
             statistics.incrementProcessed(batch.size());
             return completedFuture(statistics);
         } else {
-            final Set<CustomObjectCompositeIdentifier> identifiers = validCustomObjectDrafts.stream().map(draft ->
-                CustomObjectCompositeIdentifier.of(draft)).collect(toSet());
+            final Set<CustomObjectCompositeIdentifier> identifiers = validCustomObjectDrafts.stream().map(
+                CustomObjectCompositeIdentifier::of).collect(toSet());
 
             return customObjectService
                 .fetchMatchingCustomObjects(identifiers)

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -202,16 +202,16 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
         @Nonnull final Set<CustomObject<JsonNode>> oldCustomObjects,
         @Nonnull final Set<CustomObjectDraft<JsonNode>> newCustomObjectDrafts) {
 
-        final Map<CustomObjectCompositeIdentifier, CustomObject<JsonNode>> oldCustomObjectMap =
+        final Map<String, CustomObject<JsonNode>> oldCustomObjectMap =
             oldCustomObjects.stream().collect(
                 toMap(customObject -> CustomObjectCompositeIdentifier.of(
-                    customObject.getKey(), customObject.getContainer()), identity()));
+                    customObject.getKey(), customObject.getContainer()).toString(), identity()));
 
         return CompletableFuture.allOf(newCustomObjectDrafts
             .stream()
             .map(newCustomObjectDraft -> {
                 final CustomObject<JsonNode> oldCustomObject = oldCustomObjectMap.get(
-                    CustomObjectCompositeIdentifier.of(newCustomObjectDraft));
+                    CustomObjectCompositeIdentifier.of(newCustomObjectDraft).toString());
                 return ofNullable(oldCustomObject)
                     .map(customObject -> updateCustomObject(oldCustomObject, newCustomObjectDraft))
                     .orElseGet(() -> applyCallbackAndCreate(newCustomObjectDraft));

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -271,7 +271,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
                 .upsertCustomObject(newCustomObject)
                 .handle(ImmutablePair::new)
                 .thenCompose(updateResponse -> {
-                    final CustomObject<JsonNode> updatedCustomObject = updateResponse.getKey().get();
+                    final Optional<CustomObject<JsonNode>> updateCustomObjectOptional = updateResponse.getKey();
                     final Throwable sphereException = updateResponse.getValue();
                     if (sphereException != null) {
                         return executeSupplierIfConcurrentModificationException(sphereException,
@@ -287,7 +287,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
                             });
                     } else {
                         statistics.incrementUpdated();
-                        return CompletableFuture.completedFuture(Optional.of(updatedCustomObject));
+                        return CompletableFuture.completedFuture(Optional.of(updateCustomObjectOptional.get()));
                     }
 
                 });

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -47,7 +47,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
     public CustomObjectSync(@Nonnull final CustomObjectSyncOptions syncOptions) {
         this(syncOptions, new CustomObjectServiceImpl(syncOptions));
     }
-    
+
     /**
      * Takes a {@link CustomObjectSyncOptions} and a {@link CustomObjectService} instances to instantiate
      * a new {@link CustomObjectSync} instance that could be used to sync customObject drafts in the CTP project
@@ -101,7 +101,6 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
      *      of {@link CustomObjectSyncStatistics} which contains information about the result of syncing the supplied
      *      batch to the target project.
      */
-
     protected CompletionStage<CustomObjectSyncStatistics> processBatch(
         @Nonnull final List<CustomObjectDraft<JsonNode>> batch) {
 
@@ -199,7 +198,6 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
      * @param newCustomObjectDrafts drafts that need to be synced.
      * @return a {@link CompletionStage} which contains an empty result after execution of the update
      */
-
     @Nonnull
     private CompletionStage<Void> syncBatch(
         @Nonnull final Set<CustomObject<JsonNode>> oldCustomObjects,

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -248,9 +248,10 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
 
 
     /**
-     * Given an existing {@link CustomObject} and a new {@link CustomObjectDraft}, the method verifies whether the JSON
-     * objects between {@link CustomObject#getValue()} and {@link CustomObjectDraft#getValue()} are identical. If so, a
-     * request is made to CTP to update the existing custom object, otherwise it doesn't issue a request.
+     * Given an existing {@link CustomObject} and a new {@link CustomObjectDraft}, the method first checks whether
+     * existing {@link CustomObject} and a new {@link CustomObjectDraft} are identical. If so, the method aborts update
+     * the new draft and return an empty result, otherwise a request is made to CTP to update the existing custom
+     * object.
      *
      * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was carried
      * out successfully or not. If an exception was thrown on executing the request to CTP,the error handling method

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -6,7 +6,6 @@ import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentif
 import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.customobjects.utils.CustomObjectSyncUtils;
 import com.commercetools.sync.services.CustomObjectService;
-import com.commercetools.sync.services.impl.CustomObjectServiceImpl;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
@@ -29,7 +28,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * This class syncs custom object drafts with the corresponding custom objects in the CTP project.
@@ -41,7 +39,6 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
             "Failed to fetch existing customObjects with keys: '%s'.";
     private static final String CTP_CUSTOM_OBJECT_UPSERT_FAILED =
             "Failed to create/update customObjects with key: '%s'. Reason: %s";
-    private static final String CUSTOM_OBJECT_DRAFT_HAS_NO_KEY = "Failed to process customObject draft without key.";
     private static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "Failed to process null customObject draft.";
 
     private final CustomObjectService customObjectService;
@@ -63,10 +60,6 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
 
         super(new CustomObjectSyncStatistics(), syncOptions);
         this.customObjectService = customObjectService;
-    }
-
-    public CustomObjectSync(@Nonnull final CustomObjectSyncOptions syncOptions) {
-        this(syncOptions, new CustomObjectServiceImpl(syncOptions));
     }
 
     /**
@@ -150,12 +143,9 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
     private boolean validateDraft(@Nullable final CustomObjectDraft draft) {
         if (draft == null) {
             handleError(CUSTOM_OBJECT_DRAFT_IS_NULL, null, 1);
-        } else if (isBlank(draft.getKey())) {
-            handleError(CUSTOM_OBJECT_DRAFT_HAS_NO_KEY, null, 1);
-        } else {
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -270,9 +270,9 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
             return customObjectService
                 .upsertCustomObject(newCustomObject)
                 .handle(ImmutablePair::new)
-                .thenCompose(updateResponse -> {
-                    final Optional<CustomObject<JsonNode>> updateCustomObjectOptional = updateResponse.getKey();
-                    final Throwable sphereException = updateResponse.getValue();
+                .thenCompose(updatedResponseEntry -> {
+                    final Optional<CustomObject<JsonNode>> updateCustomObjectOptional = updatedResponseEntry.getKey();
+                    final Throwable sphereException = updatedResponseEntry.getValue();
                     if (sphereException != null) {
                         return executeSupplierIfConcurrentModificationException(sphereException,
                             () -> fetchAndUpdate(oldCustomObject, newCustomObject),
@@ -305,9 +305,9 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
         return customObjectService
             .fetchCustomObject(identifier)
             .handle(ImmutablePair::new)
-            .thenCompose(fetchResponse -> {
-                final Optional<CustomObject<JsonNode>> fetchedCustomObjectOptional = fetchResponse.getKey();
-                final Throwable exception = fetchResponse.getValue();
+            .thenCompose(fetchedResponseEntry -> {
+                final Optional<CustomObject<JsonNode>> fetchedCustomObjectOptional = fetchedResponseEntry.getKey();
+                final Throwable exception = fetchedResponseEntry.getValue();
 
                 if (exception != null) {
                     final String errorMessage = format(CTP_CUSTOM_OBJECT_UPDATE_FAILED, identifier.toString(),

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -265,7 +265,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
         @Nonnull final CustomObject<JsonNode> oldCustomObject,
         @Nonnull final CustomObjectDraft<JsonNode> newCustomObject) {
 
-        if (CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObject)) {
+        if (!CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObject)) {
             return customObjectService
                 .upsertCustomObject(newCustomObject)
                 .handle(ImmutablePair::new)

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -137,9 +137,8 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
     }
 
     /**
-     * Checks if a draft is valid for further processing. If so, then returns {@code true}. Otherwise handles an error
-     * and returns {@code false}. A valid draft is a {@link CustomObjectDraft} object that is not {@code null} and its
-     * key is not empty.
+     * Checks if a draft is empty for further processing. If so, then returns {@code true}. Otherwise handles an error
+     * and returns {@code false}. A valid draft is a {@link CustomObjectDraft} object that is not {@code null}.
      *
      * @param draft nullable draft
      * @return boolean that indicate if given {@code draft} is valid for sync

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -71,7 +71,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
      *
      * @param customObjectDrafts {@link List} of {@link CustomObjectDraft}'s that would be synced into CTP project.
      * @return {@link CompletionStage} with {@link CustomObjectSyncStatistics} holding statistics of all sync
-     * processes performed by this sync instance.
+     *     processes performed by this sync instance.
      */
     protected CompletionStage<CustomObjectSyncStatistics> process(
         @Nonnull final List<CustomObjectDraft<JsonNode>> customObjectDrafts) {

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -38,8 +38,8 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
 
     private static final String CTP_CUSTOM_OBJECT_FETCH_FAILED =
         "Failed to fetch existing custom objects with keys: '%s'.";
-    private static final String CTP_CUSTOM_OBJECT_UPSERT_FAILED =
-        "Failed to create/update custom objects with key: '%s'. Reason: %s";
+    private static final String CTP_CUSTOM_OBJECT_UPDATE_FAILED =
+        "Failed to update custom object with key: '%s'. Reason: %s";
     private static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "Failed to process null custom object draft.";
 
     private final CustomObjectService customObjectService;
@@ -277,7 +277,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
                             () -> fetchAndUpdate(oldCustomObject, newCustomObject),
                             () -> {
                                 final String errorMessage =
-                                    format(CTP_CUSTOM_OBJECT_UPSERT_FAILED,
+                                    format(CTP_CUSTOM_OBJECT_UPDATE_FAILED,
                                         CustomObjectCompositeIdentifier.of(newCustomObject).toString(),
                                         sphereException.getMessage());
                                 handleError(errorMessage, sphereException, 1,
@@ -309,7 +309,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
                 final Throwable exception = fetchResponse.getValue();
 
                 if (exception != null) {
-                    final String errorMessage = format(CTP_CUSTOM_OBJECT_UPSERT_FAILED, identifier.toString(),
+                    final String errorMessage = format(CTP_CUSTOM_OBJECT_UPDATE_FAILED, identifier.toString(),
                         "Failed to fetch from CTP while retrying after concurrency modification.");
                     handleError(errorMessage, exception, 1, oldCustomObject, customObjectDraft);
                     return CompletableFuture.completedFuture(Optional.empty());
@@ -318,7 +318,7 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
                     .map(fetchedCustomObject -> updateCustomObject(fetchedCustomObject, customObjectDraft))
                     .orElseGet(() -> {
                         final String errorMessage =
-                            format(CTP_CUSTOM_OBJECT_UPSERT_FAILED, identifier.toString(),
+                            format(CTP_CUSTOM_OBJECT_UPDATE_FAILED, identifier.toString(),
                                 "Not found when attempting to fetch while retrying "
                                     + "after concurrency modification.");
                         handleError(errorMessage, null, 1,

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSync.java
@@ -37,10 +37,10 @@ public class CustomObjectSync extends BaseSync<CustomObjectDraft<JsonNode>,
     CustomObjectSyncStatistics, CustomObjectSyncOptions> {
 
     private static final String CTP_CUSTOM_OBJECT_FETCH_FAILED =
-        "Failed to fetch existing customObjects with keys: '%s'.";
+        "Failed to fetch existing custom objects with keys: '%s'.";
     private static final String CTP_CUSTOM_OBJECT_UPSERT_FAILED =
-        "Failed to create/update customObjects with key: '%s'. Reason: %s";
-    private static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "Failed to process null customObject draft.";
+        "Failed to create/update custom objects with key: '%s'. Reason: %s";
+    private static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "Failed to process null custom object draft.";
 
     private final CustomObjectService customObjectService;
 

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptions.java
@@ -10,13 +10,11 @@ import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-
 
 public final class CustomObjectSyncOptions extends BaseSyncOptions<CustomObject<JsonNode>,
     CustomObjectDraft<JsonNode>> {

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptions.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 
-
 public final class CustomObjectSyncOptions extends BaseSyncOptions<CustomObject<JsonNode>,
     CustomObjectDraft<JsonNode>> {
 

--- a/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilder.java
+++ b/src/main/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilder.java
@@ -9,7 +9,7 @@ import io.sphere.sdk.customobjects.CustomObjectDraft;
 import javax.annotation.Nonnull;
 
 public final class CustomObjectSyncOptionsBuilder extends BaseSyncOptionsBuilder<CustomObjectSyncOptionsBuilder,
-        CustomObjectSyncOptions, CustomObject<JsonNode>, CustomObjectDraft<JsonNode>> {
+    CustomObjectSyncOptions, CustomObject<JsonNode>, CustomObjectDraft<JsonNode>> {
 
     public static final int BATCH_SIZE_DEFAULT = 50;
 

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
@@ -5,8 +5,6 @@ import io.sphere.sdk.customobjects.CustomObjectDraft;
 
 import javax.annotation.Nonnull;
 
-import java.util.Objects;
-
 import static java.lang.String.format;
 
 /**

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
@@ -19,7 +19,7 @@ public final class CustomObjectCompositeIdentifier {
     private final String container;
 
     private CustomObjectCompositeIdentifier(@Nonnull final String key,
-                                    @Nonnull final String container) {
+                                            @Nonnull final String container) {
         this.key = key;
         this.container = container;
     }
@@ -31,7 +31,7 @@ public final class CustomObjectCompositeIdentifier {
      * <ol>
      * <li>{@link CustomObjectCompositeIdentifier#key}: key of {@link CustomObjectDraft#getKey()} </li>
      * <li>{@link CustomObjectCompositeIdentifier#container}: container of {@link CustomObjectDraft#getContainer()}</li>
-
+     *
      * </ol>
      *
      * @param customObjectDraft a composite id is built using its fields.
@@ -62,7 +62,7 @@ public final class CustomObjectCompositeIdentifier {
      * Given a {@link String} and {@link String}, creates a {@link CustomObjectCompositeIdentifier} using the following
      * fields from the supplied attributes.
      *
-     * @param key key of CustomerObject to build composite Id.
+     * @param key       key of CustomerObject to build composite Id.
      * @param container container of CustomerObject to build composite Id.
      * @return a composite id comprised of the fields of the supplied {@code key} and {@code container}.
      */

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
@@ -5,6 +5,8 @@ import io.sphere.sdk.customobjects.CustomObjectDraft;
 
 import javax.annotation.Nonnull;
 
+import java.util.Objects;
+
 import static java.lang.String.format;
 
 /**
@@ -82,5 +84,22 @@ public final class CustomObjectCompositeIdentifier {
     @Override
     public String toString() {
         return format("{key='%s', container='%s'}", key, container);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CustomObjectCompositeIdentifier)) {
+            return false;
+        }
+        final CustomObjectCompositeIdentifier that = (CustomObjectCompositeIdentifier) obj;
+        return key.equals(that.key) && container.equals(that.container);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, container);
     }
 }

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
@@ -85,21 +85,4 @@ public final class CustomObjectCompositeIdentifier {
     public String toString() {
         return format("{key='%s', container='%s'}", key, container);
     }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof CustomObjectCompositeIdentifier)) {
-            return false;
-        }
-        final CustomObjectCompositeIdentifier that = (CustomObjectCompositeIdentifier) obj;
-        return key.equals(that.key) && container.equals(that.container);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(key, container);
-    }
 }

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifier.java
@@ -4,6 +4,7 @@ import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
 
 import javax.annotation.Nonnull;
+import java.util.Objects;
 
 import static java.lang.String.format;
 
@@ -23,7 +24,6 @@ public final class CustomObjectCompositeIdentifier {
         this.key = key;
         this.container = container;
     }
-
 
     /**
      * Given a {@link CustomObjectDraft}, creates a {@link CustomObjectCompositeIdentifier} using the following fields
@@ -82,5 +82,22 @@ public final class CustomObjectCompositeIdentifier {
     @Override
     public String toString() {
         return format("{key='%s', container='%s'}", key, container);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CustomObjectCompositeIdentifier)) {
+            return false;
+        }
+        final CustomObjectCompositeIdentifier that = (CustomObjectCompositeIdentifier) obj;
+        return key.equals(that.key) && container.equals(that.container);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, container);
     }
 }

--- a/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
@@ -18,8 +18,8 @@ public class CustomObjectSyncUtils {
      */
 
     public static boolean hasIdenticalValue(
-            @Nonnull final CustomObject<JsonNode> oldCustomObject,
-            @Nonnull final CustomObjectDraft<JsonNode> newCustomObject) {
+        @Nonnull final CustomObject<JsonNode> oldCustomObject,
+        @Nonnull final CustomObjectDraft<JsonNode> newCustomObject) {
         JsonNode oldValue = oldCustomObject.getValue();
         JsonNode newValue = newCustomObject.getValue();
 

--- a/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
@@ -5,8 +5,6 @@ import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 
 public class CustomObjectSyncUtils {
 
@@ -28,27 +26,4 @@ public class CustomObjectSyncUtils {
 
         return oldValue.equals(newValue);
     }
-
-    /**
-     * Given a list of {@link CustomObjectDraft} and a {@code batchSize}, this method distributes the custom
-     * object drafts into batches with the {@code batchSize}. Each batch is represented by a {@link List} of drafts and
-     * all the batches are grouped and represented by a {@link List}&lt;{@link List}&gt; of elements, which is returned
-     * by the method.
-     *
-     * @param elements  the list of custom object drafts to split into batches.
-     * @param batchSize the size of each batch.
-     * @return a list of lists where each list represents a batch of {@link CustomObjectDraft}.
-     */
-
-    @Nonnull
-    public static List<List<CustomObjectDraft<JsonNode>>> batchElements(
-            @Nonnull final List<CustomObjectDraft<JsonNode>> elements,
-            final int batchSize) {
-        List<List<CustomObjectDraft<JsonNode>>> batches = new ArrayList<>();
-        for (int i = 0; i < elements.size() && batchSize > 0; i += batchSize) {
-            batches.add(elements.subList(i, Math.min(i + batchSize, elements.size())));
-        }
-        return batches;
-    }
-
 }

--- a/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtils.java
@@ -17,7 +17,6 @@ public class CustomObjectSyncUtils {
      * @return A boolean whether the value of the CustomObject and CustomObjectDraft is identical or not.
      */
 
-    @Nonnull
     public static boolean hasIdenticalValue(
             @Nonnull final CustomObject<JsonNode> oldCustomObject,
             @Nonnull final CustomObjectDraft<JsonNode> newCustomObject) {

--- a/src/main/java/com/commercetools/sync/services/CustomObjectService.java
+++ b/src/main/java/com/commercetools/sync/services/CustomObjectService.java
@@ -26,8 +26,8 @@ public interface CustomObjectService {
      * @param identifier the identifier object containing CustomObject key and container, by which a
      *                   {@link io.sphere.sdk.customobjects.CustomObject} id should be fetched from the CTP project.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of its
-     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     * {@link CustomObject} was found in the CTP project with this identifier.
+     *     completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     *     {@link CustomObject} was found in the CTP project with this identifier.
      */
 
     @Nonnull
@@ -42,7 +42,7 @@ public interface CustomObjectService {
      * @param identifiers set of CustomObjectCompositeIdentifiers. Each identifier includes key and container to fetch
      *                    matching CustomObject.
      * @return {@link CompletionStage}&lt;{@link Map}&gt; in which the result of its completion contains a {@link Set}
-     * of all matching CustomObjects.
+     *     of all matching CustomObjects.
      */
     @Nonnull
     CompletionStage<Set<CustomObject<JsonNode>>> fetchMatchingCustomObjects(
@@ -82,7 +82,7 @@ public interface CustomObjectService {
      *
      * @param customObjectDraft the resource draft to create or update a resource based off of.
      * @return a {@link CompletionStage} containing an optional with the created/updated resource if successful
-     * otherwise an empty optional.
+     *     otherwise an empty optional.
      */
     @Nonnull
     CompletionStage<Optional<CustomObject<JsonNode>>> upsertCustomObject(

--- a/src/main/java/com/commercetools/sync/services/CustomObjectService.java
+++ b/src/main/java/com/commercetools/sync/services/CustomObjectService.java
@@ -23,11 +23,11 @@ public interface CustomObjectService {
      * a {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt;
      * in which the {@link Optional} could contain the id inside of it.
      *
-     * @param  identifier the identifier object containing CustomObject key and container, by which a
-     *         {@link io.sphere.sdk.customobjects.CustomObject} id should be fetched from the CTP project.
+     * @param identifier the identifier object containing CustomObject key and container, by which a
+     *                   {@link io.sphere.sdk.customobjects.CustomObject} id should be fetched from the CTP project.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of its
-     *         completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     *         {@link CustomObject} was found in the CTP project with this identifier.
+     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     * {@link CustomObject} was found in the CTP project with this identifier.
      */
 
     @Nonnull
@@ -42,7 +42,7 @@ public interface CustomObjectService {
      * @param identifiers set of CustomObjectCompositeIdentifiers. Each identifier includes key and container to fetch
      *                    matching CustomObject.
      * @return {@link CompletionStage}&lt;{@link Map}&gt; in which the result of its completion contains a {@link Set}
-     *          of all matching CustomObjects.
+     * of all matching CustomObjects.
      */
     @Nonnull
     CompletionStage<Set<CustomObject<JsonNode>>> fetchMatchingCustomObjects(
@@ -56,7 +56,7 @@ public interface CustomObjectService {
      *
      * @param identifier the identifier of the CustomObject to fetch.
      * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of its completion contains an
-     *         {@link Optional} that contains the matching {@link CustomObject} if exists, otherwise empty.
+     * {@link Optional} that contains the matching {@link CustomObject} if exists, otherwise empty.
      */
     @Nonnull
     CompletionStage<Optional<CustomObject<JsonNode>>> fetchCustomObject(
@@ -82,7 +82,7 @@ public interface CustomObjectService {
      *
      * @param customObjectDraft the resource draft to create or update a resource based off of.
      * @return a {@link CompletionStage} containing an optional with the created/updated resource if successful
-     *         otherwise an empty optional.
+     * otherwise an empty optional.
      */
     @Nonnull
     CompletionStage<Optional<CustomObject<JsonNode>>> upsertCustomObject(

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -43,7 +43,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  * @param <E> Expansion Model (e.g. {@link io.sphere.sdk.products.expansion.ProductExpansionModel},
  *            {@link io.sphere.sdk.categories.expansion.CategoryExpansionModel}, etc..
  */
-abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOptions,
+abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOptions,
     Q extends MetaModelQueryDsl<U, Q, M, E>, M, E> {
 
     final S syncOptions;
@@ -67,7 +67,7 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      *                              resource.
      * @param updateActions         the update actions to execute on the resource.
      * @return an instance of {@link CompletionStage}&lt;{@code U}&gt; which contains as a result an instance of
-     *         the resource {@link U} after all the update actions have been executed.
+     * the resource {@link U} after all the update actions have been executed.
      */
     @Nonnull
     CompletionStage<U> updateResource(
@@ -91,7 +91,7 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      *                              resource.
      * @param batches               the batches of update actions to execute.
      * @return an instance of {@link CompletionStage}&lt;{@code U}&gt; which contains as a result an instance of
-     *         the resource {@link U} after all the update actions in all batches have been executed.
+     * the resource {@link U} after all the update actions in all batches have been executed.
      */
     @Nonnull
     private CompletionStage<U> updateBatches(
@@ -125,7 +125,7 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      * @param keyMapper     a function to get the key from the supplied draft.
      * @param createCommand a function to get the create command using the supplied draft.
      * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
-     *         empty optional.
+     * empty optional.
      */
     @SuppressWarnings("unchecked")
     @Nonnull
@@ -173,8 +173,8 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      * @param keyMapper     a function to get the key from the resource.
      * @param querySupplier supplies the query to fetch the resource with the given key.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
-     *          completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     *          resource was found in the CTP project with this key.
+     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     * resource was found in the CTP project with this key.
      */
     @Nonnull
     CompletionStage<Optional<String>> fetchCachedResourceId(
@@ -247,7 +247,7 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      * @param keyMapper     a function to get the key from the resource.
      * @param querySupplier supplies the query to fetch the resources with the given keys.
      * @return {@link CompletionStage}&lt;{@link Set}&lt;{@code U}&gt;&gt; in which the result of it's completion
-     *         contains a {@link Set} of all matching resources.
+     * contains a {@link Set} of all matching resources.
      */
     @Nonnull
     CompletionStage<Set<U>> fetchMatchingResources(
@@ -277,7 +277,7 @@ abstract class BaseService<T, U extends ResourceView<U,U>, S extends BaseSyncOpt
      * @param key           the key of the resource to fetch
      * @param querySupplier supplies the query to fetch the resource with the given key.
      * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an
-     *         {@link Optional} that contains the matching {@code T} if exists, otherwise empty.
+     * {@link Optional} that contains the matching {@code T} if exists, otherwise empty.
      */
     @Nonnull
     CompletionStage<Optional<U>> fetchResource(

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -67,7 +67,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
      *                              resource.
      * @param updateActions         the update actions to execute on the resource.
      * @return an instance of {@link CompletionStage}&lt;{@code U}&gt; which contains as a result an instance of
-     * the resource {@link U} after all the update actions have been executed.
+     *     the resource {@link U} after all the update actions have been executed.
      */
     @Nonnull
     CompletionStage<U> updateResource(
@@ -91,7 +91,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
      *                              resource.
      * @param batches               the batches of update actions to execute.
      * @return an instance of {@link CompletionStage}&lt;{@code U}&gt; which contains as a result an instance of
-     * the resource {@link U} after all the update actions in all batches have been executed.
+     *     the resource {@link U} after all the update actions in all batches have been executed.
      */
     @Nonnull
     private CompletionStage<U> updateBatches(
@@ -125,7 +125,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
      * @param keyMapper     a function to get the key from the supplied draft.
      * @param createCommand a function to get the create command using the supplied draft.
      * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
-     * empty optional.
+     *     empty optional.
      */
     @SuppressWarnings("unchecked")
     @Nonnull
@@ -173,8 +173,8 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
      * @param keyMapper     a function to get the key from the resource.
      * @param querySupplier supplies the query to fetch the resource with the given key.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
-     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     * resource was found in the CTP project with this key.
+     *     completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     *     resource was found in the CTP project with this key.
      */
     @Nonnull
     CompletionStage<Optional<String>> fetchCachedResourceId(
@@ -247,7 +247,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
      * @param keyMapper     a function to get the key from the resource.
      * @param querySupplier supplies the query to fetch the resources with the given keys.
      * @return {@link CompletionStage}&lt;{@link Set}&lt;{@code U}&gt;&gt; in which the result of it's completion
-     * contains a {@link Set} of all matching resources.
+     *     contains a {@link Set} of all matching resources.
      */
     @Nonnull
     CompletionStage<Set<U>> fetchMatchingResources(

--- a/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
  *            {@link io.sphere.sdk.categories.expansion.CategoryExpansionModel}, etc..
  */
 abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & WithKey, S extends BaseSyncOptions,
-    Q extends MetaModelQueryDsl<U, Q, M, E>, M, E> extends BaseService<T, U , S, Q, M, E> {
+    Q extends MetaModelQueryDsl<U, Q, M, E>, M, E> extends BaseService<T, U, S, Q, M, E> {
 
     BaseServiceWithKey(@Nonnull final S syncOptions) {
         super(syncOptions);
@@ -52,7 +52,7 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * @param draft         the resource draft to create a resource based off of.
      * @param createCommand a function to get the create command using the supplied draft.
      * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
-     *         empty optional.
+     * empty optional.
      */
     @Nonnull
     CompletionStage<Optional<U>> createResource(
@@ -71,11 +71,11 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no resource
      * was found in the CTP project with this key.
      *
-     * @param key the key by which a resource id should be fetched from the CTP project.
+     * @param key           the key by which a resource id should be fetched from the CTP project.
      * @param querySupplier supplies the query to fetch the resource with the given key.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
-     *         completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     *         resource was found in the CTP project with this key.
+     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     * resource was found in the CTP project with this key.
      */
     @Nonnull
     CompletionStage<Optional<String>> fetchCachedResourceId(
@@ -92,7 +92,7 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * Given a set of keys this method caches a mapping of the keys to ids of such keys only for the keys which are
      * not already in the cache.
      *
-     * @param keys keys to cache.
+     * @param keys            keys to cache.
      * @param keysQueryMapper function that accepts a set of keys which are not cached and maps it to a query object
      *                        representing the query to CTP on such keys.
      * @return a map of key to ids of the requested keys.
@@ -112,10 +112,10 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * keys in the CTP project, defined in an injected {@link SphereClient}. A mapping of the key to the id
      * of the fetched resources is persisted in an in-memory map.
      *
-     * @param keys  set of state keys to fetch matching states by
+     * @param keys          set of state keys to fetch matching states by
      * @param querySupplier supplies the query to fetch the resources with the given keys.
      * @return {@link CompletionStage}&lt;{@link Set}&lt;{@code U}&gt;&gt; in which the result of it's completion
-     *         contains a {@link Set} of all matching resources.
+     * contains a {@link Set} of all matching resources.
      */
     @Nonnull
     CompletionStage<Set<U>> fetchMatchingResources(

--- a/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
@@ -52,7 +52,7 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * @param draft         the resource draft to create a resource based off of.
      * @param createCommand a function to get the create command using the supplied draft.
      * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
-     * empty optional.
+     *     empty optional.
      */
     @Nonnull
     CompletionStage<Optional<U>> createResource(
@@ -74,8 +74,8 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * @param key           the key by which a resource id should be fetched from the CTP project.
      * @param querySupplier supplies the query to fetch the resource with the given key.
      * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
-     * completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
-     * resource was found in the CTP project with this key.
+     *     completion could contain an {@link Optional} with the id inside of it or an empty {@link Optional} if no
+     *     resource was found in the CTP project with this key.
      */
     @Nonnull
     CompletionStage<Optional<String>> fetchCachedResourceId(
@@ -115,7 +115,7 @@ abstract class BaseServiceWithKey<T extends WithKey, U extends Resource<U> & Wit
      * @param keys          set of state keys to fetch matching states by
      * @param querySupplier supplies the query to fetch the resources with the given keys.
      * @return {@link CompletionStage}&lt;{@link Set}&lt;{@code U}&gt;&gt; in which the result of it's completion
-     * contains a {@link Set} of all matching resources.
+     *     contains a {@link Set} of all matching resources.
      */
     @Nonnull
     CompletionStage<Set<U>> fetchMatchingResources(

--- a/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
@@ -32,7 +32,7 @@ public class CustomObjectServiceImpl
     CustomObjectSyncOptions,
     CustomObjectQuery<JsonNode>,
     CustomObjectQueryModel<CustomObject<JsonNode>>, CustomObjectExpansionModel<CustomObject<JsonNode>>>
-        implements CustomObjectService {
+    implements CustomObjectService {
 
     public CustomObjectServiceImpl(@Nonnull final CustomObjectSyncOptions syncOptions) {
         super(syncOptions);
@@ -41,7 +41,7 @@ public class CustomObjectServiceImpl
     @Nonnull
     @Override
     public CompletionStage<Optional<String>> fetchCachedCustomObjectId(
-            @Nonnull final CustomObjectCompositeIdentifier identifier) {
+        @Nonnull final CustomObjectCompositeIdentifier identifier) {
 
         String container = identifier.getContainer();
         String key = identifier.getKey();
@@ -53,29 +53,31 @@ public class CustomObjectServiceImpl
         return fetchCachedResourceId(identifier.toString(),
             draft -> CustomObjectCompositeIdentifier.of(draft).toString(),
             () -> CustomObjectQuery.ofJsonNode()
-                        .withPredicates(q -> q.container().is(container).and(q.key().is(key)))
+                                   .withPredicates(q -> q.container().is(container).and(q.key().is(key)))
         );
     }
 
     @Nonnull
     @Override
     public CompletionStage<Set<CustomObject<JsonNode>>> fetchMatchingCustomObjects(
-            @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
+        @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
 
         Set<CustomObjectCompositeIdentifier> filteredIdentifiers = identifiers.stream()
-                .filter(identifier ->
-                            StringUtils.isNotEmpty(identifier.getContainer())
-                        &&  StringUtils.isNotEmpty(identifier.getKey()))
-                .collect(Collectors.toSet());
+                                                                              .filter(identifier ->
+                                                                                  StringUtils.isNotEmpty(
+                                                                                      identifier.getContainer())
+                                                                                      && StringUtils.isNotEmpty(
+                                                                                      identifier.getKey()))
+                                                                              .collect(Collectors.toSet());
 
         if (filteredIdentifiers.size() == 0) {
             return CompletableFuture.completedFuture(Collections.emptySet());
         }
 
         Set<String> identifierStrings =
-                filteredIdentifiers.stream()
-                        .map(CustomObjectCompositeIdentifier::toString)
-                        .collect(Collectors.toSet());
+            filteredIdentifiers.stream()
+                               .map(CustomObjectCompositeIdentifier::toString)
+                               .collect(Collectors.toSet());
 
         return fetchMatchingResources(identifierStrings,
             draft -> CustomObjectCompositeIdentifier.of(draft).toString(),
@@ -88,8 +90,8 @@ public class CustomObjectServiceImpl
 
     @Nonnull
     private QueryPredicate<CustomObject<JsonNode>> createQuery(
-            @Nonnull final CustomObjectQueryModel<CustomObject<JsonNode>> queryModel,
-            @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
+        @Nonnull final CustomObjectQueryModel<CustomObject<JsonNode>> queryModel,
+        @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
 
         QueryPredicate<CustomObject<JsonNode>> queryPredicate = QueryPredicate.of(null);
         boolean firstAttempt = true;
@@ -109,7 +111,7 @@ public class CustomObjectServiceImpl
     @Nonnull
     @Override
     public CompletionStage<Optional<CustomObject<JsonNode>>> fetchCustomObject(
-            @Nonnull final CustomObjectCompositeIdentifier identifier) {
+        @Nonnull final CustomObjectCompositeIdentifier identifier) {
 
         String container = identifier.getContainer();
         String key = identifier.getKey();
@@ -133,6 +135,6 @@ public class CustomObjectServiceImpl
         }
         return createResource(customObjectDraft,
             draft -> CustomObjectCompositeIdentifier.of(draft).toString(),
-                CustomObjectUpsertCommand::of);
+            CustomObjectUpsertCommand::of);
     }
 }

--- a/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
@@ -63,12 +63,10 @@ public class CustomObjectServiceImpl
         @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
 
         Set<CustomObjectCompositeIdentifier> filteredIdentifiers = identifiers.stream()
-                                                                              .filter(identifier ->
-                                                                                  StringUtils.isNotEmpty(
-                                                                                      identifier.getContainer())
-                                                                                      && StringUtils.isNotEmpty(
-                                                                                      identifier.getKey()))
-                                                                              .collect(Collectors.toSet());
+                .filter(identifier ->
+                        StringUtils.isNotEmpty(identifier.getContainer())
+                    &&  StringUtils.isNotEmpty(identifier.getKey()))
+                .collect(Collectors.toSet());
 
         if (filteredIdentifiers.size() == 0) {
             return CompletableFuture.completedFuture(Collections.emptySet());

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/AssertionsForStatistics.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/AssertionsForStatistics.java
@@ -2,6 +2,7 @@ package com.commercetools.sync.commons.asserts.statistics;
 
 import com.commercetools.sync.cartdiscounts.helpers.CartDiscountSyncStatistics;
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.inventories.helpers.InventorySyncStatistics;
 import com.commercetools.sync.products.helpers.ProductSyncStatistics;
 import com.commercetools.sync.producttypes.helpers.ProductTypeSyncStatistics;
@@ -103,4 +104,16 @@ public final class AssertionsForStatistics {
     public static TaxCategorySyncStatisticsAssert assertThat(@Nullable final TaxCategorySyncStatistics statistics) {
         return new TaxCategorySyncStatisticsAssert(statistics);
     }
+
+    /**
+     * Create assertion for {@link CustomObjectSyncStatistics}.
+     *
+     * @param statistics the actual value.
+     * @return the created assertion object.
+     */
+    @Nonnull
+    public static CustomObjectSyncStatisticsAssert assertThat(@Nullable final CustomObjectSyncStatistics statistics) {
+        return new CustomObjectSyncStatisticsAssert(statistics);
+    }
+
 }

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/AssertionsForStatistics.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/AssertionsForStatistics.java
@@ -115,5 +115,4 @@ public final class AssertionsForStatistics {
     public static CustomObjectSyncStatisticsAssert assertThat(@Nullable final CustomObjectSyncStatistics statistics) {
         return new CustomObjectSyncStatisticsAssert(statistics);
     }
-
 }

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
@@ -1,0 +1,14 @@
+package com.commercetools.sync.commons.asserts.statistics;
+
+import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
+
+
+import javax.annotation.Nullable;
+
+
+public final class CustomObjectSyncStatisticsAssert extends
+        AbstractSyncStatisticsAssert<CustomObjectSyncStatisticsAssert, CustomObjectSyncStatistics> {
+    CustomObjectSyncStatisticsAssert(@Nullable final CustomObjectSyncStatistics actual) {
+        super(actual, CustomObjectSyncStatisticsAssert.class);
+    }
+}

--- a/src/test/java/com/commercetools/sync/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
@@ -1,13 +1,11 @@
 package com.commercetools.sync.commons.asserts.statistics;
 
 import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
-
-
 import javax.annotation.Nullable;
 
-
 public final class CustomObjectSyncStatisticsAssert extends
-        AbstractSyncStatisticsAssert<CustomObjectSyncStatisticsAssert, CustomObjectSyncStatistics> {
+    AbstractSyncStatisticsAssert<CustomObjectSyncStatisticsAssert, CustomObjectSyncStatistics> {
+
     CustomObjectSyncStatisticsAssert(@Nullable final CustomObjectSyncStatistics actual) {
         super(actual, CustomObjectSyncStatisticsAssert.class);
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilderTest.java
@@ -57,8 +57,7 @@ class CustomObjectSyncOptionsBuilderTest {
     void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final QuadConsumer<SyncException, Optional<CustomObjectDraft<JsonNode>>,
             Optional<CustomObject<JsonNode>>, List<UpdateAction<CustomObject<JsonNode>>>>
-            mockErrorCallBack = (exception, newResource, oldResource, updateActions) -> {
-        };
+            mockErrorCallBack = (exception, newResource, oldResource, updateActions) -> { };
         customObjectSyncOptionsBuilder.errorCallback(mockErrorCallBack);
 
         final CustomObjectSyncOptions customObjectSyncOptions = customObjectSyncOptionsBuilder.build();
@@ -69,8 +68,7 @@ class CustomObjectSyncOptionsBuilderTest {
     void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final TriConsumer<SyncException,
             Optional<CustomObjectDraft<JsonNode>>, Optional<CustomObject<JsonNode>>> mockWarningCallBack =
-            (exception, newResource, oldResource) -> {
-            };
+                (exception, newResource, oldResource) -> { };
         customObjectSyncOptionsBuilder.warningCallback(mockWarningCallBack);
         final CustomObjectSyncOptions cutomObjectSyncOptions = customObjectSyncOptionsBuilder.build();
         assertThat(cutomObjectSyncOptions.getWarningCallback()).isNotNull();

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsBuilderTest.java
@@ -25,7 +25,7 @@ class CustomObjectSyncOptionsBuilderTest {
 
     private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
     private CustomObjectSyncOptionsBuilder customObjectSyncOptionsBuilder =
-            CustomObjectSyncOptionsBuilder.of(CTP_CLIENT);
+        CustomObjectSyncOptionsBuilder.of(CTP_CLIENT);
 
 
     @Test
@@ -56,9 +56,9 @@ class CustomObjectSyncOptionsBuilderTest {
     @Test
     void errorCallBack_WithCallBack_ShouldSetCallBack() {
         final QuadConsumer<SyncException, Optional<CustomObjectDraft<JsonNode>>,
-                Optional<CustomObject<JsonNode>>, List<UpdateAction<CustomObject<JsonNode>>>>
+            Optional<CustomObject<JsonNode>>, List<UpdateAction<CustomObject<JsonNode>>>>
             mockErrorCallBack = (exception, newResource, oldResource, updateActions) -> {
-            };
+        };
         customObjectSyncOptionsBuilder.errorCallback(mockErrorCallBack);
 
         final CustomObjectSyncOptions customObjectSyncOptions = customObjectSyncOptionsBuilder.build();
@@ -68,8 +68,9 @@ class CustomObjectSyncOptionsBuilderTest {
     @Test
     void warningCallBack_WithCallBack_ShouldSetCallBack() {
         final TriConsumer<SyncException,
-                Optional<CustomObjectDraft<JsonNode>>, Optional<CustomObject<JsonNode>>> mockWarningCallBack =
-                    (exception, newResource, oldResource) -> { };
+            Optional<CustomObjectDraft<JsonNode>>, Optional<CustomObject<JsonNode>>> mockWarningCallBack =
+            (exception, newResource, oldResource) -> {
+            };
         customObjectSyncOptionsBuilder.warningCallback(mockWarningCallBack);
         final CustomObjectSyncOptions cutomObjectSyncOptions = customObjectSyncOptionsBuilder.build();
         assertThat(cutomObjectSyncOptions.getWarningCallback()).isNotNull();
@@ -86,54 +87,55 @@ class CustomObjectSyncOptionsBuilderTest {
     @Test
     void customObjectSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
-                .of(CTP_CLIENT)
-                .batchSize(30)
-                .beforeCreateCallback((newCustomObject) -> null)
-                .beforeUpdateCallback((updateActions, newCustomObject, oldCustomObject) -> emptyList())
-                .build();
+            .of(CTP_CLIENT)
+            .batchSize(30)
+            .beforeCreateCallback((newCustomObject) -> null)
+            .beforeUpdateCallback((updateActions, newCustomObject, oldCustomObject) -> emptyList())
+            .build();
         assertThat(customObjectSyncOptions).isNotNull();
     }
 
     @Test
     void batchSize_WithPositiveValue_ShouldSetBatchSize() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .batchSize(10)
-                .build();
+                                                                                              .batchSize(10)
+                                                                                              .build();
         assertThat(customObjectSyncOptions.getBatchSize()).isEqualTo(10);
     }
 
     @Test
     void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
         final CustomObjectSyncOptions customObjectSyncOptionsWithZeroBatchSize =
-                CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .batchSize(0)
-                .build();
+            CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
+                                          .batchSize(0)
+                                          .build();
         assertThat(customObjectSyncOptionsWithZeroBatchSize.getBatchSize())
-                .isEqualTo(CustomObjectSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+            .isEqualTo(CustomObjectSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
         final CustomObjectSyncOptions customObjectSyncOptionsWithNegativeBatchSize = CustomObjectSyncOptionsBuilder
-                .of(CTP_CLIENT)
-                .batchSize(-100)
-                .build();
+            .of(CTP_CLIENT)
+            .batchSize(-100)
+            .build();
         assertThat(customObjectSyncOptionsWithNegativeBatchSize.getBatchSize())
-                .isEqualTo(CustomObjectSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+            .isEqualTo(CustomObjectSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
     }
 
     @Test
     void applyBeforeUpdateCallBack_WithNullReturnCallbackAndEmptyUpdateActions_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<CustomObject<JsonNode>>>, CustomObjectDraft<JsonNode>,
-                CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>>
-                beforeUpdateCallback = (updateActions, newCustomObject, oldCustomObject) -> null;
+            CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>>
+            beforeUpdateCallback = (updateActions, newCustomObject, oldCustomObject) -> null;
 
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeUpdateCallback(beforeUpdateCallback)
-                .build();
+                                                                                              .beforeUpdateCallback(
+                                                                                                  beforeUpdateCallback)
+                                                                                              .build();
         assertThat(customObjectSyncOptions.getBeforeUpdateCallback()).isNotNull();
 
         final List<UpdateAction<CustomObject<JsonNode>>> updateActions = Collections.emptyList();
 
         final List<UpdateAction<CustomObject<JsonNode>>> filteredList =
-                customObjectSyncOptions.applyBeforeUpdateCallback(
-                        updateActions, mock(CustomObjectDraft.class), mock(CustomObject.class));
+            customObjectSyncOptions.applyBeforeUpdateCallback(
+                updateActions, mock(CustomObjectDraft.class), mock(CustomObject.class));
         assertThat(filteredList).isEqualTo(updateActions);
         assertThat(filteredList).isEmpty();
     }
@@ -142,19 +144,20 @@ class CustomObjectSyncOptionsBuilderTest {
     void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
         final Function<CustomObjectDraft<JsonNode>, CustomObjectDraft<JsonNode>> draftFunction =
             customObjectDraft -> CustomObjectDraft.ofUnversionedUpsert(
-                    customObjectDraft.getContainer() + "_filteredContainer",
-                    customObjectDraft.getKey() + "_filteredKey",
-                    (JsonNode)customObjectDraft.getValue());
+                customObjectDraft.getContainer() + "_filteredContainer",
+                customObjectDraft.getKey() + "_filteredKey",
+                (JsonNode) customObjectDraft.getValue());
 
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeCreateCallback(draftFunction)
-                .build();
+                                                                                              .beforeCreateCallback(
+                                                                                                  draftFunction)
+                                                                                              .build();
         assertThat(customObjectSyncOptions.getBeforeCreateCallback()).isNotNull();
         final CustomObjectDraft<JsonNode> resourceDraft = mock(CustomObjectDraft.class);
         when(resourceDraft.getKey()).thenReturn("myKey");
         when(resourceDraft.getContainer()).thenReturn("myContainer");
         final Optional<CustomObjectDraft<JsonNode>> filteredDraft =
-                customObjectSyncOptions.applyBeforeCreateCallback(resourceDraft);
+            customObjectSyncOptions.applyBeforeCreateCallback(resourceDraft);
         assertThat(filteredDraft).isNotEmpty();
         assertThat(filteredDraft.get().getKey()).isEqualTo("myKey_filteredKey");
         assertThat(filteredDraft.get().getContainer()).isEqualTo("myContainer_filteredContainer");
@@ -175,12 +178,13 @@ class CustomObjectSyncOptionsBuilderTest {
         final Function<CustomObjectDraft<JsonNode>, CustomObjectDraft<JsonNode>> draftFunction =
             customObjectDraft -> null;
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeCreateCallback(draftFunction)
-                .build();
+                                                                                              .beforeCreateCallback(
+                                                                                                  draftFunction)
+                                                                                              .build();
         assertThat(customObjectSyncOptions.getBeforeCreateCallback()).isNotNull();
         final CustomObjectDraft<JsonNode> resourceDraft = mock(CustomObjectDraft.class);
         final Optional<CustomObjectDraft<JsonNode>> filteredDraft =
-                customObjectSyncOptions.applyBeforeCreateCallback(resourceDraft);
+            customObjectSyncOptions.applyBeforeCreateCallback(resourceDraft);
         assertThat(filteredDraft).isEmpty();
     }
 

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsTest.java
@@ -29,20 +29,20 @@ class CustomObjectSyncOptionsTest {
     private static SphereClient CTP_CLIENT = mock(SphereClient.class);
 
     private interface MockTriFunction extends
-            TriFunction<List<UpdateAction<CustomObject<JsonNode>>>,
-                    CustomObjectDraft<JsonNode>, CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>> {
+        TriFunction<List<UpdateAction<CustomObject<JsonNode>>>,
+            CustomObjectDraft<JsonNode>, CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>> {
     }
 
     @Test
     void applyBeforeUpdateCallback_WithNullCallbackAndEmptyUpdateActions_ShouldReturnIdenticalList() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .build();
+                                                                                              .build();
 
         final List<UpdateAction<CustomObject<JsonNode>>> updateActions = emptyList();
 
         final List<UpdateAction<CustomObject<JsonNode>>> filteredList =
-                customObjectSyncOptions.applyBeforeUpdateCallback(updateActions,
-                    mock(CustomObjectDraft.class), mock(CustomObject.class));
+            customObjectSyncOptions.applyBeforeUpdateCallback(updateActions,
+                mock(CustomObjectDraft.class), mock(CustomObject.class));
 
         assertThat(filteredList).isSameAs(updateActions);
     }
@@ -51,16 +51,17 @@ class CustomObjectSyncOptionsTest {
     @Test
     void applyBeforeUpdateCallback_WithNullReturnCallbackAndEmptyUpdateActions_ShouldReturnEmptyList() {
         final TriFunction<List<UpdateAction<CustomObject<JsonNode>>>, CustomObjectDraft<JsonNode>,
-                CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>>
-                beforeUpdateCallback = (updateActions, newCustomObject, oldCustomObject) -> null;
+            CustomObject<JsonNode>, List<UpdateAction<CustomObject<JsonNode>>>>
+            beforeUpdateCallback = (updateActions, newCustomObject, oldCustomObject) -> null;
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeUpdateCallback(beforeUpdateCallback)
-                .build();
+                                                                                              .beforeUpdateCallback(
+                                                                                                  beforeUpdateCallback)
+                                                                                              .build();
         final List<UpdateAction<CustomObject<JsonNode>>> updateActions = emptyList();
 
         final List<UpdateAction<CustomObject<JsonNode>>> filteredList =
-                customObjectSyncOptions.applyBeforeUpdateCallback(
-                        updateActions, mock(CustomObjectDraft.class), mock(CustomObject.class));
+            customObjectSyncOptions.applyBeforeUpdateCallback(
+                updateActions, mock(CustomObjectDraft.class), mock(CustomObject.class));
 
         assertAll(
             () -> assertThat(filteredList).isEqualTo(updateActions),
@@ -69,18 +70,18 @@ class CustomObjectSyncOptionsTest {
     }
 
 
-
     @Test
     void applyBeforeUpdateCallback_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
         final CustomObjectSyncOptionsTest.MockTriFunction beforeUpdateCallback =
-                mock(CustomObjectSyncOptionsTest.MockTriFunction.class);
+            mock(CustomObjectSyncOptionsTest.MockTriFunction.class);
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeUpdateCallback(beforeUpdateCallback)
-                .build();
+                                                                                              .beforeUpdateCallback(
+                                                                                                  beforeUpdateCallback)
+                                                                                              .build();
 
         final List<UpdateAction<CustomObject<JsonNode>>> filteredList =
-                customObjectSyncOptions.applyBeforeUpdateCallback(emptyList(),
-                        mock(CustomObjectDraft.class), mock(CustomObject.class));
+            customObjectSyncOptions.applyBeforeUpdateCallback(emptyList(),
+                mock(CustomObjectDraft.class), mock(CustomObject.class));
 
         assertThat(filteredList).isEmpty();
         verify(beforeUpdateCallback, never()).apply(any(), any(), any());
@@ -92,23 +93,24 @@ class CustomObjectSyncOptionsTest {
 
         final Function<CustomObjectDraft<JsonNode>, CustomObjectDraft<JsonNode>> draftFunction =
             customObjectDraft -> CustomObjectDraft.ofUnversionedUpsert(
-                        customObjectDraft.getContainer() + "_filteredContainer",
-                        customObjectDraft.getKey() + "_filteredKey", customObjectDraft.getValue());
+                customObjectDraft.getContainer() + "_filteredContainer",
+                customObjectDraft.getKey() + "_filteredKey", customObjectDraft.getValue());
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeCreateCallback(draftFunction)
-                .build();
+                                                                                              .beforeCreateCallback(
+                                                                                                  draftFunction)
+                                                                                              .build();
         final CustomObjectDraft<JsonNode> resourceDraft = mock(CustomObjectDraft.class);
         when(resourceDraft.getKey()).thenReturn("myKey");
         when(resourceDraft.getContainer()).thenReturn("myContainer");
 
         final Optional<CustomObjectDraft<JsonNode>> filteredDraft = customObjectSyncOptions
-                .applyBeforeCreateCallback(resourceDraft);
+            .applyBeforeCreateCallback(resourceDraft);
 
         assertThat(filteredDraft).hasValueSatisfying(customObjectDraft ->
-                assertAll(
-                    () -> assertThat(customObjectDraft.getKey()).isEqualTo("myKey_filteredKey"),
-                    () -> assertThat(customObjectDraft.getContainer()).isEqualTo("myContainer_filteredContainer")
-                ));
+            assertAll(
+                () -> assertThat(customObjectDraft.getKey()).isEqualTo("myKey_filteredKey"),
+                () -> assertThat(customObjectDraft.getContainer()).isEqualTo("myContainer_filteredContainer")
+            ));
     }
 
     @Test
@@ -117,7 +119,7 @@ class CustomObjectSyncOptionsTest {
         final CustomObjectDraft<JsonNode> resourceDraft = mock(CustomObjectDraft.class);
 
         final Optional<CustomObjectDraft<JsonNode>> filteredDraft = customObjectSyncOptions
-                .applyBeforeCreateCallback(resourceDraft);
+            .applyBeforeCreateCallback(resourceDraft);
 
         assertThat(filteredDraft).containsSame(resourceDraft);
     }
@@ -127,12 +129,13 @@ class CustomObjectSyncOptionsTest {
         final Function<CustomObjectDraft<JsonNode>, CustomObjectDraft<JsonNode>> draftFunction =
             customObjectDraft -> null;
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                .beforeCreateCallback(draftFunction)
-                .build();
+                                                                                              .beforeCreateCallback(
+                                                                                                  draftFunction)
+                                                                                              .build();
         final CustomObjectDraft<JsonNode> resourceDraft = mock(CustomObjectDraft.class);
 
         final Optional<CustomObjectDraft<JsonNode>> filteredDraft = customObjectSyncOptions
-                .applyBeforeCreateCallback(resourceDraft);
+            .applyBeforeCreateCallback(resourceDraft);
 
         assertThat(filteredDraft).isEmpty();
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncOptionsTest.java
@@ -35,8 +35,8 @@ class CustomObjectSyncOptionsTest {
 
     @Test
     void applyBeforeUpdateCallback_WithNullCallbackAndEmptyUpdateActions_ShouldReturnIdenticalList() {
-        final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(CTP_CLIENT)
-                                                                                              .build();
+        final CustomObjectSyncOptions customObjectSyncOptions =
+                CustomObjectSyncOptionsBuilder.of(CTP_CLIENT).build();
 
         final List<UpdateAction<CustomObject<JsonNode>>> updateActions = emptyList();
 

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.customobjects;
 
-import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
 import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.services.CustomObjectService;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -400,10 +400,10 @@ public class CustomObjectSyncTest {
         assertThat(exceptions).hasSize(0);
         assertThat(errorMessages).hasSize(0);
         assertAll(
-                () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
-                () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
-                () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
-                () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0)
+            () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+            () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0)
         );
         verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
     }
@@ -444,10 +444,10 @@ public class CustomObjectSyncTest {
         assertThat(exceptions).hasSize(0);
         assertThat(errorMessages).hasSize(0);
         assertAll(
-                () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
-                () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
-                () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
-                () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0)
+            () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+            () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+            () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+            () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0)
         );
         verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -78,9 +78,9 @@ public class CustomObjectSyncTest {
 
         assertThat(exceptions)
             .hasSize(1).singleElement().isInstanceOfSatisfying(Throwable.class, throwable -> {
-            assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
-            assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
-        });
+                assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+                assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
+            });
 
         assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -1,0 +1,147 @@
+package com.commercetools.sync.customobjects;
+
+import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
+import com.commercetools.sync.services.CustomObjectService;
+import com.commercetools.sync.types.TypeSync;
+import com.commercetools.sync.types.TypeSyncOptions;
+import com.commercetools.sync.types.TypeSyncOptionsBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customobjects.CustomObjectDraft;
+import io.sphere.sdk.models.SphereException;
+import io.sphere.sdk.types.ResourceTypeIdsSetBuilder;
+import io.sphere.sdk.types.Type;
+import io.sphere.sdk.types.TypeDraft;
+import io.sphere.sdk.types.TypeDraftBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+
+import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static io.sphere.sdk.models.LocalizedString.ofEnglish;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class CustomObjectSyncTest {
+    @Test
+    void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+        // preparation
+
+
+        final CustomObjectDraft<JsonNode> newCustomObjectDraft = CustomObjectDraft
+                .ofUnversionedUpsert("someName", "someKey",
+                        JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
+        final List<String> errorMessages = new ArrayList<>();
+        final List<Throwable> exceptions = new ArrayList<>();
+
+        final CustomObjectSyncOptions syncOptions = CustomObjectSyncOptionsBuilder
+                .of(mock(SphereClient.class))
+                .errorCallback((exception, oldResource, newResource, updateActions) -> {
+                    errorMessages.add(exception.getMessage());
+                    exceptions.add(exception.getCause());
+                })
+                .build();
+
+        final CustomObjectService mockCustomObjectService = mock(CustomObjectService.class);
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier = CustomObjectCompositeIdentifier.of("someKey", "someName");
+
+        when(mockCustomObjectService.fetchMatchingCustomObjects(singleton(customObjectCompositeIdentifier)))
+               .thenReturn(supplyAsync(() -> { throw new SphereException();}));
+
+        final CustomObjectSync customObjectSync = new CustomObjectSync(syncOptions, mockCustomObjectService);
+
+        // test
+        final CustomObjectSyncStatistics customObjectSyncStatistics = customObjectSync
+                .sync(singletonList(newCustomObjectDraft))
+                .toCompletableFuture().join();
+
+        // assertions
+        assertThat(errorMessages)
+                .hasSize(1)
+                .hasOnlyOneElementSatisfying(message ->
+                        assertThat(message).isEqualTo("Failed to fetch existing customObjects with keys: '[{key='someKey', container='someName'}]'.")
+                );
+
+        assertThat(exceptions)
+                .hasSize(1)
+                .hasOnlyOneElementSatisfying(throwable -> {
+                    assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+                    assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
+                });
+
+        assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
+    }
+/*
+
+    @Test
+    void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+        // preparation
+        final CustomObjectDraft<JsonNode> newCustomObjectDraft = CustomObjectDraft.ofUnversionedUpsert("someName", "someKey", JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
+
+        final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
+                .of(mock(SphereClient.class))
+                .build();
+
+        final CustomObjectService customObjectService = mock(CustomObjectService.class);
+        when(typeService.fetchMatchingTypesByKeys(anySet())).thenReturn(completedFuture(emptySet()));
+        when(typeService.createType(any())).thenReturn(completedFuture(Optional.empty()));
+
+        final TypeSyncOptions spyTypeSyncOptions = spy(typeSyncOptions);
+
+        // test
+        new TypeSync(spyTypeSyncOptions, typeService)
+                .sync(singletonList(newTypeDraft)).toCompletableFuture().join();
+
+        // assertion
+        verify(spyTypeSyncOptions).applyBeforeCreateCallback(newTypeDraft);
+        verify(spyTypeSyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
+    }
+
+    @Test
+    void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+        // preparation
+        final TypeDraft newTypeDraft = TypeDraftBuilder
+                .of("newType", ofEnglish( "typeName"), ResourceTypeIdsSetBuilder.of().addChannels())
+                .build();
+
+        final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder
+                .of(mock(SphereClient.class))
+                .build();
+
+        final Type mockedExistingType = mock(Type.class);
+        when(mockedExistingType.getKey()).thenReturn(newTypeDraft.getKey());
+
+        final TypeService typeService = mock(TypeService.class);
+        when(typeService.fetchMatchingTypesByKeys(anySet())).thenReturn(completedFuture(singleton(mockedExistingType)));
+        when(typeService.updateType(any(), any())).thenReturn(completedFuture(mockedExistingType));
+
+        final TypeSyncOptions spyTypeSyncOptions = spy(typeSyncOptions);
+
+        // test
+        new TypeSync(spyTypeSyncOptions, typeService)
+                .sync(singletonList(newTypeDraft)).toCompletableFuture().join();
+
+        // assertion
+        verify(spyTypeSyncOptions).applyBeforeUpdateCallback(any(), any(), any());
+        verify(spyTypeSyncOptions, never()).applyBeforeCreateCallback(newTypeDraft);
+    }
+*/
+}

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -78,11 +78,10 @@ public class CustomObjectSyncTest {
                         "'[{key='someKey', container='someContainer'}]'.");
 
         assertThat(exceptions)
-                .hasSize(1)
-                .hasOnlyOneElementSatisfying(throwable -> {
-                    assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
-                    assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
-                });
+                .hasSize(1).singleElement().isInstanceOfSatisfying(Throwable.class,throwable -> {
+            assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+            assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
+        });
 
         assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -3,28 +3,19 @@ package com.commercetools.sync.customobjects;
 import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
 import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.services.CustomObjectService;
-import com.commercetools.sync.types.TypeSync;
-import com.commercetools.sync.types.TypeSyncOptions;
-import com.commercetools.sync.types.TypeSyncOptionsBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.customobjects.CustomObjectDraft;
 import io.sphere.sdk.models.SphereException;
-import io.sphere.sdk.types.ResourceTypeIdsSetBuilder;
-import io.sphere.sdk.types.Type;
-import io.sphere.sdk.types.TypeDraft;
-import io.sphere.sdk.types.TypeDraftBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.CompletionException;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
-import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -89,59 +80,61 @@ public class CustomObjectSyncTest {
 
         assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
     }
-/*
+
 
     @Test
     void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
         // preparation
-        final CustomObjectDraft<JsonNode> newCustomObjectDraft = CustomObjectDraft.ofUnversionedUpsert("someName", "someKey", JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
+        final CustomObjectDraft<JsonNode> newCustomObjectDraft = CustomObjectDraft
+                .ofUnversionedUpsert("someName", "someKey",
+                        JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
 
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
                 .of(mock(SphereClient.class))
                 .build();
 
         final CustomObjectService customObjectService = mock(CustomObjectService.class);
-        when(typeService.fetchMatchingTypesByKeys(anySet())).thenReturn(completedFuture(emptySet()));
-        when(typeService.createType(any())).thenReturn(completedFuture(Optional.empty()));
+        when(customObjectService.fetchMatchingCustomObjects(anySet())).thenReturn(completedFuture(emptySet()));
+        when(customObjectService.upsertCustomObject(any())).thenReturn(completedFuture(Optional.empty()));
 
-        final TypeSyncOptions spyTypeSyncOptions = spy(typeSyncOptions);
+        final CustomObjectSyncOptions spyCustomObjectSyncOptions = spy(customObjectSyncOptions);
 
         // test
-        new TypeSync(spyTypeSyncOptions, typeService)
-                .sync(singletonList(newTypeDraft)).toCompletableFuture().join();
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+                .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
-        verify(spyTypeSyncOptions).applyBeforeCreateCallback(newTypeDraft);
-        verify(spyTypeSyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
+        verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+        verify(spyCustomObjectSyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
     }
 
-    @Test
+    //TODO
+   /* @Test
     void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
         // preparation
-        final TypeDraft newTypeDraft = TypeDraftBuilder
-                .of("newType", ofEnglish( "typeName"), ResourceTypeIdsSetBuilder.of().addChannels())
-                .build();
+        final CustomObjectDraft<JsonNode> newCustomObjectDraft = CustomObjectDraft
+                .ofUnversionedUpsert("someName", "someKey",
+                        JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
 
-        final TypeSyncOptions typeSyncOptions = TypeSyncOptionsBuilder
+        final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
                 .of(mock(SphereClient.class))
                 .build();
 
-        final Type mockedExistingType = mock(Type.class);
-        when(mockedExistingType.getKey()).thenReturn(newTypeDraft.getKey());
+        final CustomObject mockedExistingCustomObject = mock(CustomObject.class);
+        when(mockedExistingCustomObject.getKey()).thenReturn(newCustomObjectDraft.getKey());
 
-        final TypeService typeService = mock(TypeService.class);
-        when(typeService.fetchMatchingTypesByKeys(anySet())).thenReturn(completedFuture(singleton(mockedExistingType)));
-        when(typeService.updateType(any(), any())).thenReturn(completedFuture(mockedExistingType));
+        final CustomObjectService customObjectService = mock(CustomObjectService.class);
+        when(customObjectService.fetchMatchingCustomObjects(anySet())).thenReturn(completedFuture(singleton(mockedExistingCustomObject)));
+        when(customObjectService.upsertCustomObject(any())).thenReturn(completedFuture(mockedExistingCustomObject));
 
-        final TypeSyncOptions spyTypeSyncOptions = spy(typeSyncOptions);
+        final CustomObjectSyncOptions spyTypeSyncOptions = spy(customObjectSyncOptions);
 
         // test
-        new TypeSync(spyTypeSyncOptions, typeService)
-                .sync(singletonList(newTypeDraft)).toCompletableFuture().join();
+        new CustomObjectSync(spyTypeSyncOptions, customObjectService)
+                .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
         verify(spyTypeSyncOptions).applyBeforeUpdateCallback(any(), any(), any());
-        verify(spyTypeSyncOptions, never()).applyBeforeCreateCallback(newTypeDraft);
-    }
-*/
+        verify(spyTypeSyncOptions, never()).applyBeforeCreateCallback(newCustomObjectDraft);
+    }*/
 }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -58,10 +58,8 @@ public class CustomObjectSyncTest {
                 .build();
 
         final CustomObjectService mockCustomObjectService = mock(CustomObjectService.class);
-        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
-                CustomObjectCompositeIdentifier.of("someKey", "someContainer");
 
-        when(mockCustomObjectService.fetchMatchingCustomObjects(singleton(customObjectCompositeIdentifier)))
+        when(mockCustomObjectService.fetchMatchingCustomObjects(anySet()))
                .thenReturn(supplyAsync(() -> { throw new SphereException(); }));
 
         final CustomObjectSync customObjectSync = new CustomObjectSync(syncOptions, mockCustomObjectService);

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -39,8 +39,8 @@ public class CustomObjectSyncTest {
     @BeforeEach
     void setup() {
         newCustomObjectDraft = CustomObjectDraft
-                .ofUnversionedUpsert("someContainer", "someKey",
-                        JsonNodeFactory.instance.objectNode().put( "json-field", "json-value"));
+            .ofUnversionedUpsert("someContainer", "someKey",
+                JsonNodeFactory.instance.objectNode().put("json-field", "json-value"));
     }
 
     @Test
@@ -49,36 +49,38 @@ public class CustomObjectSyncTest {
         final List<Throwable> exceptions = new ArrayList<>();
 
         final CustomObjectSyncOptions syncOptions = CustomObjectSyncOptionsBuilder
-                .of(mock(SphereClient.class))
-                .errorCallback((exception, oldResource, newResource, updateActions) -> {
-                    errorMessages.add(exception.getMessage());
-                    exceptions.add(exception.getCause());
-                })
-                .build();
+            .of(mock(SphereClient.class))
+            .errorCallback((exception, oldResource, newResource, updateActions) -> {
+                errorMessages.add(exception.getMessage());
+                exceptions.add(exception.getCause());
+            })
+            .build();
 
         final CustomObjectService mockCustomObjectService = mock(CustomObjectService.class);
 
         when(mockCustomObjectService.fetchMatchingCustomObjects(anySet()))
-               .thenReturn(supplyAsync(() -> { throw new SphereException(); }));
+            .thenReturn(supplyAsync(() -> {
+                throw new SphereException();
+            }));
 
         final CustomObjectSync customObjectSync = new CustomObjectSync(syncOptions, mockCustomObjectService);
 
         // test
         final CustomObjectSyncStatistics customObjectSyncStatistics = customObjectSync
-                .sync(singletonList(newCustomObjectDraft))
-                .toCompletableFuture().join();
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture().join();
 
         // assertions
         assertThat(errorMessages)
-                .hasSize(1).singleElement().asString()
-                .isEqualTo("Failed to fetch existing customObjects with keys: "
-                        + "'[{key='someKey', container='someContainer'}]'.");
+            .hasSize(1).singleElement().asString()
+            .isEqualTo("Failed to fetch existing customObjects with keys: "
+                + "'[{key='someKey', container='someContainer'}]'.");
 
         assertThat(exceptions)
-                .hasSize(1).singleElement().isInstanceOfSatisfying(Throwable.class,throwable -> {
-                    assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
-                    assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
-                });
+            .hasSize(1).singleElement().isInstanceOfSatisfying(Throwable.class, throwable -> {
+            assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+            assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
+        });
 
         assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
     }
@@ -86,8 +88,8 @@ public class CustomObjectSyncTest {
     @Test
     void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback_ShouldNotCallBeforeUpdateCallback() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
-                .of(mock(SphereClient.class))
-                .build();
+            .of(mock(SphereClient.class))
+            .build();
 
         final CustomObjectService customObjectService = mock(CustomObjectService.class);
         when(customObjectService.fetchMatchingCustomObjects(anySet())).thenReturn(completedFuture(emptySet()));
@@ -97,7 +99,7 @@ public class CustomObjectSyncTest {
 
         // test
         new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
-                .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
+            .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
         verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
@@ -107,23 +109,23 @@ public class CustomObjectSyncTest {
     @Test
     void sync_WithOnlyDraftsToUpdate_ShouldCallBeforeCreateCallback_ShouldNotCallBeforeUpdateCallback() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
-                .of(mock(SphereClient.class))
-                .build();
+            .of(mock(SphereClient.class))
+            .build();
 
         final CustomObject<JsonNode> mockedExistingCustomObject = mock(CustomObject.class);
         when(mockedExistingCustomObject.getKey()).thenReturn(newCustomObjectDraft.getKey());
 
         final CustomObjectService customObjectService = mock(CustomObjectService.class);
         when(customObjectService.fetchMatchingCustomObjects(anySet()))
-                .thenReturn(completedFuture(singleton(mockedExistingCustomObject)));
+            .thenReturn(completedFuture(singleton(mockedExistingCustomObject)));
         when(customObjectService.upsertCustomObject(any()))
-                .thenReturn(completedFuture(Optional.of(mockedExistingCustomObject)));
+            .thenReturn(completedFuture(Optional.of(mockedExistingCustomObject)));
 
         final CustomObjectSyncOptions spyCustomObjectSyncOptions = spy(customObjectSyncOptions);
 
         // test
         new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
-                .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
+            .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
         verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
@@ -133,8 +135,8 @@ public class CustomObjectSyncTest {
     @Test
     void sync_WitEmptyValidDrafts_ShouldFailed() {
         final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
-                .of(mock(SphereClient.class))
-                .build();
+            .of(mock(SphereClient.class))
+            .build();
 
         final CustomObjectService customObjectService = mock(CustomObjectService.class);
         when(customObjectService.fetchMatchingCustomObjects(anySet())).thenReturn(completedFuture(emptySet()));
@@ -143,9 +145,9 @@ public class CustomObjectSyncTest {
         final CustomObjectSyncOptions spyCustomObjectSyncOptions = spy(customObjectSyncOptions);
 
         // test
-        CustomObjectSyncStatistics syncStatistics =  new CustomObjectSync(
-                spyCustomObjectSyncOptions, customObjectService).sync(
-                    singletonList(null)).toCompletableFuture().join();
+        CustomObjectSyncStatistics syncStatistics = new CustomObjectSync(
+            spyCustomObjectSyncOptions, customObjectService).sync(
+            singletonList(null)).toCompletableFuture().join();
 
         // assertion
         assertThat(syncStatistics.getProcessed().get()).isEqualTo(1);

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -220,8 +220,6 @@ public class CustomObjectSyncTest {
         verify(customObjectService).fetchCustomObject(any(CustomObjectCompositeIdentifier.class));
         verify(customObjectService).upsertCustomObject(any());
         verify(customObjectService).fetchMatchingCustomObjects(any());
-
-
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -99,8 +99,7 @@ public class CustomObjectSyncTest {
         when(customObjectService.upsertCustomObject(any())).thenReturn(completedFuture(Optional.empty()));
 
         // test
-        CustomObjectSyncStatistics syncStatistics =
-                new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
             .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
@@ -123,8 +122,7 @@ public class CustomObjectSyncTest {
             .thenReturn(completedFuture(Optional.of(mockedExistingCustomObject)));
 
         // test
-        CustomObjectSyncStatistics syncStatistics =
-                new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
             .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
         // assertion
@@ -342,10 +340,6 @@ public class CustomObjectSyncTest {
 
         final Set<CustomObject<JsonNode>> existingCustomObjectSet = new HashSet<CustomObject<JsonNode>>();
         existingCustomObjectSet.add(existingCustomObject);
-
-        final CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder
-                .of(mock(SphereClient.class))
-                .build();
 
         final CustomObjectService customObjectService = mock(CustomObjectService.class);
         when(customObjectService.fetchMatchingCustomObjects(anySet()))

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -169,11 +169,10 @@ public class CustomObjectSyncTest {
                 new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
                 .sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
 
-
         assertAll(
             () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
             () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(1),
-            () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+            () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
             () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0)
         );
     }

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -73,7 +73,7 @@ public class CustomObjectSyncTest {
         // assertions
         assertThat(errorMessages)
             .hasSize(1).singleElement().asString()
-            .isEqualTo("Failed to fetch existing customObjects with keys: "
+            .isEqualTo("Failed to fetch existing custom objects with keys: "
                 + "'[{key='someKey', container='someContainer'}]'.");
 
         assertThat(exceptions)

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -172,7 +172,7 @@ public class CustomObjectSyncTest {
     }
 
     @Test
-    void sync_WithDifferentIndentifiers_ShoudUpdateSucessfully() {
+    void sync_WithDifferentIndentifiers_ShoudCreateSucessfully() {
         final CustomObject<JsonNode> existingCustomObject = mock(CustomObject.class);
         when(existingCustomObject.getContainer()).thenReturn("otherContainer");
         when(existingCustomObject.getKey()).thenReturn("otherKey");

--- a/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/CustomObjectSyncTest.java
@@ -62,7 +62,7 @@ public class CustomObjectSyncTest {
                 CustomObjectCompositeIdentifier.of("someKey", "someContainer");
 
         when(mockCustomObjectService.fetchMatchingCustomObjects(singleton(customObjectCompositeIdentifier)))
-               .thenReturn(supplyAsync(() -> { throw new SphereException();}));
+               .thenReturn(supplyAsync(() -> { throw new SphereException(); }));
 
         final CustomObjectSync customObjectSync = new CustomObjectSync(syncOptions, mockCustomObjectService);
 
@@ -74,14 +74,14 @@ public class CustomObjectSyncTest {
         // assertions
         assertThat(errorMessages)
                 .hasSize(1).singleElement().asString()
-                .isEqualTo("Failed to fetch existing customObjects with keys: " +
-                        "'[{key='someKey', container='someContainer'}]'.");
+                .isEqualTo("Failed to fetch existing customObjects with keys: "
+                        + "'[{key='someKey', container='someContainer'}]'.");
 
         assertThat(exceptions)
                 .hasSize(1).singleElement().isInstanceOfSatisfying(Throwable.class,throwable -> {
-            assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
-            assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
-        });
+                    assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+                    assertThat(throwable).hasCauseExactlyInstanceOf(SphereException.class);
+                });
 
         assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
     }

--- a/src/test/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifierTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifierTest.java
@@ -1,0 +1,183 @@
+package com.commercetools.sync.customobjects.helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.customobjects.CustomObject;
+import io.sphere.sdk.customobjects.CustomObjectDraft;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CustomObjectCompositeIdentifierTest {
+
+    private static final String CONTAINER = "container";
+    private static final String KEY = "key";
+
+    @Test
+    void of_WithCustomObjectDraft_ShouldCreateCustomObjectCompositeIdentifier() {
+        final CustomObjectDraft<JsonNode> customObjectDraft =
+                CustomObjectDraft.ofUnversionedUpsert(CONTAINER, KEY, null);
+
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(customObjectDraft);
+
+        assertThat(customObjectCompositeIdentifier).isNotNull();
+        assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+        assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+    }
+
+    @Test
+    void of_WithContainerAndKeyParams_ShouldCreateCustomObjectCompositeIdentifier() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+        assertThat(customObjectCompositeIdentifier).isNotNull();
+        assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+        assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+    }
+
+    @Test
+    void of_WithCustomObject_ShouldCreateCustomObjectCompositeIdentifier() {
+        final CustomObject customObject = mock(CustomObject.class);
+        when(customObject.getContainer()).thenReturn(CONTAINER);
+        when(customObject.getKey()).thenReturn(KEY);
+
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(customObject);
+
+        assertThat(customObjectCompositeIdentifier).isNotNull();
+        assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+        assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+    }
+
+    @Test
+    void equals_WithSameObj_ShouldReturnTrue() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+        boolean result = customObjectCompositeIdentifier.equals(customObjectCompositeIdentifier);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void equals_WithDiffType_ShouldReturnFalse() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+        final Object other = new Object();
+
+        boolean result = customObjectCompositeIdentifier.equals(other);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void equals_WithEqualObjects_ShouldReturnTrue() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY,  CONTAINER);
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+        boolean result = customObjectCompositeIdentifier.equals(other);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void equals_WithDifferentKeys_ShouldReturnFalse() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of("key1", CONTAINER);
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of("key2", CONTAINER);
+
+        boolean result = customObjectCompositeIdentifier.equals(other);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void equals_WithDifferentContainers_ShouldReturnFalse() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, "container1");
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of(KEY, "container2");
+
+        boolean result = customObjectCompositeIdentifier.equals(other);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void hashCode_withSameInstances_ShouldBeEquals() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+        final CustomObjectCompositeIdentifier other = customObjectCompositeIdentifier;
+
+        final int hash1 = customObjectCompositeIdentifier.hashCode();
+        final int hash2 = other.hashCode();
+
+        assertEquals(hash1, hash2);
+    }
+
+    @Test
+    void hashCode_withSameKeyAndSameContainer_ShouldBeEquals() {
+        // preparation
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+        // test
+        final int hash1 = customObjectCompositeIdentifier.hashCode();
+        final int hash2 = other.hashCode();
+
+        // assertions
+        assertEquals(hash1, hash2);
+    }
+
+    @Test
+    void hashCode_withDifferentKeyAndSameContainer_ShouldNotBeEquals() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of("key1", CONTAINER);
+
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of("key2", CONTAINER);
+
+        final int hash1 = customObjectCompositeIdentifier.hashCode();
+        final int hash2 = other.hashCode();
+
+        assertNotEquals(hash1, hash2);
+    }
+
+    @Test
+    void hashCode_withSameKeyAndDifferentContainer_ShouldNotBeEquals() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of(KEY, "container1");
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of(KEY, "container2");
+
+        final int hash1 = customObjectCompositeIdentifier.hashCode();
+        final int hash2 = other.hashCode();
+
+        assertNotEquals(hash1, hash2);
+    }
+
+    @Test
+    void hashCode_withCompletelyDifferentValues_ShouldNotBeEquals() {
+        final CustomObjectCompositeIdentifier customObjectCompositeIdentifier
+                = CustomObjectCompositeIdentifier.of("key1", "container1");
+        final CustomObjectCompositeIdentifier other
+                = CustomObjectCompositeIdentifier.of("key2", "container2");
+
+        final int hash1 = customObjectCompositeIdentifier.hashCode();
+        final int hash2 = other.hashCode();
+
+        assertNotEquals(hash1, hash2);
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -102,7 +102,7 @@ class CustomObjectSyncUtilsTest {
 
     @Test
     void hasIdenticalValue_WithSameFieldAndDifferentValueInJsonNode_ShouldNotBeIdentical() {
-        
+
         ObjectNode oldValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
         ObjectNode newValue = JsonNodeFactory.instance.objectNode().put("username", "Joe");
         prepareMockObjects(oldValue, newValue);

--- a/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -11,15 +11,6 @@ import io.sphere.sdk.customobjects.CustomObjectDraft;
 
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,7 +22,6 @@ class CustomObjectSyncUtilsTest {
 
     private static final String key = "testkey";
     private static final String container = "testcontainer";
-
 
     @Test
     void hasIdenticalValue_WithSameBooleanValue_ShouldBeIdentical() throws JsonProcessingException {
@@ -249,93 +239,5 @@ class CustomObjectSyncUtilsTest {
 
         assertThat(oldJsonNode.toString()).isNotEqualTo(newJsonNode.toString());
         assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isFalse();
-    }
-
-    @Test
-    void batchElements_WithValidSize_ShouldReturnCorrectBatches() {
-        final int numberOfCustomObjectDrafts = 160;
-        final int batchSize = 10;
-        final ArrayList<CustomObjectDraft<JsonNode>> customObjectDrafts = new ArrayList<>();
-
-        for (int i = 0; i < numberOfCustomObjectDrafts; i++) {
-            customObjectDrafts.add(CustomObjectDraft
-                    .ofUnversionedUpsert("container_" + i, "key_" + i,
-                            JsonNodeFactory.instance.objectNode().put("field", "field_" + i)));
-        }
-        final List<List<CustomObjectDraft<JsonNode>>> batches = batchElements(customObjectDrafts, 10);
-        assertThat(batches.size()).isEqualTo(numberOfCustomObjectDrafts / batchSize);
-    }
-
-    @Test
-    void batchElements_WithNegativeSize_ShouldReturnNoBatches() {
-        final int numberOfCustomObjectDrafts = 160;
-        final ArrayList<CustomObjectDraft<JsonNode>> customObjectDrafts = new ArrayList<>();
-
-
-        final List<List<CustomObjectDraft<JsonNode>>> batches = batchElements(customObjectDrafts, -100);
-        assertThat(batches.size()).isEqualTo(0);
-    }
-
-    @Test
-    void batchElements_WithEmptyListAndAnySize_ShouldReturnNoBatches() {
-        final List<List<CustomObjectDraft<JsonNode>>> batches = batchElements(new ArrayList<>(), 100);
-        assertThat(batches.size()).isEqualTo(0);
-    }
-
-    @Test
-    void batchElements_WithUniformSeparation_ShouldReturnCorrectBatches() {
-        batchStringElementsAndAssertAfterBatching(100, 10);
-        batchStringElementsAndAssertAfterBatching(3, 1);
-    }
-
-    @Test
-    void batchElements_WithNonUniformSeparation_ShouldReturnCorrectBatches() {
-        batchStringElementsAndAssertAfterBatching(100, 9);
-        batchStringElementsAndAssertAfterBatching(3, 2);
-    }
-
-    @Nonnull
-    private List<String> getPrefixedStrings(final int numberOfElements, @Nonnull final String prefix) {
-        return IntStream.range(1, numberOfElements + 1)
-                .mapToObj(i -> format("%s#%s", prefix, i))
-                .collect(Collectors.toList());
-    }
-
-    private void batchStringElementsAndAssertAfterBatching(final int numberOfElements, final int batchSize) {
-        final List<String> elements = getPrefixedStrings(numberOfElements, "element");
-
-        final List<List<String>> batches = batchElements(elements, batchSize);
-
-        final int expectedNumberOfBatches = getExpectedNumberOfBatches(numberOfElements, batchSize);
-        assertThat(batches.size()).isEqualTo(expectedNumberOfBatches);
-
-        // Assert correct size of elements after batching
-        final Integer numberOfElementsAfterBatching = batches.stream()
-                .map(List::size)
-                .reduce(0,
-                    (element1, element2) -> element1 + element2);
-
-        assertThat(numberOfElementsAfterBatching).isEqualTo(numberOfElements);
-
-
-        // Assert correct splitting of batches
-        final int remainder = numberOfElements % batchSize;
-        if (remainder == 0) {
-            final int numberOfDistinctBatchSizes = batches.stream().collect(Collectors.groupingBy(List::size)).size();
-            assertThat(numberOfDistinctBatchSizes).isEqualTo(1);
-        } else {
-            final List<String> lastBatch = batches.get(batches.size() - 1);
-            assertThat(lastBatch).hasSize(remainder);
-        }
-
-        // Assert that all elements have been batched in correct order
-        final List<String> flatBatches = batches.stream()
-                .flatMap(Collection::stream).collect(Collectors.toList());
-        IntStream.range(0, flatBatches.size())
-                .forEach(index -> assertThat(flatBatches.get(index)).isEqualTo(format("element#%s", index + 1)));
-    }
-
-    private int getExpectedNumberOfBatches(int numberOfElements, int batchSize) {
-        return (int) (Math.ceil((double)numberOfElements / batchSize));
     }
 }

--- a/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -1,6 +1,8 @@
 package com.commercetools.sync.customobjects.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -30,6 +32,96 @@ class CustomObjectSyncUtilsTest {
     private static final String key = "testkey";
     private static final String container = "testcontainer";
 
+
+    @Test
+    void hasIdenticalValue_WithSameBooleanValue_ShouldBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("true");
+        JsonNode mockedObj = new ObjectMapper().readTree("true");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isBoolean()).isTrue();
+        assertThat(mockedObj.isBoolean()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isTrue();
+    }
+
+    @Test
+    void hasIdenticalValue_WithDifferentBooleanValue_ShouldNotBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("true");
+        JsonNode mockedObj = new ObjectMapper().readTree("false");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isBoolean()).isTrue();
+        assertThat(mockedObj.isBoolean()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isFalse();
+    }
+
+    @Test
+    void hasIdenticalValue_WithSameNumberValue_ShouldBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("2020");
+        JsonNode mockedObj = new ObjectMapper().readTree("2020");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isNumber()).isTrue();
+        assertThat(mockedObj.isNumber()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isTrue();
+    }
+
+    @Test
+    void hasIdenticalValue_WithDifferentNumberValue_ShouldNotBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("2020");
+        JsonNode mockedObj = new ObjectMapper().readTree("2021");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isNumber()).isTrue();
+        assertThat(mockedObj.isNumber()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isFalse();
+    }
+
+    @Test
+    void hasIdenticalValue_WithSameStringValue_ShouldBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("\"CommerceTools\"");
+        JsonNode mockedObj = new ObjectMapper().readTree("\"CommerceTools\"");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isTextual()).isTrue();
+        assertThat(mockedObj.isTextual()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isTrue();
+    }
+
+    @Test
+    void hasIdenticalValue_WithDifferentStringValue_ShouldNotBeIdentical() throws JsonProcessingException {
+        JsonNode actualObj = new ObjectMapper().readTree("\"CommerceToolsPlatform\"");
+        JsonNode mockedObj = new ObjectMapper().readTree("\"CommerceTools\"");
+
+        newCustomObjectdraft = CustomObjectDraft.ofUnversionedUpsert(container, key, actualObj);
+        oldCustomObject = mock(CustomObject.class);
+        when(oldCustomObject.getValue()).thenReturn(mockedObj);
+        when(oldCustomObject.getContainer()).thenReturn(container);
+        when(oldCustomObject.getKey()).thenReturn(key);
+        assertThat(actualObj.isTextual()).isTrue();
+        assertThat(mockedObj.isTextual()).isTrue();
+        assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft)).isFalse();
+    }
 
     @Test
     void hasIdenticalValue_WithSameFieldAndValueInJsonNode_ShouldBeIdentical() {

--- a/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -93,6 +93,7 @@ class CustomObjectSyncUtilsTest {
 
     @Test
     void hasIdenticalValue_WithSameFieldAndValueInJsonNode_ShouldBeIdentical() {
+
         ObjectNode oldValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
         ObjectNode newValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
         prepareMockObjects(oldValue, newValue);
@@ -101,6 +102,7 @@ class CustomObjectSyncUtilsTest {
 
     @Test
     void hasIdenticalValue_WithSameFieldAndDifferentValueInJsonNode_ShouldNotBeIdentical() {
+        
         ObjectNode oldValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
         ObjectNode newValue = JsonNodeFactory.instance.objectNode().put("username", "Joe");
         prepareMockObjects(oldValue, newValue);

--- a/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -113,12 +113,12 @@ class CustomObjectSyncUtilsTest {
     void hasIdenticalValue_WithSameFieldAndValueInDifferentOrderInJsonNode_ShouldBeIdentical() {
 
         ObjectNode oldValue = JsonNodeFactory.instance.objectNode()
-                .put("username", "Peter")
-                .put("userId", "123-456-789");
+                                                      .put("username", "Peter")
+                                                      .put("userId", "123-456-789");
 
         ObjectNode newValue = JsonNodeFactory.instance.objectNode()
-                .put("userId", "123-456-789")
-                .put("username", "Peter");
+                                                      .put("userId", "123-456-789")
+                                                      .put("username", "Peter");
 
         prepareMockObjects(oldValue, newValue);
 
@@ -130,17 +130,17 @@ class CustomObjectSyncUtilsTest {
     void hasIdenticalValue_WithSameNestedJsonNode_WithSameAttributeOrderInNestedJson_ShouldBeIdentical() {
 
         JsonNode oldNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("username", "Peter")
-                .put("userId", "123-456-789");
+                                                         .put("username", "Peter")
+                                                         .put("userId", "123-456-789");
         JsonNode newNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("username", "Peter")
-                .put("userId", "123-456-789");
+                                                         .put("username", "Peter")
+                                                         .put("userId", "123-456-789");
 
         JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", oldNestedJson);
+                                                       .set("nestedJson", oldNestedJson);
 
         JsonNode newJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", newNestedJson);
+                                                       .set("nestedJson", newNestedJson);
 
         prepareMockObjects(oldJsonNode, newJsonNode);
 
@@ -152,17 +152,17 @@ class CustomObjectSyncUtilsTest {
     void hasIdenticalValue_WithSameNestedJsonNode_WithDifferentAttributeOrderInNestedJson_ShouldBeIdentical() {
 
         JsonNode oldNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("username", "Peter")
-                .put("userId", "123-456-789");
+                                                         .put("username", "Peter")
+                                                         .put("userId", "123-456-789");
         JsonNode newNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("userId", "123-456-789")
-                .put("username", "Peter");
+                                                         .put("userId", "123-456-789")
+                                                         .put("username", "Peter");
 
         JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", oldNestedJson);
+                                                       .set("nestedJson", oldNestedJson);
 
         JsonNode newJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", newNestedJson);
+                                                       .set("nestedJson", newNestedJson);
 
         prepareMockObjects(oldJsonNode, newJsonNode);
 
@@ -174,17 +174,17 @@ class CustomObjectSyncUtilsTest {
     void hasIdenticalValue_WithDifferentNestedJsonNode_ShouldNotBeIdentical() {
 
         JsonNode oldNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("username", "Peter")
-                .put("userId", "123-456-789");
+                                                         .put("username", "Peter")
+                                                         .put("userId", "123-456-789");
         JsonNode newNestedJson = JsonNodeFactory.instance.objectNode()
-                .put("userId", "129-382-189")
-                .put("username", "Peter");
+                                                         .put("userId", "129-382-189")
+                                                         .put("username", "Peter");
 
         JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", oldNestedJson);
+                                                       .set("nestedJson", oldNestedJson);
 
         JsonNode newJsonNode = JsonNodeFactory.instance.objectNode()
-                .set("nestedJson", newNestedJson);
+                                                       .set("nestedJson", newNestedJson);
 
         prepareMockObjects(oldJsonNode, newJsonNode);
 

--- a/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
@@ -45,7 +45,7 @@ class BaseServiceImplTest {
 
     @SuppressWarnings("unchecked")
     private TriConsumer<SyncException, Optional<ProductDraft>, Optional<Product>> warningCallback
-            = mock(TriConsumer.class);
+        = mock(TriConsumer.class);
     private SphereClient client = mock(SphereClient.class);
     private ProductService service;
 

--- a/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
@@ -265,9 +265,8 @@ class CustomObjectServiceImplTest {
 
         when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
 
-        final Set<CustomObject<JsonNode>> customObjects = service
-            .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
-            .toCompletableFuture().join();
+        final Set<CustomObject<JsonNode>> customObjects =
+            service.fetchMatchingCustomObjects(customObjectCompositeIdentifiers).toCompletableFuture().join();
 
         List<CustomObjectCompositeIdentifier> customObjectCompositeIdlist =
             new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);

--- a/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
@@ -14,6 +14,7 @@ import io.sphere.sdk.customobjects.commands.CustomObjectUpsertCommand;
 import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.utils.CompletableFutureUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +23,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,11 +63,14 @@ class CustomObjectServiceImplTest {
         errorMessages = new ArrayList<>();
         errorExceptions = new ArrayList<>();
         CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(client)
-            .errorCallback((exception, oldResource, newResource, updateActions) -> {
-                errorMessages.add(exception.getMessage());
-                errorExceptions.add(exception.getCause());
-            })
-            .build();
+                                                                                        .errorCallback(
+                                                                                            (exception, oldResource, newResource, updateActions) -> {
+                                                                                                errorMessages.add(
+                                                                                                    exception.getMessage());
+                                                                                                errorExceptions.add(
+                                                                                                    exception.getCause());
+                                                                                            })
+                                                                                        .build();
 
         service = new CustomObjectServiceImpl(customObjectSyncOptions);
     }
@@ -121,8 +126,8 @@ class CustomObjectServiceImplTest {
 
 
         final Optional<String> fetchedId = service
-                .fetchCachedCustomObjectId(CustomObjectCompositeIdentifier.of(key, container))
-                .toCompletableFuture().join();
+            .fetchCachedCustomObjectId(CustomObjectCompositeIdentifier.of(key, container))
+            .toCompletableFuture().join();
         assertThat(fetchedId).isEmpty();
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
 
@@ -146,8 +151,8 @@ class CustomObjectServiceImplTest {
 
 
         final Optional<String> fetchedId = service
-                .fetchCachedCustomObjectId(CustomObjectCompositeIdentifier.of(key, container))
-                .toCompletableFuture().join();
+            .fetchCachedCustomObjectId(CustomObjectCompositeIdentifier.of(key, container))
+            .toCompletableFuture().join();
         assertThat(fetchedId).isEmpty();
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
     }
@@ -221,17 +226,17 @@ class CustomObjectServiceImplTest {
         when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
 
         final Set<CustomObject<JsonNode>> customObjects = service
-                .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
-                .toCompletableFuture().join();
+            .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
+            .toCompletableFuture().join();
 
         List<CustomObjectCompositeIdentifier> customObjectCompositeIdlist =
-                new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);
+            new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);
 
         assertAll(
             () -> assertThat(customObjects).isEmpty(),
             () -> assertThat(service.keyToIdCache).doesNotContainKeys(
-                        String.valueOf(customObjectCompositeIdlist.get(0)),
-                        String.valueOf(customObjectCompositeIdlist.get(1)))
+                String.valueOf(customObjectCompositeIdlist.get(0)),
+                String.valueOf(customObjectCompositeIdlist.get(1)))
         );
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
     }
@@ -263,17 +268,17 @@ class CustomObjectServiceImplTest {
         when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
 
         final Set<CustomObject<JsonNode>> customObjects = service
-                .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
-                .toCompletableFuture().join();
+            .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
+            .toCompletableFuture().join();
 
         List<CustomObjectCompositeIdentifier> customObjectCompositeIdlist =
-                new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);
+            new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);
 
         assertAll(
             () -> assertThat(customObjects).isEmpty(),
             () -> assertThat(service.keyToIdCache).doesNotContainKeys(
-                        String.valueOf(customObjectCompositeIdlist.get(0)),
-                        String.valueOf(customObjectCompositeIdlist.get(1)))
+                String.valueOf(customObjectCompositeIdlist.get(0)),
+                String.valueOf(customObjectCompositeIdlist.get(1)))
         );
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
     }
@@ -317,15 +322,15 @@ class CustomObjectServiceImplTest {
 
 
         final Optional<CustomObject<JsonNode>> customObjectOptional = service
-                .fetchCustomObject(CustomObjectCompositeIdentifier.of("", customObjectContainer))
-                .toCompletableFuture().join();
+            .fetchCustomObject(CustomObjectCompositeIdentifier.of("", customObjectContainer))
+            .toCompletableFuture().join();
 
         assertAll(
             () -> assertThat(customObjectOptional).isEmpty(),
             () -> assertThat(
-                        service.keyToIdCache.get(
-                                CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer).toString())
-                ).isNotEqualTo(customObjectId)
+                service.keyToIdCache.get(
+                    CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer).toString())
+            ).isNotEqualTo(customObjectId)
         );
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
     }
@@ -343,15 +348,15 @@ class CustomObjectServiceImplTest {
 
 
         final Optional<CustomObject<JsonNode>> customObjectOptional = service
-                .fetchCustomObject(CustomObjectCompositeIdentifier.of(customObjectKey, ""))
-                .toCompletableFuture().join();
+            .fetchCustomObject(CustomObjectCompositeIdentifier.of(customObjectKey, ""))
+            .toCompletableFuture().join();
 
         assertAll(
             () -> assertThat(customObjectOptional).isEmpty(),
             () -> assertThat(
-                        service.keyToIdCache.get(
-                                CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer).toString())
-                ).isNotEqualTo(customObjectId)
+                service.keyToIdCache.get(
+                    CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer).toString())
+            ).isNotEqualTo(customObjectId)
         );
         verify(client, times(0)).execute(any(CustomObjectQuery.class));
     }
@@ -371,10 +376,10 @@ class CustomObjectServiceImplTest {
 
 
         final CustomObjectDraft<JsonNode> draft = CustomObjectDraft
-                .ofUnversionedUpsert(customObjectContainer, customObjectKey,customObjectValue);
+            .ofUnversionedUpsert(customObjectContainer, customObjectKey, customObjectValue);
 
         final Optional<CustomObject<JsonNode>> customObjectOptional =
-                service.upsertCustomObject(draft).toCompletableFuture().join();
+            service.upsertCustomObject(draft).toCompletableFuture().join();
 
         assertThat(customObjectOptional).containsSame(mock);
         verify(client).execute(eq(CustomObjectUpsertCommand.of(draft)));
@@ -399,8 +404,8 @@ class CustomObjectServiceImplTest {
         assertAll(
             () -> assertThat(customObjectOptional).isEmpty(),
             () -> assertThat(errorMessages).singleElement().asString()
-                .contains(String.format(expectedMsg, customObjectKey, customObjectContainer))
-                .contains("BadRequestException"),
+                                           .contains(String.format(expectedMsg, customObjectKey, customObjectContainer))
+                                           .contains("BadRequestException"),
             () -> assertThat(errorExceptions).singleElement().isExactlyInstanceOf(BadRequestException.class)
         );
     }
@@ -426,10 +431,10 @@ class CustomObjectServiceImplTest {
         when(customObjectDraft.getKey()).thenReturn(customObjectKey);
         when(customObjectDraft.getContainer()).thenReturn("");
         when(customObjectDraft.getJavaType()).thenReturn(
-                getCustomObjectJavaTypeForValue(convertToJavaType(JsonNode.class)));
+            getCustomObjectJavaTypeForValue(convertToJavaType(JsonNode.class)));
 
         final Optional<CustomObject<JsonNode>> customObjectOptional =
-                service.upsertCustomObject(customObjectDraft).toCompletableFuture().join();
+            service.upsertCustomObject(customObjectDraft).toCompletableFuture().join();
 
         assertThat(customObjectOptional).isEmpty();
         verify(client, times(0)).execute(eq(CustomObjectUpsertCommand.of(customObjectDraft)));

--- a/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
@@ -63,14 +63,12 @@ class CustomObjectServiceImplTest {
         errorMessages = new ArrayList<>();
         errorExceptions = new ArrayList<>();
         CustomObjectSyncOptions customObjectSyncOptions = CustomObjectSyncOptionsBuilder.of(client)
-                                                                                        .errorCallback(
-                                                                                            (exception, oldResource, newResource, updateActions) -> {
-                                                                                                errorMessages.add(
-                                                                                                    exception.getMessage());
-                                                                                                errorExceptions.add(
-                                                                                                    exception.getCause());
-                                                                                            })
-                                                                                        .build();
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                    errorMessages.add(exception.getMessage());
+                    errorExceptions.add(exception.getCause());
+                })
+            .build();
 
         service = new CustomObjectServiceImpl(customObjectSyncOptions);
     }

--- a/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/CustomObjectServiceImplTest.java
@@ -198,48 +198,6 @@ class CustomObjectServiceImplTest {
     }
 
     @Test
-    void fetchMatchingCustomObjects_WithAllEmptyKeyAndContainer_ShouldNotFetch() {
-        final String key1 = "";
-        final String key2 = "";
-        final String container1 = "";
-        final String container2 = "";
-
-        final Set<CustomObjectCompositeIdentifier> customObjectCompositeIdentifiers = new HashSet<>();
-        customObjectCompositeIdentifiers.add(CustomObjectCompositeIdentifier.of(key1, container1));
-        customObjectCompositeIdentifiers.add(CustomObjectCompositeIdentifier.of(key2, container2));
-
-        final CustomObject mock1 = mock(CustomObject.class);
-        when(mock1.getId()).thenReturn(RandomStringUtils.random(15, true, true));
-        when(mock1.getKey()).thenReturn(key1);
-        when(mock1.getContainer()).thenReturn(container1);
-
-        final CustomObject mock2 = mock(CustomObject.class);
-        when(mock2.getId()).thenReturn(RandomStringUtils.random(15, true, true));
-        when(mock2.getKey()).thenReturn(key2);
-        when(mock2.getContainer()).thenReturn(container2);
-
-        final CustomObjectPagedQueryResult result = mock(CustomObjectPagedQueryResult.class);
-        when(result.getResults()).thenReturn(Arrays.asList(mock1, mock2));
-
-        when(client.execute(any())).thenReturn(CompletableFuture.completedFuture(result));
-
-        final Set<CustomObject<JsonNode>> customObjects = service
-            .fetchMatchingCustomObjects(customObjectCompositeIdentifiers)
-            .toCompletableFuture().join();
-
-        List<CustomObjectCompositeIdentifier> customObjectCompositeIdlist =
-            new ArrayList<CustomObjectCompositeIdentifier>(customObjectCompositeIdentifiers);
-
-        assertAll(
-            () -> assertThat(customObjects).isEmpty(),
-            () -> assertThat(service.keyToIdCache).doesNotContainKeys(
-                String.valueOf(customObjectCompositeIdlist.get(0)),
-                String.valueOf(customObjectCompositeIdlist.get(1)))
-        );
-        verify(client, times(0)).execute(any(CustomObjectQuery.class));
-    }
-
-    @Test
     void fetchMatchingCustomObjects_WithAllEmptyKey_ShouldNotFetch() {
         final String key1 = "";
         final String key2 = "";


### PR DESCRIPTION
#### Summary
Add custom objects sync

#### Description
Implement sync class to create/update custom object resources in target project.

#### Relevant Issues
https://github.com/commercetools/commercetools-sync-java/issues/565

#### Todo

- Tests
    - [x] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
- Changes are mainly at `CustomObjectSync` and `CustomObjectSyncTest`
- Similar to TypeSync class except following things
1. `applyBeforeUpdateCallback` is never called because UpdateAction is not necessary for Custom Object.
2. `buildUpdateAction()` is also removed. `updateCustomObject() `is called directly in `syncBatch`
