### PR TITLE
Cache references for categories for reference resolution

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/categories/CategorySyncIT.java
@@ -1,7 +1,6 @@
 package com.commercetools.sync.integration.ctpprojectsource.categories;
 
 import static com.commercetools.sync.categories.utils.CategoryReferenceResolutionUtils.buildCategoryQuery;
-import static com.commercetools.sync.categories.utils.CategoryReferenceResolutionUtils.mapToCategoryDrafts;
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.OLD_CATEGORY_CUSTOM_TYPE_KEY;
 import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.createCategories;
@@ -22,6 +21,8 @@ import com.commercetools.sync.categories.CategorySync;
 import com.commercetools.sync.categories.CategorySyncOptions;
 import com.commercetools.sync.categories.CategorySyncOptionsBuilder;
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.categories.service.CategoryReferenceTransformService;
+import com.commercetools.sync.categories.service.impl.CategoryReferenceTransformServiceImpl;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.CategoryDraftBuilder;
@@ -33,8 +34,10 @@ import io.sphere.sdk.models.errors.DuplicateFieldError;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +50,9 @@ class CategorySyncIT {
   private List<String> callBackErrorResponses = new ArrayList<>();
   private List<Throwable> callBackExceptions = new ArrayList<>();
   private List<String> callBackWarningResponses = new ArrayList<>();
+  private final Map<String, String> idToKeyCache = new HashMap<>();
+  CategoryReferenceTransformService categoryReferenceTransformService =
+      new CategoryReferenceTransformServiceImpl(CTP_SOURCE_CLIENT, idToKeyCache);
 
   /**
    * Delete all categories and types from source and target project. Then create custom types for
@@ -110,7 +116,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
 
     final CategorySyncStatistics syncStatistics =
         categorySync.sync(categoryDrafts).toCompletableFuture().join();
@@ -129,7 +136,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
 
     final CategorySyncStatistics syncStatistics =
         categorySync.sync(categoryDrafts).toCompletableFuture().join();
@@ -162,7 +170,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
 
     // Make sure there is no hierarchical order
     Collections.shuffle(categoryDrafts);
@@ -214,7 +223,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
     Collections.shuffle(categoryDrafts);
 
     CategorySync categorySyncWith13BatcheSize = new CategorySync(buildCategorySyncOptions(13));
@@ -252,7 +262,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
     Collections.shuffle(categoryDrafts);
 
     CategorySync categorySyncWith1BatchSize = new CategorySync(buildCategorySyncOptions(1));
@@ -336,7 +347,8 @@ class CategorySyncIT {
             .join()
             .getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
 
     // To simulate the new parent coming in a later draft
     Collections.reverse(categoryDrafts);
@@ -405,7 +417,8 @@ class CategorySyncIT {
     final List<Category> categories =
         CTP_SOURCE_CLIENT.execute(buildCategoryQuery()).toCompletableFuture().join().getResults();
 
-    final List<CategoryDraft> categoryDrafts = mapToCategoryDrafts(categories);
+    final List<CategoryDraft> categoryDrafts =
+        categoryReferenceTransformService.transformCategoryReferences(categories).join();
 
     final CategorySyncStatistics syncStatistics =
         categorySync.sync(categoryDrafts).toCompletableFuture().join();

--- a/src/main/java/com/commercetools/sync/categories/service/CategoryReferenceTransformService.java
+++ b/src/main/java/com/commercetools/sync/categories/service/CategoryReferenceTransformService.java
@@ -1,0 +1,14 @@
+package com.commercetools.sync.categories.service;
+
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+
+public interface CategoryReferenceTransformService {
+
+  @Nonnull
+  CompletableFuture<List<CategoryDraft>> transformCategoryReferences(
+      @Nonnull List<Category> categories);
+}

--- a/src/main/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImpl.java
@@ -23,10 +23,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-public class CategoryReferenceTransformTransformServiceImpl extends BaseTransformServiceImpl
+public class CategoryReferenceTransformServiceImpl extends BaseTransformServiceImpl
     implements CategoryReferenceTransformService {
 
-  public CategoryReferenceTransformTransformServiceImpl(
+  public CategoryReferenceTransformServiceImpl(
       @Nonnull final SphereClient ctpClient,
       @Nonnull final Map<String, String> referenceIdToKeyCache) {
     super(ctpClient, referenceIdToKeyCache);

--- a/src/main/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformTransformServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformTransformServiceImpl.java
@@ -1,0 +1,109 @@
+package com.commercetools.sync.categories.service.impl;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import com.commercetools.sync.categories.service.CategoryReferenceTransformService;
+import com.commercetools.sync.categories.utils.CategoryReferenceResolutionUtils;
+import com.commercetools.sync.commons.models.GraphQlQueryResources;
+import com.commercetools.sync.services.impl.BaseTransformServiceImpl;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.models.Asset;
+import io.sphere.sdk.models.Reference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+public class CategoryReferenceTransformTransformServiceImpl extends BaseTransformServiceImpl
+    implements CategoryReferenceTransformService {
+
+  public CategoryReferenceTransformTransformServiceImpl(
+      @Nonnull final SphereClient ctpClient,
+      @Nonnull final Map<String, String> referenceIdToKeyCache) {
+    super(ctpClient, referenceIdToKeyCache);
+  }
+
+  @Nonnull
+  @Override
+  public CompletableFuture<List<CategoryDraft>> transformCategoryReferences(
+      @Nonnull final List<Category> categories) {
+
+    final List<CompletableFuture<Void>> transformReferencesToRunParallel = new ArrayList<>();
+    transformReferencesToRunParallel.add(this.transformParentCategoryReference(categories));
+    transformReferencesToRunParallel.add(this.transformCustomTypeReference(categories));
+
+    return CompletableFuture.allOf(
+            transformReferencesToRunParallel.toArray(new CompletableFuture[0]))
+        .thenApply(
+            ignore ->
+                CategoryReferenceResolutionUtils.mapToCategoryDrafts(
+                    categories, referenceIdToKeyCache));
+  }
+
+  @Nonnull
+  private CompletableFuture<Void> transformParentCategoryReference(
+      @Nonnull final List<Category> categories) {
+
+    final Set<String> parentCategoryIds =
+        categories.stream()
+            .map(Category::getParent)
+            .filter(Objects::nonNull)
+            .map(Reference::getId)
+            .collect(Collectors.toSet());
+
+    /*
+    TODO (CTPI-432): Review comment:
+     https://github.com/commercetools/commercetools-project-sync/pull/240/files#r580147994
+
+    I wonder if we could fill already-fetched category keys (as it's a native field of category)
+    it means we could fill the cache with category id to category key without an extra query (or
+    at least a minimum amount)... because a category could be a parent to another category or a
+    child of another parent category, this way we could optimize the query if the parent and
+    child are in the same batch/page (which is highly probable).
+
+    The downside of this using extra memory (hash map) for fast search O(1), to improve
+    the linear search on a category list 0(n). To not complex it, we could simply iterate and
+    fill all category keys with their ids, which means more keys stored in the cache, which might
+    not be an issue as the internal cache is fast and not putting much memory overhead.
+    */
+    return fetchAndFillReferenceIdToKeyCache(parentCategoryIds, GraphQlQueryResources.CATEGORIES);
+  }
+
+  @Nonnull
+  private CompletableFuture<Void> transformCustomTypeReference(
+      @Nonnull final List<Category> categories) {
+
+    final Set<String> setOfTypeIds = new HashSet<>();
+    setOfTypeIds.addAll(
+        categories.stream()
+            .map(Category::getCustom)
+            .filter(Objects::nonNull)
+            .map(customFields -> customFields.getType().getId())
+            .collect(Collectors.toSet()));
+
+    setOfTypeIds.addAll(
+        categories.stream()
+            .map(Category::getAssets)
+            .map(
+                assets ->
+                    assets.stream()
+                        .filter(Objects::nonNull)
+                        .map(Asset::getCustom)
+                        .filter(Objects::nonNull)
+                        .map(customFields -> customFields.getType().getId())
+                        .collect(toList()))
+            .flatMap(Collection::stream)
+            .collect(toSet()));
+
+    return fetchAndFillReferenceIdToKeyCache(setOfTypeIds, GraphQlQueryResources.TYPES);
+  }
+}

