### PR TITLE
Add error callback arguments

### DIFF
--- a/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
@@ -197,7 +197,7 @@ public class CartDiscountSync
                                       FAILED_TO_PROCESS,
                                       newCartDiscount.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, null, null, 1);
+                              handleError(errorMessage, completionException, null, newCartDiscount, null, 1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
@@ -13,7 +13,6 @@ import com.commercetools.sync.cartdiscounts.helpers.CartDiscountBatchValidator;
 import com.commercetools.sync.cartdiscounts.helpers.CartDiscountReferenceResolver;
 import com.commercetools.sync.cartdiscounts.helpers.CartDiscountSyncStatistics;
 import com.commercetools.sync.commons.BaseSync;
-import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.services.CartDiscountService;
 import com.commercetools.sync.services.TypeService;
 import com.commercetools.sync.services.impl.CartDiscountServiceImpl;
@@ -28,14 +27,14 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * This class syncs cart discount drafts with the corresponding cart discounts in the CTP project.
  */
 public class CartDiscountSync
-    extends BaseSync<CartDiscountDraft, CartDiscountSyncStatistics, CartDiscountSyncOptions> {
+    extends BaseSync<
+        CartDiscountDraft, CartDiscount, CartDiscountSyncStatistics, CartDiscountSyncOptions> {
 
   private static final String CTP_CART_DISCOUNT_FETCH_FAILED =
       "Failed to fetch existing cart discounts with keys: '%s'.";
@@ -165,31 +164,6 @@ public class CartDiscountSync
               statistics.incrementProcessed(batch.size());
               return statistics;
             });
-  }
-
-  /**
-   * This method calls the optional error callback specified in the {@code syncOptions} and updates
-   * the {@code statistics} instance by incrementing the total number of failed cart discounts to
-   * sync.
-   *
-   * @param errorMessage The error message describing the reason(s) of failure.
-   * @param exception The exception that called caused the failure, if any.
-   * @param failedTimes The number of times that the failed cart discount statistic counter is
-   *     incremented.
-   */
-  private void handleError(
-      @Nonnull final String errorMessage,
-      @Nullable final Throwable exception,
-      final CartDiscount oldCartDiscount,
-      final CartDiscountDraft newCartDiscount,
-      List<UpdateAction<CartDiscount>> updateActions,
-      final int failedTimes) {
-    syncOptions.applyErrorCallback(
-        new SyncException(errorMessage, exception),
-        oldCartDiscount,
-        newCartDiscount,
-        updateActions);
-    statistics.incrementFailed(failedTimes);
   }
 
   /**

--- a/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
+++ b/src/main/java/com/commercetools/sync/cartdiscounts/CartDiscountSync.java
@@ -197,7 +197,13 @@ public class CartDiscountSync
                                       FAILED_TO_PROCESS,
                                       newCartDiscount.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, newCartDiscount, null, 1);
+                              handleError(
+                                  errorMessage,
+                                  completionException,
+                                  null,
+                                  newCartDiscount,
+                                  null,
+                                  1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/categories/CategorySync.java
@@ -14,7 +14,6 @@ import com.commercetools.sync.categories.helpers.CategoryBatchValidator;
 import com.commercetools.sync.categories.helpers.CategoryReferenceResolver;
 import com.commercetools.sync.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.commons.BaseSync;
-import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.commons.models.WaitingToBeResolvedCategories;
 import com.commercetools.sync.services.CategoryService;
 import com.commercetools.sync.services.TypeService;
@@ -38,12 +37,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class CategorySync
-    extends BaseSync<CategoryDraft, CategorySyncStatistics, CategorySyncOptions> {
+    extends BaseSync<CategoryDraft, Category, CategorySyncStatistics, CategorySyncOptions> {
 
   private static final String FAILED_TO_FETCH =
       "Failed to fetch existing categories with keys: '%s'. Reason: %s";
@@ -480,20 +478,5 @@ public class CategorySync
         .map(CompletionStage::toCompletableFuture)
         .forEach(CompletableFuture::join);
     return completedFuture(null);
-  }
-
-  private void handleError(
-      @Nonnull final String errorMessage,
-      @Nullable final Throwable exception,
-      @Nullable final Category oldCategory,
-      @Nullable final CategoryDraft newCategory,
-      @Nullable final List<UpdateAction<Category>> updateActions,
-      final int failedTimes) {
-    SyncException syncException =
-        exception != null
-            ? new SyncException(errorMessage, exception)
-            : new SyncException(errorMessage);
-    syncOptions.applyErrorCallback(syncException, oldCategory, newCategory, updateActions);
-    statistics.incrementFailed(failedTimes);
   }
 }

--- a/src/main/java/com/commercetools/sync/commons/BaseSync.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSync.java
@@ -146,9 +146,9 @@ public abstract class BaseSync<
       @Nullable final Throwable exception,
       final S oldResource,
       final T newResourceDraft,
-      List<UpdateAction<S>> updateActions,
+      final List<UpdateAction<S>> updateActions,
       final int failedTimes) {
-    SyncException syncException =
+    final SyncException syncException =
         exception != null
             ? new SyncException(errorMessage, exception)
             : new SyncException(errorMessage);

--- a/src/main/java/com/commercetools/sync/commons/BaseSync.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSync.java
@@ -140,6 +140,7 @@ public abstract class BaseSync<
    * @param failedTimes The number of times that the failed cart discount statistic counter is
    *     incremented.
    */
