### PR TITLE
Fix broken links in the docs

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -19,7 +19,7 @@ The main goal of the build process is to publish the artifacts to public reposit
 Create a new PR for the new release: 
 - Increment the release version to the new library version, please follow the [semantic versioning](https://semver.org/) for finding the new version.
 - Make sure all the dependencies are up-to-date everywhere in the documentation files and the project files where needed.
-- Make sure to add a section for the release in the [release notes](/docs/RELEASE_NOTES.md). 
+- Make sure to add a section for the release in the [release notes](./RELEASE_NOTES.md). 
 - Ask for review for this PR and then "squash and merge" to master.
 
 For example PR, see: https://github.com/commercetools/commercetools-sync-java/pull/412

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,7 +113,7 @@ https://docs.commercetools.com/merchant-center/projects.html#creating-a-project
   target.clientSecret=fff
   ```
     
-  Use [`it.properties.skeleton`](/src/integration-test/resources/it.properties.skeleton) 
+  Use [`it.properties.skeleton`](https://github.com/commercetools/commercetools-sync-java/tree/master/src/integration-test/resources/it.properties.skeleton) 
   as a template to setup the credentials.
   
   **Note**: the `it.properties` file must be ignored by VCS. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 
 Java library which allows to import/synchronise (import changes) the data from any arbitrary source to commercetools project.
 
-Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/docs/usage/PRODUCT_SYNC.md), [InventoryEntries](/docs/usage/INVENTORY_SYNC.md), [ProductTypes](/docs/usage/PRODUCT_TYPE_SYNC.md), [Types](/docs/usage/TYPE_SYNC.md), [CartDiscounts](/docs/usage/CART_DISCOUNT_SYNC.md), [States](/docs/usage/STATE_SYNC.md), [TaxCategories](/docs/usage/TAX_CATEGORY_SYNC.md), [CustomObjects](/docs/usage/CUSTOM_OBJECT_SYNC.md), [Customers](/docs/usage/CUSTOMER_SYNC.md), [ShoppingLists](/docs/usage/SHOPPING_LIST_SYNC.md)
+Supported resources: [Categories](./usage/CATEGORY_SYNC.md), [Products](./usage/PRODUCT_SYNC.md), [InventoryEntries](./usage/INVENTORY_SYNC.md), [ProductTypes](./usage/PRODUCT_TYPE_SYNC.md), [Types](./usage/TYPE_SYNC.md), [CartDiscounts](./usage/CART_DISCOUNT_SYNC.md), [States](./usage/STATE_SYNC.md), [TaxCategories](./usage/TAX_CATEGORY_SYNC.md), [CustomObjects](./usage/CUSTOM_OBJECT_SYNC.md), [Customers](./usage/CUSTOMER_SYNC.md), [ShoppingLists](./usage/SHOPPING_LIST_SYNC.md)
 
 ## Usage
 


### PR DESCRIPTION
#### Summary

Some links were broken. They were using absolute instead of relative paths. This has now been fixed and tested locally.