### PR TITLE
Update docs and Release notes about the usage of `JVM-SDK` dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,72 @@ libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "7.0.1"
 ````xml
 <dependency org="com.commercetools" name="commercetools-sync-java" rev="7.0.1"/>
 ````
+
+**Note**: To avoid `commercetools JVM SDK` libraries version mismatch between projects.
+ It is better not to add `commercetools JVM SDK` dependencies explicitly into your project and use them from `commercetools-Sync-Java` dependencies instead. 
+ Please remove them if you have already added the below dependencies in your project.
+            
+        For Gradle users, remove: 
+        
+        ````groovy
+        implementation 'com.commercetools.sdk.jvm.core:commercetools-models:<version>'
+        implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:<version>'
+        implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:<version>'
+        ````
+        
+        For Maven users, remove:
+        
+        ````xml
+        <dependency>
+          <groupId>com.commercetools.sdk.jvm.core</groupId>
+          <artifactId>commercetools-models</artifactId>
+          <version>version</version>
+        </dependency>
+        <dependency>
+          <groupId>com.commercetools.sdk.jvm.core</groupId>
+          <artifactId>commercetools-java-client-ahc-2_5</artifactId>
+          <version>version</version>
+        </dependency>
+        <dependency>
+          <groupId>com.commercetools.sdk.jvm.core</groupId>
+          <artifactId>commercetools-convenience</artifactId>
+          <version>version</version>
+        </dependency>
+        ````
+
+If you want to use different `commercetools JVM SDK` version other than the version used in this project. 
+You can exclude `commercetools JVM SDK` dependencies coming from this project and add explicitly the dependency and version you need in your project.
+
+        For Gradle: 
+        
+        ````groovy
+        implementation('com.commercetools:commercetools-sync-java') {
+            exclude group: 'com.commercetools.sdk.jvm.core', module: 'commercetools-models'
+            exclude group: 'com.commercetools.sdk.jvm.core', module: 'commercetools-java-client-ahc-2_5'
+            exclude group: 'com.commercetools.sdk.jvm.core', module: 'commercetools-convenience'
+        }
+        ````
+        
+        For Maven:
+        
+        ````xml
+        <dependency>
+          <groupId>com.commercetools</groupId>
+          <artifactId>commercetools-sync-java</artifactId>
+          <version>version</version>
+          <exclusions>
+            <exclusion>
+                <groupId>com.commercetools.sdk.jvm.core</groupId>
+                <artifactId>commercetools-models</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.commercetools.sdk.jvm.core</groupId>
+                <artifactId>commercetools-java-client-ahc-2_5</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.commercetools.sdk.jvm.core</groupId>
+                <artifactId>commercetools-convenience</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        ````

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "7.0.1"
         ````
 
 If you want to use different `commercetools JVM SDK` version other than the version used in this project. 
-You can exclude `commercetools JVM SDK` dependencies coming from this project and add explicitly the dependency and version you need in your project.
+, below you will find examples on how to exclude `commercetools JVM SDK` from commercetools-sync-java library. Beware that library might not work with the older `commercetools JVM SDK` versions.
 
         For Gradle: 
         

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "7.0.1"
         </dependency>
         ````
 
-If you want to use different `commercetools JVM SDK` version other than the version used in this project. 
+If you want to use a different `commercetools JVM SDK` version than the version used in this project. 
 , below you will find examples on how to exclude `commercetools JVM SDK` from commercetools-sync-java library. Beware that library might not work with the older `commercetools JVM SDK` versions.
 
         For Gradle: 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -42,37 +42,10 @@
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/7.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
-  - **Dependency management:** Avoid `commercetools JVM SDK` libraries version mismatch between projects.
-     It is better not to add `commercetools JVM SDK` dependencies explicitly into your project and use them from `commercetools-Sync-Java` dependencies instead. Please remove them if you have already added the below dependencies in your project.
+  - **Dependency management:** To avoid `commercetools JVM SDK` libraries version mismatch between projects.
+     It is better not to add `commercetools JVM SDK` dependencies explicitly into your project and use them from `commercetools-Sync-Java` dependencies instead.
+     Check [README.md](https://github.com/commercetools/commercetools-sync-java#installation) for more details.
      
-     For Gradle users, remove: 
-     
-     ````groovy
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-models:<version>'
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-java-client-ahc-2_5:<version>'
-     implementation 'com.commercetools.sdk.jvm.core:commercetools-convenience:<version>'
-     ````
-     
-     For Maven users, remove:
-     
-     ````xml
-     <dependency>
-       <groupId>com.commercetools.sdk.jvm.core</groupId>
-       <artifactId>commercetools-models</artifactId>
-       <version>version</version>
-     </dependency>
-     <dependency>
-       <groupId>com.commercetools.sdk.jvm.core</groupId>
-       <artifactId>commercetools-java-client-ahc-2_5</artifactId>
-       <version>version</version>
-     </dependency>
-     <dependency>
-       <groupId>com.commercetools.sdk.jvm.core</groupId>
-       <artifactId>commercetools-convenience</artifactId>
-       <version>version</version>
-     </dependency>
-     ````
-    
   ✨ **Documentation** (1)
     - Usage documentation on main readme improved, obsolete links is removed. [#758](https://github.com/commercetools/commercetools-sync-java/pull/758)
 


### PR DESCRIPTION
- Updated Readme.md to provide proper information to both existing and new users about the usage of `JVM-SDK` dependencies in their project.
- Updated Release notes as per the lastest changes.