### PR TITLE
Explizit delete transactions before deleting states.

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductITUtils.java
@@ -12,6 +12,7 @@ import static com.commercetools.sync.integration.commons.utils.StateITUtils.dele
 import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.deleteTaxCategories;
 import static com.commercetools.sync.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -55,7 +56,7 @@ public final class ProductITUtils {
     deleteAllCategories(ctpClient);
     deleteTypes(ctpClient);
     deleteChannels(ctpClient);
-    deleteStates(ctpClient);
+    deleteStates(ctpClient, empty());
     deleteTaxCategories(ctpClient);
     deleteCustomerGroups(ctpClient);
     deleteWaitingToBeResolvedCustomObjects(

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
@@ -74,8 +74,8 @@ public final class StateITUtils {
     // delete transitions
     CtpQueryUtils.queryAll(ctpClient, stateQueryBuilder.build(), Function.identity())
         .thenApply(
-            fetchedCategories ->
-                fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
+            fetchedStates ->
+                fetchedStates.stream().flatMap(List::stream).collect(Collectors.toList()))
         .thenCompose(
             result -> {
               final List<CompletionStage<State>> clearStates = new ArrayList<>();

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/StateITUtils.java
@@ -1,12 +1,12 @@
 package com.commercetools.sync.integration.commons.utils;
 
-import static com.commercetools.sync.integration.commons.utils.ITUtils.queryAndExecute;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
 import static io.sphere.sdk.states.commands.updateactions.SetTransitions.of;
 import static io.sphere.sdk.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
+import static java.util.Optional.empty;
 
 import com.commercetools.sync.commons.utils.CtpQueryUtils;
 import io.sphere.sdk.client.SphereClient;
@@ -52,21 +52,27 @@ public final class StateITUtils {
    * CTP_TARGET_CLIENT}.
    */
   public static void deleteStatesFromTargetAndSource() {
-    deleteStates(CTP_TARGET_CLIENT);
-    deleteStates(CTP_SOURCE_CLIENT);
+    deleteStates(CTP_TARGET_CLIENT, empty());
+    deleteStates(CTP_SOURCE_CLIENT, empty());
   }
 
   /**
    * Deletes all states from the CTP project defined by the {@code ctpClient}.
    *
    * @param ctpClient defines the CTP project to delete the states from.
+   * @param stateType optional type of states with should be deleted
    */
-  public static <T extends State> void deleteStates(@Nonnull final SphereClient ctpClient) {
+  public static <T extends State> void deleteStates(
+      @Nonnull final SphereClient ctpClient, final Optional<StateType> stateType) {
+    StateQueryBuilder stateQueryBuilder =
+        StateQueryBuilder.of().plusPredicates(QueryPredicate.of("builtIn = false"));
+    if (stateType.isPresent()) {
+      stateQueryBuilder =
+          stateQueryBuilder.plusPredicates(
+              QueryPredicate.of(format("type= \"%s\"", stateType.get().toSphereName())));
+    }
     // delete transitions
-    CtpQueryUtils.queryAll(
-            ctpClient,
-            StateQueryBuilder.of().plusPredicates(QueryPredicate.of("builtIn = false")).build(),
-            Function.identity())
+    CtpQueryUtils.queryAll(ctpClient, stateQueryBuilder.build(), Function.identity())
         .thenApply(
             fetchedCategories ->
                 fetchedCategories.stream().flatMap(List::stream).collect(Collectors.toList()))
@@ -93,20 +99,6 @@ public final class StateITUtils {
                     stateToRemove -> ctpClient.execute(StateDeleteCommand.of(stateToRemove))))
         .toCompletableFuture()
         .join();
-  }
-
-  /**
-   * Deletes all states with {@code stateType} from the CTP project defined by the {@code
-   * ctpClient}.
-   *
-   * @param ctpClient defines the CTP project to delete the states from.
-   */
-  public static void deleteStates(
-      @Nonnull final SphereClient ctpClient, @Nonnull final StateType stateType) {
-    final QueryPredicate<State> stateQueryPredicate =
-        QueryPredicate.of(format("type= \"%s\"", stateType.toSphereName()));
-    final StateQuery stateQuery = StateQuery.of().withPredicates(stateQueryPredicate);
-    queryAndExecute(ctpClient, stateQuery, StateDeleteCommand::of);
   }
 
   /**

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/states/StateSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/states/StateSyncIT.java
@@ -332,7 +332,7 @@ class StateSyncIT {
                   .isEqualTo(Collections.singleton(StateRole.REVIEW_INCLUDED_IN_STATISTICS));
               Assertions.assertThat(state.isInitial()).isEqualTo(true);
             });
-    deleteStates(CTP_TARGET_CLIENT);
+    deleteStates(CTP_TARGET_CLIENT, Optional.empty());
   }
 
   @Test

--- a/src/integration-test/java/com/commercetools/sync/integration/services/impl/StateServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/services/impl/StateServiceImplIT.java
@@ -66,8 +66,8 @@ class StateServiceImplIT {
     errorCallBackMessages = new ArrayList<>();
     errorCallBackExceptions = new ArrayList<>();
 
-    deleteStates(CTP_TARGET_CLIENT, STATE_TYPE);
-    deleteStates(CTP_TARGET_CLIENT, TRANSITION_STATE_TYPE);
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(STATE_TYPE));
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(TRANSITION_STATE_TYPE));
     warnings = new ArrayList<>();
     oldState = createState(CTP_TARGET_CLIENT, STATE_TYPE);
 
@@ -82,8 +82,8 @@ class StateServiceImplIT {
   /** Cleans up the target test data that were built in this test class. */
   @AfterAll
   static void tearDown() {
-    deleteStates(CTP_TARGET_CLIENT, STATE_TYPE);
-    deleteStates(CTP_TARGET_CLIENT, TRANSITION_STATE_TYPE);
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(STATE_TYPE));
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(TRANSITION_STATE_TYPE));
   }
 
   @Test
@@ -162,7 +162,7 @@ class StateServiceImplIT {
     assertThat(transition.getObj()).isNull();
 
     clearTransitions(CTP_TARGET_CLIENT, fetchState);
-    deleteStates(CTP_TARGET_CLIENT, TRANSITION_STATE_TYPE);
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(TRANSITION_STATE_TYPE));
   }
 
   @Test
@@ -261,7 +261,7 @@ class StateServiceImplIT {
     assertThat(transition.getObj()).isEqualTo(transitionState);
 
     clearTransitions(CTP_TARGET_CLIENT, fetchState);
-    deleteStates(CTP_TARGET_CLIENT, TRANSITION_STATE_TYPE);
+    deleteStates(CTP_TARGET_CLIENT, Optional.of(TRANSITION_STATE_TYPE));
   }
 
   @Test


### PR DESCRIPTION
In this pr the "deleteStates"  method was refactored so that all transitions are explicitly deleted before the states were deleted. Otherwise, it could be that some states cannot be deleted, because some transitions are still cached.