### PR TITLE
Add sync statistics and sync options unit tests

### DIFF
--- a/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/helpers/CartDiscountSyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.cartdiscounts.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 public final class CartDiscountSyncStatistics extends BaseSyncStatistics {
 
     /**
@@ -15,10 +13,6 @@ public final class CartDiscountSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
-            "Summary: %s cart discounts were processed in total (%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-
-        return reportMessage;
+        return getDefaultReportMessageForResource("cart discounts");
     }
 }

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -47,10 +47,9 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format("Summary: %s categories were processed in total "
+        return format("Summary: %s categories were processed in total "
                 + "(%s created, %s updated, %s failed to sync and %s categories with a missing parent).",
             getProcessed(), getCreated(), getUpdated(), getFailed(), getNumberOfCategoriesWithMissingParents());
-        return reportMessage;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/commons/helpers/BaseSyncStatistics.java
@@ -2,13 +2,13 @@ package com.commercetools.sync.commons.helpers;
 
 import io.netty.util.internal.StringUtil;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 
 public abstract class BaseSyncStatistics {
-    protected String reportMessage;
     private AtomicInteger updated;
     private AtomicInteger created;
     private AtomicInteger failed;
@@ -31,7 +31,6 @@ public abstract class BaseSyncStatistics {
         created = new AtomicInteger();
         failed = new AtomicInteger();
         processed = new AtomicInteger();
-        reportMessage = StringUtil.EMPTY_STRING;
         latestBatchHumanReadableProcessingTime = StringUtil.EMPTY_STRING;
     }
 
@@ -285,4 +284,18 @@ public abstract class BaseSyncStatistics {
      * @return a summary message of the statistics report.
      */
     public abstract String getReportMessage();
+
+    /**
+     * Builds a proper summary message of the statistics report of a given {@code resourceString} in following format:
+     *
+     * <p>"Summary: 2 resources were processed in total (2 created, 2 updated and 0 failed to sync)."
+     *
+     * @param resourceString a string representing the resource
+     * @return a summary message of the statistics report
+     */
+    protected String getDefaultReportMessageForResource(@Nonnull final String resourceString) {
+        return format(
+            "Summary: %s %s were processed in total (%s created, %s updated and %s failed to sync).",
+            getProcessed(), resourceString, getCreated(), getUpdated(), getFailed());
+    }
 }

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.customers.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 public class CustomerSyncStatistics extends BaseSyncStatistics {
 
     public CustomerSyncStatistics() {
@@ -19,9 +17,6 @@ public class CustomerSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
-            "Summary: %s customers were processed in total (%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-        return reportMessage;
+        return getDefaultReportMessageForResource("customers");
     }
 }

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -1,0 +1,27 @@
+package com.commercetools.sync.customers.helpers;
+
+import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
+
+import static java.lang.String.format;
+
+public class CustomerSyncStatistics extends BaseSyncStatistics {
+
+    public CustomerSyncStatistics() {
+        super();
+    }
+
+    /**
+     * Builds a summary of the customer sync statistics instance that looks like the following example:
+     *
+     * <p>"Summary: 2 customers have been processed in total (0 created, 0 updated and 0 failed to sync)."
+     *
+     * @return a summary message of the customer sync statistics instance.
+     */
+    @Override
+    public String getReportMessage() {
+        reportMessage = format(
+            "Summary: %s customers have been processed in total (%s created, %s updated and %s failed to sync).",
+            getProcessed(), getCreated(), getUpdated(), getFailed());
+        return reportMessage;
+    }
+}

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -6,6 +6,10 @@ import static java.lang.String.format;
 
 public class CustomerSyncStatistics extends BaseSyncStatistics {
 
+    public CustomerSyncStatistics() {
+        super();
+    }
+
     /**
      * Builds a summary of the customer sync statistics instance that looks like the following example:
      *

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -20,7 +20,7 @@ public class CustomerSyncStatistics extends BaseSyncStatistics {
     @Override
     public String getReportMessage() {
         reportMessage = format(
-            "Summary: %s customers have been processed in total (%s created, %s updated and %s failed to sync).",
+            "Summary: %s customers were processed in total (%s created, %s updated and %s failed to sync).",
             getProcessed(), getCreated(), getUpdated(), getFailed());
         return reportMessage;
     }

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -4,10 +4,6 @@ import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
 public class CustomerSyncStatistics extends BaseSyncStatistics {
 
-    public CustomerSyncStatistics() {
-        super();
-    }
-
     /**
      * Builds a summary of the customer sync statistics instance that looks like the following example:
      *

--- a/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customers/helpers/CustomerSyncStatistics.java
@@ -6,10 +6,6 @@ import static java.lang.String.format;
 
 public class CustomerSyncStatistics extends BaseSyncStatistics {
 
-    public CustomerSyncStatistics() {
-        super();
-    }
-
     /**
      * Builds a summary of the customer sync statistics instance that looks like the following example:
      *

--- a/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/customobjects/helpers/CustomObjectSyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.customobjects.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 public class CustomObjectSyncStatistics extends BaseSyncStatistics {
     /**
      * Builds a summary of the custom object sync statistics instance that looks like the following example:
@@ -14,10 +12,6 @@ public class CustomObjectSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
-            "Summary: %s custom objects were processed in total (%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-
-        return reportMessage;
+        return getDefaultReportMessageForResource("custom objects");
     }
 }

--- a/src/main/java/com/commercetools/sync/inventories/helpers/InventorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/inventories/helpers/InventorySyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.inventories.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 public class InventorySyncStatistics extends BaseSyncStatistics {
 
     public InventorySyncStatistics() {
@@ -20,9 +18,6 @@ public class InventorySyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format("Summary: %s inventory entries were processed in total "
-                + "(%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-        return reportMessage;
+        return getDefaultReportMessageForResource("inventory entries");
     }
 }

--- a/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductSyncStatistics.java
@@ -38,10 +38,9 @@ public class ProductSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format("Summary: %s product(s) were processed in total "
+        return format("Summary: %s product(s) were processed in total "
                 + "(%s created, %s updated, %s failed to sync and %s product(s) with missing reference(s)).",
             getProcessed(), getCreated(), getUpdated(), getFailed(), getNumberOfProductsWithMissingParents());
-        return reportMessage;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/producttypes/helpers/ProductTypeSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/producttypes/helpers/ProductTypeSyncStatistics.java
@@ -72,14 +72,12 @@ public class ProductTypeSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
+        return format(
             "Summary: %s product types were processed in total (%s created, %s updated, %s failed to sync"
                 + " and %s product types with at least one NestedType or a Set of NestedType attribute definition(s)"
                 + " referencing a missing product type).",
             getProcessed(), getCreated(), getUpdated(), getFailed(),
             getNumberOfProductTypesWithMissingNestedProductTypes());
-
-        return reportMessage;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/states/helpers/StateSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/states/helpers/StateSyncStatistics.java
@@ -38,10 +38,9 @@ public class StateSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format("Summary: %s state(s) were processed in total "
+        return format("Summary: %s state(s) were processed in total "
                 + "(%s created, %s updated, %s failed to sync and %s state(s) with missing transition(s)).",
             getProcessed(), getCreated(), getUpdated(), getFailed(), getNumberOfStatesWithMissingParents());
-        return reportMessage;
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/helpers/TaxCategorySyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.taxcategories.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 /**
  * Tax category sync statistics.
  * Keeps track of processed, created, updated and failed states through whole sync process.
@@ -19,10 +17,7 @@ public final class TaxCategorySyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
-            "Summary: %s tax categories were processed in total (%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-        return reportMessage;
+        return getDefaultReportMessageForResource("tax categories");
     }
 
 }

--- a/src/main/java/com/commercetools/sync/types/helpers/TypeSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/types/helpers/TypeSyncStatistics.java
@@ -2,8 +2,6 @@ package com.commercetools.sync.types.helpers;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 
-import static java.lang.String.format;
-
 public class TypeSyncStatistics extends BaseSyncStatistics {
     /**
      * Builds a summary of the type sync statistics instance that looks like the following example:
@@ -14,10 +12,6 @@ public class TypeSyncStatistics extends BaseSyncStatistics {
      */
     @Override
     public String getReportMessage() {
-        reportMessage = format(
-            "Summary: %s types were processed in total (%s created, %s updated and %s failed to sync).",
-            getProcessed(), getCreated(), getUpdated(), getFailed());
-
-        return reportMessage;
+        return getDefaultReportMessageForResource("types");
     }
 }