+  @SuppressWarnings("unchecked")
   protected void handleError(
       @Nonnull final String errorMessage,
       @Nullable final Throwable exception,

--- a/src/main/java/com/commercetools/sync/commons/BaseSync.java
+++ b/src/main/java/com/commercetools/sync/commons/BaseSync.java
@@ -1,13 +1,18 @@
 package com.commercetools.sync.commons;
 
+import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 import io.sphere.sdk.client.ConcurrentModificationException;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.models.Versioned;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
-public abstract class BaseSync<T, U extends BaseSyncStatistics, V extends BaseSyncOptions> {
+public abstract class BaseSync<
+    T, S extends Versioned, U extends BaseSyncStatistics, V extends BaseSyncOptions> {
   protected final U statistics;
   protected final V syncOptions;
 
@@ -121,5 +126,32 @@ public abstract class BaseSync<T, U extends BaseSyncStatistics, V extends BaseSy
       return onConcurrentModificationSupplier.get();
     }
     return onOtherExceptionSupplier.get();
+  }
+
+  /**
+   * This method calls the optional error callback specified in the {@code syncOptions} and updates
+   * the {@code statistics} instance by incrementing the total number of failed resources S to sync.
+   *
+   * @param errorMessage The error message describing the reason(s) of failure.
+   * @param exception The exception that called caused the failure, if any.
+   * @param oldResource the commercetools resource which could be updated.
+   * @param newResourceDraft the commercetools resource draft where we get the new data.
+   * @param updateActions the update actions to update the resource with.
+   * @param failedTimes The number of times that the failed cart discount statistic counter is
+   *     incremented.
+   */
+  protected void handleError(
+      @Nonnull final String errorMessage,
+      @Nullable final Throwable exception,
+      final S oldResource,
+      final T newResourceDraft,
+      List<UpdateAction<S>> updateActions,
+      final int failedTimes) {
+    SyncException syncException =
+        exception != null
+            ? new SyncException(errorMessage, exception)
+            : new SyncException(errorMessage);
+    syncOptions.applyErrorCallback(syncException, oldResource, newResourceDraft, updateActions);
+    statistics.incrementFailed(failedTimes);
   }
 }

--- a/src/main/java/com/commercetools/sync/customers/CustomerSync.java
+++ b/src/main/java/com/commercetools/sync/customers/CustomerSync.java
@@ -191,7 +191,7 @@ public class CustomerSync
                                       FAILED_TO_PROCESS,
                                       customerDraft.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, null, null, 1);
+                              handleError(errorMessage, completionException, null, customerDraft, null, 1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/customers/CustomerSync.java
+++ b/src/main/java/com/commercetools/sync/customers/CustomerSync.java
@@ -191,7 +191,8 @@ public class CustomerSync
                                       FAILED_TO_PROCESS,
                                       customerDraft.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, customerDraft, null, 1);
