### PR TITLE
Adding package rules GroupName to group all the dependencies in one PR.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,6 @@
   "automerge": true,
   "schedule": [
     "every weekend"
-  ]
+  ],
+  "groupName": "all"
 }


### PR DESCRIPTION
Check here for renovate docs: https://docs.renovatebot.com/configuration-options/#packagerules
