### PR TITLE
Support syncing Set of (Set of Set of..) of NestedType

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 5.0.0](https://img.shields.io/badge/Benchmarks-5.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-5.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.0.0/jar) 
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/)
+[![Benchmarks 5.1.0](https://img.shields.io/badge/Benchmarks-5.1.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-5.1.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.0/jar) 
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
@@ -40,7 +40,7 @@ The library supports synchronising the following entities in commercetools
     - [Ivy](#ivy)
 - [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -83,24 +83,24 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>5.0.0</version>
+  <version>5.1.0</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:5.0.0'
+implementation 'com.commercetools:commercetools-sync-java:5.1.0'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "5.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "5.1.0"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="5.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="5.1.0"/>
 ````

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 5.0.0](https://img.shields.io/badge/Benchmarks-5.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from JCenter](https://img.shields.io/badge/Bintray_JCenter-5.0.0-green.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-5.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.0.0/jar) 
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/)
+[![Benchmarks 5.1.0](https://img.shields.io/badge/Benchmarks-5.1.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from JCenter](https://img.shields.io/badge/Bintray_JCenter-5.1.0-green.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-5.1.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.0/jar) 
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
  
@@ -59,18 +59,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>5.0.0</version>
+  <version>5.1.0</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:5.0.0'
+implementation 'com.commercetools:commercetools-sync-java:5.1.0'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "5.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "5.1.0"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="5.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="5.1.0"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -26,8 +26,16 @@
 
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
-### 5.0.0 - Apr 12, 2021
 
+### 5.1.0 - MM DD, 2021
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.0.0...5.1.0) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/) |
+[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.0)
+
+- 🎉 **New Features** (1)
+  - Syncing product types with an attribute of type Set of (Set of Set of..) of NestedType attribute is supported. [#720](https://github.com/commercetools/commercetools-sync-java/pull/720)
+
+### 5.0.0 - Apr 12, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/4.0.1...5.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/) | 
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.0.0)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,7 +27,7 @@
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
 
-### 5.1.0 - MM DD, 2021
+### 5.1.0 - Apr 20, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.0.0...5.1.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/) |
 [Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.0)

--- a/docs/usage/CART_DISCOUNT_SYNC.md
+++ b/docs/usage/CART_DISCOUNT_SYNC.md
@@ -36,7 +36,7 @@ against a [CartDiscountDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -67,7 +67,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `CartDiscount` to `CartDiscountDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -36,7 +36,7 @@ against a [CategoryDraft](https://docs.commercetools.com/http-api-projects-categ
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -135,7 +135,7 @@ As soon, as the referenced parent Category draft is supplied to the sync, the dr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `Category` to `CategoryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOMER_SYNC.md
+++ b/docs/usage/CUSTOMER_SYNC.md
@@ -35,7 +35,7 @@ against a [CustomerDraft](https://docs.commercetools.com/api/projects/customers#
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -69,7 +69,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Customer` to `CustomerDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOM_OBJECT_SYNC.md
+++ b/docs/usage/CUSTOM_OBJECT_SYNC.md
@@ -31,7 +31,7 @@ against a [CustomObjectDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/IMPORTANT_USAGE_TIPS.md
+++ b/docs/usage/IMPORTANT_USAGE_TIPS.md
@@ -31,7 +31,7 @@ productSync.sync(batch1)
 By design, scaling the sync process should **not** be done by executing the batches themselves in parallel. However, it can be done either by:
  
  - Changing the number of [max parallel requests](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L116) within the `sphereClient` configuration. It defines how many requests the client can execute in parallel.
- - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
+ - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
  
 The current overridable default [configuration](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) of the `sphereClient` 
 is the recommended good balance for stability and performance for the sync process.

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -36,7 +36,7 @@ against a [InventoryEntryDraft](https://docs.commercetools.com/http-api-projects
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -68,7 +68,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `InventoryEntry` to `InventoryEntryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -39,7 +39,7 @@ against a [ProductDraft](https://docs.commercetools.com/http-api-projects-produc
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -80,7 +80,7 @@ resource on the target commercetools project and the library will issue an updat
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Product` to `ProductDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -36,7 +36,7 @@ against a [ProductTypeDraft](https://docs.commercetools.com/http-api-projects-pr
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ProductType` to `ProductTypeDraft`. It can be configured to use a cache that will speed up the reference resolution performed during the sync, for example: 
 
 ````java
@@ -278,4 +278,3 @@ More examples of those utils for different fields can be found [here](https://gi
 
 ## Caveats    
 1. The order of attribute definitions in the synced product types is not guaranteed.
-2. Syncing product types with an attribute of type `Set` of `NestedType` attribute is supported. However, `Set` of (`Set` of `Set` of..) of `NestedType` is not yet supported.

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -37,7 +37,7 @@
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>5.0.0</version>
+  <version>5.1.0</version>
 </dependency>
 ````
 - For Gradle users:
@@ -48,7 +48,7 @@ implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5
 implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.60.0'
 
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:5.0.0'
+implementation 'com.commercetools:commercetools-sync-java:5.1.0'
 ````
 
 ### 2. Setup Syncing Options

--- a/docs/usage/SHOPPING_LIST_SYNC.md
+++ b/docs/usage/SHOPPING_LIST_SYNC.md
@@ -37,7 +37,7 @@ against a [ShoppingListDraft](https://docs.commercetools.com/api/projects/shoppi
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -73,7 +73,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ShoppingList` to `ShoppingListDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/STATE_SYNC.md
+++ b/docs/usage/STATE_SYNC.md
@@ -35,7 +35,7 @@ against a [StateDraft](https://docs.commercetools.com/http-api-projects-states#s
 #### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ reference should return its `key`.
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `State` to `StateDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/TAX_CATEGORY_SYNC.md
+++ b/docs/usage/TAX_CATEGORY_SYNC.md
@@ -31,7 +31,7 @@ against a [TaxCategoryDraft](https://docs.commercetools.com/http-api-projects-ta
 ### Prerequisites
 
 #### SphereClient
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/TYPE_SYNC.md
+++ b/docs/usage/TYPE_SYNC.md
@@ -33,7 +33,7 @@ against a [TypeDraft](https://docs.commercetools.com/http-api-projects-types.htm
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/5.1.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
         - Sync Options: usage/SYNC_OPTIONS.md
         - Usage Tips: usage/IMPORTANT_USAGE_TIPS.md
         - Cleanup Unresolved References: usage/CLEANUP_GUIDE.md
-  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/5.0.0/
+  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/5.1.0/
   - Release notes: RELEASE_NOTES.md
   - Roadmap: https://github.com/commercetools/commercetools-sync-java/milestones
   - Issues: https://github.com/commercetools/commercetools-sync-java/issues

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -29,6 +29,7 @@ import io.sphere.sdk.products.attributes.EnumAttributeType;
 import io.sphere.sdk.products.attributes.LocalizedEnumAttributeType;
 import io.sphere.sdk.products.attributes.LocalizedStringAttributeType;
 import io.sphere.sdk.products.attributes.NestedAttributeType;
+import io.sphere.sdk.products.attributes.SetAttributeType;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
@@ -142,13 +143,20 @@ public final class ProductTypeITUtils {
             .toCompletableFuture()
             .join();
 
-    final AttributeDefinition nestedTypeAttr1 =
-        AttributeDefinitionBuilder.of(
-                "nestedattr", ofEnglish("nestedattr"), NestedAttributeType.of(productType1))
-            .isSearchable(false)
+    final AttributeDefinitionDraft nestedTypeAttr1 =
+        AttributeDefinitionDraftBuilder.of(
+                AttributeDefinitionBuilder.of(
+                        "nestedattr",
+                        ofEnglish("nestedattr"),
+                        SetAttributeType.of(
+                            SetAttributeType.of(
+                                SetAttributeType.of(
+                                    SetAttributeType.of(NestedAttributeType.of(productType1))))))
+                    .build())
             // isSearchable=true is not supported for attribute type 'nested' and
-            // AttributeDefinitionBuilder sets
-            // it to true by default
+            // AttributeDefinitionBuilder sets it to
+            // true by default
+            .searchable(false)
             .build();
 
     final AttributeDefinition nestedTypeAttr2 =

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -131,14 +131,14 @@ public final class ProductTypeITUtils {
         .join();
   }
 
-  public static void populateSourcesProjectWithNestedAttributes() {
+  public static void populateProjectWithNestedAttributes(@Nonnull final SphereClient ctpClient) {
     final ProductType productType1 =
-        CTP_SOURCE_CLIENT
+        ctpClient
             .execute(ProductTypeCreateCommand.of(productTypeDraft1))
             .toCompletableFuture()
             .join();
     final ProductType productType2 =
-        CTP_SOURCE_CLIENT
+        ctpClient
             .execute(ProductTypeCreateCommand.of(productTypeDraft2))
             .toCompletableFuture()
             .join();
@@ -174,10 +174,7 @@ public final class ProductTypeITUtils {
                 AttributeDefinitionDraftBuilder.of(nestedTypeAttr1).build(),
                 AttributeDefinitionDraftBuilder.of(nestedTypeAttr2).build()));
 
-    CTP_SOURCE_CLIENT
-        .execute(ProductTypeCreateCommand.of(productTypeDraft3))
-        .toCompletableFuture()
-        .join();
+    ctpClient.execute(ProductTypeCreateCommand.of(productTypeDraft3)).toCompletableFuture().join();
 
     final ProductTypeDraft productTypeDraft4 =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
@@ -186,10 +183,7 @@ public final class ProductTypeITUtils {
             PRODUCT_TYPE_DESCRIPTION_4,
             singletonList(AttributeDefinitionDraftBuilder.of(nestedTypeAttr1).build()));
 
-    CTP_SOURCE_CLIENT
-        .execute(ProductTypeCreateCommand.of(productTypeDraft4))
-        .toCompletableFuture()
-        .join();
+    ctpClient.execute(ProductTypeCreateCommand.of(productTypeDraft4)).toCompletableFuture().join();
   }
 
   /**
@@ -200,49 +194,6 @@ public final class ProductTypeITUtils {
   public static void populateTargetProject() {
     CTP_TARGET_CLIENT
         .execute(ProductTypeCreateCommand.of(productTypeDraft1))
-        .toCompletableFuture()
-        .join();
-  }
-
-  public static void populateTargetProjectWithNestedAttributes() {
-    final ProductType productType1 =
-        CTP_TARGET_CLIENT
-            .execute(ProductTypeCreateCommand.of(productTypeDraft1))
-            .toCompletableFuture()
-            .join();
-
-    final ProductType productType2 =
-        CTP_TARGET_CLIENT
-            .execute(ProductTypeCreateCommand.of(productTypeDraft2))
-            .toCompletableFuture()
-            .join();
-
-    final AttributeDefinition nestedTypeAttr1 =
-        AttributeDefinitionBuilder.of(
-                "nestedattr", ofEnglish("nestedattr"), NestedAttributeType.of(productType1))
-            .isSearchable(false)
-            // isSearchable=true is not supported for attribute type 'nested' and
-            // AttributeDefinitionBuilder sets
-            // it to true by default
-            .build();
-
-    final AttributeDefinition nestedTypeAttr2 =
-        AttributeDefinitionBuilder.of(
-                "nestedattr2", ofEnglish("nestedattr2"), NestedAttributeType.of(productType2))
-            .isSearchable(false)
-            .build();
-
-    final ProductTypeDraft productTypeDraft3 =
-        ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_3,
-            PRODUCT_TYPE_NAME_3,
-            PRODUCT_TYPE_DESCRIPTION_3,
-            asList(
-                AttributeDefinitionDraftBuilder.of(nestedTypeAttr1).build(),
-                AttributeDefinitionDraftBuilder.of(nestedTypeAttr2).build()));
-
-    CTP_TARGET_CLIENT
-        .execute(ProductTypeCreateCommand.of(productTypeDraft3))
         .toCompletableFuture()
         .join();
   }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -62,16 +62,19 @@ public final class ProductTypeITUtils {
   public static final String PRODUCT_TYPE_KEY_2 = "key_2";
   public static final String PRODUCT_TYPE_KEY_3 = "key_3";
   public static final String PRODUCT_TYPE_KEY_4 = "key_4";
+  public static final String PRODUCT_TYPE_KEY_5 = "key_5";
 
   public static final String PRODUCT_TYPE_NAME_1 = "name_1";
   public static final String PRODUCT_TYPE_NAME_2 = "name_2";
   public static final String PRODUCT_TYPE_NAME_3 = "name_3";
   public static final String PRODUCT_TYPE_NAME_4 = "name_4";
+  public static final String PRODUCT_TYPE_NAME_5 = "name_5";
 
   public static final String PRODUCT_TYPE_DESCRIPTION_1 = "description_1";
   public static final String PRODUCT_TYPE_DESCRIPTION_2 = "description_2";
   public static final String PRODUCT_TYPE_DESCRIPTION_3 = "description_3";
   public static final String PRODUCT_TYPE_DESCRIPTION_4 = "description_4";
+  public static final String PRODUCT_TYPE_DESCRIPTION_5 = "description_5";
 
   public static final AttributeDefinitionDraft ATTRIBUTE_DEFINITION_DRAFT_1 =
       AttributeDefinitionDraftBuilder.of(

--- a/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/ctpprojectsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
@@ -1,8 +1,7 @@
 package com.commercetools.sync.integration.ctpprojectsource.producttypes;
 
 import static com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics.assertThat;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateSourcesProjectWithNestedAttributes;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateTargetProjectWithNestedAttributes;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateProjectWithNestedAttributes;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.removeAttributeReferencesAndDeleteProductTypes;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_SOURCE_CLIENT;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
@@ -47,7 +46,7 @@ class ProductTypeWithNestedAttributeSyncIT {
   void setup() {
     removeAttributeReferencesAndDeleteProductTypes(CTP_SOURCE_CLIENT);
     removeAttributeReferencesAndDeleteProductTypes(CTP_TARGET_CLIENT);
-    populateSourcesProjectWithNestedAttributes();
+    populateProjectWithNestedAttributes(CTP_SOURCE_CLIENT);
 
     builtUpdateActions = new ArrayList<>();
     errorMessages = new ArrayList<>();
@@ -156,7 +155,7 @@ class ProductTypeWithNestedAttributeSyncIT {
   @Test
   void sync_WithoutUpdates_ShouldReturnProperStatistics() {
     // preparation
-    populateTargetProjectWithNestedAttributes();
+    populateProjectWithNestedAttributes(CTP_TARGET_CLIENT);
     final List<ProductType> productTypes =
         CTP_SOURCE_CLIENT.execute(ProductTypeQuery.of()).toCompletableFuture().join().getResults();
 
@@ -175,18 +174,19 @@ class ProductTypeWithNestedAttributeSyncIT {
     assertThat(errorMessages).isEmpty();
     assertThat(exceptions).isEmpty();
     assertThat(builtUpdateActions).isEmpty();
-    assertThat(productTypeSyncStatistics).hasValues(4, 1, 0, 0, 0);
+    assertThat(productTypeSyncStatistics).hasValues(4, 0, 0, 0, 0);
     assertThat(productTypeSyncStatistics.getReportMessage())
         .isEqualTo(
             "Summary: 4 product types were processed in total"
-                + " (1 created, 0 updated, 0 failed to sync and 0 product types with at least one NestedType or a Set"
+                + " (0 created, 0 updated, 0 failed to sync and 0 product types with at least one NestedType or a Set"
                 + " of NestedType attribute definition(s) referencing a missing product type).");
   }
 
   @Test
   void sync_WithUpdates_ShouldReturnProperStatistics() {
     // preparation
-    populateTargetProjectWithNestedAttributes();
+    populateProjectWithNestedAttributes(CTP_TARGET_CLIENT);
+
     final List<ProductType> productTypes =
         CTP_SOURCE_CLIENT.execute(ProductTypeQuery.of()).toCompletableFuture().join().getResults();
 
@@ -226,14 +226,12 @@ class ProductTypeWithNestedAttributeSyncIT {
     assertThat(errorMessages).isEmpty();
     assertThat(exceptions).isEmpty();
     assertThat(builtUpdateActions)
-        .containsExactly(
-            ChangeAttributeDefinitionLabel.of("nestedattr", ofEnglish("new-label")),
-            ChangeAttributeDefinitionLabel.of("nestedattr2", ofEnglish("new-label")));
-    assertThat(productTypeSyncStatistics).hasValues(4, 1, 1, 0, 0);
+        .containsExactly(ChangeAttributeDefinitionLabel.of("nestedattr2", ofEnglish("new-label")));
+    assertThat(productTypeSyncStatistics).hasValues(4, 0, 1, 0, 0);
     assertThat(productTypeSyncStatistics.getReportMessage())
         .isEqualTo(
             "Summary: 4 product types were processed in total"
-                + " (1 created, 1 updated, 0 failed to sync and 0 product types with at least one NestedType or a Set"
+                + " (0 created, 1 updated, 0 failed to sync and 0 product types with at least one NestedType or a Set"
                 + " of NestedType attribute definition(s) referencing a missing product type).");
   }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
@@ -152,19 +152,6 @@ class ProductTypeWithNestedAttributeSyncIT {
             .searchable(false)
             .build();
 
-    //    final AttributeDefinitionDraft localisedSetOfEnumsAttribute =
-    //        AttributeDefinitionDraftBuilder.of(
-    //                AttributeDefinitionBuilder.of(
-    //                        "localisedSetOfEnums",
-    //                        ofEnglish("label1"),
-    //                        SetAttributeType.of(
-    //                            LocalizedEnumAttributeType.of(
-    //                                asList(
-    //                                    LocalizedEnumValue.of("a", ofEnglish("a")),
-    //                                    LocalizedEnumValue.of("b", ofEnglish("b"))))))
-    //                    .build())
-    //            .build();
-
     final ProductTypeDraft newProductTypeDraft =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
             PRODUCT_TYPE_KEY_5,

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
@@ -15,7 +15,7 @@ import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtil
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_NAME_4;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.assertAttributesAreEqual;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.getProductTypeByKey;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateTargetProjectWithNestedAttributes;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateProjectWithNestedAttributes;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.removeAttributeReferencesAndDeleteProductTypes;
 import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
@@ -69,7 +69,7 @@ class ProductTypeWithNestedAttributeSyncIT {
   @BeforeEach
   void setup() {
     removeAttributeReferencesAndDeleteProductTypes(CTP_TARGET_CLIENT);
-    populateTargetProjectWithNestedAttributes();
+    populateProjectWithNestedAttributes(CTP_TARGET_CLIENT);
 
     builtUpdateActions = new ArrayList<>();
     errorMessages = new ArrayList<>();

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/producttypes/ProductTypeWithNestedAttributeSyncIT.java
@@ -6,13 +6,13 @@ import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtil
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.ATTRIBUTE_DEFINITION_DRAFT_3;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_DESCRIPTION_1;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_DESCRIPTION_3;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_DESCRIPTION_4;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_DESCRIPTION_5;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_KEY_1;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_KEY_3;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_KEY_4;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_KEY_5;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_NAME_1;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_NAME_3;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_NAME_4;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.PRODUCT_TYPE_NAME_5;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.assertAttributesAreEqual;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.getProductTypeByKey;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.populateProjectWithNestedAttributes;
@@ -141,25 +141,36 @@ class ProductTypeWithNestedAttributeSyncIT {
   @Test
   void sync_WithNewProductTypeWithAnExistingReference_ShouldCreateProductType() {
     // preparation
-    final AttributeDefinitionDraft nestedTypeAttr =
+    final AttributeDefinitionDraft nestedTypeAttr3 =
         AttributeDefinitionDraftBuilder.of(
                 AttributeDefinitionBuilder.of(
-                        "nestedattr",
-                        ofEnglish("nestedattr"),
-                        NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_1)))
+                        "nestedattr3",
+                        ofEnglish("nestedattr3"),
+                        SetAttributeType.of(
+                            NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_3))))
                     .build())
-            // isSearchable=true is not supported for attribute type 'nested' and
-            // AttributeDefinitionBuilder sets it to
-            // true by default
             .searchable(false)
             .build();
 
+    //    final AttributeDefinitionDraft localisedSetOfEnumsAttribute =
+    //        AttributeDefinitionDraftBuilder.of(
+    //                AttributeDefinitionBuilder.of(
+    //                        "localisedSetOfEnums",
+    //                        ofEnglish("label1"),
+    //                        SetAttributeType.of(
+    //                            LocalizedEnumAttributeType.of(
+    //                                asList(
+    //                                    LocalizedEnumValue.of("a", ofEnglish("a")),
+    //                                    LocalizedEnumValue.of("b", ofEnglish("b"))))))
+    //                    .build())
+    //            .build();
+
     final ProductTypeDraft newProductTypeDraft =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_4,
-            PRODUCT_TYPE_NAME_4,
-            PRODUCT_TYPE_DESCRIPTION_4,
-            singletonList(nestedTypeAttr));
+            PRODUCT_TYPE_KEY_5,
+            PRODUCT_TYPE_NAME_5,
+            PRODUCT_TYPE_DESCRIPTION_5,
+            singletonList(nestedTypeAttr3));
 
     final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
 
@@ -179,24 +190,26 @@ class ProductTypeWithNestedAttributeSyncIT {
                 + " of NestedType attribute definition(s) referencing a missing product type).");
 
     final Optional<ProductType> oldProductTypeAfter =
-        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_4);
+        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_5);
 
     assertThat(oldProductTypeAfter)
         .hasValueSatisfying(
             productType -> {
-              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_4);
-              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_4);
+              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_5);
+              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_5);
               assertThat(productType.getAttributes())
                   .hasSize(1)
                   .extracting(AttributeDefinition::getAttributeType)
                   .first()
                   .satisfies(
                       attributeType -> {
-                        assertThat(attributeType).isInstanceOf(NestedAttributeType.class);
-                        final NestedAttributeType nestedType = (NestedAttributeType) attributeType;
+                        assertThat(attributeType).isInstanceOf(SetAttributeType.class);
+                        final SetAttributeType setAttributeType = (SetAttributeType) attributeType;
+                        final NestedAttributeType nestedType =
+                            (NestedAttributeType) setAttributeType.getElementType();
                         assertThat(nestedType.getTypeReference().getId())
                             .isEqualTo(
-                                getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_1)
+                                getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_3)
                                     .map(Resource::getId)
                                     .orElse(null));
                       });
@@ -222,9 +235,9 @@ class ProductTypeWithNestedAttributeSyncIT {
 
     final ProductTypeDraft newProductTypeDraft =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_4,
-            PRODUCT_TYPE_NAME_4,
-            PRODUCT_TYPE_DESCRIPTION_4,
+            PRODUCT_TYPE_KEY_5,
+            PRODUCT_TYPE_NAME_5,
+            PRODUCT_TYPE_DESCRIPTION_5,
             singletonList(nestedTypeAttr));
 
     final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
@@ -248,22 +261,22 @@ class ProductTypeWithNestedAttributeSyncIT {
             productTypeSyncStatistics
                 .getProductTypeKeysWithMissingParents()
                 .get("non-existing-ref"))
-        .containsOnlyKeys(PRODUCT_TYPE_KEY_4);
+        .containsOnlyKeys(PRODUCT_TYPE_KEY_5);
     assertThat(
             productTypeSyncStatistics
                 .getProductTypeKeysWithMissingParents()
                 .get("non-existing-ref")
-                .get(PRODUCT_TYPE_KEY_4))
+                .get(PRODUCT_TYPE_KEY_5))
         .containsExactly(nestedTypeAttr);
 
     final Optional<ProductType> oldProductTypeAfter =
-        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_4);
+        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_5);
 
     assertThat(oldProductTypeAfter)
         .hasValueSatisfying(
             productType -> {
-              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_4);
-              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_4);
+              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_5);
+              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_5);
               assertThat(productType.getAttributes()).isEmpty();
             });
   }
@@ -276,7 +289,7 @@ class ProductTypeWithNestedAttributeSyncIT {
                 AttributeDefinitionBuilder.of(
                         "nestedattr",
                         ofEnglish("nestedattr"),
-                        NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_4)))
+                        NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_5)))
                     .build())
             // isSearchable=true is not supported for attribute type 'nested' and
             // AttributeDefinitionBuilder sets it to
@@ -291,11 +304,11 @@ class ProductTypeWithNestedAttributeSyncIT {
             PRODUCT_TYPE_DESCRIPTION_1,
             asList(ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2, nestedTypeAttr));
 
-    final ProductTypeDraft productTypeDraft4 =
+    final ProductTypeDraft productTypeDraft5 =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_4,
-            PRODUCT_TYPE_NAME_4,
-            PRODUCT_TYPE_DESCRIPTION_4,
+            PRODUCT_TYPE_KEY_5,
+            PRODUCT_TYPE_NAME_5,
+            PRODUCT_TYPE_DESCRIPTION_5,
             singletonList(ATTRIBUTE_DEFINITION_DRAFT_3));
 
     final SphereClient ctpClient = spy(CTP_TARGET_CLIENT);
@@ -329,7 +342,7 @@ class ProductTypeWithNestedAttributeSyncIT {
     // tests
     final ProductTypeSyncStatistics productTypeSyncStatistics =
         productTypeSync
-            .sync(asList(withMissingNestedTypeRef, productTypeDraft4))
+            .sync(asList(withMissingNestedTypeRef, productTypeDraft5))
             .toCompletableFuture()
             .join();
 
@@ -357,18 +370,18 @@ class ProductTypeWithNestedAttributeSyncIT {
         children =
             productTypeSyncStatistics
                 .getProductTypeKeysWithMissingParents()
-                .get(PRODUCT_TYPE_KEY_4);
+                .get(PRODUCT_TYPE_KEY_5);
 
     assertThat(children).hasSize(1);
     assertThat(children.get(PRODUCT_TYPE_KEY_1)).containsExactly(nestedTypeAttr);
 
-    final Optional<ProductType> productType4 =
-        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_4);
-    assertThat(productType4)
+    final Optional<ProductType> productType5 =
+        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_5);
+    assertThat(productType5)
         .hasValueSatisfying(
             productType -> {
-              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_4);
-              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_4);
+              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_5);
+              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_5);
               assertThat(productType.getAttributes()).hasSize(1);
             });
 
@@ -385,7 +398,12 @@ class ProductTypeWithNestedAttributeSyncIT {
                 AttributeDefinitionBuilder.of(
                         "nestedattr",
                         ofEnglish("nestedattr"),
-                        NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_1)))
+                        SetAttributeType.of(
+                            SetAttributeType.of(
+                                SetAttributeType.of(
+                                    SetAttributeType.of(
+                                        NestedAttributeType.of(
+                                            ProductType.referenceOfId(PRODUCT_TYPE_KEY_1)))))))
                     .build())
             // isSearchable=true is not supported for attribute type 'nested' and
             // AttributeDefinitionBuilder sets it to
@@ -400,11 +418,11 @@ class ProductTypeWithNestedAttributeSyncIT {
             PRODUCT_TYPE_DESCRIPTION_1,
             asList(ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2, nestedTypeAttr));
 
-    final ProductTypeDraft productTypeDraft4 =
+    final ProductTypeDraft productTypeDraft5 =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_4,
-            PRODUCT_TYPE_NAME_4,
-            PRODUCT_TYPE_DESCRIPTION_4,
+            PRODUCT_TYPE_KEY_5,
+            PRODUCT_TYPE_NAME_5,
+            PRODUCT_TYPE_DESCRIPTION_5,
             singletonList(ATTRIBUTE_DEFINITION_DRAFT_3));
 
     final ProductTypeSync productTypeSync = new ProductTypeSync(productTypeSyncOptions);
@@ -412,7 +430,7 @@ class ProductTypeWithNestedAttributeSyncIT {
     // tests
     final ProductTypeSyncStatistics productTypeSyncStatistics =
         productTypeSync
-            .sync(asList(newProductTypeDraft, productTypeDraft4))
+            .sync(asList(newProductTypeDraft, productTypeDraft5))
             .toCompletableFuture()
             .join();
 
@@ -429,7 +447,11 @@ class ProductTypeWithNestedAttributeSyncIT {
                         AttributeDefinitionBuilder.of(
                                 "nestedattr",
                                 ofEnglish("nestedattr"),
-                                NestedAttributeType.of(productType1.get()))
+                                SetAttributeType.of(
+                                    SetAttributeType.of(
+                                        SetAttributeType.of(
+                                            SetAttributeType.of(
+                                                NestedAttributeType.of(productType1.get()))))))
                             .build())
                     // isSearchable=true is not supported for attribute type 'nested' and
                     // AttributeDefinitionBuilder sets
@@ -444,13 +466,13 @@ class ProductTypeWithNestedAttributeSyncIT {
                 + " of NestedType attribute definition(s) referencing a missing product type).");
 
     assertThat(productTypeSyncStatistics.getProductTypeKeysWithMissingParents()).isEmpty();
-    final Optional<ProductType> productType4 =
-        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_4);
-    assertThat(productType4)
+    final Optional<ProductType> productType5 =
+        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_5);
+    assertThat(productType5)
         .hasValueSatisfying(
             productType -> {
-              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_4);
-              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_4);
+              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_5);
+              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_5);
               assertThat(productType.getAttributes()).hasSize(1);
             });
 
@@ -467,7 +489,12 @@ class ProductTypeWithNestedAttributeSyncIT {
                 AttributeDefinitionBuilder.of(
                         "nestedattr",
                         ofEnglish("nestedattr"),
-                        NestedAttributeType.of(ProductType.referenceOfId(PRODUCT_TYPE_KEY_1)))
+                        SetAttributeType.of(
+                            SetAttributeType.of(
+                                SetAttributeType.of(
+                                    SetAttributeType.of(
+                                        NestedAttributeType.of(
+                                            ProductType.referenceOfId(PRODUCT_TYPE_KEY_1)))))))
                     .build())
             // isSearchable=true is not supported for attribute type 'nested' and
             // AttributeDefinitionBuilder sets it to
@@ -482,11 +509,11 @@ class ProductTypeWithNestedAttributeSyncIT {
             PRODUCT_TYPE_DESCRIPTION_1,
             asList(ATTRIBUTE_DEFINITION_DRAFT_1, ATTRIBUTE_DEFINITION_DRAFT_2, nestedTypeAttr));
 
-    final ProductTypeDraft productTypeDraft4 =
+    final ProductTypeDraft productTypeDraft5 =
         ProductTypeDraft.ofAttributeDefinitionDrafts(
-            PRODUCT_TYPE_KEY_4,
-            PRODUCT_TYPE_NAME_4,
-            PRODUCT_TYPE_DESCRIPTION_4,
+            PRODUCT_TYPE_KEY_5,
+            PRODUCT_TYPE_NAME_5,
+            PRODUCT_TYPE_DESCRIPTION_5,
             singletonList(ATTRIBUTE_DEFINITION_DRAFT_3));
 
     productTypeSyncOptions =
@@ -509,7 +536,7 @@ class ProductTypeWithNestedAttributeSyncIT {
     // tests
     final ProductTypeSyncStatistics productTypeSyncStatistics =
         productTypeSync
-            .sync(asList(newProductTypeDraft, productTypeDraft4))
+            .sync(asList(newProductTypeDraft, productTypeDraft5))
             .toCompletableFuture()
             .join();
 
@@ -526,7 +553,11 @@ class ProductTypeWithNestedAttributeSyncIT {
                         AttributeDefinitionBuilder.of(
                                 "nestedattr",
                                 ofEnglish("nestedattr"),
-                                NestedAttributeType.of(productType1.get()))
+                                SetAttributeType.of(
+                                    SetAttributeType.of(
+                                        SetAttributeType.of(
+                                            SetAttributeType.of(
+                                                NestedAttributeType.of(productType1.get()))))))
                             .build())
                     // isSearchable=true is not supported for attribute type 'nested' and
                     // AttributeDefinitionBuilder sets
@@ -541,13 +572,13 @@ class ProductTypeWithNestedAttributeSyncIT {
                 + " of NestedType attribute definition(s) referencing a missing product type).");
 
     assertThat(productTypeSyncStatistics.getProductTypeKeysWithMissingParents()).isEmpty();
-    final Optional<ProductType> productType4 =
-        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_4);
-    assertThat(productType4)
+    final Optional<ProductType> productType5 =
+        getProductTypeByKey(CTP_TARGET_CLIENT, PRODUCT_TYPE_KEY_5);
+    assertThat(productType5)
         .hasValueSatisfying(
             productType -> {
-              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_4);
-              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_4);
+              assertThat(productType.getName()).isEqualTo(PRODUCT_TYPE_NAME_5);
+              assertThat(productType.getDescription()).isEqualTo(PRODUCT_TYPE_DESCRIPTION_5);
               assertThat(productType.getAttributes()).hasSize(1);
             });
 

--- a/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/producttypes/helpers/AttributeDefinitionReferenceResolver.java
@@ -106,6 +106,31 @@ public class AttributeDefinitionReferenceResolver
       final AtomicInteger maxDepth,
       @Nonnull NestedAttributeType nestedAttributeType) {
 
+    /*
+     As SDK types (e.g AttributeDefinitionDraftBuilder) are immutable,
+     whole object needs to be created to change typeReference after resolving the reference.
+
+     For instance, for an AttributeType type structure below which has 3 SetAttributeType and 1 NestedAttributeType,
+     It would create first NestedAttributeType and then wrap it with SetAttributeType and so on so forth until creating
+     the same object again.
+
+     "type": {
+        "name": "set",
+        "elementType": {
+          "name": "set",
+          "elementType": {
+            "name": "set",
+            "elementType": {
+              "name": "nested",
+              "typeReference": {
+                "typeId": "product-type",
+                "id": "36b14c6d-31e9-4bc5-9191-f35a773268ed"
+              }
+            }
+          }
+        }
+      }
+    */
     return resolveNestedTypeReference(nestedAttributeType)
         .thenApply(
             resolvedNestedAttributeType -> {
@@ -123,14 +148,13 @@ public class AttributeDefinitionReferenceResolver
   private AttributeType getNestedAttributeType(
       @Nonnull final SetAttributeType setAttributeType, @Nonnull final AtomicInteger maxDepth) {
     final AttributeType elementType = setAttributeType.getElementType();
+
     if (elementType instanceof SetAttributeType) {
       maxDepth.incrementAndGet();
       return getNestedAttributeType((SetAttributeType) elementType, maxDepth);
-    } else if (elementType instanceof NestedAttributeType) {
-      return elementType;
     }
 
-    return null;
+    return elementType;
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/producttypes/helpers/ProductTypeReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/producttypes/helpers/ProductTypeReferenceResolver.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 public final class ProductTypeReferenceResolver
     extends BaseReferenceResolver<ProductTypeDraft, ProductTypeSyncOptions> {
 
-  private AttributeDefinitionReferenceResolver attributeDefinitionReferenceResolver;
+  private final AttributeDefinitionReferenceResolver attributeDefinitionReferenceResolver;
 
   /**
    * Takes a {@link ProductTypeSyncOptions} instance and a {@link ProductTypeService} to instantiate


### PR DESCRIPTION
**Situation:**
Syncing product types with an attribute of type Set of NestedType attribute is supported. However, Set of (Set of Set of..) of NestedType is not yet supported.

**Complication:**
As it was an expensive query for the commercetools platform to expand that type of set chains before we decided to limit it. Now with using cache service instead of expansion, we could resolve this limitation/caveat on the product type sync, so we could provide users fully functional sync for the SetAttributeType chains. 

## TODOs:
- [x] Add release notes for the changes, remove caveat and increment the versions.