### PR TITLE
Display release tag instead of commit hash in benchmarks UI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,6 @@ jobs:
       TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
       TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
       GRGIT_USER: ${{ secrets.GRGIT_USER }}
-      GITHUB_ACTION_COMMIT: ${{github.sha}}
       SUBMIT_BENCHMARK_RESULT: true
     steps:
       - name: Git Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,30 @@ on:
       - '*.*.*'
 
 jobs:
+  benchmark_tests:
+    name: benchmark tests
+    concurrency: benchmark_tests
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_PROJECT_KEY: java-sync-target-dev2
+      SOURCE_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
+      SOURCE_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
+      TARGET_PROJECT_KEY: java-sync-target-dev2
+      TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
+      TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
+      GRGIT_USER: ${{ secrets.GRGIT_USER }}
+      GITHUB_ACTION_COMMIT: ${{github.sha}}
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Fetch Library version
+        id: vars
+        run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
+      - name: benchmark test
+        if: ${{ success() }}
+        run: ./gradlew clean setLibraryVersion benchmark
+        env:
+          GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}
   deployment:
     name: deployment
     needs: benchmark_tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,31 +6,6 @@ on:
       - '*.*.*'
 
 jobs:
-  benchmark_tests:
-    name: benchmark tests
-    concurrency: benchmark_tests
-    runs-on: ubuntu-latest
-    env:
-      SOURCE_PROJECT_KEY: java-sync-target-dev2
-      SOURCE_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
-      SOURCE_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
-      TARGET_PROJECT_KEY: java-sync-target-dev2
-      TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
-      TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
-      GRGIT_USER: ${{ secrets.GRGIT_USER }}
-      GITHUB_ACTION_COMMIT: ${{github.sha}}
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v3
-      - name: Fetch Library version
-        id: vars
-        run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
-      - name: benchmark test
-        if: ${{ success() }}
-        run: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-        env:
-          GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}
-
   deployment:
     name: deployment
     needs: benchmark_tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
       - name: benchmark test
         if: ${{ success() }}
-        run: ./gradlew clean setLibraryVersion benchmark
+        run: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
         env:
           GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}
   deployment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
       TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
       GRGIT_USER: ${{ secrets.GRGIT_USER }}
-      GITHUB_ACTION_COMMIT: ${{github.sha}}
       SUBMIT_BENCHMARK_RESULT: false
     steps:
       - name: Git Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,28 @@ jobs:
           TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET }}
       - name: Codecov
         uses: codecov/codecov-action@v3
+
+  benchmark_tests:
+    name: benchmark tests
+    concurrency: benchmark_tests
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_PROJECT_KEY: java-sync-target-dev2
+      SOURCE_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
+      SOURCE_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
+      TARGET_PROJECT_KEY: java-sync-target-dev2
+      TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
+      TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
+      GRGIT_USER: ${{ secrets.GRGIT_USER }}
+      GITHUB_ACTION_COMMIT: ${{github.sha}}
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Fetch Library version
+        id: vars
+        run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
+      - name: benchmark test
+        if: ${{ success() }}
+        run: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
+        env:
+          GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,28 +42,3 @@ jobs:
           TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET }}
       - name: Codecov
         uses: codecov/codecov-action@v3
-
-  benchmark_tests:
-    name: benchmark tests
-    concurrency: benchmark_tests
-    runs-on: ubuntu-latest
-    env:
-      SOURCE_PROJECT_KEY: java-sync-target-dev2
-      SOURCE_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
-      SOURCE_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
-      TARGET_PROJECT_KEY: java-sync-target-dev2
-      TARGET_CLIENT_ID: ${{ secrets.TARGET_CLIENT_ID_2 }}
-      TARGET_CLIENT_SECRET: ${{ secrets.TARGET_CLIENT_SECRET_2 }}
-      GRGIT_USER: ${{ secrets.GRGIT_USER }}
-      GITHUB_ACTION_COMMIT: ${{github.sha}}
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v3
-      - name: Fetch Library version
-        id: vars
-        run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
-      - name: benchmark test
-        if: ${{ success() }}
-        run: ./gradlew clean setLibraryVersion benchmark benchmarkCommit
-        env:
-          GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}

--- a/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
+++ b/src/benchmark/java/com/commercetools/sync/benchmark/BenchmarkUtils.java
@@ -23,10 +23,8 @@ final class BenchmarkUtils {
       BENCHMARK_RESULTS_FILE_DIR + BENCHMARK_RESULTS_FILE_NAME;
   private static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
   private static final String EXECUTION_TIME = "executionTime";
-  private static final String BRANCH_NAME =
-      ofNullable(System.getenv("GITHUB_ACTION_COMMIT"))
-          .map(commitMessage -> commitMessage.substring(0, 7)) // Use smaller commit sha
-          .orElse("dev-local");
+  private static final String TAG_NAME =
+      ofNullable(System.getenv("GITHUB_TAG")).orElse("DEV-SNAPSHOT");
 
   static final String PRODUCT_SYNC = "productSync";
   static final String INVENTORY_SYNC = "inventorySync";
@@ -65,12 +63,12 @@ final class BenchmarkUtils {
       final double newResult) {
 
     ObjectNode rootNode = (ObjectNode) originalRoot;
-    ObjectNode branchNode = (ObjectNode) rootNode.get(BRANCH_NAME);
+    ObjectNode branchNode = (ObjectNode) rootNode.get(TAG_NAME);
 
     // If version doesn't exist yet, create a new JSON object for the new version.
     if (branchNode == null) {
       branchNode = createVersionNode();
-      rootNode.set(BRANCH_NAME, branchNode);
+      rootNode.set(TAG_NAME, branchNode);
     }
 
     final ObjectNode syncNode = (ObjectNode) branchNode.get(sync);


### PR DESCRIPTION
#### Summary
Display Github tag in benchmarks chart.

#### Description
When the application is released, benchmark result is inserted into `benchmarks.json` in `gh-pages` branch. During this data insertion we use git commit hash currently, which is less comprehensive to developer. For this reason, we would insert release version tag into the `benchmarks.json` instead.

**Hints**
Github tag can be obtained from environment variable which is set in `cd.yaml`
https://github.com/commercetools/commercetools-sync-java/blob/master/.github/workflows/cd.yml#L33