### PR TITLE
Migrate ReferenceResolution utility classes and it's unittests

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/commons/helpers/CategoryResourceIdentifierPair.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/helpers/CategoryResourceIdentifierPair.java
@@ -1,0 +1,37 @@
+package com.commercetools.sync.sdk2.commons.helpers;
+
+import com.commercetools.api.models.category.CategoryResourceIdentifier;
+import com.commercetools.api.models.product.CategoryOrderHints;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Container for a {@link List} of {@link CategoryResourceIdentifier} and a {@link
+ * CategoryOrderHints}.
+ */
+public final class CategoryResourceIdentifierPair {
+  private List<CategoryResourceIdentifier> categoryResourceIdentifiers;
+  private CategoryOrderHints categoryOrderHints;
+
+  private CategoryResourceIdentifierPair(
+      @Nonnull final List<CategoryResourceIdentifier> categoryResourceIdentifiers,
+      @Nullable final CategoryOrderHints categoryOrderHints) {
+    this.categoryResourceIdentifiers = categoryResourceIdentifiers;
+    this.categoryOrderHints = categoryOrderHints;
+  }
+
+  public static CategoryResourceIdentifierPair of(
+      @Nonnull final List<CategoryResourceIdentifier> categoryResourceIdentifiers,
+      @Nullable final CategoryOrderHints categoryOrderHints) {
+    return new CategoryResourceIdentifierPair(categoryResourceIdentifiers, categoryOrderHints);
+  }
+
+  public List<CategoryResourceIdentifier> getCategoryResourceIdentifiers() {
+    return categoryResourceIdentifiers;
+  }
+
+  public CategoryOrderHints getCategoryOrderHints() {
+    return categoryOrderHints;
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/AssetReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/AssetReferenceResolutionUtils.java
@@ -1,0 +1,49 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CustomTypeReferenceResolutionUtils.mapToCustomFieldsDraft;
+
+import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.common.AssetDraft;
+import com.commercetools.api.models.common.AssetDraftBuilder;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/**
+ * Util class which provides utilities that can be used when syncing resources from a source
+ * commercetools project to a target one.
+ */
+public final class AssetReferenceResolutionUtils {
+
+  /**
+   * Takes an asset list that is supposed to have all its asset's custom references id's are cached
+   * in the map in order to be able to fetch the keys for the custom references. This method returns
+   * as a result a {@link List} of {@link AssetDraft} that has all custom references with keys.
+   *
+   * <p>Any custom reference that is not in the map(cache) will have its id in place and not
+   * replaced by the key.
+   *
+   * @param assets the list of assets to replace their custom ids with keys.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return a {@link List} of {@link AssetDraft} that has all channel references with keys.
+   */
+  @Nonnull
+  public static List<AssetDraft> mapToAssetDrafts(
+      @Nonnull final List<Asset> assets,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    return assets.stream()
+        .map(
+            asset ->
+                AssetDraftBuilder.of()
+                    .custom(mapToCustomFieldsDraft(asset.getCustom(), referenceIdToKeyCache))
+                    .description(asset.getDescription())
+                    .name(asset.getName())
+                    .key(asset.getKey())
+                    .sources(asset.getSources())
+                    .tags(asset.getTags())
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  private AssetReferenceResolutionUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CaffeineReferenceIdToKeyCacheImpl.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CaffeineReferenceIdToKeyCacheImpl.java
@@ -1,0 +1,53 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import com.commercetools.sync.sdk2.services.impl.BaseTransformServiceImpl;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Map;
+
+/**
+ * A Caffeine cache to store reference id to key pairs.
+ *
+ * <p>Designed to be used as an reference in memory cache as a part of {@link
+ * BaseTransformServiceImpl} instances.
+ *
+ * <p>The cache is implemented by the caffeine library which implements a LRU based cache eviction
+ * strategy. It means unused id to key pairs will be evicted, also it stores max 10000 pairs to
+ * ensure the minimum memory consumption.
+ */
+public class CaffeineReferenceIdToKeyCacheImpl implements ReferenceIdToKeyCache {
+  private static final Cache<String, String> referenceIdToKeyCache =
+      Caffeine.newBuilder().maximumSize(10_000).executor(Runnable::run).build();
+
+  public CaffeineReferenceIdToKeyCacheImpl() {}
+
+  @Override
+  public void add(String key, String value) {
+    referenceIdToKeyCache.put(key, value);
+  }
+
+  @Override
+  public void remove(String key) {
+    referenceIdToKeyCache.invalidate(key);
+  }
+
+  @Override
+  public void addAll(Map<String, String> idToKeyValues) {
+    referenceIdToKeyCache.putAll(idToKeyValues);
+  }
+
+  @Override
+  public boolean containsKey(String key) {
+    return (null != referenceIdToKeyCache.getIfPresent(key));
+  }
+
+  @Override
+  public String get(String key) {
+    return referenceIdToKeyCache.getIfPresent(key);
+  }
+
+  @Override
+  public void clearCache() {
+    referenceIdToKeyCache.invalidateAll();
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomTypeReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomTypeReferenceResolutionUtils.java
@@ -1,0 +1,81 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.getResourceIdentifierWithKey;
+
+import com.commercetools.api.models.Customizable;
+import com.commercetools.api.models.type.CustomFields;
+import com.commercetools.api.models.type.CustomFieldsDraft;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifier;
+import com.commercetools.sync.sdk2.commons.models.Custom;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Util class which provides utilities that can be used when syncing resources from a source
+ * commercetools project to a target one.
+ */
+public final class CustomTypeReferenceResolutionUtils {
+
+  /**
+   * Given a resource of type {@code T} that extends {@link Custom} (i.e. it has {@link
+   * CustomFields}, this method checks if the custom fields are existing (not null) and they are
+   * reference cached(reference idToKey value stored in the map). If they are then it returns a
+   * {@link CustomFieldsDraft} instance with the custom type key in place of the key of the
+   * reference. Otherwise, if it's not reference cached it returns a {@link CustomFieldsDraft}
+   * without the key. If the resource has null {@link Custom}, then it returns {@code null}.
+   *
+   * @param resource the resource to replace its custom type key, if possible.
+   * @param <T> the type of the resource.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return an instance of {@link CustomFieldsDraft} instance with the custom type key, if the
+   *     custom type reference was existing and reference cached on the resource. Otherwise, if its
+   *     not reference cached it returns a {@link CustomFieldsDraft} without a key. If the resource
+   *     has no or null {@link Custom}, then it returns {@code null}.
+   */
+  @Nullable
+  public static <T extends Customizable> CustomFieldsDraft mapToCustomFieldsDraft(
+      @Nonnull final T resource, @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    final CustomFields custom = resource.getCustom();
+    return mapToCustomFieldsDraft(custom, referenceIdToKeyCache);
+  }
+
+  /**
+   * Given a custom {@link CustomFields}, this method provides checking to certain resources which
+   * do not extends {@link Custom}. If the custom fields are existing (not null) and they are
+   * reference cached(reference idToKey value stored in the map). If they are then it returns a
+   * {@link CustomFieldsDraft} instance with the custom type key in place of the key of the
+   * reference. Otherwise, if it's not reference cached it returns a {@link CustomFieldsDraft}
+   * without the key. If the resource has null {@link Custom}, then it returns {@code null}.
+   *
+   * @param custom the resource to replace its custom type key, if possible.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return an instance of {@link CustomFieldsDraft} instance with the custom type key, if the
+   *     custom type reference was existing and reference cached on the resource. Otherwise, if its
+   *     not reference cached it returns a {@link CustomFieldsDraft} without a key. If the resource
+   *     has no or null {@link Custom}, then it returns {@code null}.
+   */
+  @Nullable
+  public static CustomFieldsDraft mapToCustomFieldsDraft(
+      @Nullable final CustomFields custom,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    return Optional.ofNullable(custom)
+        .map(
+            fields ->
+                CustomFieldsDraftBuilder.of()
+                    .fields(fields.getFields())
+                    .type(
+                        Optional.ofNullable(fields.getType())
+                            .map(
+                                typeReference ->
+                                    (TypeResourceIdentifier)
+                                        getResourceIdentifierWithKey(
+                                            typeReference, referenceIdToKeyCache))
+                            .orElse(null))
+                    .build())
+        .orElse(null);
+  }
+
+  private CustomTypeReferenceResolutionUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/ReferenceIdToKeyCache.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/ReferenceIdToKeyCache.java
@@ -1,0 +1,47 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import com.commercetools.sync.commons.utils.CaffeineReferenceIdToKeyCacheImpl;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * A Interface used to manage cache to store reference id to key pairs.
+ *
+ * <p>The cache can be implemented by any caching library and override the methods to perform
+ * caching operations. Default cache implementation is provided in the library class
+ * CaffeineReferenceIdToKeyCacheImpl{@link CaffeineReferenceIdToKeyCacheImpl}.
+ */
+public interface ReferenceIdToKeyCache {
+
+  /**
+   * @param key key with which the specified value is to be associated.
+   * @param value value to be associated with the specified key.
+   */
+  void add(@Nonnull final String key, @Nonnull final String value);
+
+  /**
+   * @param key key whose mapping is to be removed from the map
+   */
+  void remove(@Nonnull final String key);
+
+  /**
+   * @param idToKeyValues mappings to be stored in this cache.
+   */
+  void addAll(@Nonnull final Map<String, String> idToKeyValues);
+
+  /**
+   * @param key key whose presence in this map is to be tested
+   * @return true if this map contains a mapping for the specified key in the cache.
+   */
+  boolean containsKey(@Nonnull final String key);
+
+  /**
+   * @param key the key whose associated value is to be returned.
+   * @return the value to which the specified key is mapped, or {@code null} if the cache contains
+   *     no mapping for the key.
+   */
+  String get(@Nonnull final String key);
+
+  /** Discards all entries in the cache. */
+  void clearCache();
+}

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/AssetUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/AssetUtils.java
@@ -1,4 +1,4 @@
-package com.commercetools.sync.sdk2.products;
+package com.commercetools.sync.sdk2.products.utils;
 
 import static com.commercetools.sync.sdk2.products.utils.CustomFieldsUtils.createCustomFieldsDraft;
 

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/CustomFieldsUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/CustomFieldsUtils.java
@@ -1,13 +1,23 @@
 package com.commercetools.sync.sdk2.products.utils;
 
+import static com.commercetools.sync.sdk2.commons.utils.CustomTypeReferenceResolutionUtils.mapToCustomFieldsDraft;
+
 import com.commercetools.api.models.type.CustomFields;
 import com.commercetools.api.models.type.CustomFieldsDraft;
 import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
 import com.commercetools.api.models.type.TypeReference;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class CustomFieldsUtils {
+
+  public static CustomFieldsDraft createCustomFieldsDraft(
+      @Nullable CustomFields customFields, @Nullable ReferenceIdToKeyCache referenceIdToKeyCache) {
+    return referenceIdToKeyCache != null
+        ? mapToCustomFieldsDraft(customFields, referenceIdToKeyCache)
+        : createCustomFieldsDraft(customFields);
+  }
 
   public static CustomFieldsDraft createCustomFieldsDraft(@Nullable CustomFields customFields) {
     return Optional.ofNullable(customFields)

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/ProductReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/ProductReferenceResolutionUtils.java
@@ -1,0 +1,270 @@
+package com.commercetools.sync.sdk2.products.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.getResourceIdentifierWithKey;
+import static com.commercetools.sync.sdk2.products.utils.AssetUtils.createAssetDraft;
+import static com.commercetools.sync.sdk2.products.utils.PriceUtils.createPriceDraft;
+import static java.util.stream.Collectors.toList;
+
+import com.commercetools.api.models.category.CategoryReference;
+import com.commercetools.api.models.category.CategoryResourceIdentifier;
+import com.commercetools.api.models.category.CategoryResourceIdentifierBuilder;
+import com.commercetools.api.models.common.AssetDraft;
+import com.commercetools.api.models.common.PriceDraft;
+import com.commercetools.api.models.product.Attribute;
+import com.commercetools.api.models.product.AttributeBuilder;
+import com.commercetools.api.models.product.CategoryOrderHints;
+import com.commercetools.api.models.product.CategoryOrderHintsBuilder;
+import com.commercetools.api.models.product.Product;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductDraftBuilder;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.api.models.product.ProductVariant;
+import com.commercetools.api.models.product.ProductVariantDraft;
+import com.commercetools.api.models.product.ProductVariantDraftBuilder;
+import com.commercetools.api.models.product_type.ProductTypeReference;
+import com.commercetools.api.models.product_type.ProductTypeResourceIdentifier;
+import com.commercetools.api.models.product_type.ProductTypeResourceIdentifierBuilder;
+import com.commercetools.api.models.state.StateResourceIdentifier;
+import com.commercetools.api.models.tax_category.TaxCategoryResourceIdentifier;
+import com.commercetools.api.models.tax_category.TaxCategoryResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.commons.helpers.CategoryResourceIdentifierPair;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/**
+ * Util class which provides utilities that can be used when syncing resources from a source
+ * commercetools project to a target one.
+ */
+public final class ProductReferenceResolutionUtils {
+
+  /**
+   * Returns an {@link List}&lt;{@link ProductDraft}&gt; consisting of the results of applying the
+   * mapping from the staged version of a {@link ProductProjection} to {@link ProductDraft} with
+   * considering reference resolution.
+   *
+   * <table>
+   *   <caption>Mapping of Reference fields for the reference resolution</caption>
+   *   <thead>
+   *     <tr>
+   *       <th>Reference field</th>
+   *       <th>from</th>
+   *       <th>to</th>
+   *     </tr>
+   *   </thead>
+   *   <tbody>
+   *     <tr>
+   *       <td>productType</td>
+   *       <td>{@link ProductTypeReference}</td>
+   *       <td>{@link ProductTypeResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>categories</td>
+   *        <td>{@link List}&lt;{@link CategoryReference}&gt;</td>
+   *        <td>{@link List}&lt;{@link CategoryResourceIdentifier}&gt;</td>
+   *     </tr>
+   *     <tr>
+   *        <td>variants.prices.channel</td>
+   *        <td>{@link com.commercetools.api.models.channel.ChannelReference}</td>
+   *        <td>{@link com.commercetools.api.models.channel.ChannelResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>variants.prices.customerGroup *</td>
+   *        <td>{@link com.commercetools.api.models.customer_group.CustomerGroupReference}</td>
+   *        <td>{@link com.commercetools.api.models.customer_group.CustomerGroupResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>variants.prices.custom.type</td>
+   *        <td>{@link com.commercetools.api.models.type.TypeReference}</td>
+   *        <td>{@link com.commercetools.api.models.type.TypeResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>variants.assets.custom.type</td>
+   *        <td>{@link com.commercetools.api.models.type.TypeReference}</td>
+   *        <td>{@link com.commercetools.api.models.type.TypeResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>variants.attributes on {@link List}&lt;{@link Attribute} *</td>
+   *        <td>{@link ProductTypeReference} (example for ProductType)</td>
+   *        <td>{@link ProductTypeReference} (with key replaced with id field)</td>
+   *     </tr>
+   *     <tr>
+   *        <td>taxCategory</td>
+   *        <td>{@link com.commercetools.api.models.tax_category.TaxCategoryReference}</td>
+   *        <td>{@link com.commercetools.api.models.tax_category.TaxCategoryResourceIdentifier}</td>
+   *     </tr>
+   *     <tr>
+   *        <td>state *</td>
+   *        <td>{@link com.commercetools.api.models.state.StateReference}</td>
+   *        <td>{@link com.commercetools.api.models.state.StateResourceIdentifier}</td>
+   *     </tr>
+   *   </tbody>
+   * </table>
+   *
+   * <p><b>Note:</b> The aforementioned references should contain Id in the map(cache) with a key
+   * value. Any reference that is not available in the map will have its id in place and not
+   * replaced by the key. This reference will be considered as existing resources on the target
+   * commercetools project and the library will issues an update/create API request without
+   * reference resolution.
+   *
+   * @param products the productprojection (staged) without expansion of references.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return a {@link List} of {@link ProductDraft} built from the supplied {@link List} of {@link
+   *     Product}.
+   */
+  @Nonnull
+  public static List<ProductDraft> mapToProductDrafts(
+      @Nonnull final List<ProductProjection> products,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    return products.stream()
+        .filter(Objects::nonNull)
+        .map(
+            product -> {
+              final ProductDraft productDraft = getDraftBuilderFromStagedProduct(product).build();
+
+              final CategoryResourceIdentifierPair categoryResourceIdentifierPair =
+                  mapToCategoryReferencePair(product, referenceIdToKeyCache);
+              final List<CategoryResourceIdentifier> categoryResourceIdentifiers =
+                  categoryResourceIdentifierPair.getCategoryResourceIdentifiers();
+              final CategoryOrderHints categoryOrderHintsWithKeys =
+                  categoryResourceIdentifierPair.getCategoryOrderHints();
+
+              final List<ProductVariant> allVariants = product.getAllVariants();
+              final List<ProductVariantDraft> variantDraftsWithKeys =
+                  VariantReferenceResolutionUtils.mapToProductVariantDrafts(
+                      allVariants, referenceIdToKeyCache);
+              final ProductVariantDraft masterVariantDraftWithKeys =
+                  variantDraftsWithKeys.remove(0);
+
+              return ProductDraftBuilder.of(productDraft)
+                  .masterVariant(masterVariantDraftWithKeys)
+                  .variants(variantDraftsWithKeys)
+                  .productType(
+                      (ProductTypeResourceIdentifier)
+                          getResourceIdentifierWithKey(
+                              product.getProductType(), referenceIdToKeyCache))
+                  .categories(categoryResourceIdentifiers)
+                  .categoryOrderHints(categoryOrderHintsWithKeys)
+                  .taxCategory(
+                      (TaxCategoryResourceIdentifier)
+                          getResourceIdentifierWithKey(
+                              product.getTaxCategory(), referenceIdToKeyCache))
+                  .state(
+                      (StateResourceIdentifier)
+                          getResourceIdentifierWithKey(product.getState(), referenceIdToKeyCache))
+                  .build();
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Given a {@link Product} this method creates a {@link ProductDraftBuilder} based on the staged
+   * projection values of the supplied product.
+   *
+   * @param product the product to create a {@link ProductDraftBuilder} based on it's staged data.
+   * @return a {@link ProductDraftBuilder} based on the staged projection values of the supplied
+   *     product.
+   */
+  @Nonnull
+  public static ProductDraftBuilder getDraftBuilderFromStagedProduct(
+      @Nonnull final ProductProjection product) {
+    final List<ProductVariantDraft> allVariants =
+        product.getVariants().stream()
+            .map(productVariant -> getProductVariantDraft(productVariant))
+            .collect(toList());
+    final ProductVariantDraft masterVariant = getProductVariantDraft(product.getMasterVariant());
+
+    return ProductDraftBuilder.of()
+        .productType(
+            ProductTypeResourceIdentifierBuilder.of().id(product.getProductType().getId()).build())
+        .name(product.getName())
+        .slug(product.getSlug())
+        .masterVariant(masterVariant)
+        .variants(allVariants)
+        .metaDescription(product.getMetaDescription())
+        .metaKeywords(product.getMetaKeywords())
+        .metaTitle(product.getMetaTitle())
+        .description(product.getDescription())
+        .searchKeywords(product.getSearchKeywords())
+        .taxCategory(
+            TaxCategoryResourceIdentifierBuilder.of().id(product.getTaxCategory().getId()).build())
+        .key(product.getKey())
+        .categories(
+            product.getCategories().stream()
+                .map(
+                    categoryReference ->
+                        CategoryResourceIdentifierBuilder.of()
+                            .id(categoryReference.getId())
+                            .build())
+                .collect(toList()))
+        .categoryOrderHints(product.getCategoryOrderHints())
+        .publish(product.getPublished());
+  }
+
+  static ProductVariantDraft getProductVariantDraft(@Nonnull final ProductVariant productVariant) {
+    List<AssetDraft> assetDrafts = createAssetDraft(productVariant.getAssets());
+    List<PriceDraft> priceDrafts = createPriceDraft(productVariant.getPrices());
+    List<Attribute> attributes = createAttributes(productVariant.getAttributes());
+    return ProductVariantDraftBuilder.of()
+        .assets(assetDrafts)
+        .attributes(attributes)
+        .images(productVariant.getImages())
+        .prices(priceDrafts)
+        .sku(productVariant.getSku())
+        .key(productVariant.getKey())
+        .build();
+  }
+
+  public static List<Attribute> createAttributes(List<Attribute> attributes) {
+    return attributes.stream()
+        .map(attribute -> AttributeBuilder.of(attribute).build())
+        .collect(Collectors.toList());
+  }
+
+  @Nonnull
+  static CategoryResourceIdentifierPair mapToCategoryReferencePair(
+      @Nonnull final ProductProjection product,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    final List<CategoryReference> categoryReferences = product.getCategories();
+    final List<CategoryResourceIdentifier> categoryResourceIdentifiers = new ArrayList<>();
+
+    final CategoryOrderHints categoryOrderHints = product.getCategoryOrderHints();
+    final Map<String, String> categoryOrderHintsMapWithKeys = new HashMap<>();
+
+    categoryReferences.forEach(
+        categoryReference -> {
+          if (categoryReference != null) {
+            final String categoryId = categoryReference.getId();
+            if (referenceIdToKeyCache.containsKey(categoryId)) {
+              final String categoryKey = referenceIdToKeyCache.get(categoryId);
+
+              if (categoryOrderHints != null) {
+                final String categoryOrderHintValue = categoryOrderHints.values().get(categoryId);
+                if (categoryOrderHintValue != null) {
+                  categoryOrderHintsMapWithKeys.put(categoryKey, categoryOrderHintValue);
+                }
+              }
+              categoryResourceIdentifiers.add(
+                  CategoryResourceIdentifierBuilder.of().key(categoryKey).build());
+            } else {
+              categoryResourceIdentifiers.add(
+                  CategoryResourceIdentifierBuilder.of().id(categoryReference.getId()).build());
+            }
+          }
+        });
+
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryOrderHintsMapWithKeys.isEmpty()
+            ? categoryOrderHints
+            : CategoryOrderHintsBuilder.of().values(categoryOrderHintsMapWithKeys).build();
+    return CategoryResourceIdentifierPair.of(
+        categoryResourceIdentifiers, categoryOrderHintsWithKeys);
+  }
+
+  private ProductReferenceResolutionUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/VariantReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/VariantReferenceResolutionUtils.java
@@ -1,0 +1,141 @@
+package com.commercetools.sync.sdk2.products.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.AssetReferenceResolutionUtils.mapToAssetDrafts;
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.getResourceIdentifierWithKey;
+import static com.commercetools.sync.sdk2.products.utils.PriceUtils.createPriceDraft;
+import static java.util.stream.Collectors.toList;
+
+import com.commercetools.api.models.common.PriceDraft;
+import com.commercetools.api.models.product.Attribute;
+import com.commercetools.api.models.product.AttributeAccessor;
+import com.commercetools.api.models.product.AttributeBuilder;
+import com.commercetools.api.models.product.ProductVariant;
+import com.commercetools.api.models.product.ProductVariantDraft;
+import com.commercetools.api.models.product.ProductVariantDraftBuilder;
+import com.commercetools.api.models.product_type.ProductTypeReference;
+import com.commercetools.api.models.product_type.ProductTypeReferenceImpl;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * Util class which provides utilities that can be used when syncing resources from a source
+ * commercetools project to a target one.
+ */
+public final class VariantReferenceResolutionUtils {
+
+  /**
+   * Returns an {@link List}&lt;{@link ProductVariantDraft}&gt; consisting of the results of
+   * applying the mapping from {@link ProductVariant} to {@link ProductVariantDraft} with
+   * considering reference resolution.
+   *
+   * <p><b>Note:</b> The aforementioned references should be cached(idToKey value fetched and stored
+   * in a map). Any reference that is not cached will have its id in place and not replaced by the
+   * key will be considered as existing resources on the target commercetools project and the
+   * library will issues an update/create API request without reference resolution.
+   *
+   * @param productVariants the product variants without expansion of references.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return a {@link List} of {@link ProductVariantDraft} built from the supplied {@link List} of
+   *     {@link ProductVariant}.
+   */
+  @Nonnull
+  public static List<ProductVariantDraft> mapToProductVariantDrafts(
+      @Nonnull final List<ProductVariant> productVariants,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+
+    return productVariants.stream()
+        .filter(Objects::nonNull)
+        .map(variants -> mapToProductVariantDraft(variants, referenceIdToKeyCache))
+        .collect(toList());
+  }
+
+  @Nonnull
+  private static ProductVariantDraft mapToProductVariantDraft(
+      @Nonnull final ProductVariant productVariant,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    return ProductVariantDraftBuilder.of()
+        .sku(productVariant.getSku())
+        .key(productVariant.getKey())
+        .prices(mapToPriceDrafts(productVariant, referenceIdToKeyCache))
+        .attributes(replaceAttributesReferencesIdsWithKeys(productVariant, referenceIdToKeyCache))
+        .assets(mapToAssetDrafts(productVariant.getAssets(), referenceIdToKeyCache))
+        .build();
+  }
+
+  @Nonnull
+  static List<PriceDraft> mapToPriceDrafts(
+      @Nonnull final ProductVariant productVariant,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+
+    return createPriceDraft(productVariant.getPrices(), referenceIdToKeyCache);
+  }
+
+  /**
+   * Takes a product variant that is supposed to have all its attribute product references and
+   * product set references id's cached(fetch and store key value for the reference id) in order to
+   * be able to replace the reference ids with the corresponding keys for the references. This
+   * method returns as a result a {@link List} of {@link Attribute} that has all product references
+   * with keys replacing the ids.
+   *
+   * <p>Any product reference that is not cached(reference id is not present in the map) will have
+   * it's id in place and not replaced by the key.
+   *
+   * @param productVariant the product variant to replace its attribute product references ids with
+   *     keys.
+   * @param referenceIdToKeyCache the instance that manages cache.
+   * @return a {@link List} of {@link Attribute} that has all product references with keys replacing
+   *     the ids.
+   */
+  @Nonnull
+  static List<Attribute> replaceAttributesReferencesIdsWithKeys(
+      @Nonnull final ProductVariant productVariant,
+      @Nonnull final ReferenceIdToKeyCache referenceIdToKeyCache) {
+    final List<Attribute> productTypeReferenceAttributes =
+        productVariant.getAttributes().stream()
+            .filter(attribute -> attribute.getValue() instanceof ProductTypeReferenceImpl)
+            .map(attribute -> (ProductTypeReference) attribute.getValue())
+            .map(
+                productReference ->
+                    getResourceIdentifierWithKey(productReference, referenceIdToKeyCache))
+            .map(
+                productTypeResourceIdentifier ->
+                    AttributeBuilder.of().value(productTypeResourceIdentifier).build())
+            .collect(toList());
+    final List<Attribute> productSetTypeReferenceAttributes =
+        Optional.of(
+                productVariant.getAttributes().stream()
+                    .filter(
+                        attribute ->
+                            attribute.getValue() instanceof List
+                                && Arrays.asList(attribute.getValue()).stream()
+                                    .anyMatch(
+                                        setAttr -> setAttr instanceof ProductTypeReferenceImpl))
+                    .map(
+                        attribute ->
+                            AttributeAccessor.asSetReference(attribute).stream()
+                                .map(
+                                    productReference ->
+                                        getResourceIdentifierWithKey(
+                                            (ProductTypeReference) productReference,
+                                            referenceIdToKeyCache))
+                                .collect(toList()))
+                    .map(
+                        productTypeResourceIdentifiers ->
+                            AttributeBuilder.of().value(productTypeResourceIdentifiers).build())
+                    .collect(toList()))
+            .orElse(Collections.emptyList());
+
+    final List<Attribute> joined = new ArrayList<>();
+    joined.addAll(productTypeReferenceAttributes);
+    joined.addAll(productSetTypeReferenceAttributes);
+    return joined;
+  }
+
+  private VariantReferenceResolutionUtils() {}
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/MockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/MockUtils.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.common.LocalizedString;
 import com.commercetools.api.models.type.CustomFields;
 import com.commercetools.api.models.type.FieldContainerBuilder;
 import com.commercetools.api.models.type.TypeReference;
@@ -154,6 +155,7 @@ public class MockUtils {
     final Asset asset = mock(Asset.class);
 
     when(asset.getCustom()).thenReturn(mockCustomFields);
+    when(asset.getName()).thenReturn(LocalizedString.ofEnglish("asset-name"));
 
     return asset;
   }

--- a/src/test/java/com/commercetools/sync/sdk2/commons/helpers/CategoryResourceIdentifierPairTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/helpers/CategoryResourceIdentifierPairTest.java
@@ -1,0 +1,46 @@
+package com.commercetools.sync.sdk2.commons.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.models.category.CategoryResourceIdentifier;
+import com.commercetools.api.models.category.CategoryResourceIdentifierBuilder;
+import com.commercetools.api.models.product.CategoryOrderHints;
+import com.commercetools.api.models.product.CategoryOrderHintsBuilder;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CategoryResourceIdentifierPairTest {
+
+  @Test
+  void of_WithBothReferencesAndCategoryOrderHints_ShouldSetBoth() {
+    final List<CategoryResourceIdentifier> categoryReferences =
+        Arrays.asList(
+            CategoryResourceIdentifierBuilder.of().id("cat1").build(),
+            CategoryResourceIdentifierBuilder.of().id("cat2").build());
+    final CategoryOrderHints categoryOrderHints =
+        CategoryOrderHintsBuilder.of().addValue("cat1", "0.12").build();
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        CategoryResourceIdentifierPair.of(categoryReferences, categoryOrderHints);
+
+    assertThat(categoryReferencePair).isNotNull();
+    assertThat(categoryReferencePair.getCategoryResourceIdentifiers())
+        .containsExactlyInAnyOrderElementsOf(categoryReferences);
+    assertThat(categoryReferencePair.getCategoryOrderHints()).isEqualTo(categoryOrderHints);
+  }
+
+  @Test
+  void of_WithNullCategoryOrderHints_ShouldSetReferencesOnly() {
+    final List<CategoryResourceIdentifier> categoryReferences =
+        Arrays.asList(
+            CategoryResourceIdentifierBuilder.of().id("cat1").build(),
+            CategoryResourceIdentifierBuilder.of().id("cat2").build());
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        CategoryResourceIdentifierPair.of(categoryReferences, null);
+
+    assertThat(categoryReferencePair).isNotNull();
+    assertThat(categoryReferencePair.getCategoryResourceIdentifiers())
+        .containsExactlyInAnyOrderElementsOf(categoryReferences);
+    assertThat(categoryReferencePair.getCategoryOrderHints()).isNull();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/AssetReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/AssetReferenceResolutionUtilsTest.java
@@ -1,0 +1,101 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.MockUtils.getAssetMockWithCustomFields;
+import static com.commercetools.sync.sdk2.commons.utils.AssetReferenceResolutionUtils.mapToAssetDrafts;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.common.AssetDraft;
+import com.commercetools.api.models.type.TypeReferenceBuilder;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AssetReferenceResolutionUtilsTest {
+
+  private final ReferenceIdToKeyCache referenceIdToKeyCache =
+      new CaffeineReferenceIdToKeyCacheImpl();
+
+  @AfterEach
+  void setup() {
+    referenceIdToKeyCache.clearCache();
+  }
+
+  @Test
+  void mapToAssetDrafts_WithAllUnExpandedReferences_ShouldReturnReferencesWithReplacedKeys() {
+    // preparation
+    final String customTypeId = UUID.randomUUID().toString();
+    final String customTypeKey = "customTypeKey";
+
+    // cache reference Id to key value
+    referenceIdToKeyCache.add(customTypeId, customTypeKey);
+
+    final Asset asset =
+        getAssetMockWithCustomFields(TypeReferenceBuilder.of().id(customTypeId).build());
+
+    // test
+    final List<AssetDraft> referenceReplacedDrafts =
+        mapToAssetDrafts(singletonList(asset), referenceIdToKeyCache);
+
+    // assertion
+    referenceReplacedDrafts.forEach(
+        referenceReplacedDraft -> {
+          assertThat(referenceReplacedDraft.getCustom()).isNotNull();
+          assertThat(referenceReplacedDraft.getCustom().getType().getKey())
+              .isEqualTo(customTypeKey);
+        });
+  }
+
+  @Test
+  void mapToAssetDrafts_WithSomeExpandedReferences_ShouldReplaceOnlyExpandedRefs() {
+    // preparation
+    final String customTypeId = UUID.randomUUID().toString();
+    final String customTypeKey = "customTypeKey";
+
+    // cache reference Id to key value
+    referenceIdToKeyCache.add(customTypeId, customTypeKey);
+
+    final Asset asset1 =
+        getAssetMockWithCustomFields(TypeReferenceBuilder.of().id(customTypeId).build());
+    final Asset asset2 =
+        getAssetMockWithCustomFields(
+            TypeReferenceBuilder.of().id(UUID.randomUUID().toString()).build());
+
+    // test
+    final List<AssetDraft> referenceReplacedDrafts =
+        mapToAssetDrafts(asList(asset1, asset2), referenceIdToKeyCache);
+
+    // assertion
+    assertThat(referenceReplacedDrafts).hasSize(2);
+    assertThat(referenceReplacedDrafts.get(0).getCustom()).isNotNull();
+    assertThat(referenceReplacedDrafts.get(0).getCustom().getType().getKey())
+        .isEqualTo(customTypeKey);
+    assertThat(referenceReplacedDrafts.get(1).getCustom()).isNotNull();
+    assertThat(referenceReplacedDrafts.get(1).getCustom().getType().getId())
+        .isEqualTo(asset2.getCustom().getType().getId());
+  }
+
+  @Test
+  void
+      mapToAssetDrafts_WithNonExpandedRefsAndIdsNotCached_ShouldReturnReferencesWithoutReplacedKeys() {
+    // preparation
+    final String customTypeId = UUID.randomUUID().toString();
+
+    final Asset asset =
+        getAssetMockWithCustomFields(TypeReferenceBuilder.of().id(customTypeId).build());
+
+    // test
+    final List<AssetDraft> referenceReplacedDrafts =
+        mapToAssetDrafts(singletonList(asset), referenceIdToKeyCache);
+
+    // assertion
+    referenceReplacedDrafts.forEach(
+        referenceReplacedDraft -> {
+          assertThat(referenceReplacedDraft.getCustom()).isNotNull();
+          assertThat(referenceReplacedDraft.getCustom().getType().getId()).isEqualTo(customTypeId);
+        });
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomTypeReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomTypeReferenceResolutionUtilsTest.java
@@ -1,0 +1,77 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CustomTypeReferenceResolutionUtils.mapToCustomFieldsDraft;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.type.CustomFields;
+import com.commercetools.api.models.type.CustomFieldsDraft;
+import com.commercetools.api.models.type.TypeReference;
+import com.commercetools.api.models.type.TypeReferenceBuilder;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CustomTypeReferenceResolutionUtilsTest {
+
+  private final ReferenceIdToKeyCache referenceIdToKeyCache =
+      new CaffeineReferenceIdToKeyCacheImpl();
+
+  @Test
+  void mapToCustomFieldsDraft_WithNullCustomType_ShouldReturnNullCustomFields() {
+    final Category mockCategory = mock(Category.class);
+
+    final CustomFieldsDraft customFieldsDraft =
+        mapToCustomFieldsDraft(mockCategory, referenceIdToKeyCache);
+
+    assertThat(customFieldsDraft).isNull();
+  }
+
+  @Test
+  void
+      mapToCustomFieldsDraft_WithNonExpandedCategoryAndIdsAreCached_ShouldReturnCustomFieldsDraft() {
+    // preparation
+    final Category mockCategory = mock(Category.class);
+    final CustomFields mockCustomFields = mock(CustomFields.class);
+    final String typeKey = "typeKey";
+    final String typeId = UUID.randomUUID().toString();
+    final TypeReference mockCustomType = TypeReferenceBuilder.of().id(typeId).build();
+    when(mockCustomFields.getType()).thenReturn(mockCustomType);
+    when(mockCategory.getCustom()).thenReturn(mockCustomFields);
+
+    // Cache typeKey Value with typeId
+    referenceIdToKeyCache.add(typeId, typeKey);
+
+    // test
+    final CustomFieldsDraft customFieldsDraft =
+        mapToCustomFieldsDraft(mockCategory, referenceIdToKeyCache);
+
+    // assertion
+    assertThat(customFieldsDraft).isNotNull();
+    assertThat(customFieldsDraft.getType().getKey()).isEqualTo(typeKey);
+    assertThat(customFieldsDraft.getType().getId()).isNull();
+  }
+
+  @Test
+  void
+      mapToCustomFieldsDraft_WithNonExpandedCategoryAndIdsNotCached_ShouldReturnResourceIdentifierWithoutKey() {
+    // preparation
+    final Category mockCategory = mock(Category.class);
+    final CustomFields mockCustomFields = mock(CustomFields.class);
+    final String customTypeUuid = UUID.randomUUID().toString();
+    final TypeReference mockCustomType = TypeReferenceBuilder.of().id(customTypeUuid).build();
+    when(mockCustomFields.getType()).thenReturn(mockCustomType);
+    when(mockCategory.getCustom()).thenReturn(mockCustomFields);
+
+    // test
+    final CustomFieldsDraft customFieldsDraft =
+        mapToCustomFieldsDraft(mockCategory, referenceIdToKeyCache);
+
+    // assertion
+    assertThat(customFieldsDraft).isNotNull();
+    assertThat(customFieldsDraft.getType()).isNotNull();
+    assertThat(customFieldsDraft.getType().getId()).isEqualTo(customTypeUuid);
+    assertThat(customFieldsDraft.getType().getKey()).isNull();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncMockUtils.java
@@ -2,7 +2,8 @@ package com.commercetools.sync.sdk2.products;
 
 import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.REFERENCE_ID_FIELD;
 import static com.commercetools.sync.commons.utils.ResourceIdentifierUtils.REFERENCE_TYPE_ID_FIELD;
-import static com.commercetools.sync.sdk2.products.AssetUtils.createAssetDraft;
+import static com.commercetools.sync.sdk2.commons.helpers.DefaultCurrencyUnits.EUR;
+import static com.commercetools.sync.sdk2.products.utils.AssetUtils.createAssetDraft;
 import static com.commercetools.sync.sdk2.products.utils.PriceUtils.createPriceDraft;
 import static io.vrap.rmf.base.client.utils.json.JsonUtils.fromInputStream;
 import static java.util.Optional.ofNullable;
@@ -21,6 +22,8 @@ import com.commercetools.api.models.channel.Channel;
 import com.commercetools.api.models.channel.ChannelReference;
 import com.commercetools.api.models.common.Asset;
 import com.commercetools.api.models.common.AssetDraft;
+import com.commercetools.api.models.common.CentPrecisionMoney;
+import com.commercetools.api.models.common.CentPrecisionMoneyBuilder;
 import com.commercetools.api.models.common.LocalizedString;
 import com.commercetools.api.models.common.Price;
 import com.commercetools.api.models.common.PriceDraft;
@@ -147,20 +150,19 @@ public class ProductSyncMockUtils {
 
     @SuppressWarnings("ConstantConditions")
     final List<ProductVariantDraft> allVariants =
-        stagedProductData.getAllVariants().stream()
+        stagedProductData.getVariants().stream()
             .map(productVariant -> createProductVariantDraftBuilder(productVariant).build())
             .collect(toList());
 
-    final ProductVariantDraft masterVariant = allVariants.stream().findFirst().orElse(null);
-    final List<ProductVariantDraft> variants =
-        allVariants.stream().skip(1).collect(Collectors.toList());
+    final ProductVariantDraft masterVariant =
+        createProductVariantDraftBuilder(stagedProductData.getMasterVariant()).build();
 
     return ProductDraftBuilder.of()
         .productType(productTypeResourceIdentifier)
         .name(stagedProductData.getName())
         .slug(stagedProductData.getSlug())
         .masterVariant(masterVariant)
-        .variants(variants)
+        .variants(allVariants)
         .metaDescription(stagedProductData.getMetaDescription())
         .metaKeywords(stagedProductData.getMetaKeywords())
         .metaTitle(stagedProductData.getMetaTitle())
@@ -475,6 +477,14 @@ public class ProductSyncMockUtils {
     final Price price = mock(Price.class);
     when(price.getChannel()).thenReturn(channelReference);
     when(price.getCustomerGroup()).thenReturn(customerGroupReference);
+
+    final CentPrecisionMoney money =
+        CentPrecisionMoneyBuilder.of()
+            .centAmount(100L)
+            .currencyCode(EUR.getCurrencyCode())
+            .fractionDigits(2)
+            .build();
+    when(price.getValue()).thenReturn(money);
 
     return ofNullable(customTypeReference)
         .map(

--- a/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductReferenceResolutionUtilsTest.java
@@ -1,0 +1,203 @@
+package com.commercetools.sync.sdk2.products.utils;
+
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.createProductFromJson;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.category.CategoryReference;
+import com.commercetools.api.models.category.CategoryReferenceBuilder;
+import com.commercetools.api.models.category.CategoryResourceIdentifier;
+import com.commercetools.api.models.common.ResourceIdentifier;
+import com.commercetools.api.models.product.CategoryOrderHints;
+import com.commercetools.api.models.product.CategoryOrderHintsBuilder;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.sync.sdk2.commons.helpers.CategoryResourceIdentifierPair;
+import com.commercetools.sync.sdk2.commons.utils.CaffeineReferenceIdToKeyCacheImpl;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ProductReferenceResolutionUtilsTest {
+
+  private final ReferenceIdToKeyCache referenceIdToKeyCache =
+      new CaffeineReferenceIdToKeyCacheImpl();
+
+  @AfterEach
+  void setup() {
+    referenceIdToKeyCache.clearCache();
+  }
+
+  @Test
+  void mapToProductDrafts_WithNonExpandedReferences_ShouldUseCacheAndReplaceReferences() {
+
+    final List<ProductProjection> products =
+        asList(createProductFromJson("product-with-unresolved-references.json"));
+
+    referenceIdToKeyCache.add("cda0dbf7-b42e-40bf-8453-241d5b587f93", "productTypeKey");
+    referenceIdToKeyCache.add("1dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f", "categoryKey1");
+    referenceIdToKeyCache.add("2dfc8bea-84f2-45bc-b3c2-cdc94bf96f1f", "categoryKey2");
+    referenceIdToKeyCache.add("cdcf8bea-48f2-54bc-b3c2-cdc94bf94f2c", "channelKey");
+    referenceIdToKeyCache.add("d1229e6f-2b79-441e-b419-180311e52754", "customerGroupKey");
+    referenceIdToKeyCache.add("ebbe95fb-2282-4f9a-8747-fbe440e02dc0", "taxCategoryKey");
+    referenceIdToKeyCache.add("ste95fb-2282-4f9a-8747-fbe440e02dcs0", "stateKey");
+    referenceIdToKeyCache.add("custom_type_id", "typeKey");
+
+    final List<ProductDraft> productDraftsWithKeysOnReferences =
+        ProductReferenceResolutionUtils.mapToProductDrafts(products, referenceIdToKeyCache);
+
+    // assertions
+
+    final Optional<ProductDraft> productKey1 =
+        productDraftsWithKeysOnReferences.stream()
+            .filter(productDraft -> "productKeyResolved".equals(productDraft.getKey()))
+            .findFirst();
+
+    assertThat(productKey1)
+        .hasValueSatisfying(
+            productDraft ->
+                assertThat(productDraft.getMasterVariant().getPrices())
+                    .anySatisfy(
+                        priceDraft -> {
+                          assertThat(priceDraft.getChannel().getKey()).isEqualTo("channelKey");
+                          assertThat(priceDraft.getCustomerGroup().getKey())
+                              .isEqualTo("customerGroupKey");
+                          assertThat(priceDraft.getCustom().getType().getKey())
+                              .isEqualTo("typeKey");
+                        }));
+
+    assertThat(productKey1)
+        .hasValueSatisfying(
+            productDraft -> {
+              assertThat(productDraft.getProductType().getKey()).isEqualTo("productTypeKey");
+              assertThat(productDraft.getState().getKey()).isEqualTo("stateKey");
+              assertThat(productDraft.getTaxCategory().getKey()).isEqualTo("taxCategoryKey");
+              assertThat(productDraft.getCategories())
+                  .anySatisfy(
+                      categoryDraft -> {
+                        assertThat(categoryDraft.getKey()).isEqualTo("categoryKey1");
+                      });
+            });
+  }
+
+  @Test
+  void
+      mapToCategoryReferencePair_WithReferencesNotInCache_ShouldReturnReferencesWithoutReplacedKeys() {
+    final String categoryId = UUID.randomUUID().toString();
+    final List<CategoryReference> categoryReferences =
+        singletonList(CategoryReferenceBuilder.of().id(categoryId).build());
+    final CategoryOrderHints categoryOrderHints = getCategoryOrderHintsMock(categoryReferences);
+
+    final ProductProjection product = getProductMock(categoryReferences, categoryOrderHints);
+
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        ProductReferenceResolutionUtils.mapToCategoryReferencePair(product, referenceIdToKeyCache);
+
+    assertThat(categoryReferencePair).isNotNull();
+
+    final List<CategoryResourceIdentifier> categoryReferencesWithKeys =
+        categoryReferencePair.getCategoryResourceIdentifiers();
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryReferencePair.getCategoryOrderHints();
+
+    assertThat(categoryReferencesWithKeys)
+        .extracting(ResourceIdentifier::getId)
+        .containsExactlyInAnyOrder(categoryId);
+    assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getCategoryOrderHints());
+  }
+
+  @Test
+  void
+      mapToCategoryReferencePair_WithReferencesNotInCacheAndNoCategoryOrderHints_ShouldNotReplaceIds() {
+    final String categoryId = UUID.randomUUID().toString();
+    final List<CategoryReference> categoryReferences =
+        singletonList(CategoryReferenceBuilder.of().id(categoryId).build());
+    final ProductProjection product = getProductMock(categoryReferences, null);
+
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        ProductReferenceResolutionUtils.mapToCategoryReferencePair(product, referenceIdToKeyCache);
+
+    assertThat(categoryReferencePair).isNotNull();
+
+    final List<CategoryResourceIdentifier> categoryReferencesWithKeys =
+        categoryReferencePair.getCategoryResourceIdentifiers();
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryReferencePair.getCategoryOrderHints();
+
+    assertThat(categoryReferencesWithKeys)
+        .extracting(ResourceIdentifier::getId)
+        .containsExactlyInAnyOrder(categoryId);
+    assertThat(categoryOrderHintsWithKeys).isEqualTo(product.getCategoryOrderHints());
+  }
+
+  @Test
+  void mapToCategoryReferencePair_WithNoReferences_ShouldNotReplaceIds() {
+    final ProductProjection product = getProductMock(Collections.emptyList(), null);
+
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        ProductReferenceResolutionUtils.mapToCategoryReferencePair(product, referenceIdToKeyCache);
+
+    assertThat(categoryReferencePair).isNotNull();
+
+    final List<CategoryResourceIdentifier> categoryReferencesWithKeys =
+        categoryReferencePair.getCategoryResourceIdentifiers();
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryReferencePair.getCategoryOrderHints();
+    assertThat(categoryReferencesWithKeys).isEmpty();
+    assertThat(categoryOrderHintsWithKeys).isNull();
+  }
+
+  @Test
+  void mapToCategoryReferencePair_WithNullReferences_ShouldNotReplaceIds() {
+    final ProductProjection product = getProductMock(singletonList(null), null);
+
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        ProductReferenceResolutionUtils.mapToCategoryReferencePair(product, referenceIdToKeyCache);
+
+    assertThat(categoryReferencePair).isNotNull();
+
+    final List<CategoryResourceIdentifier> categoryReferencesWithKeys =
+        categoryReferencePair.getCategoryResourceIdentifiers();
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryReferencePair.getCategoryOrderHints();
+    assertThat(categoryReferencesWithKeys).isEmpty();
+    assertThat(categoryOrderHintsWithKeys).isNull();
+  }
+
+  @Nonnull
+  private static ProductProjection getProductMock(
+      @Nonnull final List<CategoryReference> references,
+      @Nullable final CategoryOrderHints categoryOrderHints) {
+    final ProductProjection product = mock(ProductProjection.class);
+    mockProductCategories(references, categoryOrderHints, product);
+    return product;
+  }
+
+  private static void mockProductCategories(
+      @Nonnull final List<CategoryReference> references,
+      @Nullable final CategoryOrderHints categoryOrderHints,
+      @Nonnull final ProductProjection product) {
+    when(product.getCategories()).thenReturn(references);
+    when(product.getCategoryOrderHints()).thenReturn(categoryOrderHints);
+  }
+
+  @Nonnull
+  private static CategoryOrderHints getCategoryOrderHintsMock(
+      @Nonnull final List<CategoryReference> references) {
+    final Map<String, String> categoryOrderHintMap = new HashMap<>();
+    references.forEach(
+        categoryReference -> categoryOrderHintMap.put(categoryReference.getId(), "0.1"));
+    return CategoryOrderHintsBuilder.of().values(categoryOrderHintMap).build();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/products/utils/VariantReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/utils/VariantReferenceResolutionUtilsTest.java
@@ -1,0 +1,262 @@
+package com.commercetools.sync.sdk2.products.utils;
+
+import static com.commercetools.sync.sdk2.commons.MockUtils.getAssetMockWithCustomFields;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.createProductFromJson;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.getPriceMockWithReferences;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.getProductVariantMock;
+import static com.commercetools.sync.sdk2.products.utils.VariantReferenceResolutionUtils.mapToPriceDrafts;
+import static com.commercetools.sync.sdk2.products.utils.VariantReferenceResolutionUtils.mapToProductVariantDrafts;
+import static com.commercetools.sync.sdk2.products.utils.VariantReferenceResolutionUtils.replaceAttributesReferencesIdsWithKeys;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelReferenceBuilder;
+import com.commercetools.api.models.channel.ChannelResourceIdentifier;
+import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.common.Price;
+import com.commercetools.api.models.common.PriceDraft;
+import com.commercetools.api.models.customer_group.CustomerGroupReference;
+import com.commercetools.api.models.customer_group.CustomerGroupReferenceBuilder;
+import com.commercetools.api.models.product.Attribute;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.api.models.product.ProductVariant;
+import com.commercetools.api.models.product.ProductVariantDraft;
+import com.commercetools.api.models.type.CustomFieldsDraft;
+import com.commercetools.api.models.type.TypeReference;
+import com.commercetools.api.models.type.TypeReferenceBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifier;
+import com.commercetools.sync.sdk2.commons.utils.CaffeineReferenceIdToKeyCacheImpl;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class VariantReferenceResolutionUtilsTest {
+
+  private final ReferenceIdToKeyCache referenceIdToKeyCache =
+      new CaffeineReferenceIdToKeyCacheImpl();
+
+  @AfterEach
+  void clearCache() {
+    referenceIdToKeyCache.clearCache();
+  }
+
+  @Test
+  void
+      mapToProductVariantDrafts_WithReferenceIdToKeyValuesCached_ShouldReturnVariantDraftsWithReplacedKeys() {
+
+    final String customTypeId = UUID.randomUUID().toString();
+    final String customTypeKey = "customTypeKey";
+    referenceIdToKeyCache.add(customTypeId, customTypeKey);
+
+    final String channelKey = "channelKey";
+    final String channelId = UUID.randomUUID().toString();
+    referenceIdToKeyCache.add(channelId, channelKey);
+
+    final ChannelReference channelReference = ChannelReferenceBuilder.of().id(channelId).build();
+
+    final TypeReference priceCustomTypeReference =
+        TypeReferenceBuilder.of().id(customTypeId).build();
+
+    final String customerGroupId = "customer-group-id";
+    final String customerGroupKey = "customer-group-key";
+    referenceIdToKeyCache.add(customerGroupId, customerGroupKey);
+
+    final CustomerGroupReference customerGroupReference =
+        CustomerGroupReferenceBuilder.of().id(customerGroupId).build();
+
+    final Price price =
+        getPriceMockWithReferences(
+            channelReference, priceCustomTypeReference, customerGroupReference);
+
+    final Asset asset =
+        getAssetMockWithCustomFields(TypeReferenceBuilder.of().id(customTypeId).build());
+
+    final ProductVariant productVariant =
+        getProductVariantMock(singletonList(price), singletonList(asset));
+
+    final List<ProductVariantDraft> variantDrafts =
+        mapToProductVariantDrafts(singletonList(productVariant), referenceIdToKeyCache);
+
+    assertThat(variantDrafts).hasSize(1);
+    assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
+    final ChannelResourceIdentifier channelReferenceAfterReplacement =
+        variantDrafts.get(0).getPrices().get(0).getChannel();
+    assertThat(channelReferenceAfterReplacement).isNotNull();
+    assertThat(channelReferenceAfterReplacement.getKey()).isEqualTo(channelKey);
+
+    final CustomFieldsDraft priceCustomAfterReplacement =
+        variantDrafts.get(0).getPrices().get(0).getCustom();
+    assertThat(priceCustomAfterReplacement).isNotNull();
+    final TypeResourceIdentifier priceCustomTypeAfterReplacement =
+        priceCustomAfterReplacement.getType();
+    assertThat(priceCustomTypeAfterReplacement).isNotNull();
+    assertThat(priceCustomTypeAfterReplacement.getKey()).isEqualTo(customTypeKey);
+
+    assertThat(variantDrafts.get(0).getAssets()).hasSize(1);
+    final TypeResourceIdentifier referenceReplacedType =
+        variantDrafts.get(0).getAssets().get(0).getCustom().getType();
+    assertThat(referenceReplacedType).isNotNull();
+    assertThat(referenceReplacedType.getKey()).isEqualTo(customTypeKey);
+  }
+
+  @Test
+  void mapToProductVariantDrafts_WithReferenceIdToKeyValuesNoneCached_ShouldNotReplaceIds() {
+    final ChannelReference channelReference =
+        ChannelReferenceBuilder.of().id(UUID.randomUUID().toString()).build();
+    final TypeReference customTypeReference =
+        TypeReferenceBuilder.of().id(UUID.randomUUID().toString()).build();
+
+    final Asset asset2 =
+        getAssetMockWithCustomFields(
+            TypeReferenceBuilder.of().id(UUID.randomUUID().toString()).build());
+
+    final Price price = getPriceMockWithReferences(channelReference, customTypeReference, null);
+    final ProductVariant productVariant =
+        getProductVariantMock(singletonList(price), singletonList(asset2));
+
+    final List<ProductVariantDraft> variantDrafts =
+        mapToProductVariantDrafts(singletonList(productVariant), referenceIdToKeyCache);
+
+    assertThat(variantDrafts).hasSize(1);
+    assertThat(variantDrafts.get(0).getPrices()).hasSize(1);
+
+    final ChannelResourceIdentifier channelReferenceAfterReplacement =
+        variantDrafts.get(0).getPrices().get(0).getChannel();
+    assertThat(channelReferenceAfterReplacement).isNotNull();
+    // Assert price channel reference id is not replaced.
+    assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
+
+    final CustomFieldsDraft priceCustomFields = variantDrafts.get(0).getPrices().get(0).getCustom();
+    assertThat(priceCustomFields).isNotNull();
+    final TypeResourceIdentifier priceCustomTypeAfterReplacement = priceCustomFields.getType();
+    // Assert price custom type reference id is not replaced.
+    assertThat(priceCustomTypeAfterReplacement.getId()).isEqualTo(customTypeReference.getId());
+
+    assertThat(variantDrafts.get(0).getAssets()).hasSize(1);
+    final TypeResourceIdentifier assetCustomTypeReference =
+        variantDrafts.get(0).getAssets().get(0).getCustom().getType();
+    assertThat(assetCustomTypeReference).isNotNull();
+    // Assert asset custom type reference id is not replaced.
+    assertThat(assetCustomTypeReference.getId())
+        .isEqualTo(variantDrafts.get(0).getAssets().get(0).getCustom().getType().getId());
+  }
+
+  @Test
+  void mapToPriceDraft_WithReferenceIdToKeyValuesNoneCached_ShouldNotReplaceIds() {
+    final ChannelReference channelReference =
+        ChannelReferenceBuilder.of().id(UUID.randomUUID().toString()).build();
+    final TypeReference typeReference =
+        TypeReferenceBuilder.of().id(UUID.randomUUID().toString()).build();
+
+    final Price price = getPriceMockWithReferences(channelReference, typeReference, null);
+    final ProductVariant productVariant = getProductVariantMock(singletonList(price));
+
+    final List<PriceDraft> priceDrafts = mapToPriceDrafts(productVariant, referenceIdToKeyCache);
+
+    assertThat(priceDrafts).hasSize(1);
+    final PriceDraft priceDraftAfterReplacement = priceDrafts.get(0);
+
+    final ChannelResourceIdentifier channelReferenceAfterReplacement =
+        priceDraftAfterReplacement.getChannel();
+    assertThat(channelReferenceAfterReplacement).isNotNull();
+    // Assert Id is not replaced with key.
+    assertThat(channelReferenceAfterReplacement.getId()).isEqualTo(channelReference.getId());
+
+    final CustomFieldsDraft customAfterReplacement = priceDraftAfterReplacement.getCustom();
+    assertThat(customAfterReplacement).isNotNull();
+    final TypeResourceIdentifier customTypeAfterReplacement = customAfterReplacement.getType();
+
+    assertThat(customTypeAfterReplacement).isNotNull();
+    // Assert Id is not replaced with key.
+    assertThat(customTypeAfterReplacement.getId()).isEqualTo(typeReference.getId());
+  }
+
+  @Test
+  void mapToPriceDraft_WithReferenceIdToKeyValuesCached_ShouldReplaceIds() {
+    final String customTypeId = UUID.randomUUID().toString();
+    final String customTypeKey = "customTypeKey";
+    referenceIdToKeyCache.add(customTypeId, customTypeKey);
+
+    final String channel1Key = "channel1Key";
+    final String channel1Id = UUID.randomUUID().toString();
+    referenceIdToKeyCache.add(channel1Id, channel1Key);
+
+    final String channel2Key = "channel2Key";
+    final String channel2Id = UUID.randomUUID().toString();
+    referenceIdToKeyCache.add(channel2Id, channel2Key);
+
+    final ChannelReference channelReference1 = ChannelReferenceBuilder.of().id(channel1Id).build();
+    final ChannelReference channelReference2 = ChannelReferenceBuilder.of().id(channel2Id).build();
+    final TypeReference customTypeReference = TypeReferenceBuilder.of().id(customTypeId).build();
+
+    final Price price1 = getPriceMockWithReferences(channelReference1, customTypeReference, null);
+    final Price price2 = getPriceMockWithReferences(channelReference2, customTypeReference, null);
+
+    final ProductVariant productVariant = getProductVariantMock(asList(price1, price2));
+
+    final List<PriceDraft> priceDrafts = mapToPriceDrafts(productVariant, referenceIdToKeyCache);
+
+    assertThat(priceDrafts).hasSize(2);
+
+    final PriceDraft priceDraft1AfterReplacement = priceDrafts.get(0);
+    final ChannelResourceIdentifier channelReference1AfterReplacement =
+        priceDraft1AfterReplacement.getChannel();
+    assertThat(channelReference1AfterReplacement).isNotNull();
+    assertThat(channelReference1AfterReplacement.getKey()).isEqualTo(channel1Key);
+
+    final CustomFieldsDraft custom1AfterReplacement = priceDraft1AfterReplacement.getCustom();
+    assertThat(custom1AfterReplacement).isNotNull();
+    final TypeResourceIdentifier customType1AfterReplacement = custom1AfterReplacement.getType();
+    assertThat(customType1AfterReplacement).isNotNull();
+    assertThat(customType1AfterReplacement.getKey()).isEqualTo(customTypeKey);
+
+    final PriceDraft priceDraft2AfterReplacement = priceDrafts.get(1);
+    final ChannelResourceIdentifier channelReference2AfterReplacement =
+        priceDraft2AfterReplacement.getChannel();
+    assertThat(channelReference2AfterReplacement).isNotNull();
+    assertThat(channelReference2AfterReplacement.getKey()).isEqualTo(channel2Key);
+
+    final CustomFieldsDraft custom2AfterReplacement = priceDraft2AfterReplacement.getCustom();
+    assertThat(custom2AfterReplacement).isNotNull();
+    final TypeResourceIdentifier customType2AfterReplacement = custom2AfterReplacement.getType();
+    assertThat(customType2AfterReplacement).isNotNull();
+    assertThat(customType2AfterReplacement.getKey()).isEqualTo(customTypeKey);
+  }
+
+  @Test
+  void replaceAttributesReferencesIdsWithKeys_WithNoAttributes_ShouldNotReplaceIds() {
+    final ProductVariant variant = mock(ProductVariant.class);
+    when(variant.getAttributes()).thenReturn(new ArrayList<>());
+    final List<Attribute> replacedDrafts =
+        replaceAttributesReferencesIdsWithKeys(variant, referenceIdToKeyCache);
+    assertThat(replacedDrafts).isEmpty();
+  }
+
+  @Test
+  void
+      replaceAttributesReferencesIdsWithKeys_WithAttributesWithNoReferences_ShouldNotChangeAttributes() {
+    final ProductProjection product = createProductFromJson(PRODUCT_KEY_1_RESOURCE_PATH);
+    final ProductVariant masterVariant = product.getMasterVariant();
+    final List<Attribute> replacedDrafts =
+        replaceAttributesReferencesIdsWithKeys(masterVariant, referenceIdToKeyCache);
+    replacedDrafts.forEach(
+        attributeDraft -> {
+          final String name = attributeDraft.getName();
+          final Attribute originalAttribute =
+              masterVariant.getAttributes().stream()
+                  .filter(attribute -> attribute.getName().equals(name))
+                  .findFirst()
+                  .orElse(null);
+          assertThat(originalAttribute).isNotNull();
+          assertThat(originalAttribute.getValue()).isEqualTo(attributeDraft.getValue());
+        });
+  }
+}

--- a/src/test/resources/product-with-unresolved-references.json
+++ b/src/test/resources/product-with-unresolved-references.json
@@ -125,7 +125,7 @@
     "id": "ebbe95fb-2282-4f9a-8747-fbe440e02dc0"
   },
   "state": {
-    "typeId": "state1",
+    "typeId": "state",
     "id": "ste95fb-2282-4f9a-8747-fbe440e02dcs0"
   },
   "lastVariantId": 1,


### PR DESCRIPTION
Some helper and utility classes to resolve references on products and variants when transforming product data. 
This is the base to migrate product transformation utility.
