### PR TITLE
Add customer sync options and statistics

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CustomerITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CustomerITUtils.java
@@ -1,0 +1,24 @@
+package com.commercetools.sync.integration.commons.utils;
+
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customers.commands.CustomerDeleteCommand;
+import io.sphere.sdk.customers.queries.CustomerQuery;
+
+import javax.annotation.Nonnull;
+
+import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
+
+public final class CustomerITUtils {
+
+    /**
+     * Deletes all customers from CTP project, represented by provided {@code ctpClient}.
+     *
+     * @param ctpClient represents the CTP project the customers will be deleted from.
+     */
+    public static void deleteCustomers(@Nonnull final SphereClient ctpClient) {
+        queryAndExecute(ctpClient, CustomerQuery.of(), CustomerDeleteCommand::of);
+    }
+
+    private CustomerITUtils() {
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomerServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/CustomerServiceImplIT.java
@@ -1,0 +1,236 @@
+package com.commercetools.sync.integration.services.impl;
+
+import com.commercetools.sync.customers.CustomerSyncOptions;
+import com.commercetools.sync.customers.CustomerSyncOptionsBuilder;
+import com.commercetools.sync.services.CustomerService;
+import com.commercetools.sync.services.impl.CustomerServiceImpl;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+import io.sphere.sdk.customers.CustomerDraftBuilder;
+import io.sphere.sdk.customers.commands.CustomerCreateCommand;
+import io.sphere.sdk.customers.commands.updateactions.ChangeEmail;
+import io.sphere.sdk.customers.queries.CustomerQuery;
+import io.sphere.sdk.queries.QueryPredicate;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.commercetools.sync.integration.commons.utils.CustomerITUtils.deleteCustomers;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static java.lang.String.format;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class CustomerServiceImplIT {
+    private static final String EXISTING_CUSTOMER_KEY = "existing-customer-key";
+    private CustomerService customerService;
+    private Customer customer;
+
+
+    private List<String> errorCallBackMessages;
+    private List<String> warningCallBackMessages;
+    private List<Throwable> errorCallBackExceptions;
+
+    /**
+     * Deletes Customers from target CTP projects, then it populates target CTP project with customer test data.
+     */
+    @BeforeEach
+    void setupTest() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+
+        deleteCustomers(CTP_TARGET_CLIENT);
+
+        final CustomerSyncOptions customerSyncOptions =
+            CustomerSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                                      .errorCallback(
+                                          (exception, oldResource, newResource, updateActions) -> {
+                                              errorCallBackMessages.add(exception.getMessage());
+                                              errorCallBackExceptions.add(exception.getCause());
+                                          })
+                                      .warningCallback(
+                                          (exception, oldResource, newResource) -> warningCallBackMessages
+                                              .add(exception.getMessage()))
+                                      .build();
+
+        // Create a mock new customer in the target project.
+        CustomerDraft customerDraft = CustomerDraftBuilder
+            .of("mail@mail.com", "password")
+            .key(EXISTING_CUSTOMER_KEY)
+            .build();
+        customer = CTP_TARGET_CLIENT.execute(CustomerCreateCommand.of(customerDraft))
+                                    .toCompletableFuture().join().getCustomer();
+
+        customerService = new CustomerServiceImpl(customerSyncOptions);
+    }
+
+    /**
+     * Cleans up the target test data that were built in this test class.
+     */
+    @AfterAll
+    static void tearDown() {
+        deleteCustomers(CTP_TARGET_CLIENT);
+    }
+
+    @Test
+    void fetchCachedCustomerId_WithNonExistingCustomer_ShouldNotFetchACustomerId() {
+        final Optional<String> customerId = customerService.fetchCachedCustomerId("non-existing-customer-key")
+                                                           .toCompletableFuture()
+                                                           .join();
+        assertThat(customerId).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchCachedCustomerId_WithExistingNotCachedCustomer_ShouldFetchACustomerId() {
+        final Optional<String> customerId = customerService.fetchCachedCustomerId(EXISTING_CUSTOMER_KEY)
+                                                           .toCompletableFuture()
+                                                           .join();
+        assertThat(customerId).isNotEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchCustomerByKey_WithExistingCustomer_ShouldFetchCustomer() {
+        Optional<Customer> customer = customerService.fetchCustomerByKey(EXISTING_CUSTOMER_KEY)
+                                                     .toCompletableFuture()
+                                                     .join();
+        assertThat(customer).isNotEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchCustomerByKey_WithNotExistingCustomer_ShouldReturnEmptyOptional() {
+        Optional<Customer> customer = customerService.fetchCustomerByKey("not-existing-customer-key")
+                                                     .toCompletableFuture()
+                                                     .join();
+        assertThat(customer).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void cacheKeysToIds_WithEmptyKeys_ShouldReturnCurrentCache() {
+        Map<String, String> cache = customerService.cacheKeysToIds(emptySet()).toCompletableFuture().join();
+        assertThat(cache).hasSize(0);
+
+        cache = customerService.cacheKeysToIds(singleton(EXISTING_CUSTOMER_KEY)).toCompletableFuture().join();
+        assertThat(cache).hasSize(1);
+
+        cache = customerService.cacheKeysToIds(emptySet()).toCompletableFuture().join();
+        assertThat(cache).hasSize(1);
+
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void cacheKeysToIds_WithCachedKeys_ShouldReturnCacheWithoutAnyRequests() {
+        final SphereClient spyClient = spy(CTP_TARGET_CLIENT);
+        final CustomerSyncOptions customerSyncOptions =
+            CustomerSyncOptionsBuilder.of(spyClient)
+                                      .errorCallback((exception, oldResource, newResource, updateActions) -> {
+                                          errorCallBackMessages.add(exception.getMessage());
+                                          errorCallBackExceptions.add(exception.getCause());
+                                      })
+                                      .warningCallback((exception, oldResource, newResource)
+                                          -> warningCallBackMessages.add(exception.getMessage()))
+                                      .build();
+        final CustomerServiceImpl spyCustomerService = new CustomerServiceImpl(customerSyncOptions);
+
+
+        Map<String, String> cache = spyCustomerService.cacheKeysToIds(singleton(EXISTING_CUSTOMER_KEY))
+                                                      .toCompletableFuture().join();
+        assertThat(cache).hasSize(1);
+
+        cache = spyCustomerService.cacheKeysToIds(singleton(EXISTING_CUSTOMER_KEY))
+                                  .toCompletableFuture().join();
+        assertThat(cache).hasSize(1);
+
+        verify(spyClient, times(1)).execute(any());
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+    }
+
+    @Test
+    void fetchMatchingCustomersByKeys_WithEmptyKeys_ShouldReturnEmptySet() {
+        Set<Customer> customers = customerService.fetchMatchingCustomersByKeys(emptySet())
+                                                 .toCompletableFuture()
+                                                 .join();
+
+        assertThat(customers).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+    }
+
+    @Test
+    void fetchMatchingCustomersByKeys_WithExistingCustomerKeys_ShouldReturnCustomers() {
+        Set<Customer> customers = customerService.fetchMatchingCustomersByKeys(singleton(EXISTING_CUSTOMER_KEY))
+                                                 .toCompletableFuture()
+                                                 .join();
+
+        assertThat(customers).hasSize(1);
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(errorCallBackExceptions).isEmpty();
+    }
+
+    @Test
+    void createCustomer_WithDuplicationException_ShouldNotCreateCustomer() {
+        CustomerDraft customerDraft = CustomerDraftBuilder
+            .of("mail@mail.com", "password")
+            .key("newKey")
+            .build();
+
+        Optional<Customer> customerOptional =
+            customerService.createCustomer(customerDraft).toCompletableFuture().join();
+
+        assertThat(customerOptional).isEmpty();
+        assertThat(errorCallBackMessages).hasSize(1);
+        assertThat(errorCallBackMessages.get(0)).contains("Failed to create draft with key: 'newKey'. Reason: "
+            + "detailMessage: There is already an existing customer with the email '\"mail@mail.com\"'.");
+        assertThat(errorCallBackExceptions).hasSize(1);
+    }
+
+    @Test
+    void updateCustomer_WithValidChanges_ShouldUpdateCustomerCorrectly() {
+        final String newEmail = "newMail@newmail.com";
+        final ChangeEmail changeEmail = ChangeEmail
+            .of(newEmail);
+
+        final Customer updatedCustomer = customerService
+            .updateCustomer(customer, singletonList(changeEmail))
+            .toCompletableFuture().join();
+        assertThat(updatedCustomer).isNotNull();
+
+        final Optional<Customer> queried = CTP_TARGET_CLIENT
+            .execute(CustomerQuery.of()
+                                  .withPredicates(QueryPredicate.of(format("key = \"%s\"", EXISTING_CUSTOMER_KEY))))
+            .toCompletableFuture().join().head();
+
+        assertThat(errorCallBackExceptions).isEmpty();
+        assertThat(errorCallBackMessages).isEmpty();
+        assertThat(queried).isNotEmpty();
+        final Customer fetchedCustomer = queried.get();
+        assertThat(fetchedCustomer.getEmail()).isEqualTo(updatedCustomer.getEmail());
+        assertThat(fetchedCustomer.getPassword()).isEqualTo(updatedCustomer.getPassword());
+
+    }
+
+}

--- a/src/main/java/com/commercetools/sync/customers/CustomerSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/customers/CustomerSyncOptions.java
@@ -1,0 +1,38 @@
+package com.commercetools.sync.customers;
+
+import com.commercetools.sync.commons.BaseSyncOptions;
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.commons.utils.QuadConsumer;
+import com.commercetools.sync.commons.utils.TriConsumer;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class CustomerSyncOptions extends BaseSyncOptions<Customer, CustomerDraft> {
+
+    CustomerSyncOptions(
+        @Nonnull final SphereClient ctpClient,
+        @Nullable final QuadConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>,
+            List<UpdateAction<Customer>>> errorCallback,
+        @Nullable final TriConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>>
+            warningCallback,
+        final int batchSize,
+        @Nullable final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer,
+            List<UpdateAction<Customer>>> beforeUpdateCallback,
+        @Nullable final Function<CustomerDraft, CustomerDraft> beforeCreateCallback) {
+        super(ctpClient,
+            errorCallback,
+            warningCallback,
+            batchSize,
+            beforeUpdateCallback,
+            beforeCreateCallback);
+    }
+}

--- a/src/main/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilder.java
+++ b/src/main/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilder.java
@@ -1,0 +1,58 @@
+package com.commercetools.sync.customers;
+
+
+import com.commercetools.sync.commons.BaseSyncOptionsBuilder;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+
+import javax.annotation.Nonnull;
+
+public final class CustomerSyncOptionsBuilder extends BaseSyncOptionsBuilder<CustomerSyncOptionsBuilder,
+    CustomerSyncOptions, Customer, CustomerDraft> {
+    public static final int BATCH_SIZE_DEFAULT = 50;
+
+    private CustomerSyncOptionsBuilder(@Nonnull final SphereClient ctpClient) {
+        this.ctpClient = ctpClient;
+    }
+
+    /**
+     * Creates a new instance of {@link CustomerSyncOptionsBuilder} given a {@link SphereClient} responsible for
+     * interaction with the target CTP project, with the default batch size ({@code BATCH_SIZE_DEFAULT} = 50).
+     *
+     * @param ctpClient instance of the {@link SphereClient} responsible for interaction with the target CTP project.
+     * @return new instance of {@link CustomerSyncOptionsBuilder}
+     */
+    public static CustomerSyncOptionsBuilder of(@Nonnull final SphereClient ctpClient) {
+        return new CustomerSyncOptionsBuilder(ctpClient)
+            .batchSize(BATCH_SIZE_DEFAULT);
+    }
+
+    /**
+     * Creates a new instance of {@link CustomerSyncOptions} enriched with all attributes provided to {@code this}
+     * builder.
+     *
+     * @return new instance of {@link CustomerSyncOptions}
+     */
+    @Override
+    public CustomerSyncOptions build() {
+        return new CustomerSyncOptions(
+            ctpClient,
+            errorCallback,
+            warningCallback,
+            batchSize,
+            beforeUpdateCallback,
+            beforeCreateCallback);
+    }
+
+    /**
+     * Returns an instance of this class to be used in the superclass's generic methods. Please see the JavaDoc in the
+     * overridden method for further details.
+     *
+     * @return an instance of this class.
+     */
+    @Override
+    protected CustomerSyncOptionsBuilder getThis() {
+        return this;
+    }
+}

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -1,0 +1,27 @@
+package com.commercetools.sync.customers.helpers;
+
+import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
+
+import static java.lang.String.format;
+
+public class CustomerSyncStatistics extends BaseSyncStatistics {
+
+    public CustomerSyncStatistics() {
+        super();
+    }
+
+    /**
+     * Builds a summary of the customer sync statistics instance that looks like the following example:
+     *
+     * <p>"Summary: 2 customers have been processed in total (0 created, 0 updated and 0 failed to sync)."
+     *
+     * @return a summary message of the customer sync statistics instance.
+     */
+    @Override
+    public String getReportMessage() {
+        reportMessage = format(
+            "Summary: %s customers have been processed in total (%s created, %s updated and %s failed to sync).",
+            getProcessed(), getCreated(), getUpdated(), getFailed());
+        return reportMessage;
+    }
+}

--- a/src/main/java/com/commercetools/sync/services/CustomerService.java
+++ b/src/main/java/com/commercetools/sync/services/CustomerService.java
@@ -1,0 +1,106 @@
+package com.commercetools.sync.services;
+
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+public interface CustomerService {
+
+    /**
+     * Given a set of keys this method caches in-memory a mapping of key -&gt; id only for those keys which are not
+     * already cached.
+     *
+     * @param keysToCache a set of keys to cache.
+     * @return a map of key to ids of the requested keys.
+     */
+    @Nonnull
+    CompletionStage<Map<String, String>> cacheKeysToIds(@Nonnull Set<String> keysToCache);
+
+    /**
+     * Given a {@link Set} of customer keys, this method fetches a set of all the customers, matching the given set of
+     * keys in the CTP project, defined in an injected {@link SphereClient}. A mapping of the key to the id of the
+     * fetched customers is persisted in an in-memory map.
+     *
+     * @param customerKeys set of customer keys to fetch matching resources by.
+     * @return {@link CompletionStage}&lt;{@link Set}&lt;{@link Customer}&gt;&gt; in which the result of it's completion
+     *     contains a {@link Set} of all matching customers.
+     */
+    @Nonnull
+    CompletionStage<Set<Customer>> fetchMatchingCustomersByKeys(@Nonnull Set<String> customerKeys);
+
+    /**
+     * Given a customer key, this method fetches a customer that matches this given key in the CTP project defined in a
+     * potentially injected {@link SphereClient}. If there is no matching resource an empty {@link Optional} will be
+     * returned in the returned future. A mapping of the key to the id of the fetched customer is persisted in an in
+     * -memory map.
+     *
+     * @param key the key of the resource to fetch
+     * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion contains an {@link
+     * Optional} that contains the matching {@link Customer} if exists, otherwise empty.
+     */
+    @Nonnull
+    CompletionStage<Optional<Customer>> fetchCustomerByKey(@Nullable String key);
+
+    /**
+     * Given a {@code key}, if it is blank (null/empty), a completed future with an empty optional is returned.
+     * Otherwise this method checks if the cached map of resource keys -&gt; ids contains the given key. If it does, an
+     * optional containing the matching id is returned. If the cache doesn't contain the key; this method attempts to
+     * fetch the id of the key from the CTP project, caches it and returns a {@link CompletionStage}&lt; {@link
+     * Optional}&lt;{@link String}&gt;&gt; in which the result of it's completion could contain an {@link Optional}
+     * holding the id or an empty {@link Optional} if no customer was found in the CTP project with this key.
+     *
+     * @param key the key by which a customer id should be fetched from the CTP project.
+     * @return {@link CompletionStage}&lt;{@link Optional}&lt;{@link String}&gt;&gt; in which the result of it's
+     *     completion could contain an {@link Optional} holding the id or an empty {@link Optional} if no customer
+     *     was found in the CTP project with this key.
+     */
+    @Nonnull
+    CompletionStage<Optional<String>> fetchCachedCustomerId(@Nonnull String key);
+
+    /**
+     * Given a resource draft of type {@link CustomerDraft}, this method attempts to create a resource {@link Customer}
+     * based on the draft, in the CTP project defined by the sync options.
+     *
+     * <p>A completion stage containing an empty option and the error callback will be triggered in those cases:
+     * <ul>
+     *     <li>the draft has a blank key</li>
+     *     <li>the create request fails on CTP</li>
+     * </ul>
+     *
+     * <p>On the other hand, if the resource gets created successfully on CTP, the created resource's id and
+     * key are cached and the method returns a {@link CompletionStage} in which the result of it's completion
+     * contains an instance {@link Optional} of the resource which was created.
+     *
+     * @param customerDraft the resource draft to create a resource based off of.
+     * @return a {@link CompletionStage} containing an optional with the created resource if successful otherwise an
+     *     empty optional.
+     */
+    @Nonnull
+    CompletionStage<Optional<Customer>> createCustomer(@Nonnull CustomerDraft customerDraft);
+
+    /**
+     * Given a {@link Customer} and a {@link List}&lt;{@link UpdateAction}&lt;{@link Customer}&gt;&gt;, this method
+     * issues an update request with these update actions on this {@link Customer} in the CTP project defined in a
+     * potentially injected {@link SphereClient}. This method returns {@link CompletionStage}&lt;{@link Customer}&gt; in
+     * which the result of it's completion contains an instance of the {@link Customer} which was updated in the CTP
+     * project.
+     *
+     * @param customer      the {@link Customer} to update.
+     * @param updateActions the update actions to update the {@link Customer} with.
+     * @return {@link CompletionStage}&lt;{@link Customer}&gt; containing as a result of it's completion an instance of
+     *     the {@link Customer} which was updated in the CTP project or a {@link io.sphere.sdk.models.SphereException}.
+     */
+    @Nonnull
+    CompletionStage<Customer> updateCustomer(@Nonnull Customer customer,
+                                             @Nonnull List<UpdateAction<Customer>> updateActions);
+
+}

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -51,7 +51,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
     final Map<String, String> keyToIdCache = new ConcurrentHashMap<>();
 
     private static final int MAXIMUM_ALLOWED_UPDATE_ACTIONS = 500;
-    private static final String CREATE_FAILED = "Failed to create draft with key: '%s'. Reason: %s";
+    static final String CREATE_FAILED = "Failed to create draft with key: '%s'. Reason: %s";
 
     BaseService(@Nonnull final S syncOptions) {
         this.syncOptions = syncOptions;
@@ -257,7 +257,7 @@ abstract class BaseService<T, U extends ResourceView<U, U>, S extends BaseSyncOp
     /**
      * Given a resource key, this method fetches a resource that matches this given key in the CTP project defined in a
      * potentially injected {@link SphereClient}. If there is no matching resource an empty {@link Optional} will be
-     * returned in the returned future. A mapping of the key to the id of the fetched category is persisted in an in
+     * returned in the returned future. A mapping of the key to the id of the fetched resource is persisted in an in
      * -memory map.
      *
      * @param key           the key of the resource to fetch

--- a/src/main/java/com/commercetools/sync/services/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomerServiceImpl.java
@@ -1,0 +1,120 @@
+package com.commercetools.sync.services.impl;
+
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.customers.CustomerSyncOptions;
+import com.commercetools.sync.services.CustomerService;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+import io.sphere.sdk.customers.commands.CustomerCreateCommand;
+import io.sphere.sdk.customers.commands.CustomerUpdateCommand;
+import io.sphere.sdk.customers.expansion.CustomerExpansionModel;
+import io.sphere.sdk.customers.queries.CustomerQuery;
+import io.sphere.sdk.customers.queries.CustomerQueryBuilder;
+import io.sphere.sdk.customers.queries.CustomerQueryModel;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+
+public final class CustomerServiceImpl extends BaseServiceWithKey<CustomerDraft, Customer, CustomerSyncOptions,
+    CustomerQuery, CustomerQueryModel, CustomerExpansionModel<Customer>> implements CustomerService {
+
+    public CustomerServiceImpl(@Nonnull final CustomerSyncOptions syncOptions) {
+        super(syncOptions);
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Map<String, String>> cacheKeysToIds(
+        @Nonnull final Set<String> keysToCache) {
+        return cacheKeysToIds(keysToCache, keysNotCached -> CustomerQueryBuilder
+            .of()
+            .plusPredicates(customerQueryModel -> customerQueryModel.key().isIn(keysNotCached))
+            .build());
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Set<Customer>> fetchMatchingCustomersByKeys(
+        @Nonnull final Set<String> customerKeys) {
+        return fetchMatchingResources(customerKeys, () -> CustomerQueryBuilder
+            .of()
+            .plusPredicates(customerQueryModel -> customerQueryModel.key().isIn(customerKeys))
+            .build());
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Optional<Customer>> fetchCustomerByKey(@Nullable final String key) {
+        return fetchResource(key, () -> CustomerQueryBuilder
+            .of()
+            .plusPredicates(customerQueryModel -> customerQueryModel.key().is(key))
+            .build());
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Optional<String>> fetchCachedCustomerId(@Nonnull final String key) {
+        return fetchCachedResourceId(key, () -> CustomerQueryBuilder
+            .of()
+            .plusPredicates(customerQueryModel -> customerQueryModel.key().is(key))
+            .build());
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Optional<Customer>> createCustomer(
+        @Nonnull final CustomerDraft customerDraft) {
+
+        // Uses a different implementation than in the base service because CustomerCreateCommand uses a
+        // different library as CTP responds with a CustomerSignInResult which is not extending resource but a
+        // different model, containing the customer resource.
+        final String draftKey = customerDraft.getKey();
+        final CustomerCreateCommand createCommand = CustomerCreateCommand.of(customerDraft);
+
+        if (isBlank(draftKey)) {
+            syncOptions.applyErrorCallback(
+                new SyncException(format(CREATE_FAILED, draftKey, "Draft key is blank!")),
+                null, customerDraft, null);
+            return CompletableFuture.completedFuture(Optional.empty());
+        } else {
+            return syncOptions
+                .getCtpClient()
+                .execute(createCommand)
+                .handle(((resource, exception) -> {
+                    if (exception == null && resource.getCustomer() != null) {
+                        keyToIdCache.put(draftKey, resource.getCustomer().getId());
+                        return Optional.of(resource.getCustomer());
+                    } else if (exception != null) {
+                        syncOptions.applyErrorCallback(
+                            new SyncException(format(CREATE_FAILED, draftKey, exception.getMessage()),
+                                exception),
+                            null, customerDraft, null);
+                        return Optional.empty();
+                    } else {
+                        return Optional.empty();
+                    }
+                }));
+        }
+
+    }
+
+    @Nonnull
+    @Override
+    public CompletionStage<Customer> updateCustomer(@Nonnull final Customer customer,
+                                                    @Nonnull final
+                                                    List<UpdateAction<Customer>> updateActions) {
+        return updateResource(customer, CustomerUpdateCommand::of, updateActions);
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilderTest.java
@@ -1,0 +1,262 @@
+package com.commercetools.sync.customers;
+
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.commons.utils.QuadConsumer;
+import com.commercetools.sync.commons.utils.TriConsumer;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+import io.sphere.sdk.customers.CustomerDraftBuilder;
+import io.sphere.sdk.customers.commands.updateactions.ChangeEmail;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CustomerSyncOptionsBuilderTest {
+
+    private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
+    private final CustomerSyncOptionsBuilder customerSyncOptionsBuilder = CustomerSyncOptionsBuilder.of(CTP_CLIENT);
+
+    @Test
+    void of_WithClient_ShouldCreateCustomerSyncOptionsBuilder() {
+        final CustomerSyncOptionsBuilder builder = CustomerSyncOptionsBuilder.of(CTP_CLIENT);
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void build_WithClient_ShouldBuildSyncOptions() {
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions).isNotNull();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNull();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNull();
+        assertThat(customerSyncOptions.getErrorCallback()).isNull();
+        assertThat(customerSyncOptions.getWarningCallback()).isNull();
+        assertThat(customerSyncOptions.getCtpClient()).isEqualTo(CTP_CLIENT);
+        assertThat(customerSyncOptions.getBatchSize()).isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    }
+
+    @Test
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newCustomer, oldCustomer) -> emptyList();
+
+        customerSyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+    }
+
+    @Test
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+        customerSyncOptionsBuilder.beforeCreateCallback((newCustomer) -> null);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+    }
+
+    @Test
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
+        final QuadConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>, List<UpdateAction<Customer>>>
+            mockErrorCallBack = (exception, newResource, oldResource, updateActions) -> { };
+        customerSyncOptionsBuilder.errorCallback(mockErrorCallBack);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getErrorCallback()).isNotNull();
+    }
+
+    @Test
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
+        final TriConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>> mockWarningCallBack =
+            (exception, newResource, oldResource) -> {
+            };
+        customerSyncOptionsBuilder.warningCallback(mockWarningCallBack);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getWarningCallback()).isNotNull();
+    }
+
+    @Test
+    void getThis_ShouldReturnCorrectInstance() {
+        final CustomerSyncOptionsBuilder builder = customerSyncOptionsBuilder.getThis();
+        assertThat(builder).isNotNull();
+        assertThat(builder).isInstanceOf(CustomerSyncOptionsBuilder.class);
+        assertThat(builder).isEqualTo(customerSyncOptionsBuilder);
+    }
+
+    @Test
+    void customerSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(30)
+            .beforeCreateCallback((newCustomer) -> null)
+            .beforeUpdateCallback((updateActions, newCustomer, oldCustomer) -> emptyList())
+            .build();
+        assertThat(customerSyncOptions).isNotNull();
+    }
+
+    @Test
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+        CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(10)
+            .build();
+        assertThat(customerSyncOptions.getBatchSize()).isEqualTo(10);
+    }
+
+    @Test
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+        final CustomerSyncOptions customerSyncOptionsWithZeroBatchSize = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(0)
+            .build();
+        assertThat(customerSyncOptionsWithZeroBatchSize.getBatchSize())
+            .isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+
+        final CustomerSyncOptions customerSyncOptionsWithNegativeBatchSize = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(-100)
+            .build();
+        assertThat(customerSyncOptionsWithNegativeBatchSize.getBatchSize())
+            .isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+
+        assertThat(filteredList).isSameAs(updateActions);
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newCustomer, oldCustomer) -> null;
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+        assertThat(filteredList).isNotEqualTo(updateActions);
+        assertThat(filteredList).isEmpty();
+    }
+
+    private interface MockTriFunction extends
+        TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>> {
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+        final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
+
+        final CustomerSyncOptions customerSyncOptions =
+            CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                      .beforeUpdateCallback(beforeUpdateCallback)
+                                      .build();
+
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = emptyList();
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+
+        assertThat(filteredList).isEmpty();
+        verify(beforeUpdateCallback, never()).apply(any(), any(), any());
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newType, oldType) -> emptyList();
+
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions
+                .applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class), mock(Customer.class));
+        assertThat(filteredList).isNotEqualTo(updateActions);
+        assertThat(filteredList).isEmpty();
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+        final Function<CustomerDraft, CustomerDraft> draftFunction =
+            customerDraft -> CustomerDraftBuilder.of(customerDraft)
+                                                 .key(customerDraft.getKey() + "_filteredKey")
+                                                 .build();
+
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .beforeCreateCallback(draftFunction)
+                                                                                  .build();
+
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        when(resourceDraft.getKey()).thenReturn("myKey");
+        when(resourceDraft.getDefaultBillingAddress()).thenReturn(null);
+        when(resourceDraft.getDefaultShippingAddress()).thenReturn(null);
+
+
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).isNotEmpty();
+        assertThat(filteredDraft.get().getKey()).isEqualTo("myKey_filteredKey");
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT).build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).containsSame(resourceDraft);
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
+        final Function<CustomerDraft, CustomerDraft> draftFunction = customerDraft -> null;
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .beforeCreateCallback(draftFunction)
+                                                                                  .build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).isEmpty();
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
@@ -1,0 +1,28 @@
+package com.commercetools.sync.customers.helpers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class CustomerSyncStatisticsTest {
+    private CustomerSyncStatistics customerSyncStatistics;
+
+    @BeforeEach
+    void setup() {
+        customerSyncStatistics = new CustomerSyncStatistics();
+    }
+
+    @Test
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+        customerSyncStatistics.incrementCreated(1);
+        customerSyncStatistics.incrementFailed(2);
+        customerSyncStatistics.incrementUpdated(3);
+        customerSyncStatistics.incrementProcessed(6);
+
+        assertThat(customerSyncStatistics.getReportMessage())
+            .isEqualTo("Summary: 6 customers have been processed in total "
+                + "(1 created, 3 updated and 2 failed to sync).");
+    }
+}

--- a/src/test/java/com/commercetools/sync/services/impl/CustomerServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/CustomerServiceImplTest.java
@@ -1,0 +1,198 @@
+package com.commercetools.sync.services.impl;
+
+import com.commercetools.sync.customers.CustomerSyncOptions;
+import com.commercetools.sync.customers.CustomerSyncOptionsBuilder;
+import io.sphere.sdk.client.BadGatewayException;
+import io.sphere.sdk.client.BadRequestException;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+import io.sphere.sdk.customers.CustomerName;
+import io.sphere.sdk.customers.CustomerSignInResult;
+import io.sphere.sdk.customers.commands.CustomerCreateCommand;
+import io.sphere.sdk.customers.commands.CustomerUpdateCommand;
+import io.sphere.sdk.customers.commands.updateactions.ChangeName;
+import io.sphere.sdk.utils.CompletableFutureUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CustomerServiceImplTest {
+
+    private CustomerServiceImpl service;
+    private CustomerSyncOptions customerSyncOptions;
+    private List<String> errorMessages;
+    private List<Throwable> errorExceptions;
+
+    @BeforeEach
+    void setUp() {
+        errorMessages = new ArrayList<>();
+        errorExceptions = new ArrayList<>();
+        customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(mock(SphereClient.class))
+            .errorCallback((exception, oldResource, newResource, updateActions) -> {
+                errorMessages.add(exception.getMessage());
+                errorExceptions.add(exception.getCause());
+            })
+            .build();
+        service = new CustomerServiceImpl(customerSyncOptions);
+    }
+
+    @Test
+    void createCustomer_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
+        final CustomerSignInResult resultMock = mock(CustomerSignInResult.class);
+        final Customer customerMock = mock(Customer.class);
+        when(customerMock.getId()).thenReturn("customerId");
+        when(customerMock.getKey()).thenReturn("customerKey");
+        when(resultMock.getCustomer()).thenReturn(customerMock);
+
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(completedFuture(resultMock));
+
+        final CustomerDraft draft = mock(CustomerDraft.class);
+        when(draft.getKey()).thenReturn("customerKey");
+        final Optional<Customer> customerOptional = service.createCustomer(draft).toCompletableFuture().join();
+
+        assertThat(customerOptional).isNotEmpty();
+        assertThat(customerOptional).containsSame(customerMock);
+        verify(customerSyncOptions.getCtpClient()).execute(eq(CustomerCreateCommand.of(draft)));
+    }
+
+    @Test
+    void createCustomer_WithUnSuccessfulMockResponse_ShouldNotCreate() {
+        final CustomerSignInResult resultMock = mock(CustomerSignInResult.class);
+        final Customer customerMock = mock(Customer.class);
+        when(customerMock.getId()).thenReturn("customerId");
+        when(customerMock.getKey()).thenReturn("customerKey");
+        when(resultMock.getCustomer()).thenReturn(customerMock);
+
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(
+            CompletableFutureUtils.failed(new BadRequestException("bad request")));
+
+        final CustomerDraft draft = mock(CustomerDraft.class);
+        when(draft.getKey()).thenReturn("customerKey");
+        final Optional<Customer> customerOptional = service.createCustomer(draft).toCompletableFuture().join();
+
+        assertThat(customerOptional).isEmpty();
+        assertThat(errorExceptions).hasSize(1);
+        assertThat(errorExceptions.get(0)).isExactlyInstanceOf(BadRequestException.class);
+        assertThat(errorMessages).hasSize(1);
+        assertThat(errorMessages.get(0)).contains("Failed to create draft with key: 'customerKey'.");
+        verify(customerSyncOptions.getCtpClient()).execute(eq(CustomerCreateCommand.of(draft)));
+    }
+
+    @Test
+    void createCustomer_WithDraftWithEmptyKey_ShouldNotCreate() {
+        final CustomerDraft draft = mock(CustomerDraft.class);
+        final Optional<Customer> customerOptional = service.createCustomer(draft).toCompletableFuture().join();
+
+        assertThat(customerOptional).isEmpty();
+        assertThat(errorExceptions).hasSize(1);
+        assertThat(errorMessages).hasSize(1);
+        assertThat(errorMessages.get(0))
+            .contains("Failed to create draft with key: 'null'. Reason: Draft key is blank!");
+        verifyNoInteractions(customerSyncOptions.getCtpClient());
+    }
+
+    @Test
+    void createCustomer_WithResponseIsNull_ShouldReturnEmpty() {
+        CustomerSignInResult resultMock = mock(CustomerSignInResult.class);
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(completedFuture(resultMock));
+
+        final CustomerDraft draft = mock(CustomerDraft.class);
+        when(draft.getKey()).thenReturn("key");
+        final Optional<Customer> customerOptional = service.createCustomer(draft).toCompletableFuture().join();
+
+        assertThat(customerOptional).isEmpty();
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+    }
+
+    @Test
+    void updateCustomer_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
+        Customer customer = mock(Customer.class);
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(completedFuture(customer));
+
+        List<UpdateAction<Customer>> updateActions =
+            singletonList(ChangeName.of(CustomerName.of("title", "Max", "", "Mustermann")));
+        Customer result = service.updateCustomer(customer, updateActions).toCompletableFuture().join();
+
+        assertThat(result).isSameAs(customer);
+        verify(customerSyncOptions.getCtpClient()).execute(eq(CustomerUpdateCommand.of(customer, updateActions)));
+    }
+
+    @Test
+    void fetchCachedCustomerId_WithBlankKey_ShouldNotFetchCustomerId() {
+        Optional<String> customerId = service.fetchCachedCustomerId("")
+                                             .toCompletableFuture()
+                                             .join();
+
+        assertThat(customerId).isEmpty();
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+        verifyNoInteractions(customerSyncOptions.getCtpClient());
+    }
+
+    @Test
+    void fetchCachedCustomerId_WithCachedCustomer_ShouldFetchIdFromCache() {
+        service.keyToIdCache.put("key", "id");
+        Optional<String> customerId = service.fetchCachedCustomerId("key")
+                                             .toCompletableFuture()
+                                             .join();
+
+        assertThat(customerId).contains("id");
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+        verifyNoInteractions(customerSyncOptions.getCtpClient());
+    }
+
+    @Test
+    void fetchCachedCustomerId_WithUnexpectedException_ShouldFail() {
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(
+            CompletableFutureUtils.failed(new BadGatewayException("bad gateway")));
+
+        assertThat(service.fetchCachedCustomerId("key"))
+            .hasFailedWithThrowableThat()
+            .isExactlyInstanceOf(BadGatewayException.class);
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+    }
+
+    @Test
+    void fetchCustomerByKey_WithUnexpectedException_ShouldFail() {
+        when(customerSyncOptions.getCtpClient().execute(any())).thenReturn(
+            CompletableFutureUtils.failed(new BadGatewayException("bad gateway")));
+
+        assertThat(service.fetchCustomerByKey("key"))
+            .hasFailedWithThrowableThat()
+            .isExactlyInstanceOf(BadGatewayException.class);
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+    }
+
+    @Test
+    void fetchCustomerByKey_WithBlankKey_ShouldNotFetchCustomer() {
+        Optional<Customer> customer = service.fetchCustomerByKey("")
+                                             .toCompletableFuture()
+                                             .join();
+
+        assertThat(customer).isEmpty();
+        assertThat(errorExceptions).isEmpty();
+        assertThat(errorMessages).isEmpty();
+        verifyNoInteractions(customerSyncOptions.getCtpClient());
+    }
+
+}


### PR DESCRIPTION
#### Summary
In order to configure customer sync behaviour and access statistics some helpers are required.

#### Description
Add **CustomerSyncOptions** and **CustomerSyncOptionsBuilder** including UnitTests.
Add **CustomerSyncStatistics** including UnitTests

#### Todo

- Tests
    - [x] Unit 
    - [ ] Integration
- [x] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->
