### PR TITLE
use Chunk utils

### DIFF
--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -231,8 +231,7 @@ abstract class BaseService<
 
   /**
    * Given a set of keys this method caches a mapping of the keys to ids of such keys only for the
-   * keys which are not already in the cache. This method uses {@link ChunkUtils} to chunk the keys
-   * and execute query to avoid 413 error.
+   * keys which are not already in the cache.
    *
    * @param keys keys to cache.
    * @param keyMapper a function to get the key from the resource.
@@ -286,8 +285,7 @@ abstract class BaseService<
 
   /**
    * Given a set of keys this method caches a mapping of the keys to ids of such keys only for the
-   * keys which are not already in the cache. This method uses {@link ChunkUtils} to chunk the keys
-   * and execute query to avoid 413 error.
+   * keys which are not already in the cache.
    *
    * @param keys keys to cache.
    * @param keyToIdMapper a function to get the key from the resource.
@@ -326,8 +324,7 @@ abstract class BaseService<
   /**
    * Given a {@link Set} of resource keys, this method fetches a set of all the resources, matching
    * this given set of keys in the CTP project, defined in an injected {@link SphereClient}. A
-   * mapping of the key to the id of the fetched resources is persisted in an in-memory map. This
-   * method uses {@link ChunkUtils} to chunk the keys and execute query to avoid 413 error.
+   * mapping of the key to the id of the fetched resources is persisted in an in-memory map.
    *
    * @param keys set of keys to fetch matching resources by.
    * @param keyMapper a function to get the key from the resource.

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -65,7 +65,7 @@ abstract class BaseService<
   /*
    * Considering maximum of 256 characters for key and sku fields (key and sku field doesn't have
    * limit except for ProductType(256)) We chunk them in 60 (keys or sku) we will have around a query
-   * around 15.000 characters. Above this size it could return - Error 413 (Request Entity Too Large)
+   * around 15.000 characters. Above this size it could return - Error 414 (Request-URI Too Large)
    */
   static final int CHUNK_SIZE = 60;
 

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -63,11 +63,12 @@ abstract class BaseService<
   private static final int MAXIMUM_ALLOWED_UPDATE_ACTIONS = 500;
   static final String CREATE_FAILED = "Failed to create draft with key: '%s'. Reason: %s";
   /*
-   * Considering maximum of 256 characters for key and sku fields (key and sku field doesn't have
-   * limit except for ProductType(256)) We chunk them in 60 (keys or sku) we will have around a query
-   * around 15.000 characters. Above this size it could return - Error 414 (Request-URI Too Large)
+   * To be more practical, considering 41 characters as an average for key and sku fields
+   * (key and sku field doesn't have limit except for ProductType(256)) We chunk them in 250
+   * (keys or sku) we will have a query around 11.000 characters(also considered some
+   * conservative space for headers). Above this size it could return - Error 414 (Request-URI Too Large)
    */
