### PR TITLE
Dependency management changes for JVM-SDK libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Notes:
 ### Prerequisites
  
  - Library requires the min JDK version `>= 8`.
-   > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).        
- - [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based 
-  application. (Make sure to use a version `>= 1.64.0`).
+   > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).
  - A target commercetools project for syncing your source data to.
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 6.0.0](https://img.shields.io/badge/Benchmarks-6.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-6.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/6.0.0/jar) 
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
+[![Benchmarks 7.0.0](https://img.shields.io/badge/Benchmarks-7.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-7.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar) 
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
@@ -25,7 +25,7 @@ Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/doc
     - [SBT](#sbt)
     - [Ivy](#ivy)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -62,24 +62,24 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:6.0.0'
+implementation 'com.commercetools:commercetools-sync-java:7.0.0'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "6.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "7.0.0"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="6.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="7.0.0"/>
 ````

--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,9 @@ apply from: "$rootDir/gradle-scripts/mkdocs.gradle"
 apply from: "$rootDir/gradle-scripts/spotless.gradle"
 
 dependencies {
-    implementation "com.commercetools.sdk.jvm.core:commercetools-models:${commercetoolsJvmSdkVersion}"
-    implementation "com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:${commercetoolsJvmSdkVersion}"
-    implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
+    api "com.commercetools.sdk.jvm.core:commercetools-models:${commercetoolsJvmSdkVersion}"
+    api "com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:${commercetoolsJvmSdkVersion}"
+    api "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     constraints {
         implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.3") {

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,6 @@ Notes:
 
 - Library requires the min JDK version `>= 8`.
   > The library tested with each major JDK version (i.e: 8, 9, 10, 11, 12, 13...) as well as some specific updates of LTS versions (i.e: 8.0.192, 11.0.3).
-- [commercetools-jvm-sdk](https://github.com/commercetools/commercetools-jvm-sdk) as a dependency in your JVM-based
-  application. (Make sure to use a version `>= 1.64.0`).
 - A target commercetools project for syncing your source data to.
 
 ### Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 6.0.0](https://img.shields.io/badge/Benchmarks-6.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-6.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/6.0.0/jar) 
-[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/)
+[![Benchmarks 7.0.0](https://img.shields.io/badge/Benchmarks-7.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-7.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar) 
+[![Javadoc](http://javadoc-badge.appspot.com/com.commercetools/commercetools-sync-java.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 
@@ -42,18 +42,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:6.0.0'
+implementation 'com.commercetools:commercetools-sync-java:7.0.0'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "6.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "7.0.0"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="6.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="7.0.0"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -45,15 +45,14 @@
 
 - 🚧 **Breaking Changes** (1)
   - **Dependency management:** Avoid JVM-SDK libraries version mismatch between projects.
-     You should not explicitly add JVM-SDK dependencies into your project where you are using Sync-Java. Please remove them if you have already added the below dependencies in your project.
+     It is better not to add JVM-SDK dependencies explicitly into your project and use them from Sync-Java dependencies instead. Please remove them if you have already added the below dependencies in your project.
      
      For Gradle users, remove: 
      
      ````groovy
-     // Add commercetools-jvm-sdk dependencies.
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.60.0'
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:1.60.0'
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.60.0'
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-models:<version>'
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:<version>'
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:<version>'
      ````
      
      For Maven users, remove:
@@ -62,17 +61,17 @@
      <dependency>
        <groupId>com.commercetools.sdk.jvm.core</groupId>
        <artifactId>commercetools-models</artifactId>
-       <version>1.60.0</version>
+       <version>version</version>
      </dependency>
      <dependency>
        <groupId>com.commercetools.sdk.jvm.core</groupId>
        <artifactId>commercetools-java-client-ahc-2_5</artifactId>
-       <version>1.60.0</version>
+       <version>version</version>
      </dependency>
      <dependency>
        <groupId>com.commercetools.sdk.jvm.core</groupId>
        <artifactId>commercetools-convenience</artifactId>
-       <version>1.60.0</version>
+       <version>version</version>
      </dependency>
      ````
   

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,18 +27,7 @@
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
 
-<!--
-### x.x.x - MM DD, 2021
-[Commits](https://github.com/commercetools/commercetools-sync-java/compare/7.0.0...X.X.X) |
-[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/X.X.X/) |
-[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/X.X.X/jar)
-
-- ✨ **Documentation** (1)
-  -  Usage documentation on main readme improved, obsolete links is removed. [#758](https://github.com/commercetools/commercetools-sync-java/pull/758)
-
--->
-
-### 7.0.0 - Aug 23, 2021
+### 7.0.0 - Aug 24, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/6.0.0...7.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/) |
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar)
@@ -74,6 +63,10 @@
        <version>version</version>
      </dependency>
      ````
+    
+  ✨ **Documentation** (1)
+    - Usage documentation on main readme improved, obsolete links is removed. [#758](https://github.com/commercetools/commercetools-sync-java/pull/758)
+
   
 ### 6.0.0 - Jul 19, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.3...6.0.0) |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -44,8 +44,8 @@
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
-  - **Dependency management:** Avoid JVM-SDK libraries version mismatch between projects.
-     It is better not to add JVM-SDK dependencies explicitly into your project and use them from Sync-Java dependencies instead. Please remove them if you have already added the below dependencies in your project.
+  - **Dependency management:** Avoid `commercetools JVM SDK` libraries version mismatch between projects.
+     It is better not to add `commercetools JVM SDK` dependencies explicitly into your project and use them from `commercetools-Sync-Java` dependencies instead. Please remove them if you have already added the below dependencies in your project.
      
      For Gradle users, remove: 
      

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,7 +29,7 @@
 
 <!--
 ### x.x.x - MM DD, 2021
-[Commits](https://github.com/commercetools/commercetools-sync-java/compare/6.0.0...X.X.X) |
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/7.0.0...X.X.X) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/X.X.X/) |
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/X.X.X/jar)
 
@@ -38,6 +38,44 @@
 
 -->
 
+### 7.0.0 - Aug 23, 2021
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/6.0.0...7.0.0) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar)
+
+- 🚧 **Breaking Changes** (1)
+  - **Dependency management:** Avoid JVM-SDK libraries version mismatch between projects.
+     You should not explicitly add JVM-SDK dependencies into your project where you are using Sync-Java. Please remove them if you have already added the below dependencies in your project.
+     
+     For Gradle users, remove: 
+     
+     ````groovy
+     // Add commercetools-jvm-sdk dependencies.
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.60.0'
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:1.60.0'
+     implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.60.0'
+     ````
+     
+     For Maven users, remove:
+     
+     ````xml
+     <dependency>
+       <groupId>com.commercetools.sdk.jvm.core</groupId>
+       <artifactId>commercetools-models</artifactId>
+       <version>1.60.0</version>
+     </dependency>
+     <dependency>
+       <groupId>com.commercetools.sdk.jvm.core</groupId>
+       <artifactId>commercetools-java-client-ahc-2_5</artifactId>
+       <version>1.60.0</version>
+     </dependency>
+     <dependency>
+       <groupId>com.commercetools.sdk.jvm.core</groupId>
+       <artifactId>commercetools-convenience</artifactId>
+       <version>1.60.0</version>
+     </dependency>
+     ````
+  
 ### 6.0.0 - Jul 19, 2021
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/5.1.3...6.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/) |

--- a/docs/usage/CART_DISCOUNT_SYNC.md
+++ b/docs/usage/CART_DISCOUNT_SYNC.md
@@ -36,7 +36,7 @@ against a [CartDiscountDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -67,7 +67,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `CartDiscount` to `CartDiscountDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -36,7 +36,7 @@ against a [CategoryDraft](https://docs.commercetools.com/http-api-projects-categ
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -135,7 +135,7 @@ As soon, as the referenced parent Category draft is supplied to the sync, the dr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `Category` to `CategoryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOMER_SYNC.md
+++ b/docs/usage/CUSTOMER_SYNC.md
@@ -35,7 +35,7 @@ against a [CustomerDraft](https://docs.commercetools.com/api/projects/customers#
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -69,7 +69,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Customer` to `CustomerDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOM_OBJECT_SYNC.md
+++ b/docs/usage/CUSTOM_OBJECT_SYNC.md
@@ -31,7 +31,7 @@ against a [CustomObjectDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/IMPORTANT_USAGE_TIPS.md
+++ b/docs/usage/IMPORTANT_USAGE_TIPS.md
@@ -31,7 +31,7 @@ productSync.sync(batch1)
 By design, scaling the sync process should **not** be done by executing the batches themselves in parallel. However, it can be done either by:
  
  - Changing the number of [max parallel requests](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L116) within the `sphereClient` configuration. It defines how many requests the client can execute in parallel.
- - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
+ - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
  
 The current overridable default [configuration](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) of the `sphereClient` 
 is the recommended good balance for stability and performance for the sync process.

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -36,7 +36,7 @@ against a [InventoryEntryDraft](https://docs.commercetools.com/http-api-projects
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -68,7 +68,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `InventoryEntry` to `InventoryEntryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -39,7 +39,7 @@ against a [ProductDraft](https://docs.commercetools.com/http-api-projects-produc
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -80,7 +80,7 @@ resource on the target commercetools project and the library will issue an updat
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Product` to `ProductDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -36,7 +36,7 @@ against a [ProductTypeDraft](https://docs.commercetools.com/http-api-projects-pr
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ProductType` to `ProductTypeDraft`. It can be configured to use a cache that will speed up the reference resolution performed during the sync, for example: 
 
 ````java

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -13,42 +13,20 @@
 
 ### 1. Installation
 - Make sure you have `JDK 8` installed.
-- Add the following dependencies in your application:
+- Add the following dependency in your application:
 - For Maven users: 
 ````xml
-<!-- Add commercetools-jvm-sdk dependencies. -->
-<dependency>
-  <groupId>com.commercetools.sdk.jvm.core</groupId>
-  <artifactId>commercetools-models</artifactId>
-  <version>1.60.0</version>
-</dependency>
-<dependency>
-  <groupId>com.commercetools.sdk.jvm.core</groupId>
-  <artifactId>commercetools-java-client-ahc-2_5</artifactId>
-  <version>1.60.0</version>
-</dependency>
-<dependency>
-  <groupId>com.commercetools.sdk.jvm.core</groupId>
-  <artifactId>commercetools-convenience</artifactId>
-  <version>1.60.0</version>
-</dependency>
-
 <!-- Add commercetools-sync-java dependency. -->
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
 </dependency>
 ````
 - For Gradle users:
 ````groovy
-// Add commercetools-jvm-sdk dependencies.
-implementation 'com.commercetools.sdk.jvm.core:commercetools-models:1.60.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:1.60.0'
-implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:1.60.0'
-
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:6.0.0'
+implementation 'com.commercetools:commercetools-sync-java:7.0.0'
 ````
 
 ### 2. Setup Syncing Options

--- a/docs/usage/SHOPPING_LIST_SYNC.md
+++ b/docs/usage/SHOPPING_LIST_SYNC.md
@@ -37,7 +37,7 @@ against a [ShoppingListDraft](https://docs.commercetools.com/api/projects/shoppi
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -73,7 +73,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ShoppingList` to `ShoppingListDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/STATE_SYNC.md
+++ b/docs/usage/STATE_SYNC.md
@@ -35,7 +35,7 @@ against a [StateDraft](https://docs.commercetools.com/http-api-projects-states#s
 #### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ reference should return its `key`.
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/6.0.0/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/7.0.0/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `State` to `StateDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/TAX_CATEGORY_SYNC.md
+++ b/docs/usage/TAX_CATEGORY_SYNC.md
@@ -31,7 +31,7 @@ against a [TaxCategoryDraft](https://docs.commercetools.com/http-api-projects-ta
 ### Prerequisites
 
 #### SphereClient
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/TYPE_SYNC.md
+++ b/docs/usage/TYPE_SYNC.md
@@ -33,7 +33,7 @@ against a [TypeDraft](https://docs.commercetools.com/http-api-projects-types.htm
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/6.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/7.0.0/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
         - Sync Options: usage/SYNC_OPTIONS.md
         - Usage Tips: usage/IMPORTANT_USAGE_TIPS.md
         - Cleanup Unresolved References: usage/CLEANUP_GUIDE.md
-  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/6.0.0/
+  - Javadoc: https://commercetools.github.io/commercetools-sync-java/v/7.0.0/
   - Release notes: RELEASE_NOTES.md
   - Issues: https://github.com/commercetools/commercetools-sync-java/issues
   - Benchmarks: https://commercetools.github.io/commercetools-sync-java/benchmarks/


### PR DESCRIPTION
#### Summary
Dependency scope changes to Avoid JVM-SDK libraries version mismatch between projects.

#### Description
- This will be a breaking change for the users who are already using Sync-Java library.
- Changed dependencies from Implementation to api. (For more info on this: https://tomgregory.com/how-to-use-gradle-api-vs-implementation-dependencies-with-the-java-library-plugin/)
- Updated Documentation.
- Prepare release 7.0.0.
