### PR TITLE
Migrate Dependabot to Renovate

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: java:gradle
-    directory: "/"
-    update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_name: "*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "automerge": true,
+  "schedule": [
+    "every weekend"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "stabilityDays": 3
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "dependencyDashboard": false,
   "extends": [
     "config:base"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,13 +5,5 @@
   "automerge": true,
   "schedule": [
     "every weekend"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gradle"
-      ],
-      "stabilityDays": 3
-    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
-  "dependencyDashboard": false,
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "automerge": true,
   "schedule": [


### PR DESCRIPTION
#### Hints for Review
- Move the functionality from `./dependabot/config.yml` to `./github/renovate.json`.
- Official doc about package manager in Renovate
https://docs.renovatebot.com/modules/manager/

