### PR TITLE
Handles edge cases for the update actions: `setStores` and `setCustomerNumber`.

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/customers/CustomerSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/customers/CustomerSyncIT.java
@@ -113,9 +113,9 @@ class CustomerSyncIT {
             .toCompletableFuture()
             .join();
 
-        assertThat(customerSyncStatistics).hasValues(1, 0, 0, 0);
         assertThat(errorMessages).isEmpty();
         assertThat(exceptions).isEmpty();
+        assertThat(customerSyncStatistics).hasValues(1, 0, 0, 0);
         assertThat(customerSyncStatistics
             .getReportMessage())
             .isEqualTo("Summary: 1 customers were processed in total (0 created, 0 updated and 0 failed to sync).");
@@ -142,13 +142,14 @@ class CustomerSyncIT {
             .toCompletableFuture()
             .join();
 
+        assertThat(errorMessages).isEmpty();
+        assertThat(exceptions).isEmpty();
+        assertThat(updateActionList).isEmpty();
+
         assertThat(customerSyncStatistics).hasValues(1, 1, 0, 0);
         assertThat(customerSyncStatistics
             .getReportMessage())
             .isEqualTo("Summary: 1 customers were processed in total (1 created, 0 updated and 0 failed to sync).");
-        assertThat(errorMessages).isEmpty();
-        assertThat(exceptions).isEmpty();
-        assertThat(updateActionList).isEmpty();
     }
 
     @Test
@@ -168,10 +169,6 @@ class CustomerSyncIT {
             .toCompletableFuture()
             .join();
 
-        assertThat(customerSyncStatistics).hasValues(1, 0, 1, 0);
-        assertThat(customerSyncStatistics
-            .getReportMessage())
-            .isEqualTo("Summary: 1 customers were processed in total (0 created, 1 updated and 0 failed to sync).");
 
         assertThat(errorMessages).isEmpty();
         assertThat(exceptions).isEmpty();
@@ -182,6 +179,11 @@ class CustomerSyncIT {
                 ResourceIdentifier.ofKey("store-hamburg"),
                 ResourceIdentifier.ofKey("store-berlin")))
         );
+
+        assertThat(customerSyncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(customerSyncStatistics
+            .getReportMessage())
+            .isEqualTo("Summary: 1 customers were processed in total (0 created, 1 updated and 0 failed to sync).");
     }
 
     @Test
@@ -231,11 +233,6 @@ class CustomerSyncIT {
         assertThat(errorMessages).isEmpty();
         assertThat(exceptions).isEmpty();
 
-        assertThat(customerSyncStatistics).hasValues(1, 0, 1, 0);
-        assertThat(customerSyncStatistics
-            .getReportMessage())
-            .isEqualTo("Summary: 1 customers were processed in total (0 created, 1 updated and 0 failed to sync).");
-
         final Map<String, String> addressKeyToIdMap =
             customerJohnDoe.getAddresses().stream().collect(toMap(Address::getKey, Address::getId));
 
@@ -261,5 +258,10 @@ class CustomerSyncIT {
             SetCustomField.ofJson(BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(false)),
             AddStore.of(ResourceIdentifier.ofKey(storeCologne.getKey()))
         );
+
+        assertThat(customerSyncStatistics).hasValues(1, 0, 1, 0);
+        assertThat(customerSyncStatistics
+            .getReportMessage())
+            .isEqualTo("Summary: 1 customers were processed in total (0 created, 1 updated and 0 failed to sync).");
     }
 }

--- a/src/main/java/com/commercetools/sync/customers/commands/updateactions/AddBillingAddressIdWithKey.java
+++ b/src/main/java/com/commercetools/sync/customers/commands/updateactions/AddBillingAddressIdWithKey.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.customers.Customer;
 import javax.annotation.Nonnull;
 
 // TODO (JVM-SDK), see: SUPPORT-10260, Address selection by key is not supported yet.
