### PR TITLE
Add shopping list update actions (without line items)

### DIFF
--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListCustomActionBuilder.java
@@ -1,0 +1,57 @@
+package com.commercetools.sync.shoppinglists.utils;
+
+import com.commercetools.sync.commons.helpers.GenericCustomActionBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomField;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public final class ShoppingListCustomActionBuilder implements GenericCustomActionBuilder<ShoppingList> {
+
+    private static final ShoppingListCustomActionBuilder builder = new ShoppingListCustomActionBuilder();
+
+    private ShoppingListCustomActionBuilder() {
+        super();
+    }
+
+    @Nonnull
+    public static ShoppingListCustomActionBuilder of() {
+        return builder;
+    }
+
+    @Nonnull
+    @Override
+    public UpdateAction<ShoppingList> buildRemoveCustomTypeAction(
+        @Nullable final Integer variantId,
+        @Nullable final String objectId) {
+
+        return SetCustomType.ofRemoveType();
+    }
+
+    @Nonnull
+    @Override
+    public UpdateAction<ShoppingList> buildSetCustomTypeAction(
+        @Nullable final Integer variantId,
+        @Nullable final String objectId,
+        @Nonnull final String customTypeId,
+        @Nullable final Map<String, JsonNode> customFieldsJsonMap) {
+
+        return SetCustomType.ofTypeIdAndJson(customTypeId, customFieldsJsonMap);
+    }
+
+    @Nonnull
+    @Override
+    public UpdateAction<ShoppingList> buildSetCustomFieldAction(
+        @Nullable final Integer variantId,
+        @Nullable final String objectId,
+        @Nullable final String customFieldName,
+        @Nullable final JsonNode customFieldValue) {
+
+        return SetCustomField.ofJson(customFieldName, customFieldValue);
+    }
+}

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -1,0 +1,40 @@
+package com.commercetools.sync.shoppinglists.utils;
+
+import com.commercetools.sync.shoppinglists.ShoppingListSyncOptions;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildChangeNameUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetAnonymousIdUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetCustomerUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDeleteDaysAfterLastModificationUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDescriptionUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetSlugUpdateAction;
+
+public class ShoppingListSyncUtils {
+
+    @Nonnull
+    public static List<UpdateAction<ShoppingList>> buildActions(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList,
+        @Nonnull final ShoppingListSyncOptions syncOptions) {
+
+        final List<UpdateAction<ShoppingList>> updateActions = filterEmptyOptionals(
+            buildSetSlugUpdateAction(oldShoppingList, newShoppingList),
+            buildChangeNameUpdateAction(oldShoppingList, newShoppingList),
+            buildSetDescriptionUpdateAction(oldShoppingList, newShoppingList),
+            buildSetCustomerUpdateAction(oldShoppingList, newShoppingList),
+            buildSetAnonymousIdUpdateAction(oldShoppingList, newShoppingList),
+            buildSetDeleteDaysAfterLastModificationUpdateAction(oldShoppingList, newShoppingList)
+        );
+
+        return updateActions;
+    }
+
+
+}

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -65,7 +65,13 @@ public final class ShoppingListSyncUtils {
         return updateActions;
     }
 
