### PR TITLE
ProductProjection - Use the new predicate to filter and search based on key.

### DIFF
--- a/src/test/java/com/commercetools/sync/services/impl/ProductServiceTest.java
+++ b/src/test/java/com/commercetools/sync/services/impl/ProductServiceTest.java
@@ -23,10 +23,8 @@ import io.sphere.sdk.products.ProductProjectionType;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.ProductUpdateCommand;
 import io.sphere.sdk.products.commands.updateactions.ChangeName;
-import io.sphere.sdk.queries.QueryPredicate;
 import io.sphere.sdk.utils.CompletableFutureUtils;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,34 +135,5 @@ class ProductServiceTest {
     assertThat(productProjection).isSameAs(productProjectionMock);
     verify(productSyncOptions.getCtpClient())
         .execute(eq(ProductUpdateCommand.of(productProjectionMock, updateActions)));
-  }
-
-  @Test
-  void buildProductKeysQueryPredicate_WithEmptyProductKeysSet_ShouldBuildCorrectQuery() {
-    final QueryPredicate<ProductProjection> queryPredicate =
-        service.buildProductKeysQueryPredicate(new HashSet<>());
-    assertThat(queryPredicate.toSphereQuery()).isEqualTo("key in ()");
-  }
-
-  @Test
-  void buildProductKeysQueryPredicate_WithProductKeysSet_ShouldBuildCorrectQuery() {
-    final HashSet<String> productKeys = new HashSet<>();
-    productKeys.add("key1");
-    productKeys.add("key2");
-    final QueryPredicate<ProductProjection> queryPredicate =
-        service.buildProductKeysQueryPredicate(productKeys);
-    assertThat(queryPredicate.toSphereQuery()).isEqualTo("key in (\"key1\", \"key2\")");
-  }
-
-  @Test
-  void buildProductKeysQueryPredicate_WithSomeBlankProductKeys_ShouldBuildCorrectQuery() {
-    final HashSet<String> productKeys = new HashSet<>();
-    productKeys.add("key1");
-    productKeys.add("key2");
-    productKeys.add("");
-    productKeys.add(null);
-    final QueryPredicate<ProductProjection> queryPredicate =
-        service.buildProductKeysQueryPredicate(productKeys);
-    assertThat(queryPredicate.toSphereQuery()).isEqualTo("key in (\"key1\", \"key2\")");
   }
 }


### PR DESCRIPTION
- Remove the manual construction of query for fetching product projections based on key and use key predicate provided by the new JVM-SDK version.

#### Hints for Review
- Tests are already covered, Check this PR - https://github.com/commercetools/commercetools-sync-java/pull/726/
