### PR TITLE
Change the logic for TaxRates update actions.

### DIFF
--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
@@ -111,9 +111,10 @@ final class TaxRatesUpdateActionUtils {
             oldTaxRate ->
                 newTaxRatesDrafts.stream()
                     .filter(
-                        taxRateDraft ->
-                            Objects.equals(oldTaxRate.getCountry(), taxRateDraft.getCountry())
-                                && Objects.equals(oldTaxRate.getState(), taxRateDraft.getState()))
+                        newTaxRateDraft ->
+                            Objects.equals(oldTaxRate.getCountry(), newTaxRateDraft.getCountry())
+                                && Objects.equals(
+                                    oldTaxRate.getState(), newTaxRateDraft.getState()))
                     .findFirst()
                     .map(
                         matchedTaxRateDraft -> {

--- a/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/taxcategories/utils/TaxRatesUpdateActionUtils.java
@@ -112,13 +112,8 @@ final class TaxRatesUpdateActionUtils {
                 newTaxRatesDrafts.stream()
                     .filter(
                         taxRateDraft ->
-                            Objects.equals(oldTaxRate.getCountry(), taxRateDraft.getCountry()))
-                    .filter(
-                        taxRateDraft ->
-                            oldTaxRate.getState() == null
-                                || (oldTaxRate.getState() != null
-                                    && taxRateDraft.getState() == null)
-                                || Objects.equals(oldTaxRate.getState(), taxRateDraft.getState()))
+                            Objects.equals(oldTaxRate.getCountry(), taxRateDraft.getCountry())
+                                && Objects.equals(oldTaxRate.getState(), taxRateDraft.getState()))
                     .findFirst()
                     .map(
                         matchedTaxRateDraft -> {


### PR DESCRIPTION
- **TaxCategory Sync**: This PR is to fix the Sync issue, when we have TaxRates with and without state.
- Linked Issue - https://github.com/commercetools/commercetools-project-sync/issues/298

#### Hints for Review
- To cover all the cases, now we are removing and adding taxRates, if the `state` value is changed. 