### PR TITLE
Collection of improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext{
     commercetoolsJvmSdkVersion = '1.59.0'
-    mockitoJunitJupiterVersion = '3.7.7'
+    mockitoJunitJupiterVersion = '3.8.0'
     jupiterApiVersion = '5.7.0'
     assertjVersion = '3.19.0'
     pmdVersion = '6.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply from: "$rootDir/gradle-scripts/spotless.gradle"
 
 dependencies {
     implementation "com.commercetools.sdk.jvm.core:commercetools-models:${commercetoolsJvmSdkVersion}"
-    implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${commercetoolsJvmSdkVersion}"
+    implementation "com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:${commercetoolsJvmSdkVersion}"
     implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoJunitJupiterVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.ajoberstar.grgit' version '4.1.0'
     id "com.github.ben-manes.versions" version '0.36.0'
     id 'ru.vyarus.mkdocs' version '2.0.1'
-    id "com.github.spotbugs" version "4.6.0"
+    id "com.github.spotbugs" version "4.6.2"
     id 'com.diffplug.spotless' version '5.9.0'
 }
 

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -44,7 +44,7 @@
 ````groovy
 // Add commercetools-jvm-sdk dependencies.
 implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.57.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client:1.57.0'
+implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:1.57.0'
 implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.57.0'
 
 // Add commercetools-sync-java dependency.

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/CategoryITUtils.java
@@ -6,8 +6,6 @@ import static io.sphere.sdk.models.ResourceIdentifier.ofKey;
 import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
 
-import com.commercetools.sync.categories.CategorySync;
-import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
@@ -34,7 +32,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -269,33 +266,6 @@ public final class CategoryITUtils {
     final List<Reference<Category>> categoryAncestors = category.getAncestors();
     return categoryAncestors.stream()
         .anyMatch(ancestor -> keysOfDeletedAncestors.contains(ancestor.getObj().getKey()));
-  }
-
-  /**
-   * Given a list of {@link CategoryDraft} batches represented by a {@link List}&lt;{@link
-   * List}&lt;{@link CategoryDraft}&gt;&gt; and an instance of {@link CategorySync}, this method
-   * recursively calls sync by the instance of {@link CategorySync} on each batch, then removes it,
-   * until there are no more batches, in other words, all batches have been synced.
-   *
-   * @param categorySync the categorySync instance to sync with each batch of {@link CategoryDraft}
-   * @param batches the batches of {@link CategoryDraft} to sync.
-   * @param result in the first call of this recursive method, this result is normally a completed
-   *     future, it used from within the method to recursively sync each batch once the previous
-   *     batch has finished syncing.
-   * @return an instance of {@link CompletionStage} which contains as a result an instance of {@link
-   *     CategorySyncStatistics} representing the {@code statistics} of the sync process executed on
-   *     the given list of batches.
-   */
-  public static CompletionStage<CategorySyncStatistics> syncBatches(
-      @Nonnull final CategorySync categorySync,
-      @Nonnull final List<List<CategoryDraft>> batches,
-      @Nonnull final CompletionStage<CategorySyncStatistics> result) {
-    if (batches.isEmpty()) {
-      return result;
-    }
-    final List<CategoryDraft> firstBatch = batches.remove(0);
-    return syncBatches(
-        categorySync, batches, result.thenCompose(subResult -> categorySync.sync(firstBatch)));
   }
 
   /**

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ITUtils.java
@@ -248,7 +248,6 @@ public final class ITUtils {
       @Nonnull final QueryDsl<T, C> query,
       @Nonnull final Function<T, CompletionStage<S>> resourceToStageMapper) {
 
-    // TODO: GITHUB ISSUE #248
     final Consumer<List<T>> pageConsumer =
         pageElements ->
             CompletableFuture.allOf(
@@ -404,8 +403,6 @@ public final class ITUtils {
    * Asserts that a list of {@link Asset} and a list of {@link AssetDraft} have the same ordering of
    * assets (assets are matched by key). It asserts that the matching assets have the same name,
    * description, custom fields, tags, and asset sources.
-   *
-   * <p>TODO: This should be refactored into Asset asserts helpers. GITHUB ISSUE#261
    *
    * @param assets the list of assets to compare to the list of asset drafts.
    * @param assetDrafts the list of asset drafts to compare to the list of assets.

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -132,8 +132,6 @@ public final class ProductITUtils {
    * Gets the supplied {@link ProductDraft} with the price reference attached on all its variants'
    * prices.
    *
-   * <p>TODO: GITHUB ISSUE#152
-   *
    * @param productDraft the product draft to attach the channel reference on its variants' prices.
    * @param channelReference the channel reference to attach on the product draft's variants'
    *     prices.
@@ -179,8 +177,6 @@ public final class ProductITUtils {
    * Builds a list of {@link PriceDraft} elements which are identical to the supplied {@link
    * ProductVariantDraft}'s list of prices and sets the channel and custom type references on the
    * prices if they are not null.
-   *
-   * <p>TODO: GITHUB ISSUE#152
    *
    * @param productVariant the product variant to create an identical price list from.
    * @param channelReference the channel reference to set on the resulting price drafts.

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
@@ -8,11 +8,11 @@ import static io.sphere.sdk.states.commands.updateactions.SetTransitions.of;
 import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
 
+import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
-import io.sphere.sdk.queries.QueryExecutionUtils;
 import io.sphere.sdk.queries.QueryPredicate;
 import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateDraft;
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -61,9 +63,13 @@ public final class StateITUtils {
    */
   public static <T extends State> void deleteStates(@Nonnull final SphereClient ctpClient) {
     // delete transitions
-    QueryExecutionUtils.queryAll(
+    CtpQueryUtils.queryAll(
             ctpClient,
-            StateQueryBuilder.of().plusPredicates(QueryPredicate.of("builtIn = false")).build())
+            StateQueryBuilder.of().plusPredicates(QueryPredicate.of("builtIn = false")).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenCompose(
             result -> {
               final List<CompletionStage<State>> clearStates = new ArrayList<>();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.AfterAll;
@@ -830,15 +829,8 @@ class CategorySyncIT {
 
     assertThat(syncStatistics).hasValues(2, 1, 0, 0, 1);
 
-    final Map<String, Set<String>> categoryKeysWithMissingParents =
-        syncStatistics.getCategoryKeysWithMissingParents();
-    assertThat(categoryKeysWithMissingParents).hasSize(1);
-
-    final Set<String> missingParentsChildren =
-        categoryKeysWithMissingParents.get(nonExistingParentKey);
-    assertThat(missingParentsChildren).hasSize(1);
-
-    final String childKey = missingParentsChildren.iterator().next();
+    final String childKey =
+        syncStatistics.getChildrenKeys(categoryDraftWithMissingParent.getKey()).iterator().next();
     assertThat(childKey).isEqualTo(categoryDraftWithMissingParent.getKey());
   }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/categories/CategorySyncIT.java
@@ -290,10 +290,7 @@ class CategorySyncIT {
     assertThat(errors.get(0).getCause()).isExactlyInstanceOf(BadGatewayException.class);
     assertThat(errorMessages.get(0))
         .contains(
-            format(
-                "Failed to update Category with key: '%s'. Reason: Failed to fetch from CTP while retrying "
-                    + "after concurrency modification.",
-                categoryDraft.getKey()));
+            "Reason: Failed to fetch from CTP while retrying after concurrency modification.");
   }
 
   @Nonnull
@@ -554,7 +551,7 @@ class CategorySyncIT {
             .toCompletableFuture()
             .join();
 
-    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+    assertThat(syncStatistics).hasValues(2, 0, 2, 0, 0);
 
     final Optional<Category> optionalResult =
         CTP_TARGET_CLIENT
@@ -828,9 +825,5 @@ class CategorySyncIT {
         categorySync.sync(categoryDrafts).toCompletableFuture().join();
 
     assertThat(syncStatistics).hasValues(2, 1, 0, 0, 1);
-
-    final String childKey =
-        syncStatistics.getChildrenKeys(categoryDraftWithMissingParent.getKey()).iterator().next();
-    assertThat(childKey).isEqualTo(categoryDraftWithMissingParent.getKey());
   }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithPricesIT.java
@@ -1218,8 +1218,6 @@ class ProductSyncWithPricesIT {
    * prices (prices are matched by key). It asserts that the matching assets have the same name,
    * description, custom fields, tags, and asset sources.
    *
-   * <p>TODO: This should be refactored into Asset asserts helpers. GITHUB ISSUE#261
-   *
    * @param prices the list of prices to compare to the list of price drafts.
    * @param priceDrafts the list of price drafts to compare to the list of prices.
    */

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/states/StateSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/states/StateSyncIT.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.commercetools.sync.commons.helpers.ResourceKeyIdGraphQlRequest;
 import com.commercetools.sync.commons.models.WaitingToBeResolvedTransitions;
+import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import com.commercetools.sync.services.UnresolvedReferencesService;
 import com.commercetools.sync.services.impl.StateServiceImpl;
 import com.commercetools.sync.services.impl.UnresolvedReferencesServiceImpl;
@@ -40,7 +41,6 @@ import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.queries.PagedQueryResult;
-import io.sphere.sdk.queries.QueryExecutionUtils;
 import io.sphere.sdk.states.State;
 import io.sphere.sdk.states.StateDraft;
 import io.sphere.sdk.states.StateDraftBuilder;
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
@@ -176,8 +177,13 @@ class StateSyncIT {
         stateSync.sync(singletonList(stateDraft)).toCompletableFuture().join();
 
     assertThat(stateSyncStatistics).hasValues(1, 0, 1, 0, 0);
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);
@@ -205,8 +211,13 @@ class StateSyncIT {
         stateSync.sync(singletonList(stateDraft)).toCompletableFuture().join();
 
     assertThat(stateSyncStatistics).hasValues(1, 0, 1, 0, 0);
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);
@@ -236,8 +247,13 @@ class StateSyncIT {
         stateSync.sync(singletonList(stateDraft)).toCompletableFuture().join();
 
     assertThat(stateSyncStatistics).hasValues(1, 0, 1, 0, 0);
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);
@@ -722,8 +738,13 @@ class StateSyncIT {
 
     assertThat(stateSyncStatistics).hasValues(3, 0, 1, 0, 0);
 
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);
@@ -802,8 +823,13 @@ class StateSyncIT {
 
     assertThat(stateSyncStatistics).hasValues(3, 0, 1, 0, 0);
 
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);
@@ -843,8 +869,13 @@ class StateSyncIT {
 
     assertThat(stateSyncStatistics).hasValues(3, 0, 1, 0, 0);
 
-    QueryExecutionUtils.queryAll(
-            CTP_TARGET_CLIENT, StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build())
+    CtpQueryUtils.queryAll(
+            CTP_TARGET_CLIENT,
+            StateQueryBuilder.of().plusPredicates(q -> q.key().is(keyA)).build(),
+            Function.identity())
+        .thenApply(
+            fetchedCategories ->
+                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenAccept(
             resultStates -> {
               Assertions.assertThat(resultStates.size()).isEqualTo(1);

--- a/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/inventories/InventorySyncIT.java
@@ -492,15 +492,7 @@ class InventorySyncIT {
     CompletableFuture.allOf(firstResult, secondResult, thirdResult).join();
 
     // Ensure instance's statistics.
-    assertThat(inventorySync.getStatistics()).isNotNull();
-
-    // TODO check distinct results when ISSUE #23 is resolved
-    // TODO uncomment assertions below when ISSUE #23 is resolved (otherwise they may fail)
-
-    // assertThat(inventorySync.getStatistics().getProcessed()).isEqualTo(60);
-    // assertThat(inventorySync.getStatistics().getCreated()).isEqualTo(60);
-    // assertThat(inventorySync.getStatistics().getUpdated()).isEqualTo(0);
-    // assertThat(inventorySync.getStatistics().getFailed()).isEqualTo(0);
+    assertThat(inventorySync.getStatistics()).hasValues(60, 60, 0, 0);
   }
 
   private void assertValues(

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -172,10 +172,6 @@ public class CategorySync
       @Nonnull final Set<CategoryDraft> categoryDrafts,
       @Nonnull final Map<String, String> keyToIdCache) {
 
-    if (categoryDrafts.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
-    }
-
     final Set<String> categoryDraftKeys =
         categoryDrafts.stream().map(CategoryDraft::getKey).collect(Collectors.toSet());
 

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -1,22 +1,20 @@
 package com.commercetools.sync.categories;
 
-import static com.commercetools.sync.categories.helpers.CategoryReferenceResolver.getParentCategoryKey;
 import static com.commercetools.sync.categories.utils.CategorySyncUtils.buildActions;
 import static com.commercetools.sync.commons.utils.CommonTypeUpdateActionUtils.areResourceIdentifiersEqual;
-import static com.commercetools.sync.commons.utils.CompletableFutureUtils.mapValuesToFutureOfCompletedValues;
-import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.toResourceIdentifierIfNotNull;
 import static com.commercetools.sync.commons.utils.SyncUtils.batchElements;
 import static com.commercetools.sync.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY;
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.stream.Collectors.toSet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 import com.commercetools.sync.categories.helpers.CategoryBatchValidator;
 import com.commercetools.sync.categories.helpers.CategoryReferenceResolver;
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.commons.BaseSync;
-import com.commercetools.sync.commons.exceptions.ReferenceResolutionException;
 import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.commons.models.WaitingToBeResolvedCategories;
 import com.commercetools.sync.services.CategoryService;
@@ -27,10 +25,9 @@ import com.commercetools.sync.services.impl.TypeServiceImpl;
 import com.commercetools.sync.services.impl.UnresolvedReferencesServiceImpl;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
-import io.sphere.sdk.categories.CategoryDraftBuilder;
 import io.sphere.sdk.client.ConcurrentModificationException;
 import io.sphere.sdk.commands.UpdateAction;
-import java.util.ArrayList;
+import io.sphere.sdk.models.ResourceIdentifier;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -50,6 +47,8 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class CategorySync
     extends BaseSync<CategoryDraft, CategorySyncStatistics, CategorySyncOptions> {
 
+  private static final String FAILED_TO_FETCH =
+      "Failed to fetch existing categories with keys: '%s'. Reason: %s";
   private static final String FAILED_TO_PROCESS =
       "Failed to process the CategoryDraft with key: '%s'. Reason: %s";
   private static final String UPDATE_FAILED =
@@ -62,31 +61,8 @@ public class CategorySync
   private final CategoryReferenceResolver referenceResolver;
   private final CategoryBatchValidator batchValidator;
 
-  /**
-   * The following set ({@code processedCategoryKeys}) is thread-safe because it is
-   * accessed/modified in a concurrent context, specifically when updating products in parallel in
-   * {@link #updateCategory(Category, CategoryDraft, List)}. It also has a global scope across the
-   * entire sync process, which means the same instance is used across all batch executions.
-   */
-  private final ConcurrentHashMap.KeySetView<String, Boolean> processedCategoryKeys =
-      ConcurrentHashMap.newKeySet();
-
-  /**
-   * The following map ({@code categoryDraftsToUpdate}) are thread-safe because they are
-   * accessed/modified in a concurrent context, specifically when updating products in parallel in
-   * {@link #updateCategoriesInParallel(Map)}. They have a local scope within every batch execution,
-   * which means that they are re-initialized on every {@link #processBatch(List)} call.
-   */
-  private ConcurrentHashMap<CategoryDraft, Category> categoryDraftsToUpdate =
-      new ConcurrentHashMap<>();
-
-  /**
-   * The following set {@code referencesResolvedDrafts} is not thread-safe because they are
-   * accessed/modified in a non-concurrent/sequential context. They have a local scope within every
-   * batch execution, which means that they are re-initialized on every {@link #processBatch(List)}
-   * call.
-   */
-  private final Set<CategoryDraft> referencesResolvedDrafts = new HashSet<>();
+  private ConcurrentHashMap.KeySetView<String, Boolean> readyToResolve;
+  private ConcurrentHashMap<CategoryDraft, Category> categoryDraftsToUpdateSequentially;
 
   /**
    * Takes a {@link CategorySyncOptions} instance to instantiate a new {@link CategorySync} instance
@@ -104,22 +80,6 @@ public class CategorySync
         new UnresolvedReferencesServiceImpl<>(syncOptions));
   }
 
-  /**
-   * Takes a {@link CategorySyncOptions}, a {@link TypeService} and {@link CategoryService}
-   * instances to instantiate a new {@link CategorySync} instance that could be used to sync
-   * categories or category drafts with the given categories in the CTP project specified in the
-   * injected {@link CategorySyncOptions} instance.
-   *
-   * <p>NOTE: This constructor is mainly to be used for tests where the services can be mocked and
-   * passed to.
-   *
-   * @param syncOptions the container of all the options of the sync process including the CTP
-   *     project client and/or configuration and other sync-specific options.
-   * @param typeService the type service which is responsible for fetching/caching the Types from
-   *     the CTP project.
-   * @param categoryService the category service which is responsible for fetching, creating and
-   *     updating categories from and to the CTP project.
-   */
   CategorySync(
       @Nonnull final CategorySyncOptions syncOptions,
       @Nonnull final TypeService typeService,
@@ -135,23 +95,6 @@ public class CategorySync
     this.batchValidator = new CategoryBatchValidator(getSyncOptions(), getStatistics());
   }
 
-  /**
-   * Given a list of {@code CategoryDraft} that represent a batch of category drafts, this method
-   * for the first batch only caches a list of all the categories in the CTP project in a cached map
-   * that representing each category's key to the id. It then validates the category drafts, then
-   * resolves all the references. Then it creates all categories that need to be created in parallel
-   * while keeping track of the categories that have their non-existing parents. Then it does update
-   * actions that don't require parent changes in parallel. Then in a blocking fashion issues update
-   * actions that don't involve parent changes sequentially.
-   *
-   * <p>More on the exact implementation of how the sync works here:
-   * https://sphere.atlassian.net/wiki/spaces/PS/pages/145193124/Category+Parallelisation+Technical+Concept
-   *
-   * @param categoryDrafts the list of new category drafts to sync to the CTP project.
-   * @return an instance of {@link CompletionStage}&lt;{@link CategorySyncStatistics}&gt; which
-   *     contains as a result an instance of {@link CategorySyncStatistics} representing the {@code
-   *     statistics} instance attribute of {@code this} {@link CategorySync}.
-   */
   @Override
   protected CompletionStage<CategorySyncStatistics> process(
       @Nonnull final List<CategoryDraft> categoryDrafts) {
@@ -185,8 +128,9 @@ public class CategorySync
   protected CompletionStage<CategorySyncStatistics> processBatch(
       @Nonnull final List<CategoryDraft> categoryDrafts) {
 
-    categoryDraftsToUpdate = new ConcurrentHashMap<>();
-    final int numberOfNewDraftsToProcess = getNumberOfDraftsToProcess(categoryDrafts);
+    readyToResolve = ConcurrentHashMap.newKeySet();
+    categoryDraftsToUpdateSequentially = new ConcurrentHashMap<>();
+
     final ImmutablePair<Set<CategoryDraft>, CategoryBatchValidator.ReferencedKeys> result =
         batchValidator.validateAndCollectReferencedKeys(categoryDrafts);
 
@@ -204,421 +148,203 @@ public class CategorySync
               final Throwable cachingException = cachingResponse.getValue();
               if (cachingException != null) {
                 handleError(
-                    new SyncException("Failed to build a cache of keys to ids.", cachingException),
+                    "Failed to build a cache of keys to ids.",
+                    cachingException,
+                    null,
+                    null,
+                    null,
                     validDrafts.size());
                 return completedFuture(null);
               }
 
-              final Map<String, String> categoryKeyToIdCache = cachingResponse.getKey();
-              return createAndUpdate(
-                  prepareDraftsForProcessing(new ArrayList<>(validDrafts), categoryKeyToIdCache),
-                  categoryKeyToIdCache);
+              final Map<String, String> keyToIdCache = cachingResponse.getKey();
+              return syncBatch(validDrafts, keyToIdCache);
             })
         .thenApply(
             ignoredResult -> {
-              statistics.incrementProcessed(numberOfNewDraftsToProcess);
+              statistics.incrementProcessed(categoryDrafts.size());
               return statistics;
             });
   }
 
-  /**
-   * Given a list of {@code CategoryDraft} elements, this method calculates the number of drafts
-   * that need to be processed in this batch, given they weren't processed before, plus the number
-   * of null drafts and drafts with null keys. Drafts which were processed before, will have their
-   * keys stored in {@code processedCategoryKeys}.
-   *
-   * @param categoryDrafts the input list of category drafts in the sync batch.
-   * @return the number of drafts that are needed to be processed.
-   */
-  private int getNumberOfDraftsToProcess(@Nonnull final List<CategoryDraft> categoryDrafts) {
-    final long numberOfNullCategoryDrafts = categoryDrafts.stream().filter(Objects::isNull).count();
-
-    final long numberOfCategoryDraftsNotProcessedBefore =
-        categoryDrafts.stream()
-            .filter(Objects::nonNull)
-            .map(CategoryDraft::getKey)
-            .filter(
-                categoryDraftKey ->
-                    categoryDraftKey == null || !processedCategoryKeys.contains(categoryDraftKey))
-            .count();
-
-    return (int) (numberOfCategoryDraftsNotProcessedBefore + numberOfNullCategoryDrafts);
-  }
-
-  private CompletionStage<Void> fetchAndUpdate(
-      @Nonnull final Set<CategoryDraft> existingCategories,
+  @Nonnull
+  private CompletionStage<Void> syncBatch(
+      @Nonnull final Set<CategoryDraft> categoryDrafts,
       @Nonnull final Map<String, String> keyToIdCache) {
 
-    Set<String> categoryKeysToFetch =
-        existingCategories.stream().map(CategoryDraft::getKey).collect(toSet());
+    if (categoryDrafts.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final Set<String> categoryDraftKeys =
+        categoryDrafts.stream().map(CategoryDraft::getKey).collect(Collectors.toSet());
+
     return categoryService
-        .fetchMatchingCategoriesByKeys(categoryKeysToFetch)
+        .fetchMatchingCategoriesByKeys(categoryDraftKeys)
         .handle(ImmutablePair::new)
         .thenCompose(
             fetchResponse -> {
-              final Set<Category> fetchedCategories = fetchResponse.getKey();
+              final Throwable fetchException = fetchResponse.getValue();
+              if (fetchException != null) {
+                final String errorMessage =
+                    format(FAILED_TO_FETCH, categoryDraftKeys, fetchException.getMessage());
+                handleError(
+                    errorMessage, fetchException, null, null, null, categoryDraftKeys.size());
+                return CompletableFuture.completedFuture(null);
+              } else {
+                final Set<Category> matchingCategories = fetchResponse.getKey();
+                return syncOrKeepTrack(categoryDrafts, matchingCategories, keyToIdCache)
+                    .thenCompose(
+                        aVoid -> updateCategoriesSequentially(categoryDraftsToUpdateSequentially))
+                    .thenCompose(aVoid -> resolveNowReadyReferences(keyToIdCache));
+              }
+            });
+  }
+
+  /**
+   * Given a set of category drafts, for each new draft: if it doesn't have any parent category
+   * reference which are missing, it syncs the new draft. However, if it does have missing parent
+   * category reference, it keeps track of it by persisting it.
+   *
+   * @param oldCategories old category types.
+   * @param newCategories drafts that need to be synced.
+   * @return a {@link CompletionStage} which contains an empty result after execution of the update
+   */
+  @Nonnull
+  private CompletionStage<Void> syncOrKeepTrack(
+      @Nonnull final Set<CategoryDraft> newCategories,
+      @Nonnull final Set<Category> oldCategories,
+      @Nonnull final Map<String, String> keyToIdCache) {
+
+    return allOf(
+        newCategories.stream()
+            .map(
+                newDraft -> {
+                  final Optional<String> missingReferencedParentCategoryKey =
+                      getMissingReferencedParentCategoryKey(newDraft, keyToIdCache);
+
+                  if (missingReferencedParentCategoryKey.isPresent()) {
+                    return keepTrackOfMissingReference(
+                        newDraft, missingReferencedParentCategoryKey.get());
+                  } else {
+                    return syncDraft(oldCategories, newDraft);
+                  }
+                })
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+  }
+
+  private Optional<String> getMissingReferencedParentCategoryKey(
+      @Nonnull final CategoryDraft newCategory, @Nonnull final Map<String, String> keyToIdCache) {
+
+    final String parentCategoryKey =
+        Optional.ofNullable(newCategory.getParent()).map(ResourceIdentifier::getKey).orElse(null);
+
+    if (StringUtils.isBlank(parentCategoryKey) || keyToIdCache.containsKey(parentCategoryKey)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(parentCategoryKey);
+  }
+
+  private CompletionStage<Optional<WaitingToBeResolvedCategories>> keepTrackOfMissingReference(
+      @Nonnull final CategoryDraft newCategory, @Nonnull final String parentCategoryKey) {
+
+    statistics.addMissingDependency(parentCategoryKey, newCategory.getKey());
+    return unresolvedReferencesService.save(
+        new WaitingToBeResolvedCategories(newCategory, Collections.singleton(parentCategoryKey)),
+        CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+        WaitingToBeResolvedCategories.class);
+  }
+
+  @Nonnull
+  private CompletionStage<Void> syncDraft(
+      @Nonnull final Set<Category> oldCategories, @Nonnull final CategoryDraft newCategory) {
+
+    final Map<String, Category> oldCategoryMap =
+        oldCategories.stream().collect(toMap(Category::getKey, identity()));
+
+    return referenceResolver
+        .resolveReferences(newCategory)
+        .thenCompose(
+            resolvedDraft -> {
+              final Category oldCategory = oldCategoryMap.get(newCategory.getKey());
+
+              return ofNullable(oldCategory)
+                  .map(category -> fetchAndUpdate(category, resolvedDraft))
+                  .orElseGet(() -> applyCallbackAndCreate(resolvedDraft));
+            })
+        .exceptionally(
+            completionException -> {
+              final String errorMessage =
+                  format(FAILED_TO_PROCESS, newCategory.getKey(), completionException.getMessage());
+              handleError(errorMessage, completionException, null, newCategory, null, 1);
+              return null;
+            });
+  }
+
+  @Nonnull
+  private CompletionStage<Void> applyCallbackAndCreate(@Nonnull final CategoryDraft categoryDraft) {
+    return syncOptions
+        .applyBeforeCreateCallback(categoryDraft)
+        .map(
+            draft ->
+                categoryService
+                    .createCategory(draft)
+                    .thenAccept(
+                        categoryOptional -> {
+                          if (categoryOptional.isPresent()) {
+                            readyToResolve.add(categoryDraft.getKey());
+                            statistics.incrementCreated();
+                          } else {
+                            statistics.incrementFailed();
+                          }
+                        }))
+        .orElse(completedFuture(null));
+  }
+
+  @Nonnull
+  private CompletionStage<Void> fetchAndUpdate(
+      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
+
+    String key = oldCategory.getKey();
+    return categoryService
+        .fetchCategory(key)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchResponse -> {
+              Optional<Category> fetchedCategoryOptional = fetchResponse.getKey();
               final Throwable exception = fetchResponse.getValue();
 
               if (exception != null) {
                 final String errorMessage =
                     format(
-                        "Failed to fetch existing categories with keys: '%s'.",
-                        categoryKeysToFetch);
-                handleError(new SyncException(errorMessage, exception), categoryKeysToFetch.size());
+                        FAILED_TO_FETCH,
+                        key,
+                        "Failed to fetch from CTP while retrying after concurrency modification.");
+                handleError(errorMessage, exception, oldCategory, newCategory, null, 1);
                 return completedFuture(null);
               }
 
-              return processFetchedCategoriesAndUpdate(keyToIdCache, fetchedCategories);
-            });
-  }
-
-  @Nonnull
-  private CompletionStage<Void> processFetchedCategoriesAndUpdate(
-      @Nonnull final Map<String, String> keyToIdCache,
-      @Nonnull final Set<Category> fetchedCategories) {
-
-    processFetchedCategories(fetchedCategories, referencesResolvedDrafts, keyToIdCache);
-    updateCategoriesSequentially(categoryDraftsToUpdate);
-    return updateCategoriesInParallel(categoryDraftsToUpdate);
-  }
-
-  /**
-   * This method does the following on each category draft input in the sync batch:
-   *
-   * <ol>
-   *   <li>First it checks if the category, have a resolvable parent category. If not, the category
-   *       is saved in a customobject and its key is added to the map {@code
-   *       statistics#categoryKeysWithMissingParents} (mapping from parent key to list of
-   *       subcategory keys) and it is skipped in the further process.
-   *   <li>Then it resolves the references (parent category reference and custom type reference) on
-   *       each remaining draft. For each draft with resolved references:
-   *       <ol>
-   *         <li>Checks if the draft exists, then it adds it to the {@code existingCategoryDrafts}
-   *             array.
-   *         <li>If the draft doesn't exist, then it adds it to the {@code newCategoryDrafts} array.
-   *       </ol>
-   * </ol>
-   *
-   * If reference resolution failed either during getting the parent category key or during actual
-   * reference resolution, the error callback is triggered and the category is skipped.
-   *
-   * @param categoryDrafts the input list of category drafts in the sync batch.
-   * @param keyToIdCache the cache containing the mapping of all existing category keys to ids.
-   */
-  private ImmutablePair<Set<CategoryDraft>, Set<CategoryDraft>> prepareDraftsForProcessing(
-      @Nonnull final List<CategoryDraft> categoryDrafts,
-      @Nonnull final Map<String, String> keyToIdCache) {
-
-    final Set<CategoryDraft> existingCategoryDrafts = new HashSet<>();
-    final Set<CategoryDraft> newCategoryDrafts = new HashSet<>();
-    for (CategoryDraft draft : categoryDrafts) {
-      final String categoryKey = draft.getKey();
-      try {
-        checkParentCategoriesAndKeepTrack(draft, keyToIdCache)
-            .ifPresent(
-                categoryDraft -> {
-                  referenceResolver
-                      .resolveReferences(categoryDraft)
-                      .thenAccept(
-                          referencesResolvedDraft -> {
-                            referencesResolvedDrafts.add(referencesResolvedDraft);
-                            if (keyToIdCache.containsKey(categoryKey)) {
-                              existingCategoryDrafts.add(referencesResolvedDraft);
-                            } else {
-                              newCategoryDrafts.add(referencesResolvedDraft);
-                            }
-                          })
-                      .exceptionally(
-                          completionException -> {
-                            final String errorMessage =
-                                format(
-                                    FAILED_TO_PROCESS,
-                                    categoryKey,
-                                    completionException.getMessage());
-                            handleError(errorMessage, completionException);
-                            return null;
-                          })
-                      .toCompletableFuture()
-                      .join();
-                });
-      } catch (Exception exception) {
-        final String errorMessage = format(FAILED_TO_PROCESS, categoryKey, exception);
-        handleError(errorMessage, exception);
-      }
-    }
-    return ImmutablePair.of(newCategoryDrafts, existingCategoryDrafts);
-  }
-
-  @Nonnull
-  private CompletionStage<Void> createAndUpdate(
-      ImmutablePair<Set<CategoryDraft>, Set<CategoryDraft>> preparedDraftsForProcessing,
-      @Nonnull final Map<String, String> keyToIdCache) {
-    return createCategories(preparedDraftsForProcessing.getLeft())
-        .thenAccept(createdCategories -> processCreatedCategories(createdCategories, keyToIdCache))
-        .thenCompose(
-            ignoredResult -> fetchAndUpdate(preparedDraftsForProcessing.getRight(), keyToIdCache));
-  }
-
-  @Nonnull
-  private CompletionStage<Set<Category>> createCategories(
-      @Nonnull final Set<CategoryDraft> categoryDrafts) {
-    return mapValuesToFutureOfCompletedValues(categoryDrafts, this::applyCallbackAndCreate)
-        .thenApply(results -> results.filter(Optional::isPresent).map(Optional::get))
-        .thenApply(
-            result -> {
-              Set<Category> createdCategories = result.collect(toSet());
-              statistics.incrementCreated(createdCategories.size());
-
-              final int numberOfFailedCategories = categoryDrafts.size() - createdCategories.size();
-              if (numberOfFailedCategories > 0) {
-                statistics.incrementFailed(numberOfFailedCategories);
+              if (requiresChangeParentUpdateAction(oldCategory, newCategory)) {
+                categoryDraftsToUpdateSequentially.putIfAbsent(newCategory, oldCategory);
+                return completedFuture(null);
               }
-              return createdCategories;
+
+              return fetchedCategoryOptional
+                  .map(fetchedCategory -> buildUpdateActionsAndUpdate(fetchedCategory, newCategory))
+                  .orElseGet(
+                      () -> {
+                        final String errorMessage =
+                            format(
+                                UPDATE_FAILED,
+                                key,
+                                "Not found when attempting to fetch while retrying "
+                                    + "after concurrency modification.");
+                        handleError(errorMessage, null, oldCategory, newCategory, null, 1);
+                        return completedFuture(null);
+                      });
             });
-  }
-
-  @Nonnull
-  private CompletionStage<Optional<Category>> applyCallbackAndCreate(
-      @Nonnull final CategoryDraft categoryDraft) {
-    return syncOptions
-        .applyBeforeCreateCallback(categoryDraft)
-        .map(categoryService::createCategory)
-        .orElse(completedFuture(Optional.empty()));
-  }
-
-  /**
-   * This method first gets the parent key either from the expanded category object or from the id
-   * field on the reference and validates it. If it is valid, then it checks if the parent category
-   * is missing, this is done by checking if the key exists in the {@code keyToIdCache} map. If it
-   * is missing, the category is added to a customobject,its key is added to the map {@code
-   * statistics#categoryKeysWithMissingParents} and it is skipped for the futher
-   * processing.Otherwise an optinal of the given category draft is returned,
-   *
-   * @param categoryDraft the category draft to check whether it's parent is missing or not.
-   * @param keyToIdCache the cache containing the mapping of all existing category keys to ids.
-   * @return Optional of the categorydraft, if its parent exists, otherwise an Optional.empty
-   * @throws ReferenceResolutionException thrown if the parent key is not valid.
-   */
-  @Nonnull
-  private Optional<CategoryDraft> checkParentCategoriesAndKeepTrack(
-      @Nonnull final CategoryDraft categoryDraft, @Nonnull final Map<String, String> keyToIdCache)
-      throws ReferenceResolutionException {
-    String parentCategoryKey = getParentCategoryKey(categoryDraft).orElse("");
-    if (StringUtils.isBlank(parentCategoryKey)
-        || !isMissingCategory(parentCategoryKey, keyToIdCache)) {
-      return Optional.of(categoryDraft);
-    }
-
-    unresolvedReferencesService
-        .save(
-            new WaitingToBeResolvedCategories(
-                categoryDraft, Collections.singleton(parentCategoryKey)),
-            CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
-            WaitingToBeResolvedCategories.class)
-        .toCompletableFuture()
-        .join();
-
-    statistics.putMissingParentCategoryChildKey(parentCategoryKey, categoryDraft.getKey());
-    return Optional.empty();
-  }
-
-  /**
-   * Checks if the category with the given {@code categoryKey} exists or not, by checking if its key
-   * exists in the {@code keyToIdCache} map.
-   *
-   * @param categoryKey the key of the category to check for existence.
-   * @param keyToIdCache the cache of existing category keys to ids.
-   * @return true or false, whether the category exists or not.
-   */
-  private boolean isMissingCategory(
-      @Nonnull final String categoryKey, @Nonnull final Map<String, String> keyToIdCache) {
-    return !keyToIdCache.containsKey(categoryKey);
-  }
-
-  /**
-   * This method does the following on each category created from the provided {@link Set} of
-   * categories:
-   *
-   * <ol>
-   *   <li>It fetches all unresolvable categories, whose parent is one of the created categories,
-   *       from the custom objects.
-   *   <li>Then it prepares the fetched categories for syncing by resolving references.
-   *   <li>Then it updates/creates the fetched categories and deletes the corresponding
-   *       customobjects.
-   * </ol>
-   *
-   * * @param keyToIdCache the cache containing mapping of all existing category keys to ids.
-   *
-   * @param createdCategories the set of created categories that needs to be processed.
-   */
-  private void processCreatedCategories(
-      @Nonnull final Set<Category> createdCategories,
-      @Nonnull final Map<String, String> keyToIdCache) {
-    if (!createdCategories.isEmpty()) {
-      final Set<String> resolvedParentKeys =
-          createdCategories.stream().map(c -> c.getKey()).collect(toSet());
-
-      fetchResolvableCategories(resolvedParentKeys)
-          .thenAccept(
-              readyToSync -> {
-                if (!readyToSync.isEmpty()) {
-                  // process ready drafts
-                  ImmutablePair<Set<CategoryDraft>, Set<CategoryDraft>> preparedDraft =
-                      prepareDraftsForProcessing(readyToSync, keyToIdCache);
-                  createAndUpdate(preparedDraft, keyToIdCache).toCompletableFuture().join();
-                  removeFromWaiting(
-                      readyToSync.stream()
-                          .filter(c -> keyToIdCache.containsKey(c.getKey()))
-                          .collect(Collectors.toList()));
-                }
-              })
-          .toCompletableFuture()
-          .join();
-    }
-  }
-
-  @Nonnull
-  private CompletionStage<List<CategoryDraft>> fetchResolvableCategories(
-      Set<String> resolvedParent) {
-    final List<CategoryDraft> readyToSync = new ArrayList<>();
-    final Set<String> resolvableCategoryKeys =
-        resolvedParent.stream()
-            .map(statistics::removeAndGetChildrenKeys)
-            .filter(Objects::nonNull)
-            .flatMap(Set::stream)
-            .collect(toSet());
-    if (resolvableCategoryKeys.isEmpty()) {
-      return completedFuture(Collections.emptyList());
-    }
-    return unresolvedReferencesService
-        .fetch(
-            resolvableCategoryKeys,
-            CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
-            WaitingToBeResolvedCategories.class)
-        .handle(ImmutablePair::new)
-        .thenApply(
-            fetchResponse -> {
-              final Throwable fetchException = fetchResponse.getValue();
-              if (fetchException != null) {
-                final String errorMessage =
-                    format(
-                        FAILED_TO_FETCH_WAITING_DRAFTS,
-                        String.join(",", resolvableCategoryKeys.toString()));
-                handleError(new SyncException(errorMessage, fetchException), 1);
-                return readyToSync;
-              }
-              // Each waitingdraft have only one parents, so we can sync the waitingdraft right
-              // away, because only waitingdraft with resolved categories was fetched
-              final Set<WaitingToBeResolvedCategories> waitingDrafts = fetchResponse.getKey();
-              waitingDrafts.forEach(
-                  draft -> {
-                    final CategoryDraft categoryDraft = draft.getCategoryDraft();
-                    readyToSync.add(categoryDraft);
-                  });
-              return readyToSync;
-            });
-  }
-
-  private void removeFromWaiting(@Nonnull final List<CategoryDraft> drafts) {
-    allOf(
-            drafts.stream()
-                .map(CategoryDraft::getKey)
-                .map(
-                    key ->
-                        unresolvedReferencesService.delete(
-                            key,
-                            CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
-                            WaitingToBeResolvedCategories.class))
-                .map(CompletionStage::toCompletableFuture)
-                .toArray(CompletableFuture[]::new))
-        .toCompletableFuture()
-        .join();
-  }
-
-  /**
-   * Given a {@code Set} of categories which have just been fetched, this method does the following
-   * on each category:
-   *
-   * <ol>
-   *   <li>If the the draft exists in the input list:
-   *       <ol>
-   *         <li>a copy is created from it.
-   *         <li>If the parent reference on the draft is null, It means the parent might not yet be
-   *             created, therefore the parent from the fetched category is used. This is to avoid
-   *             having the error callback being called for un setting a parent (which is not
-   *             possible by the CTP API).
-   *       </ol>
-   *   <li>If not, the draft is copied from the fetched category.
-   *   <li>If the key of this draft exists in the {@code categoryKeysWithResolvedParents}, overwrite
-   *       the parent with the parent saved in {@code statistics#categoryKeysWithMissingParents} for
-   *       the draft.
-   *   <li>After a draft has been created, it is added to {@code categoryDraftsToUpdate} map as a
-   *       key and the value is the fetched {@link Category}.
-   * </ol>
-   *
-   * @param fetchedCategories {@code Set} of categories which have just been fetched and
-   * @param resolvedReferencesDrafts {@code Set} of CategoryDrafts with resolved references, they
-   *     are used to get a draft with a resolved reference for the input list of drafts.
-   * @param keyToIdCache the cache containing mapping of all existing category keys to ids.
-   */
-  private void processFetchedCategories(
-      @Nonnull final Set<Category> fetchedCategories,
-      @Nonnull final Set<CategoryDraft> resolvedReferencesDrafts,
-      @Nonnull final Map<String, String> keyToIdCache) {
-    fetchedCategories.forEach(
-        fetchedCategory -> {
-          final String fetchedCategoryKey = fetchedCategory.getKey();
-          final Optional<CategoryDraft> draftByKeyIfExists =
-              getDraftByKeyIfExists(resolvedReferencesDrafts, fetchedCategoryKey);
-          final CategoryDraftBuilder categoryDraftBuilder =
-              draftByKeyIfExists
-                  .map(
-                      categoryDraft -> {
-                        if (categoryDraft.getParent() == null) {
-                          return CategoryDraftBuilder.of(categoryDraft)
-                              .parent(toResourceIdentifierIfNotNull(fetchedCategory.getParent()));
-                        }
-                        return CategoryDraftBuilder.of(categoryDraft);
-                      })
-                  .orElseGet(() -> CategoryDraftBuilder.of(fetchedCategory));
-
-          categoryDraftsToUpdate.put(categoryDraftBuilder.build(), fetchedCategory);
-        });
-  }
-
-  /**
-   * Given a {@link Set} of categoryDrafts and a {@code key}. This method tries to find a
-   * categoryDraft with this key in this set and returns an optional containing it or an empty
-   * optional if no categoryDraft exists with such key.
-   *
-   * @param categoryDrafts set of categoryDrafts to look for a categoryDraft with such key.
-   * @param key the key to look for a categoryDraft for in the supplied set of categoryDrafts.
-   * @return an optional containing the categoryDraft or an empty optional if no category exists
-   *     with such key.
-   */
-  private static Optional<CategoryDraft> getDraftByKeyIfExists(
-      @Nonnull final Set<CategoryDraft> categoryDrafts, @Nonnull final String key) {
-    return categoryDrafts.stream()
-        .filter(categoryDraft -> Objects.equals(categoryDraft.getKey(), key))
-        .findFirst();
-  }
-
-  /**
-   * Given a {@link Map} of categoryDrafts to Categories that require syncing, this method filters
-   * out the pairs that need a {@link io.sphere.sdk.categories.commands.updateactions.ChangeParent}
-   * update action, and in turn performs the sync on them in a sequential/blocking fashion as
-   * advised by the CTP documentation:
-   * http://dev.commercetools.com/http-api-projects-categories.html#change-parent
-   *
-   * @param matchingCategories a {@link Map} of categoryDrafts to Categories that require syncing.
-   */
-  private void updateCategoriesSequentially(
-      @Nonnull final Map<CategoryDraft, Category> matchingCategories) {
-    matchingCategories.entrySet().stream()
-        .filter(entry -> requiresChangeParentUpdateAction(entry.getValue(), entry.getKey()))
-        .map(entry -> buildUpdateActionsAndUpdate(entry.getValue(), entry.getKey()))
-        .map(CompletionStage::toCompletableFuture)
-        .forEach(CompletableFuture::join);
   }
 
   /**
@@ -636,55 +362,6 @@ public class CategorySync
       @Nonnull final Category category, @Nonnull final CategoryDraft categoryDraft) {
     return !areResourceIdentifiersEqual(category.getParent(), categoryDraft.getParent());
   }
-
-  /**
-   * Given a {@link Map} of categoryDrafts to Categories that require syncing, this method filters
-   * out the pairs that don't need a {@link
-   * io.sphere.sdk.categories.commands.updateactions.ChangeParent} update action, and in turn
-   * performs the sync on them in a parallel/non-blocking fashion.
-   *
-   * @param matchingCategories a {@link Map} of categoryDrafts to Categories that require syncing.
-   */
-  private CompletionStage<Void> updateCategoriesInParallel(
-      @Nonnull final Map<CategoryDraft, Category> matchingCategories) {
-
-    final List<CompletableFuture<Void>> futures =
-        matchingCategories.entrySet().stream()
-            .filter(entry -> !requiresChangeParentUpdateAction(entry.getValue(), entry.getKey()))
-            .map(entry -> buildUpdateActionsAndUpdate(entry.getValue(), entry.getKey()))
-            .map(CompletionStage::toCompletableFuture)
-            .collect(Collectors.toList());
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
-  }
-
-  /**
-   * Given an existing {@link Category} and a new {@link CategoryDraft}, first resolves all
-   * references on the category draft, then it calculates all the update actions required to
-   * synchronize the existing category to be the same as the new one. Then the method applies the
-   * {@code ProductSyncOptions#beforeUpdateCallback} on the resultant list of actions.
-   *
-   * <p>If there are update actions in the resulting list, a request is made to CTP to update the
-   * existing category, otherwise it doesn't issue a request.
-   *
-   * @param oldCategory the category which could be updated.
-   * @param newCategory the category draft where we get the new data.
-   * @return a future which contains an empty result after execution of the update.
-   */
-  private CompletionStage<Void> buildUpdateActionsAndUpdate(
-      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
-
-    final List<UpdateAction<Category>> updateActions =
-        buildActions(oldCategory, newCategory, syncOptions);
-    final List<UpdateAction<Category>> beforeUpdateCallBackApplied =
-        syncOptions.applyBeforeUpdateCallback(updateActions, newCategory, oldCategory);
-
-    if (!beforeUpdateCallBackApplied.isEmpty()) {
-      return updateCategory(oldCategory, newCategory, beforeUpdateCallBackApplied);
-    }
-
-    return completedFuture(null);
-  }
-
   /**
    * Given a {@link Category} and a {@link List} of {@link UpdateAction} elements, this method
    * issues a request to the CTP project defined by the client configuration stored in the {@code
@@ -709,123 +386,151 @@ public class CategorySync
     final String categoryKey = oldCategory.getKey();
     return categoryService
         .updateCategory(oldCategory, updateActions)
-        .handle((updatedCategory, sphereException) -> sphereException)
+        .handle(ImmutablePair::new)
         .thenCompose(
-            sphereException -> {
+            updateResponse -> {
+              final Throwable sphereException = updateResponse.getValue();
+
               if (sphereException != null) {
                 return executeSupplierIfConcurrentModificationException(
                     sphereException,
-                    () -> refetchAndUpdate(oldCategory, newCategory),
+                    () -> fetchAndUpdate(oldCategory, newCategory),
                     () -> {
-                      if (!processedCategoryKeys.contains(categoryKey)) {
-                        handleError(
-                            format(UPDATE_FAILED, categoryKey, sphereException),
-                            sphereException,
-                            oldCategory,
-                            newCategory,
-                            updateActions);
-                        processedCategoryKeys.add(categoryKey);
-                      }
+                      final String errorMessage =
+                          format(UPDATE_FAILED, categoryKey, sphereException.getMessage());
+                      handleError(
+                          errorMessage,
+                          sphereException,
+                          oldCategory,
+                          newCategory,
+                          updateActions,
+                          1);
+
+                      categoryDraftsToUpdateSequentially.remove(newCategory);
                       return completedFuture(null);
                     });
               } else {
-                if (!processedCategoryKeys.contains(categoryKey)) {
-                  statistics.incrementUpdated();
-                  processedCategoryKeys.add(categoryKey);
-                }
+                categoryDraftsToUpdateSequentially.remove(newCategory);
+                statistics.incrementUpdated();
                 return completedFuture(null);
               }
             });
   }
 
-  private CompletionStage<Void> refetchAndUpdate(
-      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
+  @Nonnull
+  private CompletionStage<Void> resolveNowReadyReferences(
+      @Nonnull final Map<String, String> keyToIdCache) {
 
-    final String key = oldCategory.getKey();
-    return categoryService
-        .fetchCategory(key)
+    final Set<String> referencingDraftKeys =
+        readyToResolve.stream()
+            .map(statistics::getChildrenKeys)
+            .filter(Objects::nonNull)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+
+    if (referencingDraftKeys.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final Set<CategoryDraft> readyToSync = new HashSet<>();
+
+    return unresolvedReferencesService
+        .fetch(
+            referencingDraftKeys,
+            CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+            WaitingToBeResolvedCategories.class)
         .handle(ImmutablePair::new)
         .thenCompose(
             fetchResponse -> {
-              final Optional<Category> fetchedCategoryOptional = fetchResponse.getKey();
-              final Throwable exception = fetchResponse.getValue();
+              final Set<WaitingToBeResolvedCategories> waitingDrafts = fetchResponse.getKey();
+              final Throwable fetchException = fetchResponse.getValue();
 
-              if (exception != null) {
+              if (fetchException != null) {
                 final String errorMessage =
-                    format(
-                        UPDATE_FAILED,
-                        key,
-                        "Failed to fetch from CTP while "
-                            + "retrying after concurrency modification.");
-                handleError(errorMessage, exception, oldCategory, newCategory, null);
-                return completedFuture(null);
+                    format(FAILED_TO_FETCH_WAITING_DRAFTS, referencingDraftKeys);
+                handleError(
+                    errorMessage, fetchException, null, null, null, referencingDraftKeys.size());
+                return CompletableFuture.completedFuture(null);
               }
 
-              return fetchedCategoryOptional
-                  .map(fetchedCategory -> buildUpdateActionsAndUpdate(fetchedCategory, newCategory))
-                  .orElseGet(
-                      () -> {
-                        final String errorMessage =
-                            format(
-                                UPDATE_FAILED,
-                                key,
-                                "Not found when attempting to fetch while retrying "
-                                    + "after concurrency modification.");
-                        handleError(errorMessage, null, oldCategory, newCategory, null);
-                        return completedFuture(null);
-                      });
+              waitingDrafts.forEach(
+                  waitingDraft -> {
+                    waitingDraft
+                        .getMissingReferencedCategoriesKeys()
+                        .forEach(
+                            parentKey -> {
+                              statistics.removeChildCategoryKeyFromMissingParentsMap(
+                                  parentKey, waitingDraft.getKey());
+                            });
+                    readyToSync.add(waitingDraft.getCategoryDraft());
+                  });
+
+              return syncBatch(readyToSync, keyToIdCache)
+                  .thenCompose(aVoid -> removeFromWaiting(readyToSync));
             });
   }
 
-  /**
-   * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this
-   * method calls the optional error callback specified in the {@code syncOptions} and updates the
-   * {@code statistics} instance by incrementing the total number of failed categories to sync.
-   *
-   * @param errorMessage The error message describing the reason(s) of failure.
-   * @param exception The exception that called caused the failure, if any.
-   */
-  private void handleError(
-      @Nonnull final String errorMessage, @Nullable final Throwable exception) {
-    handleError(errorMessage, exception, null, null, null);
+  @Nonnull
+  private CompletableFuture<Void> removeFromWaiting(@Nonnull final Set<CategoryDraft> drafts) {
+    return allOf(
+        drafts.stream()
+            .map(CategoryDraft::getKey)
+            .map(
+                key ->
+                    unresolvedReferencesService.delete(
+                        key,
+                        CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+                        WaitingToBeResolvedCategories.class))
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+  }
+
+  private CompletionStage<Void> buildUpdateActionsAndUpdate(
+      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
+
+    final List<UpdateAction<Category>> updateActions =
+        buildActions(oldCategory, newCategory, syncOptions);
+
+    final List<UpdateAction<Category>> beforeUpdateCallBackApplied =
+        syncOptions.applyBeforeUpdateCallback(updateActions, newCategory, oldCategory);
+
+    if (!beforeUpdateCallBackApplied.isEmpty()) {
+      return updateCategory(oldCategory, newCategory, beforeUpdateCallBackApplied);
+    }
+
+    return completedFuture(null);
   }
 
   /**
-   * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this
-   * method calls the optional error callback specified in the {@code syncOptions} and updates the
-   * {@code statistics} instance by incrementing the total number of failed categories to sync.
+   * Given a {@link Map} of categoryDrafts to Categories that require syncing, this method filters
+   * out the pairs that need a {@link io.sphere.sdk.categories.commands.updateactions.ChangeParent}
+   * update action, and in turn performs the sync on them in a sequential/blocking fashion as
+   * advised by the CTP documentation:
+   * https://docs.commercetools.com/api/projects/categories#change-parent
    *
-   * @param errorMessage The error message describing the reason(s) of failure.
-   * @param exception The exception that called caused the failure, if any.
-   * @param oldCategory the category to update.
-   * @param newCategory the category draft where we get the new data.
-   * @param updateActions the list of update actions to update the category with.
+   * @param matchingCategories a {@link Map} of categoryDrafts to Categories that require syncing.
    */
+  private CompletableFuture<Void> updateCategoriesSequentially(
+      @Nonnull final Map<CategoryDraft, Category> matchingCategories) {
+    matchingCategories.entrySet().stream()
+        .map(entry -> buildUpdateActionsAndUpdate(entry.getValue(), entry.getKey()))
+        .map(CompletionStage::toCompletableFuture)
+        .forEach(CompletableFuture::join);
+    return completedFuture(null);
+  }
+
   private void handleError(
       @Nonnull final String errorMessage,
       @Nullable final Throwable exception,
       @Nullable final Category oldCategory,
       @Nullable final CategoryDraft newCategory,
-      @Nullable final List<UpdateAction<Category>> updateActions) {
+      @Nullable final List<UpdateAction<Category>> updateActions,
+      final int failedTimes) {
     SyncException syncException =
         exception != null
             ? new SyncException(errorMessage, exception)
             : new SyncException(errorMessage);
     syncOptions.applyErrorCallback(syncException, oldCategory, newCategory, updateActions);
-    statistics.incrementFailed();
-  }
-
-  /**
-   * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this
-   * method calls the optional error callback specified in the {@code syncOptions} and updates the
-   * {@code statistics} instance by incrementing the total number of failed category to sync with
-   * the supplied {@code failedTimes}.
-   *
-   * @param syncException The exception that caused the failure.
-   * @param failedTimes The number of times that the failed category counter is incremented.
-   */
-  private void handleError(@Nonnull final SyncException syncException, final int failedTimes) {
-    syncOptions.applyErrorCallback(syncException);
     statistics.incrementFailed(failedTimes);
   }
 }

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategoryReferenceResolver.java
@@ -114,7 +114,7 @@ public final class CategoryReferenceResolver
     final ResourceIdentifier<Category> parent = draftBuilder.getParent();
     if (parent != null && parent.getId() == null) {
       try {
-        return getParentCategoryKey(draftBuilder)
+        return getParentCategoryKey(parent, draftBuilder.getKey())
             .map(
                 parentCategoryKey ->
                     fetchAndResolveParentReference(draftBuilder, parentCategoryKey))
@@ -127,36 +127,19 @@ public final class CategoryReferenceResolver
   }
 
   @Nonnull
-  public static Optional<String> getParentCategoryKey(
-      @Nonnull final CategoryDraftBuilder draftBuilder) throws ReferenceResolutionException {
-    return getParentCategoryKey(draftBuilder.getParent(), draftBuilder.getKey());
-  }
-
-  @Nonnull
-  public static Optional<String> getParentCategoryKey(@Nonnull final CategoryDraft draft)
-      throws ReferenceResolutionException {
-    return getParentCategoryKey(draft.getParent(), draft.getKey());
-  }
-
-  @Nonnull
   private static Optional<String> getParentCategoryKey(
-      @Nullable final ResourceIdentifier<Category> parentCategoryResourceIdentifier,
+      @Nonnull final ResourceIdentifier<Category> parentCategoryResourceIdentifier,
       @Nullable final String categoryKey)
       throws ReferenceResolutionException {
 
-    if (parentCategoryResourceIdentifier != null
-        && parentCategoryResourceIdentifier.getId() == null) {
-      try {
-        final String parentKey = getKeyFromResourceIdentifier(parentCategoryResourceIdentifier);
-        return Optional.of(parentKey);
-      } catch (ReferenceResolutionException referenceResolutionException) {
-        throw new ReferenceResolutionException(
-            format(
-                FAILED_TO_RESOLVE_PARENT, categoryKey, referenceResolutionException.getMessage()),
-            referenceResolutionException);
-      }
+    try {
+      final String parentKey = getKeyFromResourceIdentifier(parentCategoryResourceIdentifier);
+      return Optional.of(parentKey);
+    } catch (ReferenceResolutionException referenceResolutionException) {
+      throw new ReferenceResolutionException(
+          format(FAILED_TO_RESOLVE_PARENT, categoryKey, referenceResolutionException.getMessage()),
+          referenceResolutionException);
     }
-    return Optional.empty();
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -35,8 +35,8 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
    * Builds a summary of the category sync statistics instance that looks like the following
    * example:
    *
-   * <p>"Summary: 2 categories were processed in total (0 created, 0 updated and 0 categories failed
-   * to sync)."
+   * <p>"Summary: 2 categories were processed in total (1 created, 1 updated and 0 categories failed
+   * to sync and 0 categories with a missing parent)."
    *
    * @return a summary message of the category sync statistics instance.
    */

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -124,7 +124,7 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
    * <p>NOTE: When all the children keys of a missing parent are removed, the value of the map entry
    * will be an empty list. i.e. the entry itself will not be removed. However, this could be
    * investigated whether removing the entry at all when the list is empty will affect the
-   * algorithm. TODO: RELATED BUT NOT SAME AS GITHUB ISSUE#77
+   * algorithm.
    *
    * @param childCategoryKey the child category key to remove from {@code
    *     categoryKeysWithMissingParents}

--- a/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/categories/helpers/CategorySyncStatistics.java
@@ -3,13 +3,9 @@ package com.commercetools.sync.categories.helpers;
 import static java.lang.String.format;
 
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
-import io.sphere.sdk.categories.Category;
-import io.sphere.sdk.categories.CategoryDraft;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -26,12 +22,9 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
    *   <li>value: a set of the parent's children category keys
    * </ul>
    *
-   * <p>The map is thread-safe (by instantiating it with {@link ConcurrentHashMap}) because it is
-   * accessed/modified in a concurrent context, specifically when updating products in parallel in
-   * {@link com.commercetools.sync.categories.CategorySync#updateCategory(Category, CategoryDraft,
-   * List)}.
+   * <p>The map is thread-safe (by instantiating it with {@link ConcurrentHashMap}).
    */
-  private ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents =
+  private final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents =
       new ConcurrentHashMap<>();
 
   public CategorySyncStatistics() {
@@ -65,76 +58,58 @@ public class CategorySyncStatistics extends BaseSyncStatistics {
    * @return the total number of categories with missing parents.
    */
   public int getNumberOfCategoriesWithMissingParents() {
-    return categoryKeysWithMissingParents.values().stream().mapToInt(Set::size).sum();
-  }
-
-  public Map<String, Set<String>> getCategoryKeysWithMissingParents() {
-    return Collections.unmodifiableMap(categoryKeysWithMissingParents);
-  }
-
-  public void setCategoryKeysWithMissingParents(
-      @Nonnull final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents) {
-    this.categoryKeysWithMissingParents = categoryKeysWithMissingParents;
+    return (int)
+        categoryKeysWithMissingParents.values().stream()
+            .flatMap(Collection::stream)
+            .distinct()
+            .count();
   }
 
   /**
    * This method checks if there is an entry with the key of the {@code missingParentCategoryKey} in
    * the {@code categoryKeysWithMissingParents}, if there isn't it creates a new entry with this
    * parent key and as a value a new set containing the {@code childKey}. Otherwise, if there is
-   * already, it just adds the {@code categoryKey} to the existing set.
+   * already, it just adds the {@code childKey} to the existing set.
    *
    * @param missingParentCategoryKey the key of the missing parent.
-   * @param childKey the key of the category with a missing parent.
+   * @param childKey the key of the state with a missing parent.
    */
-  public void putMissingParentCategoryChildKey(
+  public void addMissingDependency(
       @Nonnull final String missingParentCategoryKey, @Nonnull final String childKey) {
-    final Set<String> missingParentCategoryChildrenKeys =
-        categoryKeysWithMissingParents.get(missingParentCategoryKey);
-    if (missingParentCategoryChildrenKeys != null) {
-      missingParentCategoryChildrenKeys.add(childKey);
-    } else {
-      final Set<String> newChildCategoryKeys = new HashSet<>();
-      newChildCategoryKeys.add(childKey);
-      categoryKeysWithMissingParents.put(missingParentCategoryKey, newChildCategoryKeys);
-    }
+
+    categoryKeysWithMissingParents
+        .computeIfAbsent(missingParentCategoryKey, ign -> new HashSet<>())
+        .add(childKey);
   }
 
   /**
-   * Given a {@code childCategoryKey} this method, checks in the {@code
-   * categoryKeysWithMissingParents} if it exists as a child to a missing parent, and returns the
-   * key of first found (since a category can have only one parent) missing parent in an optional.
-   * Otherwise, it returns an empty optional.
-   *
-   * @param childCategoryKey key of the category to find it's has a missing parent key.
-   * @return the key of that missing parent in an optional, if it exists. Otherwise, it returns an
-   *     empty optional.
-   */
-  @Nonnull
-  public Optional<String> getMissingParentKey(@Nonnull final String childCategoryKey) {
-    return categoryKeysWithMissingParents.entrySet().stream()
-        .filter(missingParentEntry -> missingParentEntry.getValue().contains(childCategoryKey))
-        .findFirst()
-        .map(Map.Entry::getKey);
-  }
-
-  /**
-   * Given a child {@code categoryKey} this method removes its occurrences from the map {@code
+   * Given a child {@code childKey} this method removes its occurrences from the map {@code
    * categoryKeysWithMissingParents}.
    *
    * <p>NOTE: When all the children keys of a missing parent are removed, the value of the map entry
-   * will be an empty list. i.e. the entry itself will not be removed. However, this could be
-   * investigated whether removing the entry at all when the list is empty will affect the
-   * algorithm.
+   * will be removed.
    *
-   * @param childCategoryKey the child category key to remove from {@code
-   *     categoryKeysWithMissingParents}
+   * @param parentKey the key of the missing parent.
+   * @param childKey the child category key to remove from {@code categoryKeysWithMissingParents}
    */
-  public void removeChildCategoryKeyFromMissingParentsMap(@Nonnull final String childCategoryKey) {
-    categoryKeysWithMissingParents.forEach((key, value) -> value.remove(childCategoryKey));
+  public void removeChildCategoryKeyFromMissingParentsMap(
+      @Nonnull final String parentKey, @Nonnull final String childKey) {
+
+    categoryKeysWithMissingParents.computeIfPresent(
+        parentKey,
+        (key, values) -> {
+          values.remove(childKey);
+          return values.isEmpty() ? null : values;
+        });
   }
 
+  /**
+   * Returns the children keys of given {@code parentKey}.
+   *
+   * @return Returns the children keys of given {@code parentKey}.
+   */
   @Nullable
-  public Set<String> removeAndGetChildrenKeys(@Nonnull final String key) {
-    return categoryKeysWithMissingParents.remove(key);
+  public Set<String> getChildrenKeys(@Nonnull final String parentKey) {
+    return categoryKeysWithMissingParents.get(parentKey);
   }
 }

--- a/src/main/java/com/commercetools/sync/commons/models/WaitingToBeResolvedCategories.java
+++ b/src/main/java/com/commercetools/sync/commons/models/WaitingToBeResolvedCategories.java
@@ -7,14 +7,14 @@ import javax.annotation.Nonnull;
 
 public final class WaitingToBeResolvedCategories implements WaitingToBeResolved {
   private CategoryDraft categoryDraft;
-  private Set<String> MissingReferencedCategoriesKeys;
+  private Set<String> missingReferencedCategoriesKeys;
 
   public Set<String> getMissingReferencedCategoriesKeys() {
-    return MissingReferencedCategoriesKeys;
+    return missingReferencedCategoriesKeys;
   }
 
   public void setMissingReferencedCategoriesKeys(Set<String> missingReferencedCategoriesKeys) {
-    this.MissingReferencedCategoriesKeys = missingReferencedCategoriesKeys;
+    this.missingReferencedCategoriesKeys = missingReferencedCategoriesKeys;
   }
 
   // Needed for the 'com.fasterxml.jackson' deserialization, for example, when fetching

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -62,9 +62,9 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, ProductSyncOptions> {
   private static final String CTP_PRODUCT_FETCH_FAILED =
-      "Failed to fetch existing products with keys:" + " '%s'.";
+      "Failed to fetch existing products with keys: '%s'.";
   private static final String UNRESOLVED_REFERENCES_STORE_FETCH_FAILED =
-      "Failed to fetch ProductDrafts waiting to " + "be resolved with keys '%s'.";
+      "Failed to fetch ProductDrafts waiting to be resolved with keys '%s'.";
   private static final String UPDATE_FAILED = "Failed to update Product with key: '%s'. Reason: %s";
   private static final String FAILED_TO_PROCESS =
       "Failed to process the ProductDraft with key:'%s'. Reason: %s";

--- a/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
+++ b/src/main/java/com/commercetools/sync/products/templates/beforeupdatecallback/SyncSingleLocale.java
@@ -90,7 +90,6 @@ public final class SyncSingleLocale {
       @Nonnull final UpdateAction<Product> updateAction,
       @Nonnull final ProductDraft newProductDraft,
       @Nonnull final Product oldProduct,
-      // TODO: ProductType should be passes to for attribute comparison. GITHUB ISSUE #189
       @Nonnull final Locale locale) {
 
     if (updateAction instanceof ChangeName) {

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -432,9 +432,6 @@ public final class ProductUpdateActionUtils {
         new HashMap<>(oldProductVariantsNoMaster);
     oldProductVariantsWithMaster.put(oldMasterVariant.getKey(), oldMasterVariant);
 
-    // TODO: Should use getAllVariants as soon as
-    // https://github.com/commercetools/commercetools-sync-java/issues/13
-    // is fixed.
     final List<ProductVariantDraft> newAllProductVariants =
         new ArrayList<>(newProduct.getVariants());
     newAllProductVariants.add(newProduct.getMasterVariant());

--- a/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductVariantUpdateActionUtils.java
@@ -182,7 +182,6 @@ public final class ProductVariantUpdateActionUtils {
     // Unfortunately, currently there is no easy solution to sync 2 ordered lists
     // having only AddExternalImage/RemoveImage/MoveImageToPosition actions.
     // This solution should be re-optimized in the next releases to avoid O(N^2) for large lists.
-    // TODO: GITHUB ISSUE#133
 
     if (!Objects.equals(oldProductVariantImages, newProductVariantImages)) {
       final List<Image> updatedOldImages = new ArrayList<>(oldProductVariantImages);
@@ -221,7 +220,7 @@ public final class ProductVariantUpdateActionUtils {
    *
    * <p><b>Note</b>: the solution is still not optimized and may contain {@link MoveImageToPosition}
    * actions for items which are already on desired positions (after previous moves in the
-   * sequence). This will be re-optimized in the next releases. TODO: GITHUB ISSUE#133
+   * sequence). This will be re-optimized in the next releases.
    *
    * @param variantId the variantId for the {@link MoveImageToPosition} update actions.
    * @param oldImages the old list of images.

--- a/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
+++ b/src/main/java/com/commercetools/sync/producttypes/ProductTypeSync.java
@@ -666,7 +666,6 @@ public class ProductTypeSync
                         CTP_PRODUCT_TYPE_UPDATE_FAILED,
                         key,
                         "Failed to fetch from CTP while retrying after concurrency modification.");
-                // todo: add newProductType or updateActions to handleError
                 handleError(errorMessage, exception, 1, oldProductType, null, null);
                 return CompletableFuture.completedFuture(null);
               }
@@ -681,7 +680,6 @@ public class ProductTypeSync
                                 key,
                                 "Not found when attempting to fetch while retrying "
                                     + "after concurrency modification.");
-                        // todo: add newProductType or updateActions to handleError
                         handleError(errorMessage, null, 1, oldProductType, null, null);
                         return CompletableFuture.completedFuture(null);
                       });

--- a/src/main/java/com/commercetools/sync/services/ProductTypeService.java
+++ b/src/main/java/com/commercetools/sync/services/ProductTypeService.java
@@ -49,12 +49,12 @@ public interface ProductTypeService {
   CompletionStage<Optional<String>> fetchCachedProductTypeId(@Nonnull String key);
 
   /**
-   * TODO FIX JAVADOC AND TEST METHOD Given a {@code productType}, this method first checks if a
-   * cached map of ProductType ids -&gt; map of {@link AttributeMetaData} is not empty. If not, it
-   * returns a completed future that contains an optional that contains what this productType id
-   * maps to in the cache. If the cache is empty, the method populates the cache with the mapping of
-   * all ProductType ids to maps of each product type's attributes' {@link AttributeMetaData} in the
-   * CTP project, by querying the CTP project for all ProductTypes.
+   * Given a {@code productType}, this method first checks if a cached map of ProductType ids -&gt;
+   * map of {@link AttributeMetaData} is not empty. If not, it returns a completed future that
+   * contains an optional that contains what this productType id maps to in the cache. If the cache
+   * is empty, the method populates the cache with the mapping of all ProductType ids to maps of
+   * each product type's attributes' {@link AttributeMetaData} in the CTP project, by querying the
+   * CTP project for all ProductTypes.
    *
    * <p>After that, the method returns a {@link CompletionStage}&lt;{@link Optional}&lt;{@link
    * String}&gt;&gt; in which the result of it's completion could contain an {@link Optional} with a

--- a/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** Implementation of TypeService interface. TODO: USE graphQL to get only keys. GITHUB ISSUE#84 */
 public final class TypeServiceImpl
     extends BaseServiceWithKey<
         TypeDraft, Type, BaseSyncOptions, TypeQuery, TypeQueryModel, TypeExpansionModel<Type>>

--- a/src/main/java/com/commercetools/sync/states/StateSync.java
+++ b/src/main/java/com/commercetools/sync/states/StateSync.java
@@ -149,7 +149,6 @@ public class StateSync extends BaseSync<StateDraft, StateSyncStatistics, StateSy
       @Nullable final List<UpdateAction<State>> updateActions,
       final int failedTimes) {
     syncOptions.applyErrorCallback(syncException, entry, draft, updateActions);
-    ;
     statistics.incrementFailed(failedTimes);
   }
 

--- a/src/test/java/com/commercetools/sync/commons/asserts/actions/AbstractSetCustomTypeAssert.java
+++ b/src/test/java/com/commercetools/sync/commons/asserts/actions/AbstractSetCustomTypeAssert.java
@@ -21,7 +21,7 @@ public class AbstractSetCustomTypeAssert<
 
   /**
    * Verifies that the actual {@link SetCustomTypeBase} value has identical fields as the ones
-   * supplied. TODO: GITHUB ISSUE#257
+   * supplied.
    *
    * @param actionName the update action name.
    * @param customFields the new custom type fields.

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -109,7 +109,6 @@ public class ProductSyncMockUtils {
   /**
    * Builds a {@link ProductDraftBuilder} based on the staged projection of the product JSON
    * resource located at the {@code jsonResourcePath} and based on the supplied {@code productType}.
-   * TODO: GITHUB ISSUE#152
    *
    * @param jsonResourcePath the path of the JSON resource to build the product draft from.
    * @param productTypeReference the reference of the product type that the product draft belongs
@@ -219,7 +218,7 @@ public class ProductSyncMockUtils {
    * located at the {@code jsonResourcePath} and based on the supplied {@code productType}, {@code
    * taxCategoryReference} and {@code stateReference}. The method also attaches the created {@link
    * ProductDraft} to all the {@code categories} specified and assigns {@code categoryOrderHints}
-   * for it for each category assigned. TODO: GITHUB ISSUE#152
+   * for it for each category assigned.
    *
    * @param jsonResourcePath the path of the JSON resource to build the product draft from.
    * @param productTypeReference the reference of the product type that the product draft belongs


### PR DESCRIPTION
- A patch to fix the issue on the build (CategorySyncIT on the shuffled batch of data) - Due to concurrency sometimes the key requested from the custom object is not returning and it was removed from hashmap (in statistics) before resolving it, it's updated to fix the issue.
- Refactor CategorySync considering changeParent actions, remove unused statistic methods, use a simple and consistent algorithm similar to the ProductSync, StateSync for managing statistics.
- Use CTPQueryUtils instead of QueryExecutionUtils for removing resources. #248 
- Cleanup obsolete/unmanaged to-do comments in code.
- and additional boy-scout changes 