-    // TODO: https://github.com/commercetools/commercetools-jvm-sdk/issues/2073
+    /**
+     * The class is needed by `buildPrimaryResourceCustomUpdateActions` generic utility method,
+     * because required generic type `S` is based on the CustomDraft interface (S extends CustomDraft).
+     *
+     * <p>TODO (JVM-SDK): Missing the interface CustomDraft.
+     * See for more details: https://github.com/commercetools/commercetools-jvm-sdk/issues/2073
+     */
     private static class CustomShoppingListDraft implements CustomDraft {
         private final ShoppingListDraft shoppingListDraft;
 

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -2,6 +2,8 @@ package com.commercetools.sync.shoppinglists.utils;
 
 import com.commercetools.sync.shoppinglists.ShoppingListSyncOptions;
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.customers.CustomerDraft;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 
@@ -18,11 +20,21 @@ import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActio
 
 public class ShoppingListSyncUtils {
 
+    /**
+     * Compares all the fields of a {@link Customer} and a {@link CustomerDraft}. It returns a {@link List} of
+     * {@link UpdateAction}&lt;{@link Customer}&gt; as a result. If no update action is needed, for example in
+     * case where both the {@link CustomerDraft} and the {@link CustomerDraft} have the same fields, an empty
+     * {@link List} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft where we get the new data
+     * @return A list of shopping list specific update actions.
+     */
+
     @Nonnull
     public static List<UpdateAction<ShoppingList>> buildActions(
         @Nonnull final ShoppingList oldShoppingList,
-        @Nonnull final ShoppingListDraft newShoppingList,
-        @Nonnull final ShoppingListSyncOptions syncOptions) {
+        @Nonnull final ShoppingListDraft newShoppingList) {
 
         final List<UpdateAction<ShoppingList>> updateActions = filterEmptyOptionals(
             buildSetSlugUpdateAction(oldShoppingList, newShoppingList),

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -20,7 +20,7 @@ import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActio
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDescriptionUpdateAction;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetSlugUpdateAction;
 
-public class ShoppingListSyncUtils {
+public final class ShoppingListSyncUtils {
 
     private static final ShoppingListCustomActionBuilder shoppingListCustomActionBuilder =
         ShoppingListCustomActionBuilder.of();
@@ -65,7 +65,7 @@ public class ShoppingListSyncUtils {
         return updateActions;
     }
 
-    // todo (ahmetoz), open a request to jvm sdk, ShoppingListDraft needs to extend CustomDraft.
+    // TODO: https://github.com/commercetools/commercetools-jvm-sdk/issues/2073
     private static class CustomShoppingListDraft implements CustomDraft {
         private final ShoppingListDraft shoppingListDraft;
 
@@ -78,5 +78,8 @@ public class ShoppingListSyncUtils {
         public CustomFieldsDraft getCustom() {
             return shoppingListDraft.getCustom();
         }
+    }
+
+    private ShoppingListSyncUtils() {
     }
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -1,14 +1,17 @@
 package com.commercetools.sync.shoppinglists.utils;
 
+import com.commercetools.sync.shoppinglists.ShoppingListSyncOptions;
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.customers.Customer;
-import io.sphere.sdk.customers.CustomerDraft;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+import io.sphere.sdk.types.CustomDraft;
+import io.sphere.sdk.types.CustomFieldsDraft;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
+import static com.commercetools.sync.commons.utils.CustomUpdateActionUtils.buildPrimaryResourceCustomUpdateActions;
 import static com.commercetools.sync.commons.utils.OptionalUtils.filterEmptyOptionals;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildChangeNameUpdateAction;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetAnonymousIdUpdateAction;
@@ -19,21 +22,28 @@ import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActio
 
 public class ShoppingListSyncUtils {
 
+    private static final ShoppingListCustomActionBuilder shoppingListCustomActionBuilder =
+        ShoppingListCustomActionBuilder.of();
+
     /**
-     * Compares all the fields of a {@link Customer} and a {@link CustomerDraft}. It returns a {@link List} of
-     * {@link UpdateAction}&lt;{@link Customer}&gt; as a result. If no update action is needed, for example in
-     * case where both the {@link CustomerDraft} and the {@link CustomerDraft} have the same fields, an empty
+     * Compares all the fields of a {@link ShoppingList} and a {@link ShoppingListDraft}. It returns a {@link List} of
+     * {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result. If no update action is needed, for example in
+     * case where both the {@link ShoppingListDraft} and the {@link ShoppingList} have the same fields, an empty
      * {@link List} is returned.
      *
      * @param oldShoppingList the shopping list which should be updated.
-     * @param newShoppingList the shopping list draft where we get the new data
+     * @param newShoppingList the shopping list draft where we get the new data.
+     * @param syncOptions the sync options wrapper which contains options related to the sync process supplied
+     *                    by the user. For example, custom callbacks to call in case of warnings or errors occurring
+     *                    on the build update action process. And other options (See {@link ShoppingListSyncOptions}
+     *                    for more info.
      * @return A list of shopping list specific update actions.
      */
-
     @Nonnull
     public static List<UpdateAction<ShoppingList>> buildActions(
         @Nonnull final ShoppingList oldShoppingList,
-        @Nonnull final ShoppingListDraft newShoppingList) {
+        @Nonnull final ShoppingListDraft newShoppingList,
+        @Nonnull final ShoppingListSyncOptions syncOptions) {
 
         final List<UpdateAction<ShoppingList>> updateActions = filterEmptyOptionals(
             buildSetSlugUpdateAction(oldShoppingList, newShoppingList),
@@ -44,8 +54,29 @@ public class ShoppingListSyncUtils {
             buildSetDeleteDaysAfterLastModificationUpdateAction(oldShoppingList, newShoppingList)
         );
 
+        final List<UpdateAction<ShoppingList>> shoppingListCustomUpdateActions =
+            buildPrimaryResourceCustomUpdateActions(oldShoppingList,
+                new CustomShoppingListDraft(newShoppingList),
+                shoppingListCustomActionBuilder,
+                syncOptions);
+
+        updateActions.addAll(shoppingListCustomUpdateActions);
+
         return updateActions;
     }
 
+    // todo (ahmetoz), open a request to jvm sdk, ShoppingListDraft needs to extend CustomDraft.
+    private static class CustomShoppingListDraft implements CustomDraft {
+        private final ShoppingListDraft shoppingListDraft;
 
+        public CustomShoppingListDraft(@Nonnull final ShoppingListDraft shoppingListDraft) {
+            this.shoppingListDraft = shoppingListDraft;
+        }
+
+        @Nullable
+        @Override
+        public CustomFieldsDraft getCustom() {
+            return shoppingListDraft.getCustom();
+        }
+    }
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtils.java
@@ -1,6 +1,5 @@
 package com.commercetools.sync.shoppinglists.utils;
 
-import com.commercetools.sync.shoppinglists.ShoppingListSyncOptions;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.customers.CustomerDraft;

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -19,13 +19,13 @@ import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateActionForReferences;
 
 public final class ShoppingListUpdateActionUtils {
+
     private ShoppingListUpdateActionUtils() {
     }
 
@@ -122,14 +122,14 @@ public final class ShoppingListUpdateActionUtils {
     }
 
     /**
-     * Compares the AnonymousIds of {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * Compares the anonymousIds of {@link ShoppingList} and a {@link ShoppingListDraft} and
      * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
-     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same AnonymousId, then no update action is needed
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same anonymousId, then no update action is needed
      * and hence an empty {@link Optional} is returned.
      *
      * @param oldShoppingList the shopping list which should be updated.
-     * @param newShoppingList the shopping list draft which holds the new AnonymousId.
-     * @return A filled optional with the update action or an empty optional if the Ids are identical.
+     * @param newShoppingList the shopping list draft which holds the new anonymousId.
+     * @return A filled optional with the update action or an empty optional if the anonymousIds are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ShoppingList>> buildSetAnonymousIdUpdateAction(
@@ -141,15 +141,15 @@ public final class ShoppingListUpdateActionUtils {
     }
 
     /**
-     * Compares the Number for Delete Days of {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * Compares the deleteDaysAfterLastModification of {@link ShoppingList} and a {@link ShoppingListDraft} and
      * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
-     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same number for delete days, then no update
-     * action is needed and hence an empty {@link Optional} is returned.
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same deleteDaysAfterLastModification, then no
+     * update action is needed and hence an empty {@link Optional} is returned.
      *
      * @param oldShoppingList the shopping list which should be updated.
-     * @param newShoppingList the shopping list draft which holds the new number of days after which the ShoppingList
-     *                        shall be deleted .
-     * @return A filled optional with the update action or an empty optional if the Ids are identical.
+     * @param newShoppingList the shopping list draft which holds the new deleteDaysAfterLastModification.
+     * @return A filled optional with the update action or an empty optional if the deleteDaysAfterLastModifications
+     *         are identical.
      */
     @Nonnull
     public static Optional<UpdateAction<ShoppingList>> buildSetDeleteDaysAfterLastModificationUpdateAction(
@@ -160,6 +160,4 @@ public final class ShoppingListUpdateActionUtils {
             newShoppingList.getDeleteDaysAfterLastModification(), () -> SetDeleteDaysAfterLastModification.of(
                 newShoppingList.getDeleteDaysAfterLastModification()));
     }
-
-
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -5,6 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
 
 import javax.annotation.Nonnull;
@@ -29,6 +30,7 @@ public final class ShoppingListUpdateActionUtils {
     public static Optional<UpdateAction<ShoppingList>> buildSetSlugUpdateAction(
         @Nonnull final ShoppingList oldShoppingList,
         @Nonnull final ShoppingListDraft newShoppingList) {
+
         return buildUpdateAction(oldShoppingList.getSlug(),
             newShoppingList.getSlug(), () -> SetSlug.of(newShoppingList.getSlug()));
     }
@@ -47,7 +49,27 @@ public final class ShoppingListUpdateActionUtils {
     public static Optional<UpdateAction<ShoppingList>> buildChangeNameUpdateAction(
         @Nonnull final ShoppingList oldShoppingList,
         @Nonnull final ShoppingListDraft newShoppingList) {
+
         return buildUpdateAction(oldShoppingList.getName(),
             newShoppingList.getName(), () -> ChangeName.of(newShoppingList.getName()));
+    }
+
+    /**
+     * Compares the {@link LocalizedString} descriptions of {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same description, then no update action is needed
+     * and hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft where we get the new description.
+     * @return A filled optional with the update action or an empty optional if the descriptions are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildSetDescriptionUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+
+        return buildUpdateAction(oldShoppingList.getDescription(),
+            newShoppingList.getDescription(), () -> SetDescription.of(newShoppingList.getDescription()));
     }
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -1,0 +1,53 @@
+package com.commercetools.sync.shoppinglists.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+
+public final class ShoppingListUpdateActionUtils {
+    private ShoppingListUpdateActionUtils() { }
+
+    /**
+     * Compares the {@link LocalizedString} slugs of a {@link ShoppingList} and a {@link ShoppingListDraft} and returns
+     * an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same slug, then no update action is needed and
+     * hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft where we get the new slug.
+     * @return A filled optional with the update action or an empty optional if the slugs are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildSetSlugUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+        return buildUpdateAction(oldShoppingList.getSlug(),
+            newShoppingList.getSlug(), () -> SetSlug.of(newShoppingList.getSlug()));
+    }
+
+    /**
+     * Compares the {@link LocalizedString} names of a {@link ShoppingList} and a {@link ShoppingListDraft} and returns
+     * an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same name, then no update action is needed and
+     * hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft where we get the new name.
+     * @return A filled optional with the update action or an empty optional if the names are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildChangeNameUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+        return buildUpdateAction(oldShoppingList.getName(),
+            newShoppingList.getName(), () -> ChangeName.of(newShoppingList.getName()));
+    }
+}

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -162,5 +162,4 @@ public final class ShoppingListUpdateActionUtils {
     }
 
 
-
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -1,20 +1,33 @@
 package com.commercetools.sync.shoppinglists.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.Referenceable;
+import io.sphere.sdk.models.ResourceIdentifier;
+import io.sphere.sdk.models.ResourceImpl;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetAnonymousId;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomer;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDeleteDaysAfterLastModification;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.buildUpdateActionForReferences;
 
 public final class ShoppingListUpdateActionUtils {
-    private ShoppingListUpdateActionUtils() { }
+    private ShoppingListUpdateActionUtils() {
+    }
 
     /**
      * Compares the {@link LocalizedString} slugs of a {@link ShoppingList} and a {@link ShoppingListDraft} and returns
@@ -72,4 +85,82 @@ public final class ShoppingListUpdateActionUtils {
         return buildUpdateAction(oldShoppingList.getDescription(),
             newShoppingList.getDescription(), () -> SetDescription.of(newShoppingList.getDescription()));
     }
+
+    /**
+     * Compares the customer references of a {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same customer, then no update action is needed
+     * and hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft which holds the new customer.
+     * @return A filled optional with the update action or an empty optional if the customers are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildSetCustomerUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+
+        return buildUpdateActionForReferences(oldShoppingList.getCustomer(), newShoppingList.getCustomer(),
+            () -> SetCustomer.of(mapResourceIdentifierToReferenceable(newShoppingList.getCustomer())));
+    }
+
+    @Nullable
+    private static Referenceable<Customer> mapResourceIdentifierToReferenceable(
+        @Nullable final ResourceIdentifier<Customer> resourceIdentifier) {
+
+        if (resourceIdentifier == null) {
+            return null; // unset
+        }
+
+        return new ResourceImpl<Customer>(null, null, null, null) {
+            @Override
+            public Reference<Customer> toReference() {
+                return Reference.of(CustomerGroup.referenceTypeId(), resourceIdentifier.getId());
+            }
+        };
+    }
+
+    /**
+     * Compares the AnonymousIds of {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same AnonymousId, then no update action is needed
+     * and hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft which holds the new AnonymousId.
+     * @return A filled optional with the update action or an empty optional if the Ids are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildSetAnonymousIdUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+
+        return buildUpdateAction(oldShoppingList.getAnonymousId(), newShoppingList.getAnonymousId(),
+            () -> SetAnonymousId.of(newShoppingList.getAnonymousId()));
+    }
+
+    /**
+     * Compares the Number for Delete Days of {@link ShoppingList} and a {@link ShoppingListDraft} and
+     * returns an {@link UpdateAction}&lt;{@link ShoppingList}&gt; as a result in an {@link Optional}. If both the
+     * {@link ShoppingList} and the {@link ShoppingListDraft} have the same number for delete days, then no update
+     * action is needed and hence an empty {@link Optional} is returned.
+     *
+     * @param oldShoppingList the shopping list which should be updated.
+     * @param newShoppingList the shopping list draft which holds the new number of days after which the ShoppingList
+     *                        shall be deleted .
+     * @return A filled optional with the update action or an empty optional if the Ids are identical.
+     */
+    @Nonnull
+    public static Optional<UpdateAction<ShoppingList>> buildSetDeleteDaysAfterLastModificationUpdateAction(
+        @Nonnull final ShoppingList oldShoppingList,
+        @Nonnull final ShoppingListDraft newShoppingList) {
+
+        return buildUpdateAction(oldShoppingList.getDeleteDaysAfterLastModification(),
+            newShoppingList.getDeleteDaysAfterLastModification(), () -> SetDeleteDaysAfterLastModification.of(
+                newShoppingList.getDeleteDaysAfterLastModification()));
+    }
+
+
+
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtils.java
@@ -1,7 +1,6 @@
 package com.commercetools.sync.shoppinglists.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.customergroups.CustomerGroup;
 import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
@@ -113,10 +112,12 @@ public final class ShoppingListUpdateActionUtils {
             return null; // unset
         }
 
+        // TODO (JVM-SDK), see: SUPPORT-10261 SetCustomerGroup could be created with a ResourceIdentifier
+        // https://github.com/commercetools/commercetools-jvm-sdk/issues/2072
         return new ResourceImpl<Customer>(null, null, null, null) {
             @Override
             public Reference<Customer> toReference() {
-                return Reference.of(CustomerGroup.referenceTypeId(), resourceIdentifier.getId());
+                return Reference.of(Customer.referenceTypeId(), resourceIdentifier.getId());
             }
         };
     }

--- a/src/test/java/com/commercetools/sync/commons/utils/ShoppingListCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/ShoppingListCustomUpdateActionUtilsTest.java
@@ -1,0 +1,59 @@
+package com.commercetools.sync.commons.utils;
+
+import com.commercetools.sync.shoppinglists.ShoppingListSyncOptionsBuilder;
+import com.commercetools.sync.shoppinglists.utils.ShoppingListCustomActionBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomField;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static com.commercetools.sync.commons.asserts.actions.AssertionsForUpdateActions.assertThat;
+import static io.sphere.sdk.models.ResourceIdentifier.ofId;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ShoppingListCustomUpdateActionUtilsTest {
+
+    @Test
+    void buildTypedSetCustomTypeUpdateAction_WithCustomerResource_ShouldBuildCustomerUpdateAction() {
+        final String newCustomTypeId = UUID.randomUUID().toString();
+
+        final UpdateAction<ShoppingList> updateAction =
+            GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction(newCustomTypeId, new HashMap<>(),
+                mock(ShoppingList.class), ShoppingListCustomActionBuilder.of(), null, ShoppingList::getId,
+                shoppingListResource -> shoppingListResource.toReference().getTypeId(), shoppingListResource -> null,
+                ShoppingListSyncOptionsBuilder.of(mock(SphereClient.class)).build()).orElse(null);
+
+        assertThat(updateAction).isInstanceOf(SetCustomType.class);
+        assertThat((SetCustomType) updateAction).hasValues("setCustomType", emptyMap(), ofId(newCustomTypeId));
+    }
+
+    @Test
+    void buildRemoveCustomTypeAction_WithShoppingListResource_ShouldBuildShoppingListUpdateAction() {
+        final UpdateAction<ShoppingList> updateAction =
+            ShoppingListCustomActionBuilder.of().buildRemoveCustomTypeAction(null, null);
+
+        assertThat(updateAction).isInstanceOf(SetCustomType.class);
+        assertThat((SetCustomType) updateAction).hasValues("setCustomType", null, ofId(null));
+    }
+
+    @Test
+    void buildSetCustomFieldAction_WithShoppingListResource_ShouldBuildShoppingListUpdateAction() {
+        final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
+        final String customFieldName = "name";
+
+        final UpdateAction<ShoppingList> updateAction = ShoppingListCustomActionBuilder.of()
+            .buildSetCustomFieldAction(null, null, customFieldName, customFieldValue);
+
+        assertThat(updateAction).isInstanceOf(SetCustomField.class);
+        assertThat((SetCustomField) updateAction).hasValues("setCustomField", customFieldName, customFieldValue);
+    }
+}

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
@@ -6,9 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
-import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.ShoppingListDraftBuilder;
@@ -50,8 +48,6 @@ class ShoppingListSyncUtilsTest {
     void setup() {
         oldShoppingList = mock(ShoppingList.class);
         when(oldShoppingList.getName()).thenReturn(LocalizedString.ofEnglish("name"));
-
-        // todo (ahmetoz): check why SetDeleteDaysAfterLastModification is created when the line below is removed.
         when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(null);
 
         final CustomFields customFields = mock(CustomFields.class);
@@ -66,24 +62,18 @@ class ShoppingListSyncUtilsTest {
 
     @Test
     void buildActions_WithDifferentValues_ShouldReturnActions() {
-        final String customerId = "1";
-        final Reference<Customer> oldCustomerReference = Reference.of(Customer.referenceTypeId(), customerId);
         final ShoppingList oldShoppingList = mock(ShoppingList.class);
         when(oldShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
         when(oldShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "oldName"));
         when(oldShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
-        when(oldShoppingList.getCustomer()).thenReturn(oldCustomerReference);
-        when(oldShoppingList.getAnonymousId()).thenReturn("123");
+        when(oldShoppingList.getAnonymousId()).thenReturn("oldAnonymousId");
         when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(50);
 
-        final String newCustomerId = "2";
-        final Reference<Customer> newCustomerReference = Reference.of(Customer.referenceTypeId(), newCustomerId);
         final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
         when(newShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "newSlug"));
         when(newShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "newName"));
         when(newShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "newDescription"));
-        when(newShoppingList.getCustomer()).thenReturn(newCustomerReference);
-        when(newShoppingList.getAnonymousId()).thenReturn("567");
+        when(newShoppingList.getAnonymousId()).thenReturn("newAnonymousId");
         when(newShoppingList.getDeleteDaysAfterLastModification()).thenReturn(70);
 
         final List<UpdateAction<ShoppingList>> updateActions = buildActions(oldShoppingList, newShoppingList,
@@ -93,8 +83,6 @@ class ShoppingListSyncUtilsTest {
         assertThat(updateActions).contains(SetSlug.of(newShoppingList.getSlug()));
         assertThat(updateActions).contains(ChangeName.of(newShoppingList.getName()));
         assertThat(updateActions).contains(SetDescription.of(newShoppingList.getDescription()));
-        //TODO: Fix assertion for SetCustomer action
-        //assertThat(updateActions).contains(SetCustomer.of(newCustomerReference));
         assertThat(updateActions).contains(SetAnonymousId.of(newShoppingList.getAnonymousId()));
         assertThat(updateActions).contains(
             SetDeleteDaysAfterLastModification.of(newShoppingList.getDeleteDaysAfterLastModification()));

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
@@ -1,0 +1,61 @@
+package com.commercetools.sync.shoppinglists.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customers.Customer;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetAnonymousId;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDeleteDaysAfterLastModification;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListSyncUtils.buildActions;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ShoppingListSyncUtilsTest {
+    private static final Locale LOCALE = Locale.GERMAN;
+
+    @Test
+    void buildActions_WithDifferentValues_ShouldReturnActions() {
+        final String customerId = "1";
+        final Reference<Customer> oldCustomerReference = Reference.of(Customer.referenceTypeId(), customerId);
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
+        when(oldShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "oldName"));
+        when(oldShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
+        when(oldShoppingList.getCustomer()).thenReturn(oldCustomerReference);
+        when(oldShoppingList.getAnonymousId()).thenReturn("123");
+        when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(50);
+
+        final String newCustomerId = "2";
+        final Reference<Customer> newCustomerReference = Reference.of(Customer.referenceTypeId(), newCustomerId);
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "newSlug"));
+        when(newShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "newName"));
+        when(newShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "newDescription"));
+        when(newShoppingList.getCustomer()).thenReturn(newCustomerReference);
+        when(newShoppingList.getAnonymousId()).thenReturn("567");
+        when(newShoppingList.getDeleteDaysAfterLastModification()).thenReturn(70);
+
+        final List<UpdateAction<ShoppingList>> updateActions = buildActions(oldShoppingList, newShoppingList);
+
+        assertThat(updateActions).isNotEmpty();
+        assertThat(updateActions).contains(SetSlug.of(newShoppingList.getSlug()));
+        assertThat(updateActions).contains(ChangeName.of(newShoppingList.getName()));
+        assertThat(updateActions).contains(SetDescription.of(newShoppingList.getDescription()));
+        //TODO: Fix assertion for SetCustomer action
+        //assertThat(updateActions).contains(SetCustomer.of(newCustomerReference));
+        assertThat(updateActions).contains(SetAnonymousId.of(newShoppingList.getAnonymousId()));
+        assertThat(updateActions).contains(
+            SetDeleteDaysAfterLastModification.of(newShoppingList.getDeleteDaysAfterLastModification()));
+    }
+}

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListSyncUtilsTest.java
@@ -1,28 +1,68 @@
 package com.commercetools.sync.shoppinglists.utils;
 
+import com.commercetools.sync.shoppinglists.ShoppingListSyncOptions;
+import com.commercetools.sync.shoppinglists.ShoppingListSyncOptionsBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+import io.sphere.sdk.shoppinglists.ShoppingListDraftBuilder;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetAnonymousId;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomField;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomType;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetDeleteDaysAfterLastModification;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
+import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.types.CustomFieldsDraftBuilder;
+import io.sphere.sdk.types.Type;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListSyncUtils.buildActions;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ShoppingListSyncUtilsTest {
+class ShoppingListSyncUtilsTest {
     private static final Locale LOCALE = Locale.GERMAN;
+
+    private static final String CUSTOM_TYPE_ID = "id";
+    private static final String CUSTOM_FIELD_NAME = "field";
+    private static final String CUSTOM_FIELD_VALUE = "value";
+
+    private ShoppingList oldShoppingList;
+
+    @BeforeEach
+    void setup() {
+        oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getName()).thenReturn(LocalizedString.ofEnglish("name"));
+
+        // todo (ahmetoz): check why SetDeleteDaysAfterLastModification is created when the line below is removed.
+        when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(null);
+
+        final CustomFields customFields = mock(CustomFields.class);
+        when(customFields.getType()).thenReturn(Type.referenceOfId(CUSTOM_TYPE_ID));
+
+        final Map<String, JsonNode> customFieldsJsonMapMock = new HashMap<>();
+        customFieldsJsonMapMock.put(CUSTOM_FIELD_NAME, JsonNodeFactory.instance.textNode(CUSTOM_FIELD_VALUE));
+        when(customFields.getFieldsJsonMap()).thenReturn(customFieldsJsonMapMock);
+
+        when(oldShoppingList.getCustom()).thenReturn(customFields);
+    }
 
     @Test
     void buildActions_WithDifferentValues_ShouldReturnActions() {
@@ -46,7 +86,8 @@ public class ShoppingListSyncUtilsTest {
         when(newShoppingList.getAnonymousId()).thenReturn("567");
         when(newShoppingList.getDeleteDaysAfterLastModification()).thenReturn(70);
 
-        final List<UpdateAction<ShoppingList>> updateActions = buildActions(oldShoppingList, newShoppingList);
+        final List<UpdateAction<ShoppingList>> updateActions = buildActions(oldShoppingList, newShoppingList,
+            mock(ShoppingListSyncOptions.class));
 
         assertThat(updateActions).isNotEmpty();
         assertThat(updateActions).contains(SetSlug.of(newShoppingList.getSlug()));
@@ -57,5 +98,78 @@ public class ShoppingListSyncUtilsTest {
         assertThat(updateActions).contains(SetAnonymousId.of(newShoppingList.getAnonymousId()));
         assertThat(updateActions).contains(
             SetDeleteDaysAfterLastModification.of(newShoppingList.getDeleteDaysAfterLastModification()));
+    }
+
+    @Test
+    void buildActions_WithDifferentCustomType_ShouldBuildUpdateAction() {
+        final CustomFieldsDraft customFieldsDraft =
+            CustomFieldsDraftBuilder.ofTypeId("newId")
+                                    .addObject("newField", "newValue")
+                                    .build();
+
+        final ShoppingListDraft newShoppingList =
+            ShoppingListDraftBuilder.of(LocalizedString.ofEnglish("name"))
+                                    .custom(customFieldsDraft)
+                                    .build();
+
+        final List<UpdateAction<ShoppingList>> actions = buildActions(oldShoppingList, newShoppingList,
+            ShoppingListSyncOptionsBuilder.of(mock(SphereClient.class)).build());
+
+        Assertions.assertThat(actions).containsExactly(
+            SetCustomType.ofTypeIdAndJson(customFieldsDraft.getType().getId(), customFieldsDraft.getFields()));
+    }
+
+    @Test
+    void buildActions_WithSameCustomTypeWithNewCustomFields_ShouldBuildUpdateAction() {
+        final CustomFieldsDraft sameCustomFieldDraftWithNewCustomField =
+            CustomFieldsDraftBuilder.ofTypeId(CUSTOM_TYPE_ID)
+                                    .addObject(CUSTOM_FIELD_NAME, CUSTOM_FIELD_VALUE)
+                                    .addObject("name_2", "value_2")
+                                    .build();
+
+        final ShoppingListDraft newShoppingList =
+            ShoppingListDraftBuilder.of(LocalizedString.ofEnglish("name"))
+                                    .custom(sameCustomFieldDraftWithNewCustomField)
+                                    .build();
+
+        final List<UpdateAction<ShoppingList>> actions = buildActions(oldShoppingList, newShoppingList,
+            ShoppingListSyncOptionsBuilder.of(mock(SphereClient.class)).build());
+
+        Assertions.assertThat(actions).containsExactly(
+            SetCustomField.ofJson("name_2", JsonNodeFactory.instance.textNode("value_2")));
+    }
+
+    @Test
+    void buildActions_WithSameCustomTypeWithDifferentCustomFieldValues_ShouldBuildUpdateAction() {
+
+        final CustomFieldsDraft sameCustomFieldDraftWithNewValue =
+            CustomFieldsDraftBuilder.ofTypeId(CUSTOM_TYPE_ID)
+                                    .addObject(CUSTOM_FIELD_NAME,
+                                        "newValue")
+                                    .build();
+
+        final ShoppingListDraft newShoppingList =
+            ShoppingListDraftBuilder.of(LocalizedString.ofEnglish("name"))
+                                    .custom(sameCustomFieldDraftWithNewValue)
+                                    .build();
+
+        final List<UpdateAction<ShoppingList>> actions = buildActions(oldShoppingList, newShoppingList,
+            ShoppingListSyncOptionsBuilder.of(mock(SphereClient.class)).build());
+
+        Assertions.assertThat(actions).containsExactly(
+            SetCustomField.ofJson(CUSTOM_FIELD_NAME, JsonNodeFactory.instance.textNode("newValue")));
+    }
+
+    @Test
+    void buildActions_WithJustNewShoppingListHasNullCustomType_ShouldBuildUpdateAction() {
+        final ShoppingListDraft newShoppingList =
+            ShoppingListDraftBuilder.of(LocalizedString.ofEnglish("name"))
+                                    .custom(null)
+                                    .build();
+
+        final List<UpdateAction<ShoppingList>> actions = buildActions(oldShoppingList, newShoppingList,
+            ShoppingListSyncOptionsBuilder.of(mock(SphereClient.class)).build());
+
+        Assertions.assertThat(actions).containsExactly(SetCustomType.ofRemoveType());
     }
 }

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
@@ -4,6 +4,7 @@ import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
@@ -183,8 +184,8 @@ class ShoppingListUpdateActionUtilsTest {
         final ShoppingList oldShoppingList = mock(ShoppingList.class);
         when(oldShoppingList.getCustomer()).thenReturn(customerReference);
 
-        final String newCustomerId = UUID.randomUUID().toString();
-        final Reference<Customer> newCustomerReference = Reference.of(Customer.referenceTypeId(), newCustomerId);
+        final String resolvedCustomerId = UUID.randomUUID().toString();
+        final Reference<Customer> newCustomerReference = Reference.of(Customer.referenceTypeId(), resolvedCustomerId);
         final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
         when(newShoppingList.getCustomer()).thenReturn(newCustomerReference);
 
@@ -193,6 +194,8 @@ class ShoppingListUpdateActionUtilsTest {
 
         assertThat(setCustomerUpdateAction).isNotEmpty();
         assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
+        assertThat(((SetCustomer)setCustomerUpdateAction.get()).getCustomer())
+            .isEqualTo(Reference.of(Customer.referenceTypeId(), resolvedCustomerId));
     }
 
     @Test
@@ -203,7 +206,7 @@ class ShoppingListUpdateActionUtilsTest {
         when(oldShoppingList.getCustomer()).thenReturn(customerReference);
 
         final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
-        when(newShoppingList.getCustomer()).thenReturn(customerReference);
+        when(newShoppingList.getCustomer()).thenReturn(ResourceIdentifier.ofId(customerId));
 
         final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
             buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
@@ -214,17 +217,18 @@ class ShoppingListUpdateActionUtilsTest {
     @Test
     void buildSetCustomerUpdateAction_WithOnlyNewReference_ShouldBuildUpdateAction() {
         final ShoppingList oldShoppingList = mock(ShoppingList.class);
-        final String customerId = UUID.randomUUID().toString();
-        final Reference<Customer> customerReference = Reference.of(Customer.referenceTypeId(), customerId);
 
+        final String newCustomerId = UUID.randomUUID().toString();
         final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
-        when(newShoppingList.getCustomer()).thenReturn(customerReference);
+        when(newShoppingList.getCustomer()).thenReturn(ResourceIdentifier.ofId(newCustomerId));
 
         final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
             buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
 
         assertThat(setCustomerUpdateAction).isNotEmpty();
         assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
+        assertThat(((SetCustomer)setCustomerUpdateAction.get()).getCustomer())
+            .isEqualTo(Reference.of(Customer.referenceTypeId(), newCustomerId));
     }
 
     @Test
@@ -242,7 +246,8 @@ class ShoppingListUpdateActionUtilsTest {
 
         assertThat(setCustomerUpdateAction).isNotEmpty();
         assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
-
+        //Note: If the old value is set, but the new one is empty - the command will unset the customer.
+        assertThat(((SetCustomer) setCustomerUpdateAction.get()).getCustomer()).isNull();
     }
 
     @Test

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
@@ -1,7 +1,6 @@
 package com.commercetools.sync.shoppinglists.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.customergroups.CustomerGroup;
 import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
@@ -319,5 +318,4 @@ class ShoppingListUpdateActionUtilsTest {
         assertThat(setDeleteDaysUpdateAction).isNotNull();
         assertThat(setDeleteDaysUpdateAction).containsInstanceOf(SetDeleteDaysAfterLastModification.class);
     }
-
 }

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
@@ -1,0 +1,118 @@
+package com.commercetools.sync.shoppinglists.utils;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.shoppinglists.ShoppingList;
+import io.sphere.sdk.shoppinglists.ShoppingListDraft;
+import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildChangeNameUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetSlugUpdateAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShoppingListUpdateActionUtilsTest {
+    private static final Locale LOCALE = Locale.GERMAN;
+
+    @Test
+    void buildSetSlugUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "newSlug"));
+
+        final UpdateAction<ShoppingList> setSlugUpdateAction =
+            buildSetSlugUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(setSlugUpdateAction).isNotNull();
+        assertThat(setSlugUpdateAction.getAction()).isEqualTo("setSlug");
+        assertThat(((SetSlug) setSlugUpdateAction).getSlug())
+            .isEqualTo(LocalizedString.of(LOCALE, "newSlug"));
+    }
+
+    @Test
+    void buildSetSlugUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getSlug()).thenReturn(null);
+
+        final UpdateAction<ShoppingList> setSlugUpdateAction =
+            buildSetSlugUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(setSlugUpdateAction).isNotNull();
+        assertThat(setSlugUpdateAction.getAction()).isEqualTo("setSlug");
+        assertThat(((SetSlug) setSlugUpdateAction).getSlug()).isNull();
+    }
+
+    @Test
+    void buildSetSlugUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getSlug()).thenReturn(LocalizedString.of(LOCALE, "oldSlug"));
+
+        final Optional<UpdateAction<ShoppingList>> setSlugUpdateAction =
+            buildSetSlugUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setSlugUpdateAction).isNotNull();
+        assertThat(setSlugUpdateAction).isNotPresent();
+    }
+
+    @Test
+    void buildChangeNameUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "oldName"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "newName"));
+
+        final UpdateAction<ShoppingList> changeNameUpdateAction =
+            buildChangeNameUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(changeNameUpdateAction).isNotNull();
+        assertThat(changeNameUpdateAction.getAction()).isEqualTo("changeName");
+        assertThat(((ChangeName) changeNameUpdateAction).getName()).isEqualTo(LocalizedString.of(LOCALE, "newName"));
+    }
+
+    @Test
+    void buildChangeNameUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "oldName"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getName()).thenReturn(null);
+
+        final UpdateAction<ShoppingList> changeNameUpdateAction =
+            buildChangeNameUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(changeNameUpdateAction).isNotNull();
+        assertThat(changeNameUpdateAction.getAction()).isEqualTo("changeName");
+        assertThat(((ChangeName) changeNameUpdateAction).getName()).isNull();
+    }
+
+    @Test
+    void buildChangeNameUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getName()).thenReturn(LocalizedString.of(LOCALE, "oldName"));
+
+        final ShoppingListDraft newShoppingListWithSameName = mock(ShoppingListDraft.class);
+        when(newShoppingListWithSameName.getName())
+            .thenReturn(LocalizedString.of(LOCALE, "oldName"));
+
+        final Optional<UpdateAction<ShoppingList>> changeNameUpdateAction =
+            buildChangeNameUpdateAction(oldShoppingList, newShoppingListWithSameName);
+
+        assertThat(changeNameUpdateAction).isNotNull();
+        assertThat(changeNameUpdateAction).isNotPresent();
+    }
+}

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
@@ -5,6 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildChangeNameUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDescriptionUpdateAction;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetSlugUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -115,4 +117,54 @@ class ShoppingListUpdateActionUtilsTest {
         assertThat(changeNameUpdateAction).isNotNull();
         assertThat(changeNameUpdateAction).isNotPresent();
     }
