### PR TITLE
251 Fix test cases for client decoration

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSyncOptions.java
@@ -4,6 +4,7 @@ import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.commons.utils.QuadConsumer;
 import com.commercetools.sync.commons.utils.TriConsumer;
 import com.commercetools.sync.commons.utils.TriFunction;
+import com.commercetools.sync.internals.helpers.CustomHeaderSphereClientDecorator;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 
@@ -53,7 +54,7 @@ public class BaseSyncOptions<U, V> {
      * @return the {@link SphereClient} responsible for interaction with the target CTP project.
      */
     public SphereClient getCtpClient() {
-        return ctpClient;
+        return CustomHeaderSphereClientDecorator.of(ctpClient);
     }
 
     /**

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.commons.utils;
 import io.sphere.sdk.client.SolutionInfo;
 
 public final class SyncSolutionInfo extends SolutionInfo {
-    private static final String LIB_NAME = "commercetools-sync-java";
+    public static final String LIB_NAME = "commercetools-sync-java";
     /**
      * This value is injected by the script at gradle-scripts/set-library-version.gradle.
      */

--- a/src/main/java/com/commercetools/sync/internals/helpers/CustomHeaderSphereClientDecorator.java
+++ b/src/main/java/com/commercetools/sync/internals/helpers/CustomHeaderSphereClientDecorator.java
@@ -1,0 +1,48 @@
+package com.commercetools.sync.internals.helpers;
+
+import io.sphere.sdk.client.HttpRequestIntent;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.client.SphereClientDecorator;
+import io.sphere.sdk.client.SphereRequest;
+import io.sphere.sdk.client.SphereRequestDecorator;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletionStage;
+
+import static com.commercetools.sync.commons.utils.SyncSolutionInfo.LIB_NAME;
+import static com.commercetools.sync.commons.utils.SyncSolutionInfo.LIB_VERSION;
+
+public final class CustomHeaderSphereClientDecorator extends SphereClientDecorator {
+
+    private SphereRequestDecorator delegatedSphereRequestDecorator;
+
+    private CustomHeaderSphereClientDecorator(@Nonnull final SphereClient sphereClient) {
+        super(sphereClient);
+    }
+
+    @Nonnull
+    public static SphereClient of(@Nonnull final SphereClient sphereClient) {
+        return new CustomHeaderSphereClientDecorator(sphereClient);
+    }
+
+    @Override
+    public <T> CompletionStage<T> execute(@Nonnull final SphereRequest<T> sphereRequest) {
+        delegatedSphereRequestDecorator = new CustomHeaderSphereRequestDecorator<>(sphereRequest);
+        return super.execute(new CustomHeaderSphereRequestDecorator<>(sphereRequest));
+    }
+
+    protected HttpRequestIntent getHttpRequestIntent() {
+        return delegatedSphereRequestDecorator.httpRequestIntent();
+    }
+
+    private static final class CustomHeaderSphereRequestDecorator<T> extends SphereRequestDecorator<T> {
+        CustomHeaderSphereRequestDecorator(@Nonnull final SphereRequest<T> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public HttpRequestIntent httpRequestIntent() {
+            return super.httpRequestIntent().plusHeader(LIB_NAME, LIB_VERSION);
+        }
+    }
+}

--- a/src/test/java/com/commercetools/sync/internals/helpers/CustomHeaderSphereClientDecoratorTest.java
+++ b/src/test/java/com/commercetools/sync/internals/helpers/CustomHeaderSphereClientDecoratorTest.java
@@ -1,0 +1,40 @@
+package com.commercetools.sync.internals.helpers;
+
+import io.sphere.sdk.client.HttpRequestIntent;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.client.SphereRequest;
+import io.sphere.sdk.http.HttpHeaders;
+import io.sphere.sdk.models.Versioned;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.commands.ProductTypeUpdateCommand;
+import java.util.Collections;
+
+import io.sphere.sdk.producttypes.commands.updateactions.ChangeName;
+import org.junit.jupiter.api.Test;
+
+import static com.commercetools.sync.commons.utils.SyncSolutionInfo.LIB_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+public class CustomHeaderSphereClientDecoratorTest {
+
+    private static final String LIB_NAME = "commercetools-sync-java";
+    
+    @Test
+    void executeRequest_shouldHaveLibVersionInRequestHeader() {
+
+        SphereClient sphereClient = CustomHeaderSphereClientDecorator.of(mock(SphereClient.class));
+        SphereRequest<ProductType> productTypeUpdateSphereRequest =
+                ProductTypeUpdateCommand.of(
+                        Versioned.of("ID", 1L),
+                        Collections.singletonList(ChangeName.of("newName")));
+
+        sphereClient.execute(productTypeUpdateSphereRequest);
+        HttpRequestIntent requestIntent = ((CustomHeaderSphereClientDecorator)sphereClient).getHttpRequestIntent();
+        HttpHeaders headers = requestIntent.getHeaders();
+        assertThat(headers.getHeader(LIB_NAME).size()).isGreaterThan(0);
+        assertThat(headers.getHeader(LIB_NAME).get(0)).isEqualTo(LIB_VERSION);
+
+    }
+}

--- a/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
@@ -159,9 +159,8 @@ class ProductSyncTest {
                 .build();
 
         final ProductService productService = spy(new ProductServiceImpl(syncOptions));
-        CompletableFuture<Set<Product>> future = new CompletableFuture<>();
-        future.completeExceptionally(new CompletionException(new SphereException()));
-        when(productService.fetchMatchingProductsByKeys(anySet())).thenReturn(future);
+        when(productService.fetchMatchingProductsByKeys(anySet()))
+                .thenReturn(supplyAsync(() -> { throw new CompletionException( new SphereException()); }));
 
         final Map<String, String> keyToIds = new HashMap<>();
         keyToIds.put(productDraft.getKey(), UUID.randomUUID().toString());

--- a/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncTest.java
@@ -148,8 +148,6 @@ class ProductSyncTest {
 
         final SphereClient mockClient = mock(SphereClient.class);
 
-
-
         final List<String> errorMessages = new ArrayList<>();
         final List<Throwable> exceptions = new ArrayList<>();
         final ProductSyncOptions syncOptions = ProductSyncOptionsBuilder


### PR DESCRIPTION
#### Summary
Fix mocking problem in unit test

#### Description
After decorating CTP client in sync options, expected result in unit test is affected.

#### Relevant Issues
https://github.com/commercetools/commercetools-sync-java/issues/251

#### Todo

- Tests
    - [x] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
Service class is mocked instead of CTP client in unit test cases. `CustomHeaderSphereClientDecorator` class type returned from Sync Options no longer affects the test cases result.