+                              handleError(
+                                  errorMessage, completionException, null, customerDraft, null, 1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -180,7 +180,7 @@ public class ProductSync
             cachingResponse -> {
               final Throwable cachingException = cachingResponse.getValue();
               if (cachingException != null) {
-                super.handleError(
+                handleError(
                     "Failed to build a cache of keys to ids.",
                     cachingException,
                     null,
@@ -220,7 +220,7 @@ public class ProductSync
               final Throwable fetchException = fetchResponse.getValue();
               if (fetchException != null) {
                 final String errorMessage = format(CTP_PRODUCT_FETCH_FAILED, productDraftKeys);
-                super.handleError(
+                handleError(
                     errorMessage, fetchException, null, null, null, productDraftKeys.size());
                 return CompletableFuture.completedFuture(null);
               } else {
@@ -324,7 +324,7 @@ public class ProductSync
               if (fetchException != null) {
                 final String errorMessage =
                     format(UNRESOLVED_REFERENCES_STORE_FETCH_FAILED, referencingDraftKeys);
-                super.handleError(
+                handleError(
                     errorMessage, fetchException, null, null, null, referencingDraftKeys.size());
                 return CompletableFuture.completedFuture(null);
               }
@@ -406,7 +406,7 @@ public class ProductSync
                       FAILED_TO_PROCESS,
                       newProductDraft.getKey(),
                       completionException.getMessage());
-              super.handleError(errorMessage, completionException, null, null, null, 1);
+              handleError(errorMessage, completionException, null, null, null, 1);
               return null;
             });
   }
@@ -442,7 +442,7 @@ public class ProductSync
                           final String errorMessage =
                               format(
                                   UPDATE_FAILED, oldProduct.getKey(), FAILED_TO_FETCH_PRODUCT_TYPE);
-                          super.handleError(errorMessage, null, oldProduct, newProduct, null, 1);
+                          handleError(errorMessage, null, oldProduct, newProduct, null, 1);
                           return CompletableFuture.completedFuture(null);
                         }));
   }
@@ -465,7 +465,7 @@ public class ProductSync
                     () -> fetchAndUpdate(oldProduct, newProduct),
                     () -> {
                       final String productKey = oldProduct.getKey();
-                      handleError(
+                      handleProductSyncError(
                           format(UPDATE_FAILED, productKey, sphereException),
                           sphereException,
                           oldProduct,
@@ -510,7 +510,7 @@ public class ProductSync
                         key,
                         "Failed to fetch from CTP while "
                             + "retrying after concurrency modification.");
-                super.handleError(errorMessage, exception, oldProduct, newProduct, null, 1);
+                handleError(errorMessage, exception, oldProduct, newProduct, null, 1);
                 return CompletableFuture.completedFuture(null);
               }
 
@@ -526,7 +526,7 @@ public class ProductSync
                                 key,
                                 "Not found when attempting to fetch "
                                     + "while retrying after concurrency modification.");
-                        super.handleError(errorMessage, null, oldProduct, newProduct, null, 1);
+                        handleError(errorMessage, null, oldProduct, newProduct, null, 1);
                         return CompletableFuture.completedFuture(null);
                       });
             });
@@ -567,7 +567,7 @@ public class ProductSync
    * @param newProduct the ProductProjection draft where we get the new data.
    * @param updateActions the update actions to update the {@link Product} with.
    */