-  static final int CHUNK_SIZE = 60;
+  static final int CHUNK_SIZE = 250;
 
   BaseService(@Nonnull final S syncOptions) {
     this.syncOptions = syncOptions;

--- a/src/main/java/com/commercetools/sync/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseService.java
@@ -63,11 +63,11 @@ abstract class BaseService<
   private static final int MAXIMUM_ALLOWED_UPDATE_ACTIONS = 500;
   static final String CREATE_FAILED = "Failed to create draft with key: '%s'. Reason: %s";
   /*
-   * A key is a 41 characters long hashed string. (i.e: c25a67e262265fbc36edb33ed0375263586be278) We
-   * chunk them in 250 keys we will have around a query around 11.000 characters. Above this size it
-   * could return - Error 413 (Request Entity Too Large)
+   * Considering maximum of 256 characters for key and sku fields (key and sku field doesn't have
+   * limit except for ProductType(256)) We chunk them in 60 (keys or sku) we will have around a query
+   * around 15.000 characters. Above this size it could return - Error 413 (Request Entity Too Large)
    */
-  static final int CHUNK_SIZE = 250;
+  static final int CHUNK_SIZE = 60;
 
   BaseService(@Nonnull final S syncOptions) {
     this.syncOptions = syncOptions;

--- a/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
+++ b/src/main/java/com/commercetools/sync/services/impl/BaseServiceWithKey.java
@@ -131,7 +131,7 @@ abstract class BaseServiceWithKey<
    */
   @Nonnull
   CompletionStage<Set<U>> fetchMatchingResources(
-      @Nonnull final Set<String> keys, @Nonnull final Supplier<Q> querySupplier) {
+      @Nonnull final Set<String> keys, @Nonnull final Function<Set<String>, Q> querySupplier) {
 
     // Why method reference is not used:
     // http://mail.openjdk.java.net/pipermail/compiler-dev/2015-November/009824.html

--- a/src/main/java/com/commercetools/sync/services/impl/CartDiscountServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CartDiscountServiceImpl.java
@@ -39,9 +39,9 @@ public class CartDiscountServiceImpl
 
     return fetchMatchingResources(
         keys,
-        () ->
+        (keysNotCached) ->
             CartDiscountQueryBuilder.of()
-                .plusPredicates(queryModel -> queryModel.key().isIn(keys))
+                .plusPredicates(queryModel -> queryModel.key().isIn(keysNotCached))
                 .build());
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CategoryServiceImpl.java
@@ -55,9 +55,10 @@ public final class CategoryServiceImpl
 
     return fetchMatchingResources(
         categoryKeys,
-        () ->
+        (keysNotCached) ->
             CategoryQuery.of()
-                .plusPredicates(categoryQueryModel -> categoryQueryModel.key().isIn(categoryKeys)));
+                .plusPredicates(
+                    categoryQueryModel -> categoryQueryModel.key().isIn(keysNotCached)));
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomObjectServiceImpl.java
@@ -72,7 +72,7 @@ public class CustomObjectServiceImpl
       @Nonnull final Set<CustomObjectCompositeIdentifier> identifiers) {
 
     return fetchMatchingResources(
-        getKeys(identifiers), this::keyMapper, () -> queryIdentifiers(identifiers));
+        getKeys(identifiers), this::keyMapper, (keysNotCached) -> queryIdentifiers(identifiers));
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/services/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/CustomerServiceImpl.java
@@ -56,9 +56,9 @@ public final class CustomerServiceImpl
       @Nonnull final Set<String> customerKeys) {
     return fetchMatchingResources(
         customerKeys,
-        () ->
+        (keysNotCached) ->
             CustomerQueryBuilder.of()
-                .plusPredicates(customerQueryModel -> customerQueryModel.key().isIn(customerKeys))
+                .plusPredicates(customerQueryModel -> customerQueryModel.key().isIn(keysNotCached))
                 .build());
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/InventoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/InventoryServiceImpl.java
@@ -40,9 +40,9 @@ public final class InventoryServiceImpl
     return fetchMatchingResources(
         skus,
         draft -> String.valueOf(InventoryEntryIdentifier.of(draft)),
-        () ->
+        (skusNotCached) ->
             InventoryEntryQueryBuilder.of()
-                .plusPredicates(queryModel -> queryModel.sku().isIn(skus))
+                .plusPredicates(queryModel -> queryModel.sku().isIn(skusNotCached))
                 .build());
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductServiceImpl.java
@@ -79,7 +79,8 @@ public final class ProductServiceImpl
 
     return fetchMatchingResources(
         productKeys,
-        () -> ProductQuery.of().withPredicates(buildProductKeysQueryPredicate(productKeys)));
+        (keysNotCached) ->
+            ProductQuery.of().withPredicates(buildProductKeysQueryPredicate(keysNotCached)));
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/services/impl/ProductTypeServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ProductTypeServiceImpl.java
@@ -112,9 +112,9 @@ public final class ProductTypeServiceImpl
       @Nonnull final Set<String> keys) {
     return fetchMatchingResources(
         keys,
-        () ->
+        (keysNotCached) ->
             ProductTypeQueryBuilder.of()
-                .plusPredicates(queryModel -> queryModel.key().isIn(keys))
+                .plusPredicates(queryModel -> queryModel.key().isIn(keysNotCached))
                 .build());
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/ShoppingListServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/ShoppingListServiceImpl.java
@@ -57,9 +57,9 @@ public final class ShoppingListServiceImpl
     return fetchMatchingResources(
         keys,
         ShoppingList::getKey,
-        () ->
+        (keysNotCached) ->
             ShoppingListQuery.of()
-                .plusPredicates(queryModel -> queryModel.key().isIn(keys))
+                .plusPredicates(queryModel -> queryModel.key().isIn(keysNotCached))
                 .plusExpansionPaths(ExpansionPath.of("lineItems[*].variant")));
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/StateServiceImpl.java
@@ -79,10 +79,10 @@ public final class StateServiceImpl
       @Nonnull final Set<String> stateKeys, final boolean withTransitions) {
     return fetchMatchingResources(
         stateKeys,
-        () -> {
+        (keysNotCached) -> {
           StateQuery stateQuery =
               StateQuery.of()
-                  .plusPredicates(stateQueryModel -> stateQueryModel.key().isIn(stateKeys));
+                  .plusPredicates(stateQueryModel -> stateQueryModel.key().isIn(keysNotCached));
           if (withTransitions) {
             stateQuery = stateQuery.withExpansionPaths(StateExpansionModel::transitions);
           }

--- a/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TaxCategoryServiceImpl.java
@@ -65,9 +65,9 @@ public final class TaxCategoryServiceImpl
       @Nonnull final Set<String> keys) {
     return fetchMatchingResources(
         keys,
-        () ->
+        (keysNotCached) ->
             TaxCategoryQueryBuilder.of()
-                .plusPredicates(queryModel -> queryModel.key().isIn(keys))
+                .plusPredicates(queryModel -> queryModel.key().isIn(keysNotCached))
                 .build());
   }
 

--- a/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/services/impl/TypeServiceImpl.java
@@ -55,9 +55,9 @@ public final class TypeServiceImpl
 
     return fetchMatchingResources(
         keys,
-        () ->
+        (keysNotCached) ->
             TypeQueryBuilder.of()
-                .plusPredicates(queryModel -> queryModel.key().isIn(keys))
+                .plusPredicates(queryModel -> queryModel.key().isIn(keysNotCached))
                 .build());
   }
 

--- a/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
@@ -220,7 +220,7 @@ class BaseServiceImplTest {
 
     // assertions
     assertThat(resources).containsExactlyInAnyOrder(mock1, mock2);
-    verify(client, times(9)).execute(any(ProductQuery.class));
+    verify(client, times(2)).execute(any(ProductQuery.class));
 
     // test caching
     final Optional<String> cachedKey1 =
@@ -232,7 +232,7 @@ class BaseServiceImplTest {
     // assertions
     assertThat(cachedKey1).contains(mock1.getId());
     assertThat(cachedKey2).contains(mock2.getId());
-    verify(client, times(9)).execute(any(ProductQuery.class));
+    verify(client, times(2)).execute(any(ProductQuery.class));
   }
 
   @Test
@@ -419,7 +419,7 @@ class BaseServiceImplTest {
 
     // assertions
     assertThat(optional).containsExactly(MapEntry.entry(key, id));
-    verify(client, times(9)).execute(any(ResourceKeyIdGraphQlRequest.class));
+    verify(client, times(2)).execute(any(ResourceKeyIdGraphQlRequest.class));
   }
 
   @Test
@@ -535,6 +535,6 @@ class BaseServiceImplTest {
     serviceImpl.cacheKeysToIds(randomIdentifiers).toCompletableFuture().join();
 
     // assertion
-    verify(client, times(9)).execute(any(CustomObjectQuery.class));
+    verify(client, times(2)).execute(any(CustomObjectQuery.class));
   }
 }

--- a/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
@@ -34,7 +34,6 @@ import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.utils.CompletableFutureUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -47,7 +46,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.AfterEach;
@@ -198,10 +196,7 @@ class BaseServiceImplTest {
   void fetchMatchingResources_WithKeySetOf500_ShouldChunkAndFetchResourcesAndCacheKeys() {
     // preparation
     List<String> randomKeys = new ArrayList<>();
-    IntStream.range(0, 500)
-             .forEach(ignore ->
-                 randomKeys.add(RandomStringUtils.random(15))
-             );
+    IntStream.range(0, 500).forEach(ignore -> randomKeys.add(RandomStringUtils.random(15)));
 
     final HashSet<String> resourceKeys = new HashSet<>();
     resourceKeys.addAll(randomKeys);
@@ -406,10 +401,7 @@ class BaseServiceImplTest {
   void cacheKeysToIdsUsingGraphQl_With500Keys_ShouldChunkAndMakeRequestAndReturnCachedEntry() {
     // preparation
     Set<String> randomKeys = new HashSet<>();
-    IntStream.range(0, 500)
-             .forEach(ignore ->
-                 randomKeys.add(RandomStringUtils.random(15))
-             );
+    IntStream.range(0, 500).forEach(ignore -> randomKeys.add(RandomStringUtils.random(15)));
 
     final ResourceKeyIdGraphQlResult resourceKeyIdGraphQlResult =
         mock(ResourceKeyIdGraphQlResult.class);
@@ -511,16 +503,16 @@ class BaseServiceImplTest {
   }
 
   @Test
-  void cacheKeysToIds_With500CustomObjectIdentifiers_ShouldChunkAndMakeRequestAndReturnCacheEntries() {
+  void
+      cacheKeysToIds_With500CustomObjectIdentifiers_ShouldChunkAndMakeRequestAndReturnCacheEntries() {
     // preparation
     Set<CustomObjectCompositeIdentifier> randomIdentifiers = new HashSet<>();
     IntStream.range(0, 500)
-             .forEach(i ->
-                 randomIdentifiers.add(
-                     CustomObjectCompositeIdentifier.of(
-                         "customObjectId"+i, "customObjectContainer"+i)
-             ));
-
+        .forEach(
+            i ->
+                randomIdentifiers.add(
+                    CustomObjectCompositeIdentifier.of(
+                        "customObjectId" + i, "customObjectContainer" + i)));
 
     final CustomObjectSyncOptions customObjectSyncOptions =
         CustomObjectSyncOptionsBuilder.of(client).build();
@@ -529,7 +521,8 @@ class BaseServiceImplTest {
     final PagedQueryResult pagedQueryResult = mock(PagedQueryResult.class);
     final CustomObject customObject = mock(CustomObject.class);
     final String customObjectId = randomIdentifiers.stream().findFirst().get().getKey();
-    final String customObjectContainer = randomIdentifiers.stream().findFirst().get().getContainer();
+    final String customObjectContainer =
+        randomIdentifiers.stream().findFirst().get().getContainer();
     final String customObjectKey = "customObjectKey";
 
     when(customObject.getId()).thenReturn(customObjectId);
@@ -538,13 +531,10 @@ class BaseServiceImplTest {
     when(pagedQueryResult.getResults()).thenReturn(singletonList(customObject));
     when(client.execute(any())).thenReturn(completedFuture(pagedQueryResult));
 
-    //test
-    serviceImpl
-            .cacheKeysToIds(randomIdentifiers)
-            .toCompletableFuture()
-            .join();
+    // test
+    serviceImpl.cacheKeysToIds(randomIdentifiers).toCompletableFuture().join();
 
-    //assertion
+    // assertion
     verify(client, times(2)).execute(any(CustomObjectQuery.class));
   }
 }

--- a/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java
@@ -220,7 +220,7 @@ class BaseServiceImplTest {
 
     // assertions
     assertThat(resources).containsExactlyInAnyOrder(mock1, mock2);
-    verify(client, times(2)).execute(any(ProductQuery.class));
+    verify(client, times(9)).execute(any(ProductQuery.class));
 
     // test caching
     final Optional<String> cachedKey1 =
@@ -232,7 +232,7 @@ class BaseServiceImplTest {
     // assertions
     assertThat(cachedKey1).contains(mock1.getId());
     assertThat(cachedKey2).contains(mock2.getId());
-    verify(client, times(2)).execute(any(ProductQuery.class));
+    verify(client, times(9)).execute(any(ProductQuery.class));
   }
 
   @Test
@@ -419,7 +419,7 @@ class BaseServiceImplTest {
 
     // assertions
     assertThat(optional).containsExactly(MapEntry.entry(key, id));
-    verify(client, times(2)).execute(any(ResourceKeyIdGraphQlRequest.class));
+    verify(client, times(9)).execute(any(ResourceKeyIdGraphQlRequest.class));
   }
 
   @Test
@@ -535,6 +535,6 @@ class BaseServiceImplTest {
     serviceImpl.cacheKeysToIds(randomIdentifiers).toCompletableFuture().join();
 
     // assertion
-    verify(client, times(2)).execute(any(CustomObjectQuery.class));
+    verify(client, times(9)).execute(any(CustomObjectQuery.class));
   }
 }


### PR DESCRIPTION
Use Chunk utils for running Query and caching.

CHUNK_SIZE - has to be decided. By default I have considered it same as for Id value of 41 characters.
But I see while creating ProductType with Key - Placeholder says as below - 
  "May only contain between 2 and 256 alphanumeric characters, underscores, or hyphens (no white space or special characters like ñ, ü, #, %) " 
  Let me know your suggestion.