### PR TITLE
Document that sync should be used rather as delta than full import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The library supports synchronising the following entities in commercetools: [Cat
     - [Gradle](#gradle)
     - [SBT](#sbt)
     - [Ivy](#ivy)
-- [Roadmap](#roadmap)
 - [Release Notes](/docs/RELEASE_NOTES.md)
 - [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)

--- a/README.md
+++ b/README.md
@@ -31,20 +31,13 @@ Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/doc
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Usage
 
-commercetools sync is a Java library that imports commercetools platform data in the following ways:
+Create you own event or cronjob based application and use the library to transform any external data (JSON, CSV, XML, REST API, DB, ...) into [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects (e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)) and import those into the commercetools project.
 
-1. Synchronise data coming from an external system in any form (CSV, XML, etc..) that has been already mapped to 
-[commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
-(e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)).
-    - The amount of data that needs to be synced between your external system and a commercetools project can be huge. To assure good performance we strongly recommend implementing a **delta sync** approach for your logic instead of **full sync**; means that only resources
-      which have been modified since the last time the sync has run need to be synced.
+Notes:
 
-2. Synchronise data from another commercetools project as 
-[commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
-(e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java))
-   - 🔛 Check out the [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) for a ready-to-use CLI application that syncs your entire data catalogue between 2 commercetools projects!
-
-> **Note**: During a synchronisation, resources are either created or updated, but **not** deleted.
+- It is often more efficient if you can setup your external data source to provide you only the changes (deltas) instead of the full data set on every import iteration.
+- There is dockerized ready-to-use CLI application [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) which based on this library can synchronize entire data catalogue between the 2 commercetools projects.
+- During a synchronisation, resources are either created or updated, but **not** deleted.
 
 ⚡ See the [Quick Start Guide](/docs/usage/QUICK_START.md) for more information on building a product importer!
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,8 @@
 More at https://commercetools.github.io/commercetools-sync-java
  
 Java library for importing and syncing (taking care of changes) data into one or more commercetools projects from external data files or from another commercetools project.
+The library supports synchronising the following entities in commercetools: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
 
-The library supports synchronising the following entities in commercetools
-    
- - [Categories](/docs/usage/CATEGORY_SYNC.md)
- - [Products](/docs/usage/PRODUCT_SYNC.md)
- - [InventoryEntries](/docs/usage/INVENTORY_SYNC.md)
- - [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md)
- - [Types](/docs/usage/TYPE_SYNC.md)
- - [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md)
- - [States](/docs/usage/STATE_SYNC.md)
- - [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md)
- - [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md)
- - [Customers](/docs/usage/CUSTOMER_SYNC.md)
- - [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
-
-
-![commercetools-java-sync-final 001](https://user-images.githubusercontent.com/9512131/31230702-0f2255a6-a9e5-11e7-9412-04ed52641dde.png)
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -51,26 +36,27 @@ commercetools sync is a Java library that imports commercetools platform data in
 1. Synchronise data coming from an external system in any form (CSV, XML, etc..) that has been already mapped to 
 [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
 (e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)).
+    - The amount of data that needs to be synced between your external system and a commercetools project can be huge. To assure good performance we strongly recommend implementing a **delta sync** approach for your logic instead of **full sync**; means that only resources
+      which have been modified since the last time the sync has run need to be synced.
 
 2. Synchronise data from another commercetools project as 
 [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
-(e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)).
-
+(e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java))
+   - 🔛 Check out the [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) for a ready-to-use CLI application that syncs your entire data catalogue between 2 commercetools projects!
 
 > **Note**: During a synchronisation, resources are either created or updated, but **not** deleted.
 
 ⚡ See the [Quick Start Guide](/docs/usage/QUICK_START.md) for more information on building a product importer!
 
-🔛 Check out the [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) for a ready-to-use CLI application that syncs your entire data catalogue between 2 commercetools projects!
+![commercetools-java-sync-final 001](https://user-images.githubusercontent.com/3469524/126317637-a946a81c-2948-4751-86bb-02bcecfeca95.png)
 
 ### Prerequisites
  
- - Library is requires the min JDK version `>= 8`.
+ - Library requires the min JDK version `>= 8`.
    > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).        
  - [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based 
   application. (Make sure to use a version `>= 1.60.0`).
- - a target commercetools project for syncing your source data to.
-
+ - A target commercetools project for syncing your source data to.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
- 
-Java library for importing and syncing (taking care of changes) data into one or more commercetools projects from external data files or from another commercetools project.
-The library supports synchronising the following entities in commercetools: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
+
+Java library which allows to import/synchronise (import changes) the data from any arbitrary source to commercetools project.
+
+Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -54,7 +55,7 @@ commercetools sync is a Java library that imports commercetools platform data in
  - Library requires the min JDK version `>= 8`.
    > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).        
  - [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based 
-  application. (Make sure to use a version `>= 1.60.0`).
+  application. (Make sure to use a version `>= 1.64.0`).
  - A target commercetools project for syncing your source data to.
 
 ### Installation

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thanks for taking the time to contribute :+1::tada: All contributions are welcom
       - [Full build with tests, but without install to maven local repo (Recommended)](#full-build-with-tests-but-without-install-to-maven-local-repo-recommended)
       - [Install to local maven repo](#install-to-local-maven-repo)
       - [Publish JavaDoc](#publish-javadoc)
-      - [Build and publish to Bintray](#build-and-publish-to-bintray)
+      - [Build and publish to Maven Central](#build-and-publish-to-maven-central)
   - [Integration Tests](#integration-tests)
     - [Running](#running)
 - [Using the google java style and code formatter](#using-the-google-java-style-and-code-formatter)
@@ -77,9 +77,9 @@ If you have push access to the repository you can fix them directly otherwise ju
 ./gradlew clean javadoc gitPublishPush -Dbuild.version={version}
 ````
 
-##### Build and publish to Bintray
+##### Build and publish to Maven Central
 ````bash
-./gradlew clean build bintrayUpload -Dbuild.version={version} 
+./gradlew clean setLibraryVersion -Dbuild.version={version} publishToSonatype closeAndReleaseSonatypeStagingRepository
 ````
 
 For more detailed information on the build and the release process, see [Build and Release](BUILD.md) documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
 [![Benchmarks 6.0.0](https://img.shields.io/badge/Benchmarks-6.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from JCenter](https://img.shields.io/badge/Bintray_JCenter-6.0.0-green.svg) ](https://bintray.com/commercetools/maven/commercetools-sync-java/_latestVersion)
 [![Download from Maven Central](https://img.shields.io/badge/Maven_Central-6.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/6.0.0/jar) 
 [![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,21 +11,18 @@
 Java library which allows to import/synchronise (import changes) the data from any arbitrary source to commercetools project.
 
 Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
-             
- 1. Synchronise data coming from an external system in any form (CSV, XML, etc..) that has been already mapped to 
- [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
- (e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)).
- 
- 2. Synchronise data from another commercetools project as 
- [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
- (e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)).
- 
- 
- > Synchronise: Resources will either be created or updated. But they will **not** be deleted.
- 
- ⚡ See the [Quick Start Guide](https://commercetools.github.io/commercetools-sync-java/doc/usage/QUICK_START/) for more information on building a product importer!
- 
- 🔛 Check out the [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) for a ready-to-use CLI application that syncs your entire data catalogue between 2 commercetools projects! 
+
+## Usage
+
+Create you own event or cronjob based application and use the library to transform any external data (JSON, CSV, XML, REST API, DB, ...) into [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects (e.g. [CategoryDraft](https://github.com/commercetools/commercetools-jvm-sdk/blob/master/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java)) and import those into the commercetools project.
+
+Notes:
+
+- It is often more efficient if you can setup your external data source to provide you only the changes (deltas) instead of the full data set on every import iteration.
+- There is dockerized ready-to-use CLI application [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) which based on this library can synchronize entire data catalogue between the 2 commercetools projects.
+- During a synchronisation, resources are either created or updated, but **not** deleted.
+
+⚡ See the [Quick Start Guide](/docs/usage/QUICK_START.md) for more information on building a product importer!
 
 ![commercetools-java-sync-final 001](https://user-images.githubusercontent.com/3469524/126317637-a946a81c-2948-4751-86bb-02bcecfeca95.png)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,10 @@
 [![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
- 
-Java library that imports commercetools platform data in the following ways:
+
+Java library which allows to import/synchronise (import changes) the data from any arbitrary source to commercetools project.
+
+Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
              
  1. Synchronise data coming from an external system in any form (CSV, XML, etc..) that has been already mapped to 
  [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) resource draft objects 
@@ -25,30 +27,15 @@ Java library that imports commercetools platform data in the following ways:
  
  🔛 Check out the [commercetools-project-sync](https://github.com/commercetools/commercetools-project-sync) for a ready-to-use CLI application that syncs your entire data catalogue between 2 commercetools projects! 
 
-The library supports synchronising the following entities in commercetools
-    
- - [Categories](usage/CATEGORY_SYNC.md)
- - [Products](usage/PRODUCT_SYNC.md)
- - [InventoryEntries](usage/INVENTORY_SYNC.md)
- - [ProductTypes](usage/PRODUCT_TYPE_SYNC.md)
- - [Types](usage/TYPE_SYNC.md)
- - [CartDiscounts](usage/CART_DISCOUNT_SYNC.md)
- - [States](usage/STATE_SYNC.md)
- - [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md)
- - [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md)
- - [Customers](/docs/usage/CUSTOMER_SYNC.md)
- - [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
-
-![commercetools-java-sync-final 001](https://user-images.githubusercontent.com/9512131/31230702-0f2255a6-a9e5-11e7-9412-04ed52641dde.png)
-
+![commercetools-java-sync-final 001](https://user-images.githubusercontent.com/3469524/126317637-a946a81c-2948-4751-86bb-02bcecfeca95.png)
 
 ### Prerequisites
- 
- - Make sure you have `JDK 8` installed.
- - [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based 
-  application. (Make sure to use a version `>=` [1.60.0](https://search.maven.org/artifact/com.commercetools.sdk.jvm.core/commercetools-jvm-sdk/1.60.0/pom)).
- - a target commercetools project for syncing your source data to.
 
+- Library requires the min JDK version `>= 8`.
+  > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).
+- [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based
+  application. (Make sure to use a version `>= 1.64.0`).
+- A target commercetools project for syncing your source data to.
 
 ### Installation
 There are multiple ways to add the commercetools sync dependency to your project, based on your dependency manager. 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -26,6 +26,18 @@
 
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
+
+<!--
+### x.x.x - MM DD, 2021
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/6.0.0...X.X.X) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/X.X.X/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/X.X.X/jar)
+
+- ✨ **Documentation** (1)
+  -  Usage documentation on main readme improved, obsolete links is removed. [#758](https://github.com/commercetools/commercetools-sync-java/pull/758)
+
+-->
+
 ### 6.0.0 - Jul 19, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.3...6.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/) |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,7 +29,7 @@
 ### 6.0.0 - Jul 19, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.3...6.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/6.0.0)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/6.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
   - **Inventory Sync**: `InventoryService.fetchInventoryEntriesBySkus(Set<String> skus)` is renamed to `InventoryService.fetchInventoryEntriesByIdentifiers(Set<InventoryEntryIdentifier> inventoryEntryIdentifiers)`. [#757](https://github.com/commercetools/commercetools-sync-java/pull/757)
@@ -40,7 +40,7 @@
 ### 5.1.3 - Jul 8, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.2...5.1.3) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.3/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.3)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.3/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **TaxCategory Sync** - TaxCategories to sync properly when we have many TaxRates with different states.
@@ -58,7 +58,7 @@
 ### 5.1.2 - May 31, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.1...5.1.2) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.2/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.2)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.2/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Product Sync** - The user is now aware of unresolvable references as the transform service will not skip the products.
@@ -71,7 +71,7 @@
 ### 5.1.1 - May 18, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.0...5.1.1) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.1/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.1)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.1/jar)
 
 - 🐞 **Bug Fixes** (2)
     - **Product Sync** - Special characters can be defined for ProductDraft key. [#269](https://github.com/commercetools/commercetools-project-sync/issues/269)
@@ -92,15 +92,15 @@
 ### 5.1.0 - Apr 20, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.0.0...5.1.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.1.0/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.1.0)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.1.0/jar)
 
 - 🎉 **New Features** (1)
   - Syncing product types with an attribute of type Set of (Set of Set of..) of NestedType attribute is supported. [#720](https://github.com/commercetools/commercetools-sync-java/pull/720)
 
 ### 5.0.0 - Apr 12, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/4.0.1...5.0.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/5.0.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/5.0.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/5.0.0/jar)
 
 - 🚧 **Breaking Changes** (2)
     - For mapping a `resource` (Product, Category, CartDiscount, ShoppingList, State, InventoryEntry, ProductType, Customer) to `resourceDraft` 
@@ -142,8 +142,8 @@
  
 ### 4.0.1 - Mar 19, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/4.0.0...4.0.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/4.0.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/4.0.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/4.0.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/4.0.1/jar)
 
 - ✨ **Enhancements** (1)
     -  To avoid 414 request-URI too large error, the services are using chunking on the input list(keys or sku's) to
@@ -161,8 +161,8 @@
     
 ### 4.0.0 - Feb 26, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/3.2.0...4.0.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/4.0.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/4.0.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/4.0.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/4.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
     - **Product Sync**: `PriceDraft.getCustomerGroup()` is changed from `Reference<CustomerGroup>` to `ResourceIdentifier<CustomerGroup>`, so as a library user you don't need to provide a key field in the id field of the Reference. (Now API and JVM SDK support `ResourceIdentifiers` and it supports id or key as a field). [#676](https://github.com/commercetools/commercetools-sync-java/pull/676)
@@ -179,8 +179,8 @@
 
 ### 3.2.0 - Feb 3, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/3.1.0...3.2.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.2.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/3.2.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.2.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/3.2.0/jar)
 
 - 🎉 **New Features** (1)
     - Now the categories, which have an unresolvable parent category, are persisted in custom objects, 
@@ -197,8 +197,8 @@
     
 ### 3.1.0 - Jan 13, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/3.0.2...3.1.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.1.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/3.1.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.1.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/3.1.0/jar)
 
 - 🎉 **New Features** (1)
     - Added clean up implementation for the outdated pending reference resolution custom objects. [#650](https://github.com/commercetools/commercetools-sync-java/issues/650)
@@ -211,8 +211,8 @@
 
 ### 3.0.2 - Dec 16, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/3.0.1...3.0.2) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.0.2/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/3.0.2)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.0.2/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/3.0.2/jar)
 
 - ✨ **Documentation** (2)
     -  Documentation for the [cacheSize](https://github.com/commercetools/commercetools-sync-java/blob/master/docs/usage/PRODUCT_SYNC.md#cachesize) sync option is added.
@@ -223,8 +223,8 @@
 
 ### 3.0.1 - Nov 24, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/3.0.0...3.0.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.0.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/3.0.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.0.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/3.0.1/jar)
 
 - ✨ **Enhancements** (1)
     -  To improve performance of the library, the services are using graphQL API to fetch resource ids only; also the 
@@ -238,7 +238,7 @@
 ### 3.0.0 - Nov 18, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/2.3.0...3.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/3.0.0/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/3.0.0)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/3.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
     - **Product Sync**: `ProductDraft.getState()` is changed from `Reference<State>` to `ResourceIdentifier<State>`, so as a library user you don't need to provide a key field in the id field of the Reference. (Now API and JVM SDK support `ResourceIdentifiers` and it supports id or key as a field). [#589](https://github.com/commercetools/commercetools-sync-java/pull/589)
@@ -260,7 +260,7 @@
 ### 2.3.0 - Oct 15, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/2.2.1...2.3.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.3.0/) |
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/2.3.0)
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/2.3.0/jar)
 
 - 🎉 **New Features** (4)
     - **Customer Sync** - Added support for syncing customers between ctp projects. [#579](https://github.com/commercetools/commercetools-sync-java/issues/579)
@@ -270,8 +270,8 @@
 
 ### 2.2.1 - Sep 29, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/2.2.0...2.2.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.2.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/2.2.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.2.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/2.2.1/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Product Sync** - Fixed a bug in the `ProductSync` related handling of unresolved product references provided in 
@@ -280,8 +280,8 @@
 
 ### 2.2.0 - Sep 25, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/2.1.0...2.2.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.2.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/2.2.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.2.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/2.2.0/jar)
 
 - 🎉 **New Features** (2)
     - **Product Sync** - Added support for resolving `key-value-document` (custom object) references on attributes of type `Reference`, `Set` of `Reference`, `NestedType` or `Set` of `NestedType`. [#564](https://github.com/commercetools/commercetools-sync-java/issues/564)     
@@ -300,8 +300,8 @@
 
 ### 2.1.0 - Sep 21, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/2.0.0...2.1.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.1.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/2.1.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.1.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/2.1.0/jar)
 - 🎉 **New Features** (2)
     - **CustomObject Sync** - Added support for syncing custom objects between ctp projects. [#565](https://github.com/commercetools/commercetools-sync-java/issues/565) For more info how to use it please refer to [CustomObject usage doc](/docs/usage/CUSTOM_OBJECT_SYNC.md).
     - **CustomObject Sync** - Exposed `CustomObjectSyncUtils#hasIdenticalValue` which determines whether update process is required after comparing a `CustomObject` and a `CustomObjectDraft`. [#565](https://github.com/commercetools/commercetools-sync-java/issues/565)
@@ -313,8 +313,8 @@
 
 ### 2.0.0 - Sept 14, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.9.1...2.0.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.0.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/2.0.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/2.0.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/2.0.0/jar)
 
 - 🚧 **Breaking Changes** (2)
     - Sync options:
@@ -343,8 +343,8 @@
     
 ### 1.9.1 -  Aug 5, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.9.0...1.9.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.9.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.9.1/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Product Sync** - Fixed a bug in the `ProductSync` related to publish/unpublish of the product update actions,
@@ -353,8 +353,8 @@
 
 ### 1.9.0 -  July 27, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.8.2...1.9.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.9.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.9.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.9.0/jar)
 
 - 🎉 **New Features** (6)
     - **TaxCategory Sync** - Added support for syncing tax categories. [#417](https://github.com/commercetools/commercetools-sync-java/issues/417) For more info how to use it please refer to [TaxCategory usage doc](/docs/usage/TAX_CATEGORY_SYNC.md).
@@ -375,8 +375,8 @@
         
 ### 1.8.2 -  April 30, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.8.1...1.8.2) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.2/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.8.2)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.2/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.8.2/jar)
 
 - 🐞 **Bug Fixes** (2)
     - **Commons** - Fixed a bug in the Sync implementations causing the sync fail with throwing `ClassCastException`. [#466](https://github.com/commercetools/commercetools-sync-java/issues/466)
@@ -385,8 +385,8 @@
 
 ### 1.8.1 -  April 22, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.8.0...1.8.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.8.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.8.1/jar)
 
 - ✨ **Enhancements** (1)
     - **Commons** - Remove final keyword on interface/abstract method params. [#165](https://github.com/commercetools/commercetools-sync-java/issues/165)
@@ -410,8 +410,8 @@
     
 ### 1.8.0 -  Jan 17, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.7.0...1.8.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.8.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.8.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.8.0/jar)
 
 - ✨ **Enhancements** (1)
     - **Inventory Sync** - Only cache the needed keys of `Channel` references instead of 
@@ -421,8 +421,8 @@
 
 ### 1.7.0 -  Jan 7, 2020
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.6.1...1.7.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.7.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.7.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.7.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.7.0/jar)
 
 
 - ✨ **Enhancements** (2)
@@ -450,8 +450,8 @@
 
 ### 1.6.1 -  Oct 17, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.6.0...1.6.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.6.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.6.1/jar)
 
 - 🐞 **Bug Fixes** (3)
     - **Commons** - Fixed a bug in the `CtpQueryUtils` which was overwriting the query input query for every page after
@@ -470,8 +470,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.6.0 -  Oct 10, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.5.0...1.6.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.6.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.6.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.6.0/jar)
 
 - 🎉 **New Features** (1)
     - **Product Sync** - Introduced support for syncing products with other product references as attributes in any order. [#447](https://github.com/commercetools/commercetools-sync-java/issues/447)
@@ -481,8 +481,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.5.0 -  Sept 13, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.4.1...1.5.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.5.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.5.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.5.0/jar)
 
 - 🎉 **New Features** (4)
     - **Product Sync** - Added support for resolving `Product` references on attributes of type `Reference`, `Set` of `Reference`, `NestedType` or `Set` of `NestedType`. [#438](https://github.com/commercetools/commercetools-sync-java/issues/438)
@@ -502,8 +502,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.4.1 -  Sept 2, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.4.0...1.4.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.4.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.4.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.4.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.4.1/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Commons** - Fixed a bug in the custom fields update actions builders which generated duplicated unnecessary update actions for `null` custom field values. This affected any sync module where the resource contained custom fields (i.e. Product Sync, Category Sync, CartDiscount Sync and Inventory Sync). It also affected any update actions building utility in which the resource/sub-resource contained custom fields.  [#428](https://github.com/commercetools/commercetools-sync-java/issues/428)
@@ -513,8 +513,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.4.0 -  Aug 8, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.3.0...1.4.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.4.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.4.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.4.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.4.0/jar)
 
 
 - 🎉 **New Features** (5)
@@ -536,8 +536,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.3.0 -  Jul 3, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.2.0...1.3.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.3.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.3.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.3.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.3.0/jar)
 
 - 🎉 **New Features** (6)
     - **CartDiscount Sync** - Added support for syncing cart discounts. [#379](https://github.com/commercetools/commercetools-sync-java/issues/379) For more info how to use it please refer to [CartDiscount usage doc](/docs/usage/CART_DISCOUNT_SYNC.md).
@@ -560,8 +560,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.2.0 -  Jun 14, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.1.1...1.2.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.2.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.2.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.2.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.2.0/jar)
 
 - 🚧 **Breaking Changes** (2)
     - **ProductType Sync** - Removed the unneeded `AttributeDefinitionCustomBuilder` which was an exposed but internal helper. [#377](https://github.com/commercetools/commercetools-sync-java/issues/377). 
@@ -593,8 +593,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.1.1 -  Jan 16, 2019
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.1.0...1.1.1) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.1.1/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Product Sync** - Fixed a bug in the `product` sync which would fail on syncing attributes of type `Set` that has
@@ -603,8 +603,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.1.0 -  Dec 19, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/1.0.0...1.1.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.1.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.1.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.1.0/jar)
 
 - 🎉 **New Features** (4)
     - **Product Sync** - Added support for syncing assets of newly added variants. [#357](https://github.com/commercetools/commercetools-sync-java/issues/357).
@@ -629,8 +629,8 @@ failed fetches of missing references. [#426](https://github.com/commercetools/co
 
 ### 1.0.0 -  Dec 10, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M14...1.0.0) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.0.0/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/1.0.0)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/1.0.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/1.0.0/jar)
 
 ##### The Beta is Over 🎉
 
@@ -698,8 +698,8 @@ the library. `1.0.0` is here for you to use with all new features, enhancements 
 
 ### v1.0.0-M14 -  Oct 5, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M13...v1.0.0-M14) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M14/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M14)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M14/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M14/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Product Sync** - Fixed a bug where the removed attributes in the source product variant draft were not being removed from the target variant. [#238](https://github.com/commercetools/commercetools-sync-java/issues/308)
@@ -721,8 +721,8 @@ the library. `1.0.0` is here for you to use with all new features, enhancements 
 
 ### v1.0.0-M13 -  Sept 5, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M12...v1.0.0-M13) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M13/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M13)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M13/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M13/jar)
 
 - 🎉 **New Features** (15)
     - **ProductType Sync** - Support for syncing productTypes. [#286](https://github.com/commercetools/commercetools-sync-java/issues/286) For more info how to use it please refer to [ProductType usage doc](/docs/usage/PRODUCT_TYPE_SYNC.md). 
@@ -758,8 +758,8 @@ the library. `1.0.0` is here for you to use with all new features, enhancements 
 
 ### v1.0.0-M12 -  Jun 05, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M11...v1.0.0-M12) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M12/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M12)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M12/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M12/jar)
 
 - 🛠️ **Enhancements** (13)
     - **Product Sync** - Support for syncing price custom fields. [#277](https://github.com/commercetools/commercetools-sync-java/issues/277)
@@ -779,8 +779,8 @@ the library. `1.0.0` is here for you to use with all new features, enhancements 
 
 ### v1.0.0-M11 -  Mar 08, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M10...v1.0.0-M11) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M11/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M11)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M11/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M11/jar)
 
 - 🎉 **New Features** (19)
     - **Category Sync** - Support of categories' asset syncing. [#3](https://github.com/commercetools/commercetools-sync-java/issues/3)
@@ -824,8 +824,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M10 -  Feb 13, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M9...v1.0.0-M10) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M10)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M10/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M10/jar)
 
 - 🎉 **New Features** (1)
     - **Commons** - Added [benchmarking setup](/docs/BENCHMARKS.md) for the library on every release. [#155](https://github.com/commercetools/commercetools-sync-java/issues/155)
@@ -837,8 +837,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M9 -  Jan 22, 2018
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M8...v1.0.0-M9) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M9/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M9)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M9/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M9/jar)
 
 - 🎉 **New Features** (1)
     - **Commons** - Added `getSyncOptions` to the `ProductSync`, `CategorySync` and `InventorySync`. [#230](https://github.com/commercetools/commercetools-sync-java/issues/230)
@@ -856,8 +856,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M8 -  Dec 29, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M7...v1.0.0-M8) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M8/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M8)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M8/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M8/jar)
 
 - 🎉 **New Features** (1)
     - **Category Sync** - Exposed new method `CategorySyncStatistics#getNumberOfCategoriesWithMissingParents` which gets the
@@ -874,8 +874,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M7 -  Dec 15, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M6...v1.0.0-M7) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M7/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M7)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M7/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M7/jar)
 
 - 🐞 **Bug Fixes** (1)
     - **Commons** - Changed offset-based pagination of querying all elements to a limit-based with sorted ids approach 
@@ -884,8 +884,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M6 -  Dec 5, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M5...v1.0.0-M6) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M6/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M6)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M6/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M6/jar)
 
 -  🎉 **New Features** (3)
     - **Category Sync** - Introduced `beforeCreateCallback` option which is callback applied on a category draft before a request to create it on CTP is issued. [#183](https://github.com/commercetools/commercetools-sync-java/issues/183)
@@ -919,8 +919,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M5 -  Nov 16, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M4...v1.0.0-M5) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M5/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M5)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M5/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M5/jar)
 
 - 🎉 **New Features** (3)
     - **Inventory Sync** - Introduced `beforeUpdateCallback` which is applied after generation of update actions and before 
@@ -952,8 +952,8 @@ only be triggered on the full build. [#249](https://github.com/commercetools/com
 
 ### v1.0.0-M4 -  Nov 7, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M3...v1.0.0-M4) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M4/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M4)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M4/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M4/jar)
 
 - 🔥 **Hotfix** (1)
     - **Product Sync** - Fixed an issue with `replaceAttributesReferencesIdsWithKeys` which nullifies localized text attributes due 
@@ -962,8 +962,8 @@ to JSON parsing not throwing exception on parsing it to reference set. [#179](ht
 
 ### v1.0.0-M3 -  Nov 3, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M2...v1.0.0-M3) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M3/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M3)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M3/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M3/jar)
 
 - 🎉 **New Features** (7)
     - **ProductSync** - Introduced Product TaxCategory reference resolution and syncing. [#120](https://github.com/commercetools/commercetools-sync-java/issues/120).
@@ -1001,9 +1001,8 @@ to JSON parsing not throwing exception on parsing it to reference set. [#179](ht
 ### v1.0.0-M2 -  Oct 12, 2017 
 
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M2-beta...v1.0.0-M2) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M2/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M2)
-
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M2/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M2/jar)
 - 🎉 **New Features** (3)
     - **Product Sync** - Supported syncing entire product variant images, putting order into consideration. [#114](https://github.com/commercetools/commercetools-sync-java/issues/114)
     - **Product Sync** - Exposed `ProductVariantUpdateActionUtils#buildProductVariantImagesUpdateActions` and `ProductVariantUpdateActionUtils#buildMoveImageToPositionUpdateActions` action build util. [#114](https://github.com/commercetools/commercetools-sync-java/issues/114)
@@ -1027,8 +1026,8 @@ to JSON parsing not throwing exception on parsing it to reference set. [#179](ht
      - **Build Tools** - Added JavaDoc badge to repo. [#145](https://github.com/commercetools/commercetools-sync-java/issues/145)
 
 ### v1.0.0-M2-beta -  Sep 28, 2017 
-[Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M1...v1.0.0-M2-beta) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M2-beta)
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/v1.0.0-M1...v1.0.0-M2-beta) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M2-beta/jar)
 
 
 - **Beta Features** (11)
@@ -1050,8 +1049,8 @@ to JSON parsing not throwing exception on parsing it to reference set. [#179](ht
 
 ### v1.0.0-M1 -  Sep 06, 2017
 [Commits](https://github.com/commercetools/commercetools-sync-java/commits/v1.0.0-M1) | 
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M1/) | 
-[Jar](https://bintray.com/commercetools/maven/commercetools-sync-java/v1.0.0-M1)
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/v1.0.0-M1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/v1.0.0-M1/jar)
 
 - 🎉 **New Features** (16) 
     - **Category Sync** - Introduced syncing category name, description, orderHint, metaDescription, metaTitle, 

--- a/gradle-scripts/repositories.gradle
+++ b/gradle-scripts/repositories.gradle
@@ -1,5 +1,3 @@
 repositories {
     mavenCentral()
-    jcenter()
-    mavenLocal()
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,6 @@ nav:
         - Cleanup Unresolved References: usage/CLEANUP_GUIDE.md
   - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/6.0.0/
   - Release notes: RELEASE_NOTES.md
-  - Roadmap: https://github.com/commercetools/commercetools-sync-java/milestones
   - Issues: https://github.com/commercetools/commercetools-sync-java/issues
   - Benchmarks: https://commercetools.github.io/commercetools-sync-java/benchmarks/
 


### PR DESCRIPTION
**Situation**
Many customers use our sync library.

**Complication**
But not all of them are aware what is the best practice when it comes to efficiently import new data since it is not documented.

**Resolution**
Make sure we document and encourage customers to not import always a full-import every hour but consider to use delta updates - importing only changed data not always all of them.