+// https://github.com/commercetools/commercetools-jvm-sdk/issues/2071
 public final class AddBillingAddressIdWithKey extends UpdateActionImpl<Customer> {
     private final String addressKey;
 

--- a/src/main/java/com/commercetools/sync/customers/commands/updateactions/AddShippingAddressIdWithKey.java
+++ b/src/main/java/com/commercetools/sync/customers/commands/updateactions/AddShippingAddressIdWithKey.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.customers.Customer;
 import javax.annotation.Nonnull;
 
 // TODO (JVM-SDK), see: SUPPORT-10260, Address selection by key is not supported yet.
+// https://github.com/commercetools/commercetools-jvm-sdk/issues/2071
 public final class AddShippingAddressIdWithKey extends UpdateActionImpl<Customer> {
     private final String addressKey;
 

--- a/src/main/java/com/commercetools/sync/customers/commands/updateactions/SetDefaultBillingAddressWithKey.java
+++ b/src/main/java/com/commercetools/sync/customers/commands/updateactions/SetDefaultBillingAddressWithKey.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.customers.Customer;
 import javax.annotation.Nullable;
 
 // TODO (JVM-SDK), see: SUPPORT-10260, Address selection by key is not supported yet.
+// https://github.com/commercetools/commercetools-jvm-sdk/issues/2071
 public final class SetDefaultBillingAddressWithKey extends UpdateActionImpl<Customer> {
     private final String addressKey;
 

--- a/src/main/java/com/commercetools/sync/customers/commands/updateactions/SetDefaultShippingAddressWithKey.java
+++ b/src/main/java/com/commercetools/sync/customers/commands/updateactions/SetDefaultShippingAddressWithKey.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.customers.Customer;
 import javax.annotation.Nullable;
 
 // TODO (JVM-SDK), see: SUPPORT-10260, Address selection by key is not supported yet.
+// https://github.com/commercetools/commercetools-jvm-sdk/issues/2071
 public final class SetDefaultShippingAddressWithKey extends UpdateActionImpl<Customer> {
     private final String addressKey;
 

--- a/src/main/java/com/commercetools/sync/customers/utils/CustomerSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/customers/utils/CustomerSyncUtils.java
@@ -58,7 +58,7 @@ public final class CustomerSyncUtils {
             buildSetTitleUpdateAction(oldCustomer, newCustomer),
             buildSetSalutationUpdateAction(oldCustomer, newCustomer),
             buildSetCustomerGroupUpdateAction(oldCustomer, newCustomer),
-            buildSetCustomerNumberUpdateAction(oldCustomer, newCustomer),
+            buildSetCustomerNumberUpdateAction(oldCustomer, newCustomer, syncOptions),
             buildSetExternalIdUpdateAction(oldCustomer, newCustomer),
             buildSetCompanyNameUpdateAction(oldCustomer, newCustomer),
             buildSetDateOfBirthUpdateAction(oldCustomer, newCustomer),

--- a/src/main/java/com/commercetools/sync/customers/utils/CustomerUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/customers/utils/CustomerUpdateActionUtils.java
@@ -64,7 +64,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public final class CustomerUpdateActionUtils {
 
     public static final String CUSTOMER_NUMBER_EXISTS_WARNING = "Customer with key: \"%s\" has "
-        + "already a customer number \"%s\", once it's set it cannot be changed. "
+        + "already a customer number: \"%s\", once it's set it cannot be changed. "
         + "Hereby, the update action is not created.";
 
     private CustomerUpdateActionUtils() {

--- a/src/main/java/com/commercetools/sync/customers/utils/CustomerUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/customers/utils/CustomerUpdateActionUtils.java
@@ -458,7 +458,7 @@ public final class CustomerUpdateActionUtils {
      * @return A list containing the update actions or an empty list if the store references are identical.
      */
     @Nonnull
-    private static List<UpdateAction<Customer>> buildRemoveStoreUpdateActions(
+    public static List<UpdateAction<Customer>> buildRemoveStoreUpdateActions(
         @Nonnull final List<KeyReference<Store>> oldStores,
         @Nonnull final List<ResourceIdentifier<Store>> newStores) {
 
@@ -490,7 +490,7 @@ public final class CustomerUpdateActionUtils {
      * @return A list containing the update actions or an empty list if the store references are identical.
      */
     @Nonnull
-    private static List<UpdateAction<Customer>> buildAddStoreUpdateActions(
+    public static List<UpdateAction<Customer>> buildAddStoreUpdateActions(
         @Nonnull final List<KeyReference<Store>> oldStores,
         @Nonnull final List<ResourceIdentifier<Store>> newStores) {
 

--- a/src/test/java/com/commercetools/sync/customers/utils/StoreUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/customers/utils/StoreUpdateActionUtilsTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked")
 public class StoreUpdateActionUtilsTest {
 
     private Customer oldCustomer;
@@ -273,7 +274,7 @@ public class StoreUpdateActionUtilsTest {
     }
 
     @Test
-    void buildStoreUpdateActions_WithMixedStores_ShouldReturnAddAndRemoveStoreActions() {
+    void buildStoreUpdateActions_WithMixedStores_ShouldReturnSetStoresAction() {
 
         final KeyReference<Store> keyReference1 = mock(KeyReference.class);
         when(keyReference1.getKey()).thenReturn("store-key1");
@@ -299,9 +300,10 @@ public class StoreUpdateActionUtilsTest {
 
         assertThat(updateActions)
             .isNotEmpty()
-            .containsExactly(
-                RemoveStore.of(ResourceIdentifier.ofKey("store-key4")),
-                AddStore.of(ResourceIdentifier.ofKey("store-key2")));
+            .containsExactly(SetStores.of(
+                asList(ResourceIdentifier.ofKey("store-key1"),
+                       ResourceIdentifier.ofKey("store-key2"),
+                       ResourceIdentifier.ofKey("store-key3"))));
     }
 
     @Test


### PR DESCRIPTION
## Solutions:
1- We will return a warning message with a callback. For example: `"Customer with key: "key1" has already a customer number: "1234", once it's set it cannot be changed. Hereby, the update action is not created."`

2- Instead of using `addStore` and `removeStore` actions together for this we will use `setStores`.

# Problems:
It is possible that the library will create some update actions that are not valid or un-necessary. We figured out those actions while working with integration tests.

1 - Customer number uniqueness: https://docs.commercetools.com/api/projects/customers#set-customer-number


Currently, the library will create an update action for customer numbers and it will be failed by API because the customer number can not be changed after it set.

```
http response formatted body: {
"statusCode" : 400,
"message" : "A Customer number already exists and cannot be set again.",
"errors" : [ {
"code" : "InvalidOperation",
"message" : "A Customer number already exists and cannot be set again.",
"action" : {
"action" : "setCustomerNumber",
"customerNumber" : "gold-2"
},
"actionIndex" : 7
} ]
```

2 - Email uniqueness: https://docs.commercetools.com/api/projects/customers#email-uniqueness

The case only happening when email changes and some existing stores are removed, 
````
{
"action" : "changeEmail",
"email" : "jane@example.com"
}
{
"action" : "removeStore",
"store" : {
"key" : "store-hamburg"
}
````

````
http response formatted body: {
"statusCode" : 400,
"message" : "There is already an existing customer with the email '\"john@example.com\"'.",
"errors" : [ {
"code" : "DuplicateField",
"message" : "There is already an existing customer with the email '\"john@example.com\"'.",
"duplicateValue" : "john@example.com",
"field" : "email"
} ]
}
````