-  private void handleError(
+  private void handleProductSyncError(
       @Nonnull final String errorMessage,
       @Nullable final Throwable exception,
       @Nullable final ProductProjection oldProduct,

--- a/src/main/java/com/commercetools/sync/products/ProductSync.java
+++ b/src/main/java/com/commercetools/sync/products/ProductSync.java
@@ -64,7 +64,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, ProductSyncOptions> {
+public class ProductSync
+    extends BaseSync<ProductDraft, ProductProjection, ProductSyncStatistics, ProductSyncOptions> {
   private static final String CTP_PRODUCT_FETCH_FAILED =
       "Failed to fetch existing products with keys: '%s'.";
   private static final String UNRESOLVED_REFERENCES_STORE_FETCH_FAILED =
@@ -179,8 +180,12 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
             cachingResponse -> {
               final Throwable cachingException = cachingResponse.getValue();
               if (cachingException != null) {
-                handleError(
-                    new SyncException("Failed to build a cache of keys to ids.", cachingException),
+                super.handleError(
+                    "Failed to build a cache of keys to ids.",
+                    cachingException,
+                    null,
+                    null,
+                    null,
                     validDrafts.size());
                 return CompletableFuture.completedFuture(null);
               }
@@ -215,8 +220,8 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
               final Throwable fetchException = fetchResponse.getValue();
               if (fetchException != null) {
                 final String errorMessage = format(CTP_PRODUCT_FETCH_FAILED, productDraftKeys);
-                handleError(
-                    new SyncException(errorMessage, fetchException), productDraftKeys.size());
+                super.handleError(
+                    errorMessage, fetchException, null, null, null, productDraftKeys.size());
                 return CompletableFuture.completedFuture(null);
               } else {
                 final Set<ProductProjection> matchingProducts = fetchResponse.getKey();
@@ -319,8 +324,8 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
               if (fetchException != null) {
                 final String errorMessage =
                     format(UNRESOLVED_REFERENCES_STORE_FETCH_FAILED, referencingDraftKeys);
-                handleError(
-                    new SyncException(errorMessage, fetchException), referencingDraftKeys.size());
+                super.handleError(
+                    errorMessage, fetchException, null, null, null, referencingDraftKeys.size());
                 return CompletableFuture.completedFuture(null);
               }
 
@@ -401,7 +406,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                       FAILED_TO_PROCESS,
                       newProductDraft.getKey(),
                       completionException.getMessage());
-              handleError(new SyncException(errorMessage, completionException), 1);
+              super.handleError(errorMessage, completionException, null, null, null, 1);
               return null;
             });
   }
@@ -437,7 +442,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                           final String errorMessage =
                               format(
                                   UPDATE_FAILED, oldProduct.getKey(), FAILED_TO_FETCH_PRODUCT_TYPE);
-                          handleError(errorMessage, oldProduct, newProduct);
+                          super.handleError(errorMessage, null, oldProduct, newProduct, null, 1);
                           return CompletableFuture.completedFuture(null);
                         }));
   }
@@ -505,7 +510,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                         key,
                         "Failed to fetch from CTP while "
                             + "retrying after concurrency modification.");
-                handleError(errorMessage, exception, oldProduct, newProduct, null);
+                super.handleError(errorMessage, exception, oldProduct, newProduct, null, 1);
                 return CompletableFuture.completedFuture(null);
               }
 
@@ -521,7 +526,7 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
                                 key,
                                 "Not found when attempting to fetch "
                                     + "while retrying after concurrency modification.");
-                        handleError(errorMessage, oldProduct, newProduct);
+                        super.handleError(errorMessage, null, oldProduct, newProduct, null, 1);
                         return CompletableFuture.completedFuture(null);
                       });
             });
@@ -548,23 +553,13 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
   }
 
   /**
-   * Given a {@link String} {@code errorMessage}, this method calls the optional error callback
-   * specified in the {@code syncOptions} and updates the {@code statistics} instance by
-   * incrementing the total number of failed products to sync.
-   *
-   * @param errorMessage The error message describing the reason(s) of failure.
-   */
-  private void handleError(
-      @Nonnull final String errorMessage,
-      @Nullable final ProductProjection oldResource,
-      @Nullable final ProductDraft newResource) {
-    handleError(errorMessage, null, oldResource, newResource, null);
-  }
-
-  /**
    * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this
    * method calls the optional error callback specified in the {@code syncOptions} and updates the
-   * {@code statistics} instance by incrementing the total number of failed products to sync.
+   * {@code statistics} instance by incrementing the total number of failed products to sync. <br>
+   * <br>
+   * NOTE: This method is similar to {@link com.commercetools.sync.commons.BaseSync#handleError}. It
+   * is left here because of usage of different classes for view ({@link ProductProjection}) and
+   * updates ({@link Product}) from commercetools. This is specific only for ProductSync.
    *
    * @param errorMessage The error message describing the reason(s) of failure.
    * @param exception The exception that called caused the failure, if any.
@@ -584,19 +579,5 @@ public class ProductSync extends BaseSync<ProductDraft, ProductSyncStatistics, P
             : new SyncException(errorMessage);
     syncOptions.applyErrorCallback(syncException, oldProduct, newProduct, updateActions);
     statistics.incrementFailed();
-  }
-
-  /**
-   * Given a {@link String} {@code errorMessage} and a {@link Throwable} {@code exception}, this
-   * method calls the optional error callback specified in the {@code syncOptions} and updates the
-   * {@code statistics} instance by incrementing the total number of failed ProductProjection to
-   * sync with the supplied {@code failedTimes}.
-   *
-   * @param syncException The exception that caused the failure.
-   * @param failedTimes The number of times that the failed products counter is incremented.
-   */
-  private void handleError(@Nonnull final SyncException syncException, final int failedTimes) {
-    syncOptions.applyErrorCallback(syncException);
-    statistics.incrementFailed(failedTimes);
   }
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
@@ -358,12 +358,12 @@ public class ShoppingListSync
 
   private void handleError(
       @Nonnull final SyncException syncException,
-      @Nullable final ShoppingList entry,
-      @Nullable final ShoppingListDraft draft,
+      @Nullable final ShoppingList oldShoppingList,
+      @Nullable final ShoppingListDraft newShoppingList,
       @Nullable final List<UpdateAction<ShoppingList>> updateActions,
       final int failedTimes) {
 
-    syncOptions.applyErrorCallback(syncException);
+    syncOptions.applyErrorCallback(syncException, oldShoppingList, newShoppingList, updateActions);
     statistics.incrementFailed(failedTimes);
   }
 }