--- a/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtils.java
@@ -7,14 +7,13 @@ import static com.commercetools.sync.commons.utils.SyncUtils.getResourceIdentifi
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.CategoryDraftBuilder;
-import io.sphere.sdk.categories.expansion.CategoryExpansionModel;
 import io.sphere.sdk.categories.queries.CategoryQuery;
-import io.sphere.sdk.expansion.ExpansionPath;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.queries.QueryExecutionUtils;
 import io.sphere.sdk.types.Type;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -67,18 +66,21 @@ public final class CategoryReferenceResolutionUtils {
    *     Category}.
    */
   @Nonnull
-  public static List<CategoryDraft> mapToCategoryDrafts(@Nonnull final List<Category> categories) {
+  public static List<CategoryDraft> mapToCategoryDrafts(
+      @Nonnull final List<Category> categories,
+      @Nonnull final Map<String, String> referenceIdToKeyMap) {
     return categories.stream()
-        .map(CategoryReferenceResolutionUtils::mapToCategoryDraft)
+        .map(category -> mapToCategoryDraft(category, referenceIdToKeyMap))
         .collect(Collectors.toList());
   }
 
   @Nonnull
-  private static CategoryDraft mapToCategoryDraft(@Nonnull final Category category) {
+  private static CategoryDraft mapToCategoryDraft(
+      @Nonnull final Category category, @Nonnull final Map<String, String> referenceIdToKeyMap) {
     return CategoryDraftBuilder.of(category)
-        .custom(mapToCustomFieldsDraft(category))
-        .assets(mapToAssetDrafts(category.getAssets()))
-        .parent(getResourceIdentifierWithKey(category.getParent()))
+        .custom(mapToCustomFieldsDraft(category, referenceIdToKeyMap))
+        .assets(mapToAssetDrafts(category.getAssets(), referenceIdToKeyMap))
+        .parent(getResourceIdentifierWithKey(category.getParent(), referenceIdToKeyMap))
         .build();
   }
 
@@ -101,10 +103,6 @@ public final class CategoryReferenceResolutionUtils {
    *     aforementioned references expanded.
    */
   public static CategoryQuery buildCategoryQuery() {
-    return CategoryQuery.of()
-        .withLimit(QueryExecutionUtils.DEFAULT_PAGE_SIZE)
-        .withExpansionPaths(ExpansionPath.of("custom.type"))
-        .plusExpansionPaths(ExpansionPath.of("assets[*].custom.type"))
-        .plusExpansionPaths(CategoryExpansionModel::parent);
+    return CategoryQuery.of().withLimit(QueryExecutionUtils.DEFAULT_PAGE_SIZE);
   }
 }

--- a/src/test/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImplTest.java
@@ -30,7 +30,7 @@ public class CategoryReferenceTransformServiceImplTest {
     Map<String, String> idToKeyValueMap = new HashMap<>();
     final SphereClient sourceClient = mock(SphereClient.class);
     CategoryReferenceTransformService categoryReferenceTransformService =
-        new CategoryReferenceTransformTransformServiceImpl(sourceClient, idToKeyValueMap);
+        new CategoryReferenceTransformServiceImpl(sourceClient, idToKeyValueMap);
     final List<Category> categoryPage =
         asList(
             readObjectFromResource("category-key-1.json", Category.class),

--- a/src/test/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/categories/service/impl/CategoryReferenceTransformServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.commercetools.sync.categories.service.impl;
+
+import static com.commercetools.sync.categories.utils.CategoryReferenceResolutionUtils.mapToCategoryDrafts;
+import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.sync.categories.service.CategoryReferenceTransformService;
+import com.commercetools.sync.commons.models.ResourceKeyIdGraphQlResult;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.json.SphereJsonUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class CategoryReferenceTransformServiceImplTest {
+
+  @Test
+  void transform_ShouldReplaceCategoryReferenceIdsWithKeys() {
+    // preparation
+    Map<String, String> idToKeyValueMap = new HashMap<>();
+    final SphereClient sourceClient = mock(SphereClient.class);
+    CategoryReferenceTransformService categoryReferenceTransformService =
+        new CategoryReferenceTransformTransformServiceImpl(sourceClient, idToKeyValueMap);
+    final List<Category> categoryPage =
+        asList(
+            readObjectFromResource("category-key-1.json", Category.class),
+            readObjectFromResource("category-key-2.json", Category.class));
+    final List<String> referenceIds =
+        categoryPage.stream()
+            .filter(category -> category.getCustom() != null)
+            .map(category -> category.getCustom().getType().getId())
+            .collect(Collectors.toList());
+
+    String jsonStringCategories =
+        "{\"results\":[{\"id\":\"53c4a8b4-754f-4b95-b6f2-3e1e70e3d0c3\",\"key\":\"cat1\"}]}";
+    final ResourceKeyIdGraphQlResult categoriesResult =
+        SphereJsonUtils.readObject(jsonStringCategories, ResourceKeyIdGraphQlResult.class);
+
+    when(sourceClient.execute(any()))
+        .thenReturn(CompletableFuture.completedFuture(categoriesResult));
+
+    // test
+    final CompletionStage<List<CategoryDraft>> draftsFromPageStage =
+        categoryReferenceTransformService.transformCategoryReferences(categoryPage);
+
+    // assertions
+    final List<CategoryDraft> expectedResult = mapToCategoryDrafts(categoryPage, idToKeyValueMap);
+    final List<String> referenceKeys =
+        expectedResult.stream()
+            .filter(category -> category.getCustom() != null)
+            .map(category -> category.getCustom().getType().getId())
+            .collect(Collectors.toList());
+    assertThat(referenceKeys).doesNotContainSequence(referenceIds);
+    assertThat(draftsFromPageStage).isCompletedWithValue(expectedResult);
+  }
+}

--- a/src/test/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtilsTest.java
@@ -11,18 +11,21 @@ import static org.mockito.Mockito.when;
 import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.categories.queries.CategoryQuery;
-import io.sphere.sdk.expansion.ExpansionPath;
 import io.sphere.sdk.models.Asset;
 import io.sphere.sdk.models.AssetDraft;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class CategoryReferenceResolutionUtilsTest {
+
+  Map<String, String> idToKeyValueMap = new HashMap<>();
 
   @Test
   void mapToCategoryDrafts_WithAllExpandedCategoryReferences_ShouldReturnReferencesWithKeys() {
@@ -65,7 +68,7 @@ class CategoryReferenceResolutionUtilsTest {
       assertThat(category.getCustom().getType().getId()).isEqualTo(mockCustomType.getId());
     }
     final List<CategoryDraft> referenceReplacedDrafts =
-        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories);
+        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories, idToKeyValueMap);
 
     for (int i = 0; i < referenceReplacedDrafts.size(); i++) {
       assertThat(referenceReplacedDrafts.get(i).getParent().getKey()).isEqualTo("parentKey" + i);
@@ -118,7 +121,7 @@ class CategoryReferenceResolutionUtilsTest {
       assertThat(category.getCustom().getType().getId()).isEqualTo(customTypeId);
     }
     final List<CategoryDraft> referenceReplacedDrafts =
-        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories);
+        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories, idToKeyValueMap);
 
     for (CategoryDraft referenceReplacedDraft : referenceReplacedDrafts) {
       assertThat(referenceReplacedDraft.getParent().getId()).isEqualTo(parentId);
@@ -143,7 +146,7 @@ class CategoryReferenceResolutionUtilsTest {
       mockCategories.add(mockCategory);
     }
     final List<CategoryDraft> referenceReplacedDrafts =
-        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories);
+        CategoryReferenceResolutionUtils.mapToCategoryDrafts(mockCategories, idToKeyValueMap);
     for (CategoryDraft referenceReplacedDraft : referenceReplacedDrafts) {
       assertThat(referenceReplacedDraft.getParent()).isNull();
       assertThat(referenceReplacedDraft.getCustom()).isNull();
@@ -152,12 +155,8 @@ class CategoryReferenceResolutionUtilsTest {
   }
 
   @Test
-  void buildCategoryQuery_Always_ShouldReturnQueryWithAllNeededReferencesExpanded() {
+  void buildCategoryQuery_Always_ShouldReturnQueryWithoutReferencesExpanded() {
     final CategoryQuery categoryQuery = CategoryReferenceResolutionUtils.buildCategoryQuery();
-    assertThat(categoryQuery.expansionPaths())
-        .containsExactly(
-            ExpansionPath.of("custom.type"),
-            ExpansionPath.of("assets[*].custom.type"),
-            ExpansionPath.of("parent"));
+    assertThat(categoryQuery.expansionPaths()).isEmpty();
   }
 }

--- a/src/test/resources/category-key-1.json
+++ b/src/test/resources/category-key-1.json
@@ -14,5 +14,14 @@
   "parent": {
     "id": "53c4a8b4-754f-4b95-b6f2-3e1e70e3d0c3",
     "typeId": "category"
+  },
+  "custom": {
+    "type": {
+      "typeId": "type",
+      "id": "53c4a8b4-754f-4b95-b6f2-3e1e70e3d0c3"
+    },
+    "fields": {
+      "color": "Test"
+    }
   }
 }

--- a/src/test/resources/category-key-2.json
+++ b/src/test/resources/category-key-2.json
@@ -1,0 +1,14 @@
+{
+  "id": "ba81a6da-cf83-435b-a89e-2afab579846f",
+  "name": {
+    "en": "category-name-1"
+  },
+  "key" : "categoryKey2",
+  "slug": {
+    "en": "category-slug-1"
+  },
+  "description": {
+    "en": "description-1"
+  },
+  "assets": []
+}


### PR DESCRIPTION
#### Summary
Resources will not be expanded on references anymore.
So, A service has been created to handle fetching and caching the Id to Key values for all the references of Categories.

Hints: This PR will be similar to the below one for Products,
https://github.com/commercetools/commercetools-sync-java/pull/697

Note: Here the base branch is not master. Once the changes for all resources completes, then i will merge it into master.
