### PR TITLE
Issue 447 master variant switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 9.2.1](https://img.shields.io/badge/Benchmarks-9.2.1-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-9.2.1-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.1/jar) 
-[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/)
+[![Benchmarks 9.2.2](https://img.shields.io/badge/Benchmarks-9.2.2-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-9.2.2-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.2/jar) 
+[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 More at https://commercetools.github.io/commercetools-sync-java
@@ -25,7 +25,7 @@ Supported resources: [Categories](/docs/usage/CATEGORY_SYNC.md), [Products](/doc
     - [SBT](#sbt)
     - [Ivy](#ivy)
 - [Release Notes](/docs/RELEASE_NOTES.md)
-- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/)
+- [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/)
 - [Benchmarks](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -60,26 +60,26 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>9.2.1</version>
+  <version>9.2.2</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:9.2.1'
+implementation 'com.commercetools:commercetools-sync-java:9.2.2'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "9.2.1"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "9.2.2"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="9.2.1"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="9.2.2"/>
 ````
 
 **Note**: To avoid `commercetools JVM SDK` libraries version mismatch between projects.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 9.2.1](https://img.shields.io/badge/Benchmarks-9.2.1-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-9.2.1-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.1/jar) 
-[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/)
+[![Benchmarks 9.2.2](https://img.shields.io/badge/Benchmarks-9.2.2-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-9.2.2-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.2/jar) 
+[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 
@@ -40,18 +40,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>9.2.1</version>
+  <version>9.2.2</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:9.2.1'
+implementation 'com.commercetools:commercetools-sync-java:9.2.2'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "9.2.1"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "9.2.2"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="9.2.1"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="9.2.2"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,13 +27,21 @@
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
 
+### 9.2.2 - Mar 21, 2023
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/9.2.1...9.2.2) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.2/jar)
+
+- 🐞 **Bug Fixes**
+  - Fix the problem when switching master variants [#918](https://github.com/commercetools/commercetools-sync-java/pull/918)
+
 ### 9.2.1 - Feb 10, 2023
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/9.2.0...9.2.1) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/) |
 [Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/9.2.1/jar)
 
 - 🐞 **Bug Fixes**
-  - Fix rich type reference issue in porduct type [#893](https://github.com/commercetools/commercetools-sync-java/pull/893)
+  - Fix rich type reference issue in product type [#893](https://github.com/commercetools/commercetools-sync-java/pull/893)
 
 - 🛠️ **Dependency Updates**
   - Migrated `com.commercetools.sdk.jvm.core` to [`2.12.0`](https://github.com/commercetools/commercetools-jvm-sdk/releases/tag/v2.12.0)

--- a/docs/usage/CART_DISCOUNT_SYNC.md
+++ b/docs/usage/CART_DISCOUNT_SYNC.md
@@ -36,7 +36,7 @@ against a [CartDiscountDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -67,7 +67,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCartDiscountDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/cartdiscounts/utils/CartDiscountTransformUtils.html#toCartDiscountDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `CartDiscount` to `CartDiscountDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CATEGORY_SYNC.md
+++ b/docs/usage/CATEGORY_SYNC.md
@@ -36,7 +36,7 @@ against a [CategoryDraft](https://docs.commercetools.com/http-api-projects-categ
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -135,7 +135,7 @@ As soon, as the referenced parent Category draft is supplied to the sync, the dr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCategoryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/categories/utils/CategoryTransformUtils.html#toCategoryDrafts-java.util.List-)
 method that transforms(resolves by querying and caching key-id pairs) and maps from a `Category` to `CategoryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOMER_SYNC.md
+++ b/docs/usage/CUSTOMER_SYNC.md
@@ -35,7 +35,7 @@ against a [CustomerDraft](https://docs.commercetools.com/api/projects/customers#
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -69,7 +69,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toCustomerDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/customers/utils/CustomerTransformUtils.html#toCustomerDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Customer` to `CustomerDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/CUSTOM_OBJECT_SYNC.md
+++ b/docs/usage/CUSTOM_OBJECT_SYNC.md
@@ -31,7 +31,7 @@ against a [CustomObjectDraft](https://docs.commercetools.com/http-api-projects-c
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/IMPORTANT_USAGE_TIPS.md
+++ b/docs/usage/IMPORTANT_USAGE_TIPS.md
@@ -40,7 +40,7 @@ productSync.sync(batch1)
 By design, scaling the sync process should **not** be done by executing the batches themselves in parallel. However, it can be done either by:
  
  - Changing the number of [max parallel requests](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L116) within the `sphereClient` configuration. It defines how many requests the client can execute in parallel.
- - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
+ - or changing the draft [batch size](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/commons/BaseSyncOptionsBuilder.html#batchSize-int-). It defines how many drafts can one batch contains.
  
 The current overridable default [configuration](https://github.com/commercetools/commercetools-sync-java/tree/master/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) of the `sphereClient` 
 is the recommended good balance for stability and performance for the sync process.

--- a/docs/usage/INVENTORY_SYNC.md
+++ b/docs/usage/INVENTORY_SYNC.md
@@ -36,7 +36,7 @@ against a [InventoryEntryDraft](https://docs.commercetools.com/http-api-projects
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -68,7 +68,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toInventoryEntryDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/inventories/utils/InventoryTransformUtils.html#toInventoryEntryDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `InventoryEntry` to `InventoryEntryDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_SYNC.md
+++ b/docs/usage/PRODUCT_SYNC.md
@@ -39,7 +39,7 @@ against a [ProductDraft](https://docs.commercetools.com/http-api-projects-produc
 
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -80,7 +80,7 @@ resource on the target commercetools project and the library will issue an updat
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/products/utils/ProductTransformUtils.html#toProductDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `Product` to `ProductDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/PRODUCT_TYPE_SYNC.md
+++ b/docs/usage/PRODUCT_TYPE_SYNC.md
@@ -36,7 +36,7 @@ against a [ProductTypeDraft](https://docs.commercetools.com/http-api-projects-pr
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toProductTypeDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/producttypes/utils/ProductTypeTransformUtils.html#toProductTypeDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ProductType` to `ProductTypeDraft`. It can be configured to use a cache that will speed up the reference resolution performed during the sync, for example: 
 
 ````java

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -20,13 +20,13 @@
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>9.2.1</version>
+  <version>9.2.2</version>
 </dependency>
 ````
 - For Gradle users:
 ````groovy
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:9.2.1'
+implementation 'com.commercetools:commercetools-sync-java:9.2.2'
 ````
 
 ### 2. Setup Syncing Options

--- a/docs/usage/SHOPPING_LIST_SYNC.md
+++ b/docs/usage/SHOPPING_LIST_SYNC.md
@@ -37,7 +37,7 @@ against a [ShoppingListDraft](https://docs.commercetools.com/api/projects/shoppi
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -73,7 +73,7 @@ Therefore, in order to resolve the actual ids of those references in the sync pr
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toShoppingListDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/shoppinglists/utils/ShoppingListTransformUtils.html#toShoppingListDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `ShoppingList` to `ShoppingListDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/STATE_SYNC.md
+++ b/docs/usage/STATE_SYNC.md
@@ -35,7 +35,7 @@ against a [StateDraft](https://docs.commercetools.com/http-api-projects-states#s
 #### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java
@@ -66,7 +66,7 @@ reference should return its `key`.
 
 ##### Syncing from a commercetools project
 
-When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.1/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
+When syncing from a source commercetools project, you can use [`toStateDrafts`](https://commercetools.github.io/commercetools-sync-java/v/9.2.2/com/commercetools/sync/states/utils/StateTransformUtils.html#toStateDrafts-java.util.List-)
  method that transforms(resolves by querying and caching key-id pairs) and maps from a `State` to `StateDraft` using cache in order to make them ready for reference resolution by the sync, for example: 
 
 ````java

--- a/docs/usage/TAX_CATEGORY_SYNC.md
+++ b/docs/usage/TAX_CATEGORY_SYNC.md
@@ -31,7 +31,7 @@ against a [TaxCategoryDraft](https://docs.commercetools.com/http-api-projects-ta
 ### Prerequisites
 
 #### SphereClient
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/docs/usage/TYPE_SYNC.md
+++ b/docs/usage/TYPE_SYNC.md
@@ -33,7 +33,7 @@ against a [TypeDraft](https://docs.commercetools.com/http-api-projects-types.htm
 ### Prerequisites
 #### SphereClient
 
-Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.1/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
+Use the [ClientConfigurationUtils](https://github.com/commercetools/commercetools-sync-java/blob/9.2.2/src/main/java/com/commercetools/sync/commons/utils/ClientConfigurationUtils.java#L45) which apply the best practices for `SphereClient` creation.
 If you have custom requirements for the sphere client creation, have a look into the [Important Usage Tips](IMPORTANT_USAGE_TIPS.md).
 
 ````java

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
@@ -16,7 +16,6 @@ import com.commercetools.sync.products.ProductSync;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.helpers.ProductSyncStatistics;
-import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductProjection;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
@@ -38,8 +37,6 @@ public class ProductSyncMultipleVariantsIT {
   private List<String> warningCallBackMessages;
 
   private List<Throwable> errorCallBackExceptions;
-
-  private Product product;
 
   private ProductSyncOptions syncOptions;
 
@@ -70,7 +67,7 @@ public class ProductSyncMultipleVariantsIT {
                 PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference())
             .build();
 
-    product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
+    executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
   }
 
   @AfterAll

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
@@ -1,0 +1,128 @@
+package com.commercetools.sync.integration.externalsource.products;
+
+import com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics;
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.commons.utils.TriConsumer;
+import com.commercetools.sync.products.ProductSync;
+import com.commercetools.sync.products.ProductSyncOptions;
+import com.commercetools.sync.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.products.helpers.ProductSyncStatistics;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryDraft;
+import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.ProductDraft;
+import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.commands.ProductCreateCommand;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.states.StateType;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.*;
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.replaceCategoryOrderHintCategoryIdsWithKeys;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.integration.commons.utils.StateITUtils.createState;
+import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxCategory;
+import static com.commercetools.sync.products.ProductSyncMockUtils.*;
+import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProductSyncMultipleVariantsIT {
+
+    private static ProductType productType;
+
+    private List<String> errorCallBackMessages;
+
+    private List<String> warningCallBackMessages;
+
+    private List<Throwable> errorCallBackExceptions;
+
+    private Product product;
+
+    private ProductSyncOptions syncOptions;
+
+    /**
+     * Delete all product related test data from the target project. Then creates for the target CTP
+     * project price a product type, a tax category, 2 categories, custom types for the categories and
+     * a product state.
+     */
+    @BeforeAll
+    static void setup() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+
+        productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    }
+
+    /**
+     * Deletes Products and Types from the target CTP project, then it populates target CTP project
+     * with product test data.
+     */
+    @BeforeEach
+    void setupTest() {
+        clearSyncTestCollections();
+        deleteAllProducts(CTP_TARGET_CLIENT);
+        syncOptions = buildSyncOptions();
+
+        final ProductDraft productDraft =
+                createProductDraftBuilder(PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference())
+                        .build();
+
+        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
+    }
+
+
+    @AfterAll
+    static void tearDown() {
+        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    }
+
+    @Test
+    void sync_withReassignmentOfMasterVariant_shouldSyncProductCorrectly() {
+        // preparation
+        final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference()).build();
+
+        final ProductSync productSync = new ProductSync(syncOptions);
+        final ProductSyncStatistics syncStatistics =
+                executeBlocking(productSync.sync(singletonList(productDraft)));
+
+        AssertionsForStatistics.assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+    }
+
+    private void clearSyncTestCollections() {
+        errorCallBackMessages = new ArrayList<>();
+        errorCallBackExceptions = new ArrayList<>();
+        warningCallBackMessages = new ArrayList<>();
+    }
+
+    private ProductSyncOptions buildSyncOptions() {
+        final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+                warningCallBack =
+                (exception, newResource, oldResource) ->
+                        warningCallBackMessages.add(exception.getMessage());
+
+        return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+                .errorCallback(
+                        (exception, oldResource, newResource, updateActions) ->
+                                collectErrors(exception.getMessage(), exception.getCause()))
+                .warningCallback(warningCallBack)
+                .build();
+    }
+
+    private void collectErrors(final String errorMessage, final Throwable exception) {
+        errorCallBackMessages.add(errorMessage);
+        errorCallBackExceptions.add(exception);
+    }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncMultipleVariantsIT.java
@@ -1,5 +1,14 @@
 package com.commercetools.sync.integration.externalsource.products;
 
+import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.*;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
+import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.products.ProductSyncMockUtils.*;
+import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
+import static java.util.Collections.singletonList;
+
 import com.commercetools.sync.commons.asserts.statistics.AssertionsForStatistics;
 import com.commercetools.sync.commons.exceptions.SyncException;
 import com.commercetools.sync.commons.utils.TriConsumer;
@@ -7,122 +16,105 @@ import com.commercetools.sync.products.ProductSync;
 import com.commercetools.sync.products.ProductSyncOptions;
 import com.commercetools.sync.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.products.helpers.ProductSyncStatistics;
-import io.sphere.sdk.categories.Category;
-import io.sphere.sdk.categories.CategoryDraft;
 import io.sphere.sdk.products.Product;
 import io.sphere.sdk.products.ProductDraft;
 import io.sphere.sdk.products.ProductProjection;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.producttypes.ProductType;
-import io.sphere.sdk.states.StateType;
-import io.sphere.sdk.taxcategories.TaxCategory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.*;
-import static com.commercetools.sync.integration.commons.utils.CategoryITUtils.replaceCategoryOrderHintCategoryIdsWithKeys;
-import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
-import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
-import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.createProductType;
-import static com.commercetools.sync.integration.commons.utils.SphereClientUtils.CTP_TARGET_CLIENT;
-import static com.commercetools.sync.integration.commons.utils.StateITUtils.createState;
-import static com.commercetools.sync.integration.commons.utils.TaxCategoryITUtils.createTaxCategory;
-import static com.commercetools.sync.products.ProductSyncMockUtils.*;
-import static com.commercetools.sync.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
-import static com.commercetools.tests.utils.CompletionStageUtil.executeBlocking;
-import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class ProductSyncMultipleVariantsIT {
 
-    private static ProductType productType;
+  private static ProductType productType;
 
-    private List<String> errorCallBackMessages;
+  private List<String> errorCallBackMessages;
 
-    private List<String> warningCallBackMessages;
+  private List<String> warningCallBackMessages;
 
-    private List<Throwable> errorCallBackExceptions;
+  private List<Throwable> errorCallBackExceptions;
 
-    private Product product;
+  private Product product;
 
-    private ProductSyncOptions syncOptions;
+  private ProductSyncOptions syncOptions;
 
-    /**
-     * Delete all product related test data from the target project. Then creates for the target CTP
-     * project price a product type, a tax category, 2 categories, custom types for the categories and
-     * a product state.
-     */
-    @BeforeAll
-    static void setup() {
-        deleteProductSyncTestData(CTP_TARGET_CLIENT);
+  /**
+   * Delete all product related test data from the target project. Then creates for the target CTP
+   * project price a product type, a tax category, 2 categories, custom types for the categories and
+   * a product state.
+   */
+  @BeforeAll
+  static void setup() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
 
-        productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
-    }
+    productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+  }
 
-    /**
-     * Deletes Products and Types from the target CTP project, then it populates target CTP project
-     * with product test data.
-     */
-    @BeforeEach
-    void setupTest() {
-        clearSyncTestCollections();
-        deleteAllProducts(CTP_TARGET_CLIENT);
-        syncOptions = buildSyncOptions();
+  /**
+   * Deletes Products and Types from the target CTP project, then it populates target CTP project
+   * with product test data.
+   */
+  @BeforeEach
+  void setupTest() {
+    clearSyncTestCollections();
+    deleteAllProducts(CTP_TARGET_CLIENT);
+    syncOptions = buildSyncOptions();
 
-        final ProductDraft productDraft =
-                createProductDraftBuilder(PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference())
-                        .build();
+    final ProductDraft productDraft =
+        createProductDraftBuilder(
+                PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference())
+            .build();
 
-        product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
-    }
+    product = executeBlocking(CTP_TARGET_CLIENT.execute(ProductCreateCommand.of(productDraft)));
+  }
 
+  @AfterAll
+  static void tearDown() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
+  }
 
-    @AfterAll
-    static void tearDown() {
-        deleteProductSyncTestData(CTP_TARGET_CLIENT);
-    }
+  @Test
+  void sync_withReassignmentOfMasterVariant_shouldSyncProductCorrectly() {
+    // preparation
+    final ProductDraft productDraft =
+        createProductDraftBuilder(
+                PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference())
+            .build();
 
-    @Test
-    void sync_withReassignmentOfMasterVariant_shouldSyncProductCorrectly() {
-        // preparation
-        final ProductDraft productDraft = createProductDraftBuilder(PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH, productType.toReference()).build();
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        executeBlocking(productSync.sync(singletonList(productDraft)));
 
-        final ProductSync productSync = new ProductSync(syncOptions);
-        final ProductSyncStatistics syncStatistics =
-                executeBlocking(productSync.sync(singletonList(productDraft)));
+    AssertionsForStatistics.assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+  }
 
-        AssertionsForStatistics.assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
-    }
+  private void clearSyncTestCollections() {
+    errorCallBackMessages = new ArrayList<>();
+    errorCallBackExceptions = new ArrayList<>();
+    warningCallBackMessages = new ArrayList<>();
+  }
 
-    private void clearSyncTestCollections() {
-        errorCallBackMessages = new ArrayList<>();
-        errorCallBackExceptions = new ArrayList<>();
-        warningCallBackMessages = new ArrayList<>();
-    }
+  private ProductSyncOptions buildSyncOptions() {
+    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+        warningCallBack =
+            (exception, newResource, oldResource) ->
+                warningCallBackMessages.add(exception.getMessage());
 
-    private ProductSyncOptions buildSyncOptions() {
-        final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
-                warningCallBack =
-                (exception, newResource, oldResource) ->
-                        warningCallBackMessages.add(exception.getMessage());
+    return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+        .errorCallback(
+            (exception, oldResource, newResource, updateActions) ->
+                collectErrors(exception.getMessage(), exception.getCause()))
+        .warningCallback(warningCallBack)
+        .build();
+  }
 
-        return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
-                .errorCallback(
-                        (exception, oldResource, newResource, updateActions) ->
-                                collectErrors(exception.getMessage(), exception.getCause()))
-                .warningCallback(warningCallBack)
-                .build();
-    }
-
-    private void collectErrors(final String errorMessage, final Throwable exception) {
-        errorCallBackMessages.add(errorMessage);
-        errorCallBackExceptions.add(exception);
-    }
+  private void collectErrors(final String errorMessage, final Throwable exception) {
+    errorCallBackMessages.add(errorMessage);
+    errorCallBackExceptions.add(exception);
+  }
 }

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -86,7 +86,7 @@ import javax.annotation.Nonnull;
 
 public final class ProductUpdateActionUtils {
   private static final String BLANK_VARIANT_KEY = "The variant key is blank.";
-  private static final String NULL_VARIANT = "The variant is null.";
+  static final String NULL_VARIANT = "The variant is null.";
   static final String BLANK_OLD_MASTER_VARIANT_KEY = "Old master variant key is blank.";
   static final String BLANK_NEW_MASTER_VARIANT_KEY = "New master variant null or has blank key.";
   static final String BLANK_NEW_MASTER_VARIANT_SKU = "New master variant has blank SKU.";

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -508,7 +508,7 @@ public final class ProductUpdateActionUtils {
       }
 
       updateActions.addAll(
-          buildSetAttributeInAllVariantsAction(
+          buildSetAttributeInAllVariantsUpdateAction(
               attributesMetaData, oldProduct.getMasterVariant(), newMasterVariant));
     }
     return updateActions;
@@ -873,7 +873,7 @@ public final class ProductUpdateActionUtils {
         });
   }
 
-  private static List<UpdateAction<Product>> buildSetAttributeInAllVariantsAction(
+  private static List<UpdateAction<Product>> buildSetAttributeInAllVariantsUpdateAction(
       @Nonnull final Map<String, AttributeMetaData> attributesMetaData,
       @Nonnull final ProductVariant oldMasterVariant,
       @Nonnull final ProductVariantDraft newMasterVariant) {

--- a/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductUpdateActionUtils.java
@@ -495,7 +495,8 @@ public final class ProductUpdateActionUtils {
         && hasChangeMasterVariantUpdateAction(updateActions)) {
 
       // Following update actions helps with the changing of master variants.
-      // The details are described here: https://github.com/commercetools/commercetools-project-sync/issues/447
+      // The details are described here:
+      // https://github.com/commercetools/commercetools-project-sync/issues/447
       final String oldMasterVariantSku = oldMasterVariant.getSku();
       final boolean hasConflictingAddVariant =
           hasConflictingAddVariantUpdateAction(updateActions, oldMasterVariantSku);

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -64,6 +64,8 @@ import javax.annotation.Nullable;
 
 public class ProductSyncMockUtils {
   public static final String PRODUCT_KEY_1_RESOURCE_PATH = "product-key-1.json";
+
+  public static final String PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH = "product-key-1-multiple-variants.json";
   public static final String PRODUCT_KEY_1_NO_ATTRIBUTES_RESOURCE_PATH =
       "product-key-1-no-attributes.json";
   public static final String PRODUCT_KEY_SPECIAL_CHARS_RESOURCE_PATH =
@@ -76,6 +78,9 @@ public class ProductSyncMockUtils {
   public static final String PRODUCT_KEY_1_CHANGED_WITH_PRICES_RESOURCE_PATH =
       "product-key-1-changed-with-prices.json";
   public static final String PRODUCT_KEY_2_RESOURCE_PATH = "product-key-2.json";
+
+  public static final String PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH = "product-key-2-multiple-variants.json";
+
   public static final String PRODUCT_WITH_VARS_RESOURCE_PATH = "product-with-variants.json";
   public static final String PRODUCT_NO_VARS_RESOURCE_PATH = "product-with-no-variants.json";
   public static final String PRODUCT_TYPE_RESOURCE_PATH = "product-type.json";

--- a/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/products/ProductSyncMockUtils.java
@@ -65,7 +65,8 @@ import javax.annotation.Nullable;
 public class ProductSyncMockUtils {
   public static final String PRODUCT_KEY_1_RESOURCE_PATH = "product-key-1.json";
 
-  public static final String PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH = "product-key-1-multiple-variants.json";
+  public static final String PRODUCT_KEY_1_MULTIPLE_VARIANTS_RESOURCE_PATH =
+      "product-key-1-multiple-variants.json";
   public static final String PRODUCT_KEY_1_NO_ATTRIBUTES_RESOURCE_PATH =
       "product-key-1-no-attributes.json";
   public static final String PRODUCT_KEY_SPECIAL_CHARS_RESOURCE_PATH =
@@ -79,7 +80,8 @@ public class ProductSyncMockUtils {
       "product-key-1-changed-with-prices.json";
   public static final String PRODUCT_KEY_2_RESOURCE_PATH = "product-key-2.json";
 
-  public static final String PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH = "product-key-2-multiple-variants.json";
+  public static final String PRODUCT_KEY_2_MULTIPLE_VARIANTS_RESOURCE_PATH =
+      "product-key-2-multiple-variants.json";
 
   public static final String PRODUCT_WITH_VARS_RESOURCE_PATH = "product-with-variants.json";
   public static final String PRODUCT_NO_VARS_RESOURCE_PATH = "product-with-no-variants.json";

--- a/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductSyncUtilsTest.java
@@ -415,10 +415,11 @@ class ProductSyncUtilsTest {
             oldProduct, newProductDraft, productSyncOptions, attributesMetaData);
 
     // check the generated attribute update actions
-    assertThat(updateActions.size()).isEqualTo(9);
+    assertThat(updateActions.size()).isEqualTo(10);
     assertThat(updateActions)
         .containsSequence(
             RemoveVariant.ofVariantId(5, true),
+            SetSku.of(1, "1065833-temp"),
             AddVariant.of(
                     Arrays.asList(
                         AttributeDraft.of("priceInfo", "64,90/kg"),

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -98,7 +98,10 @@ class ProductUpdateActionUtilsTest {
     final Map<String, AttributeMetaData> attributesMetaData = new HashMap<>();
     final AttributeMetaData priceInfo =
         AttributeMetaData.of(AttributeDefinitionBuilder.of("priceInfo", null, null).build());
+    final AttributeMetaData sizeAttributeMetaData =
+        AttributeMetaData.of(AttributeDefinitionBuilder.of("size", null, null).build());
     attributesMetaData.put("priceInfo", priceInfo);
+    attributesMetaData.put("size", sizeAttributeMetaData);
 
     final List<UpdateAction<Product>> updateActions =
         buildVariantsUpdateActions(
@@ -215,7 +218,10 @@ class ProductUpdateActionUtilsTest {
 
     final AttributeMetaData priceInfo =
         AttributeMetaData.of(AttributeDefinitionBuilder.of("priceInfo", null, null).build());
+    final AttributeMetaData size =
+        AttributeMetaData.of(AttributeDefinitionBuilder.of("size", null, null).build());
     attributesMetaData.put("priceInfo", priceInfo);
+    attributesMetaData.put("size", size);
 
     final List<UpdateAction<Product>> updateActions =
         buildVariantsUpdateActions(

--- a/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductUpdateActionUtilsTest.java
@@ -2,13 +2,7 @@ package com.commercetools.sync.products.utils;
 
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductDraftFromJson;
 import static com.commercetools.sync.products.ProductSyncMockUtils.createProductFromJson;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_NEW_MASTER_VARIANT_KEY;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_NEW_MASTER_VARIANT_SKU;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.BLANK_OLD_MASTER_VARIANT_KEY;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildAddVariantUpdateActionFromDraft;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildChangeMasterVariantUpdateAction;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.buildVariantsUpdateActions;
-import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.getAllVariants;
+import static com.commercetools.sync.products.utils.ProductUpdateActionUtils.*;
 import static io.sphere.sdk.models.LocalizedString.ofEnglish;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -61,6 +55,8 @@ class ProductUpdateActionUtilsTest {
   private static final String RES_ROOT =
       "com/commercetools/sync/products/utils/productVariantUpdateActionUtils/";
   private static final String OLD_PROD_WITH_VARIANTS = RES_ROOT + "productOld.json";
+  private static final String OLD_PROD_WITH_MASTER_VARIANT_ONLY =
+      RES_ROOT + "productOld_onlyMasterVariant.json";
   private static final String OLD_PROD_WITHOUT_MV_KEY_SKU =
       RES_ROOT + "productOld_noMasterVariantKeySku.json";
 
@@ -84,6 +80,9 @@ class ProductUpdateActionUtilsTest {
 
   private static final String NEW_PROD_DRAFT_WITHOUT_MV_SKU =
       RES_ROOT + "productDraftNew_noMasterVariantSku.json";
+
+  private static final String NEW_PROD_DRAFT_WITH_NULL_VARIANT =
+      RES_ROOT + "productDraftNew_nullVariant.json";
 
   @Test
   void buildVariantsUpdateActions_updatesVariants() {
@@ -281,6 +280,12 @@ class ProductUpdateActionUtilsTest {
         NEW_PROD_DRAFT_WITHOUT_MV_KEY,
         BLANK_OLD_MASTER_VARIANT_KEY,
         BLANK_NEW_MASTER_VARIANT_KEY);
+  }
+
+  @Test
+  void buildVariantsUpdateActions_withNullProductVariant_shouldNotBuildActionAndTriggerCallback() {
+    assertMissingMasterVariantKey(
+        OLD_PROD_WITH_MASTER_VARIANT_ONLY, NEW_PROD_DRAFT_WITH_NULL_VARIANT, NULL_VARIANT);
   }
 
   private void assertMissingMasterVariantKey(

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_nullVariant.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productDraftNew_nullVariant.json
@@ -1,0 +1,9 @@
+{
+  "key": "productToSyncKey",
+  "masterVariant":{
+    "id": 1,
+    "key": "var-1-key",
+    "sku": "var-1-sku"
+  },
+  "variants": [null]
+}

--- a/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld_onlyMasterVariant.json
+++ b/src/test/resources/com/commercetools/sync/products/utils/productVariantUpdateActionUtils/productOld_onlyMasterVariant.json
@@ -1,0 +1,21 @@
+{
+  "key": "productToSyncKey",
+  "masterData": {
+    "staged": {
+      "masterVariant": {
+        "id": 1,
+        "key": "var-1-key",
+        "sku": "var-1-sku",
+        "prices": [
+        ],
+        "images": [
+        ],
+        "attributes": [
+        ],
+        "assets": []
+      },
+      "variants": []
+    },
+    "published": true
+  }
+}

--- a/src/test/resources/product-key-1-multiple-variants.json
+++ b/src/test/resources/product-key-1-multiple-variants.json
@@ -1,0 +1,46 @@
+{
+  "id": "5ce8aaae-6026-407f-8180-5b75d38c897d",
+  "version": 338,
+  "productType": {
+    "typeId": "product-type",
+    "id": "5fbf6deb-0fa2-4566-8367-cdc13b03fab2"
+  },
+  "masterData": {
+    "staged": {
+      "name": {
+        "en": "Purple Foundation",
+        "en-US": "Purple Foundation"
+      },
+      "categories": [
+      ],
+      "categoryOrderHints": {},
+      "slug": {
+        "en": "purple-foundation",
+        "en-US": "purple-foundation"
+      },
+      "masterVariant": {
+        "id": 1,
+        "sku": "10-38-45868",
+        "key": "4364064522287-08",
+        "attributes": [{
+          "name": "priceInfo",
+          "value": "64,90/kg"
+        }]
+      },
+      "variants": [
+        {
+          "id": 2,
+          "sku": "10-38-45862",
+          "key": "4364064522287-02",
+          "attributes": [{
+            "name": "priceInfo",
+            "value": "64,90/kg"
+          }]
+        }
+      ]
+    },
+    "hasStagedChanges": false,
+    "published": true
+  },
+  "key": "1eab5094-1e4d-475c-a09a-b8e7439edd53"
+}

--- a/src/test/resources/product-key-2-multiple-variants.json
+++ b/src/test/resources/product-key-2-multiple-variants.json
@@ -1,0 +1,50 @@
+{
+  "id": "2b2a2ce2-3ba3-47a4-9c9b-13770d664dd2",
+  "version": 448,
+  "productType": {
+    "typeId": "product-type",
+    "id": "db860040-dcb7-4db5-8f87-7dfc89611599"
+  },
+  "masterData": {
+    "staged": {
+      "name": {
+        "en": "Purple Foundation",
+        "en-US": "Purple Foundation"
+      },
+      "categories": [
+        {
+          "typeId": "category",
+          "id": "d4558303-854c-49c1-9d8d-cb5ed610946e"
+        }
+      ],
+      "categoryOrderHints": {},
+      "slug": {
+        "en": "purple-foundation",
+        "en-US": "purple-foundation"
+      },
+      "masterVariant": {
+        "id": 1,
+        "sku": "10-38-45862",
+        "key": "4364064522287-31280524787759",
+        "attributes": [{
+          "name": "priceInfo",
+          "value": "90/kg"
+        }]
+      },
+      "variants": [
+        {
+          "id": 2,
+          "sku": "10-38-45868",
+          "key": "4364064522287-31280524820527",
+          "attributes": [{
+            "name": "priceInfo",
+            "value": "90/kg"
+          }]
+        }
+      ]
+    },
+    "hasStagedChanges": false,
+    "published": true
+  },
+  "key": "1eab5094-1e4d-475c-a09a-b8e7439edd53"
+}

--- a/src/test/resources/product-key-2-multiple-variants.json
+++ b/src/test/resources/product-key-2-multiple-variants.json
@@ -12,10 +12,6 @@
         "en-US": "Purple Foundation"
       },
       "categories": [
-        {
-          "typeId": "category",
-          "id": "d4558303-854c-49c1-9d8d-cb5ed610946e"
-        }
       ],
       "categoryOrderHints": {},
       "slug": {


### PR DESCRIPTION
#### Summary

This PR fixes the issue that was reported in project-sync: https://github.com/commercetools/commercetools-project-sync/issues/447

However, after fixing the reported issue, there is a new issue that comes up and the test case is still failing. The next issue is that to add a new variant with the same SKU as the master variant, the following has to be done:
1. temporarily rename the existing master SKU (I choose to add a `-temp` suffix to the SKU)
2. add the new variant
3. change master to the new variant
4. remove the old master variant

Q: Why does it add new variant with the same SKU instead of updating the existing variant?
A: The matching of variant is NOT done by SKU, but by key. In this case, the keys of the variants are different. However, their SKUs are the same. Therefore we have this issue.

Q: Will the temporary SKU be saved in the product?
A: No. It will be applied only in memory when processing the requests.

Q: Do we need to rename the temporary SKU back once the master is switched?
A: No. It is replaced by another variant that has the same SKU, but different key. As we always remove the temporary variant afterwards, there is no need to rename back.