--- a/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
@@ -207,7 +207,7 @@ public class ShoppingListSync
                                       FAILED_TO_PROCESS,
                                       shoppingListDraft.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, null, null, 1);
+                              handleError(errorMessage, completionException, null, shoppingListDraft, null, 1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
@@ -31,9 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import io.sphere.sdk.states.State;
-import io.sphere.sdk.states.StateDraft;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
@@ -145,9 +142,9 @@ public class ShoppingListSync
               if (cachingException != null) {
                 handleError(
                     new SyncException("Failed to build a cache of keys to ids.", cachingException),
-                        null,
-                        null,
-                        null,
+                    null,
+                    null,
+                    null,
                     shoppingListDrafts.size());
                 return CompletableFuture.completedFuture(null);
               }
@@ -168,9 +165,9 @@ public class ShoppingListSync
                               format(CTP_SHOPPING_LIST_FETCH_FAILED, shoppingListDraftKeys);
                           handleError(
                               new SyncException(errorMessage, exception),
-                                  null,
-                                  null,
-                                  null,
+                              null,
+                              null,
+                              null,
                               shoppingListDraftKeys.size());
                           return CompletableFuture.completedFuture(null);
                         } else {
@@ -209,7 +206,12 @@ public class ShoppingListSync
                                       FAILED_TO_PROCESS,
                                       shoppingListDraft.getKey(),
                                       completionException.getMessage());
-                              handleError(new SyncException(errorMessage, completionException), null, null, null,1);
+                              handleError(
+                                  new SyncException(errorMessage, completionException),
+                                  null,
+                                  null,
+                                  null,
+                                  1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)
@@ -267,7 +269,12 @@ public class ShoppingListSync
                               CTP_SHOPPING_LIST_UPDATE_FAILED,
                               newShoppingListDraft.getKey(),
                               exception.getMessage());
-                      handleError(new SyncException(errorMessage, exception), oldShoppingList, newShoppingListDraft, updateActionsAfterCallback, 1);
+                      handleError(
+                          new SyncException(errorMessage, exception),
+                          oldShoppingList,
+                          newShoppingListDraft,
+                          updateActionsAfterCallback,
+                          1);
                       return CompletableFuture.completedFuture(null);
                     });
               } else {
@@ -339,11 +346,12 @@ public class ShoppingListSync
         .orElseGet(() -> CompletableFuture.completedFuture(null));
   }
 
-  private void handleError(@Nonnull final SyncException syncException,
-                           @Nullable final ShoppingList entry,
-                           @Nullable final ShoppingListDraft draft,
-                           @Nullable final List<UpdateAction<ShoppingList>> updateActions,
-                           final int failedTimes) {
+  private void handleError(
+      @Nonnull final SyncException syncException,
+      @Nullable final ShoppingList entry,
+      @Nullable final ShoppingListDraft draft,
+      @Nullable final List<UpdateAction<ShoppingList>> updateActions,
+      final int failedTimes) {
 
     syncOptions.applyErrorCallback(syncException);
     statistics.incrementFailed(failedTimes);

--- a/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
@@ -207,7 +207,13 @@ public class ShoppingListSync
                                       FAILED_TO_PROCESS,
                                       shoppingListDraft.getKey(),
                                       completionException.getMessage());
-                              handleError(errorMessage, completionException, null, shoppingListDraft, null, 1);
+                              handleError(
+                                  errorMessage,
+                                  completionException,
+                                  null,
+                                  shoppingListDraft,
+                                  null,
+                                  1);
                               return null;
                             }))
             .map(CompletionStage::toCompletableFuture)