--- a/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/helpers/BaseSyncStatisticsTest.java
@@ -109,4 +109,11 @@ class BaseSyncStatisticsTest {
         assertThat(baseSyncStatistics.getLatestBatchHumanReadableProcessingTime())
             .contains(format(", %dms", remainingMillis));
     }
+
+    @Test
+    void getDefaultReportMessageForResource_withResourceString_ShouldBuildCorrectSummary() {
+        String message = baseSyncStatistics.getDefaultReportMessageForResource("resources");
+        assertThat(message).isEqualTo("Summary: 0 resources were processed in total (0 created, 0 updated and 0 "
+            + "failed to sync).");
+    }
 }

--- a/src/test/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/customers/CustomerSyncOptionsBuilderTest.java
@@ -1,0 +1,262 @@
+package com.commercetools.sync.customers;
+
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.commons.utils.QuadConsumer;
+import com.commercetools.sync.commons.utils.TriConsumer;
+import com.commercetools.sync.commons.utils.TriFunction;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
+import io.sphere.sdk.customers.CustomerDraftBuilder;
+import io.sphere.sdk.customers.commands.updateactions.ChangeEmail;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CustomerSyncOptionsBuilderTest {
+
+    private static final SphereClient CTP_CLIENT = mock(SphereClient.class);
+    private final CustomerSyncOptionsBuilder customerSyncOptionsBuilder = CustomerSyncOptionsBuilder.of(CTP_CLIENT);
+
+    @Test
+    void of_WithClient_ShouldCreateCustomerSyncOptionsBuilder() {
+        final CustomerSyncOptionsBuilder builder = CustomerSyncOptionsBuilder.of(CTP_CLIENT);
+        assertThat(builder).isNotNull();
+    }
+
+    @Test
+    void build_WithClient_ShouldBuildSyncOptions() {
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions).isNotNull();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNull();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNull();
+        assertThat(customerSyncOptions.getErrorCallback()).isNull();
+        assertThat(customerSyncOptions.getWarningCallback()).isNull();
+        assertThat(customerSyncOptions.getCtpClient()).isEqualTo(CTP_CLIENT);
+        assertThat(customerSyncOptions.getBatchSize()).isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    }
+
+    @Test
+    void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newCustomer, oldCustomer) -> emptyList();
+
+        customerSyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+    }
+
+    @Test
+    void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+        customerSyncOptionsBuilder.beforeCreateCallback((newCustomer) -> null);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+    }
+
+    @Test
+    void errorCallBack_WithCallBack_ShouldSetCallBack() {
+        final QuadConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>, List<UpdateAction<Customer>>>
+            mockErrorCallBack = (exception, newResource, oldResource, updateActions) -> { };
+        customerSyncOptionsBuilder.errorCallback(mockErrorCallBack);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getErrorCallback()).isNotNull();
+    }
+
+    @Test
+    void warningCallBack_WithCallBack_ShouldSetCallBack() {
+        final TriConsumer<SyncException, Optional<CustomerDraft>, Optional<Customer>> mockWarningCallBack =
+            (exception, newResource, oldResource) -> {
+            };
+        customerSyncOptionsBuilder.warningCallback(mockWarningCallBack);
+
+        final CustomerSyncOptions customerSyncOptions = customerSyncOptionsBuilder.build();
+        assertThat(customerSyncOptions.getWarningCallback()).isNotNull();
+    }
+
+    @Test
+    void getThis_ShouldReturnCorrectInstance() {
+        final CustomerSyncOptionsBuilder builder = customerSyncOptionsBuilder.getThis();
+        assertThat(builder).isNotNull();
+        assertThat(builder).isInstanceOf(CustomerSyncOptionsBuilder.class);
+        assertThat(builder).isEqualTo(customerSyncOptionsBuilder);
+    }
+
+    @Test
+    void customerSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(30)
+            .beforeCreateCallback((newCustomer) -> null)
+            .beforeUpdateCallback((updateActions, newCustomer, oldCustomer) -> emptyList())
+            .build();
+        assertThat(customerSyncOptions).isNotNull();
+    }
+
+    @Test
+    void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+        CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(10)
+            .build();
+        assertThat(customerSyncOptions.getBatchSize()).isEqualTo(10);
+    }
+
+    @Test
+    void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+        final CustomerSyncOptions customerSyncOptionsWithZeroBatchSize = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(0)
+            .build();
+        assertThat(customerSyncOptionsWithZeroBatchSize.getBatchSize())
+            .isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+
+        final CustomerSyncOptions customerSyncOptionsWithNegativeBatchSize = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .batchSize(-100)
+            .build();
+        assertThat(customerSyncOptionsWithNegativeBatchSize.getBatchSize())
+            .isEqualTo(CustomerSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+
+        assertThat(filteredList).isSameAs(updateActions);
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newCustomer, oldCustomer) -> null;
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+        assertThat(filteredList).isNotEqualTo(updateActions);
+        assertThat(filteredList).isEmpty();
+    }
+
+    private interface MockTriFunction extends
+        TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>> {
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+        final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
+
+        final CustomerSyncOptions customerSyncOptions =
+            CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                      .beforeUpdateCallback(beforeUpdateCallback)
+                                      .build();
+
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = emptyList();
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions.applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class),
+                mock(Customer.class));
+
+        assertThat(filteredList).isEmpty();
+        verify(beforeUpdateCallback, never()).apply(any(), any(), any());
+    }
+
+    @Test
+    void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+        final TriFunction<List<UpdateAction<Customer>>, CustomerDraft, Customer, List<UpdateAction<Customer>>>
+            beforeUpdateCallback = (updateActions, newType, oldType) -> emptyList();
+
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder
+            .of(CTP_CLIENT)
+            .beforeUpdateCallback(beforeUpdateCallback)
+            .build();
+        assertThat(customerSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+        final List<UpdateAction<Customer>> updateActions = singletonList(ChangeEmail.of("mail@mail.com"));
+        final List<UpdateAction<Customer>> filteredList =
+            customerSyncOptions
+                .applyBeforeUpdateCallback(updateActions, mock(CustomerDraft.class), mock(Customer.class));
+        assertThat(filteredList).isNotEqualTo(updateActions);
+        assertThat(filteredList).isEmpty();
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+        final Function<CustomerDraft, CustomerDraft> draftFunction =
+            customerDraft -> CustomerDraftBuilder.of(customerDraft)
+                                                 .key(customerDraft.getKey() + "_filteredKey")
+                                                 .build();
+
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .beforeCreateCallback(draftFunction)
+                                                                                  .build();
+
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        when(resourceDraft.getKey()).thenReturn("myKey");
+        when(resourceDraft.getDefaultBillingAddress()).thenReturn(null);
+        when(resourceDraft.getDefaultShippingAddress()).thenReturn(null);
+
+
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).isNotEmpty();
+        assertThat(filteredDraft.get().getKey()).isEqualTo("myKey_filteredKey");
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT).build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).containsSame(resourceDraft);
+    }
+
+    @Test
+    void applyBeforeCreateCallBack_WithCallbackReturningNull_ShouldReturnEmptyOptional() {
+        final Function<CustomerDraft, CustomerDraft> draftFunction = customerDraft -> null;
+        final CustomerSyncOptions customerSyncOptions = CustomerSyncOptionsBuilder.of(CTP_CLIENT)
+                                                                                  .beforeCreateCallback(draftFunction)
+                                                                                  .build();
+        assertThat(customerSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+        final CustomerDraft resourceDraft = mock(CustomerDraft.class);
+        final Optional<CustomerDraft> filteredDraft = customerSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+        assertThat(filteredDraft).isEmpty();
+    }
+
+}