+
+    @Test
+    void buildSetDescriptionUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "newDescription"));
+
+        final UpdateAction<ShoppingList> setDescriptionUpdateAction =
+            buildSetDescriptionUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(setDescriptionUpdateAction).isNotNull();
+        assertThat(setDescriptionUpdateAction.getAction()).isEqualTo("setDescription");
+        assertThat(((SetDescription) setDescriptionUpdateAction).getDescription())
+            .isEqualTo(LocalizedString.of(LOCALE, "newDescription"));
+    }
+
+    @Test
+    void buildSetDescriptionUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getDescription()).thenReturn(null);
+
+        final UpdateAction<ShoppingList> setDescriptionUpdateAction =
+            buildSetDescriptionUpdateAction(oldShoppingList, newShoppingList).orElse(null);
+
+        assertThat(setDescriptionUpdateAction).isNotNull();
+        assertThat(setDescriptionUpdateAction.getAction()).isEqualTo("setDescription");
+        assertThat(((SetDescription) setDescriptionUpdateAction).getDescription()).isEqualTo(null);
+    }
+
+    @Test
+    void buildSetDescriptionUpdateAction_WithSameValues_ShouldNotBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getDescription()).thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getDescription())
+            .thenReturn(LocalizedString.of(LOCALE, "oldDescription"));
+
+        final Optional<UpdateAction<ShoppingList>> setDescriptionUpdateAction =
+            buildSetDescriptionUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setDescriptionUpdateAction).isNotNull();
+        assertThat(setDescriptionUpdateAction).isNotPresent();
+    }
+
 }