--- a/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
+++ b/src/main/java/com/commercetools/sync/shoppinglists/ShoppingListSync.java
@@ -304,7 +304,12 @@ public class ShoppingListSync
                         CTP_SHOPPING_LIST_UPDATE_FAILED,
                         shoppingListKey,
                         "Failed to fetch from CTP while retrying after concurrency modification.");
-                handleError(new SyncException(errorMessage, exception), 1);
+                handleError(
+                    new SyncException(errorMessage, exception),
+                    oldShoppingList,
+                    newShoppingListDraft,
+                    null,
+                    1);
                 return CompletableFuture.completedFuture(null);
               }
 
@@ -319,7 +324,12 @@ public class ShoppingListSync
                                 CTP_SHOPPING_LIST_UPDATE_FAILED,
                                 shoppingListKey,
                                 "Not found when attempting to fetch while retrying after concurrency modification.");
-                        handleError(new SyncException(errorMessage, null), 1);
+                        handleError(
+                            new SyncException(errorMessage, null),
+                            oldShoppingList,
+                            newShoppingListDraft,
+                            null,
+                            1);
                         return CompletableFuture.completedFuture(null);
                       });
             });

--- a/src/test/java/com/commercetools/sync/customers/CustomerSyncTest.java
+++ b/src/test/java/com/commercetools/sync/customers/CustomerSyncTest.java
@@ -625,8 +625,7 @@ public class CustomerSyncTest {
                 () -> {
                   throw new SphereException();
                 }));
-    when(mockCustomerService.cacheKeysToIds(anySet()))
-        .thenReturn(CompletableFuture.completedFuture(emptyMap()));
+
     when(mockCustomerService.createCustomer(any()))
         .thenReturn(CompletableFuture.completedFuture(Optional.of(existingCustomer)));
     when(mockCustomerService.fetchCustomerByKey(any()))

--- a/src/test/java/com/commercetools/sync/shoppinglists/ShoppingListSyncTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/ShoppingListSyncTest.java
@@ -743,7 +743,8 @@ public class ShoppingListSyncTest {
   }
 
   @Test
-  void sync_WithErrorUpdatingShoppingListAndCustomErrorCallback_ShouldCallErrorCallbackAndContainResourceName() {
+  void
+      sync_WithErrorUpdatingShoppingListAndCustomErrorCallback_ShouldCallErrorCallbackAndContainResourceName() {
     // preparation
     final ShoppingListDraft newShoppingListDraft1 =
         ShoppingListDraftBuilder.of(LocalizedString.ofEnglish("shoppingListName1"))

--- a/src/test/java/com/commercetools/sync/shoppinglists/ShoppingListSyncTest.java
+++ b/src/test/java/com/commercetools/sync/shoppinglists/ShoppingListSyncTest.java
@@ -783,8 +783,6 @@ public class ShoppingListSyncTest {
                 () -> {
                   throw new SphereException();
                 }));
-    when(mockShoppingListService.cacheKeysToIds(anySet()))
-        .thenReturn(CompletableFuture.completedFuture(emptyMap()));
     when(mockShoppingListService.createShoppingList(any()))
         .thenReturn(CompletableFuture.completedFuture(Optional.of(existingShoppingList)));
     when(mockShoppingListService.fetchShoppingList(any()))


### PR DESCRIPTION
#### Summary
Missing old resource, new draft and updateActions as arguments in error callback.

#### Description
When there is an exception during sync, a method called handleError is invoked. Users can supply an error callback and their callback will be called inside that method once error happens. However, error callback does not receive old resource, new draft and updateActions in ShoppingListSync, CustomerSync and CartDiscountSync. 

#### Relevant Issues
https://github.com/commercetools/commercetools-sync-java/issues/841

#### Todo
- [x] Add new arguments in error callback and `handleError` methods in `ShoppingListSync`, `CustomerSync` and `CartDiscountSync`.
- [x] Create new unit test case in `ShoppingListSyncTest`, `CustomerSyncTest` and `CartDiscountSyncTest`