--- a/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
@@ -22,7 +22,7 @@ class CustomerSyncStatisticsTest {
         customerSyncStatistics.incrementProcessed(6);
 
         assertThat(customerSyncStatistics.getReportMessage())
-            .isEqualTo("Summary: 6 customers have been processed in total "
+            .isEqualTo("Summary: 6 customers were processed in total "
                 + "(1 created, 3 updated and 2 failed to sync).");
     }
 }

--- a/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/customers/helpers/CustomerSyncStatisticsTest.java
@@ -1,0 +1,28 @@
+package com.commercetools.sync.customers.helpers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class CustomerSyncStatisticsTest {
+    private CustomerSyncStatistics customerSyncStatistics;
+
+    @BeforeEach
+    void setup() {
+        customerSyncStatistics = new CustomerSyncStatistics();
+    }
+
+    @Test
+    void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+        customerSyncStatistics.incrementCreated(1);
+        customerSyncStatistics.incrementFailed(2);
+        customerSyncStatistics.incrementUpdated(3);
+        customerSyncStatistics.incrementProcessed(6);
+
+        assertThat(customerSyncStatistics.getReportMessage())
+            .isEqualTo("Summary: 6 customers have been processed in total "
+                + "(1 created, 3 updated and 2 failed to sync).");
+    }
+}


### PR DESCRIPTION
#### Summary
In order to configure customer sync behaviour and access statistics some helpers are required.

Related task: #579 

#### Description
Add **CustomerSyncOptionsBuilderTest** .
Add **CustomerSyncStatistics** including UnitTests

#### Todo

- Tests
    - [x] Unit 
    - [x] Integration
- [x] Documentation
- [x] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->