--- a/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/utils/ShoppingListUpdateActionUtilsTest.java
@@ -1,18 +1,28 @@
 package com.commercetools.sync.shoppinglists.utils;
 
 import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customergroups.CustomerGroup;
+import io.sphere.sdk.customers.Customer;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.shoppinglists.ShoppingList;
 import io.sphere.sdk.shoppinglists.ShoppingListDraft;
 import io.sphere.sdk.shoppinglists.commands.updateactions.ChangeName;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetAnonymousId;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetCustomer;
+import io.sphere.sdk.shoppinglists.commands.updateactions.SetDeleteDaysAfterLastModification;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetDescription;
 import io.sphere.sdk.shoppinglists.commands.updateactions.SetSlug;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildChangeNameUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetAnonymousIdUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetCustomerUpdateAction;
+import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDeleteDaysAfterLastModificationUpdateAction;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetDescriptionUpdateAction;
 import static com.commercetools.sync.shoppinglists.utils.ShoppingListUpdateActionUtils.buildSetSlugUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,6 +175,149 @@ class ShoppingListUpdateActionUtilsTest {
 
         assertThat(setDescriptionUpdateAction).isNotNull();
         assertThat(setDescriptionUpdateAction).isNotPresent();
+    }
+
+    @Test
+    void buildSetCustomerUpdateAction_WithDifferentReference_ShouldBuildUpdateAction() {
+        final String customerId = UUID.randomUUID().toString();
+        final Reference<Customer> customerReference = Reference.of(Customer.referenceTypeId(), customerId);
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getCustomer()).thenReturn(customerReference);
+
+        final String newCustomerId = UUID.randomUUID().toString();
+        final Reference<Customer> newCustomerReference = Reference.of(Customer.referenceTypeId(), newCustomerId);
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getCustomer()).thenReturn(newCustomerReference);
+
+        final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
+            buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setCustomerUpdateAction).isNotEmpty();
+        assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
+    }
+
+    @Test
+    void buildSetCustomerUpdateAction_WithSameReference_ShouldNotBuildUpdateAction() {
+        final String customerId = UUID.randomUUID().toString();
+        final Reference<Customer> customerReference = Reference.of(Customer.referenceTypeId(), customerId);
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getCustomer()).thenReturn(customerReference);
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getCustomer()).thenReturn(customerReference);
+
+        final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
+            buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setCustomerUpdateAction).isEmpty();
+    }
+
+    @Test
+    void buildSetCustomerUpdateAction_WithOnlyNewReference_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        final String customerId = UUID.randomUUID().toString();
+        final Reference<Customer> customerReference = Reference.of(Customer.referenceTypeId(), customerId);
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getCustomer()).thenReturn(customerReference);
+
+        final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
+            buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setCustomerUpdateAction).isNotEmpty();
+        assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
+    }
+
+    @Test
+    void buildSetCustomerUpdateAction_WithoutNewReference_ShouldReturnUnsetAction() {
+        final String customerId = UUID.randomUUID().toString();
+        final Reference<Customer> customerReference = Reference.of(Customer.referenceTypeId(), customerId);
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getCustomer()).thenReturn(customerReference);
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getCustomer()).thenReturn(null);
+
+        final Optional<UpdateAction<ShoppingList>> setCustomerUpdateAction =
+            buildSetCustomerUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setCustomerUpdateAction).isNotEmpty();
+        assertThat(setCustomerUpdateAction).containsInstanceOf(SetCustomer.class);
+
+    }
+
+    @Test
+    void buildSetAnonymousId_WithDifferentValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getAnonymousId()).thenReturn("123");
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getAnonymousId()).thenReturn("567");
+
+        final Optional<UpdateAction<ShoppingList>> setAnonymousIdUpdateAction =
+            buildSetAnonymousIdUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setAnonymousIdUpdateAction).isNotNull();
+        assertThat(setAnonymousIdUpdateAction).containsInstanceOf(SetAnonymousId.class);
+    }
+
+    @Test
+    void buildSetAnonymousId_WithNullValues_ShouldBuildUpdateActions() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getAnonymousId()).thenReturn("123");
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getAnonymousId()).thenReturn(null);
+
+        final Optional<UpdateAction<ShoppingList>> setAnonymousIdUpdateAction =
+            buildSetAnonymousIdUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setAnonymousIdUpdateAction).isNotNull();
+        assertThat(setAnonymousIdUpdateAction).containsInstanceOf(SetAnonymousId.class);
+    }
+
+    @Test
+    void buildSetAnonymousId_WithSameValues_ShouldNotBuildUpdateActions() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getAnonymousId()).thenReturn("123");
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getAnonymousId()).thenReturn("123");
+
+        final Optional<UpdateAction<ShoppingList>> setAnonymousIdUpdateAction =
+            buildSetAnonymousIdUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setAnonymousIdUpdateAction).isEmpty();
+    }
+
+    @Test
+    void buildSetDeleteDaysAfterLastModificationUpdateAction_WithDifferentValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(50);
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getDeleteDaysAfterLastModification()).thenReturn(70);
+
+        final Optional<UpdateAction<ShoppingList>> setDeleteDaysUpdateAction =
+            buildSetDeleteDaysAfterLastModificationUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setDeleteDaysUpdateAction).isNotNull();
+        assertThat(setDeleteDaysUpdateAction).containsInstanceOf(SetDeleteDaysAfterLastModification.class);
+    }
+
+    @Test
+    void buildSetDeleteDaysAfterLastModificationUpdateAction_WithNullValues_ShouldBuildUpdateAction() {
+        final ShoppingList oldShoppingList = mock(ShoppingList.class);
+        when(oldShoppingList.getDeleteDaysAfterLastModification()).thenReturn(50);
+
+        final ShoppingListDraft newShoppingList = mock(ShoppingListDraft.class);
+        when(newShoppingList.getDeleteDaysAfterLastModification()).thenReturn(null);
+
+        final Optional<UpdateAction<ShoppingList>> setDeleteDaysUpdateAction =
+            buildSetDeleteDaysAfterLastModificationUpdateAction(oldShoppingList, newShoppingList);
+
+        assertThat(setDeleteDaysUpdateAction).isNotNull();
+        assertThat(setDeleteDaysUpdateAction).containsInstanceOf(SetDeleteDaysAfterLastModification.class);
     }
 
 }


### PR DESCRIPTION
The PR consists of the update actions and its unit tests.

Note: The implementation does not have line item and text line item actions, will be part of a later PR.