### PR TITLE
Make mkdocsBuild part of the checks on CI build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: ./gradlew pmdBenchmark pmdIntegrationTest pmdMain pmdTest
       - name: Spotbugs
         run: ./gradlew spotbugsBenchmark spotbugsIntegrationTest spotbugsMain spotbugsTest
+      - name: mkdocsBuild
+        run: ./gradlew mkdocsBuild
 
   tests:
     name: Tests

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -32,7 +32,7 @@
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/8.0.0/jar)
 
 - 🚧 **Breaking Changes** (1)
-  - Removed support of changing the attribute definition type [#787](https://github.com/commercetools/commercetools-sync-java/pull/787) since removal and addition of the attribute with the same name in a single request is not possible by commercetools API anymore. For more information please [check](../docs/adr/0003-syncing-attribute-type-changes.md).
+  - Removed support of changing the attribute definition type [#787](https://github.com/commercetools/commercetools-sync-java/pull/787) since removal and addition of the attribute with the same name in a single request is not possible by commercetools API anymore. For more information please [check](https://github.com/commercetools/commercetools-sync-java/blob/master/docs/adr/0003-syncing-attribute-type-changes.md).
 
 - ✨ **Enhancement** (1)
   - Use the new concurrency keyword on github actions to limit the concurrency of the workflow runs. [#772](https://github.com/commercetools/commercetools-sync-java/issues/772)

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -278,4 +278,4 @@ More examples of those utils for different fields can be found [here](https://gi
 
 ## Caveats    
 1. The order of attribute definitions in the synced product types is not guaranteed.
-2. Changing the attribute definition type is not supported. Instead, remove and re-add it with a new type manually, either over API or merchant center. For more information please [check](../../docs/adr/0003-syncing-attribute-type-changes.md).
+2. Changing the attribute definition type is not supported. Instead, remove and re-add it with a new type manually, either over API or merchant center. For more information please [check](https://github.com/commercetools/commercetools-sync-java/blob/master/docs/adr/0003-syncing-attribute-type-changes.md).


### PR DESCRIPTION
The CD failed because mkdocsPublish is failed, I added a fix for the issue and make the mkdocsBuild is a check on build so we would see the issue early on development not after tagging a release. 