### PR TITLE
Migrate price reference resolver

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/inventories/helpers/InventoryEntryIdentifier.java
+++ b/src/main/java/com/commercetools/sync/sdk2/inventories/helpers/InventoryEntryIdentifier.java
@@ -11,9 +11,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * This class provides as a container of the unique identifier of an {@link
- * io.sphere.sdk.inventory.InventoryEntry} for the sync which is a combination of the SKU and the
- * supply channel id of this inventory entry.
+ * This class provides as a container of the unique identifier of an {@link InventoryEntry} for the
+ * sync which is a combination of the SKU and the supply channel id of this inventory entry.
  */
 public final class InventoryEntryIdentifier {
   private final String sku;
@@ -27,8 +26,7 @@ public final class InventoryEntryIdentifier {
 
   /**
    * Builds an {@link com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier}
-   * instance given an {@link io.sphere.sdk.inventory.InventoryEntryDraft} using its sku and supply
-   * channel id.
+   * instance given an {@link InventoryEntryDraft} using its sku and supply channel id.
    *
    * @param inventoryEntryDraft the draft to take the sku and supply channel id value from.
    * @return an instance of {@link
@@ -47,8 +45,7 @@ public final class InventoryEntryIdentifier {
 
   /**
    * Builds an {@link com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier}
-   * instance given an {@link io.sphere.sdk.inventory.InventoryEntry} using it's sku and supply
-   * channel id.
+   * instance given an {@link InventoryEntry} using it's sku and supply channel id.
    *
    * @param inventoryEntry the entry to take the sku and channel id value from.
    * @return an instance of {@link

--- a/src/main/java/com/commercetools/sync/sdk2/inventories/helpers/InventoryEntryIdentifier.java
+++ b/src/main/java/com/commercetools/sync/sdk2/inventories/helpers/InventoryEntryIdentifier.java
@@ -1,0 +1,97 @@
+package com.commercetools.sync.sdk2.inventories.helpers;
+
+import static java.lang.String.format;
+
+import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelResourceIdentifier;
+import com.commercetools.api.models.inventory.InventoryEntry;
+import com.commercetools.api.models.inventory.InventoryEntryDraft;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This class provides as a container of the unique identifier of an {@link
+ * io.sphere.sdk.inventory.InventoryEntry} for the sync which is a combination of the SKU and the
+ * supply channel id of this inventory entry.
+ */
+public final class InventoryEntryIdentifier {
+  private final String sku;
+  private final String supplyChannelId;
+
+  private InventoryEntryIdentifier(
+      @Nonnull final String sku, @Nullable final String supplyChannelId) {
+    this.sku = sku;
+    this.supplyChannelId = supplyChannelId;
+  }
+
+  /**
+   * Builds an {@link com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier}
+   * instance given an {@link io.sphere.sdk.inventory.InventoryEntryDraft} using its sku and supply
+   * channel id.
+   *
+   * @param inventoryEntryDraft the draft to take the sku and supply channel id value from.
+   * @return an instance of {@link
+   *     com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier} for the given
+   *     draft.
+   */
+  public static InventoryEntryIdentifier of(
+      @Nonnull final InventoryEntryDraft inventoryEntryDraft) {
+
+    final ChannelResourceIdentifier supplyChannelIdentifier =
+        inventoryEntryDraft.getSupplyChannel();
+    return new InventoryEntryIdentifier(
+        inventoryEntryDraft.getSku(),
+        supplyChannelIdentifier != null ? supplyChannelIdentifier.getId() : null);
+  }
+
+  /**
+   * Builds an {@link com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier}
+   * instance given an {@link io.sphere.sdk.inventory.InventoryEntry} using it's sku and supply
+   * channel id.
+   *
+   * @param inventoryEntry the entry to take the sku and channel id value from.
+   * @return an instance of {@link
+   *     com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier} for the given
+   *     entry.
+   */
+  public static InventoryEntryIdentifier of(@Nonnull final InventoryEntry inventoryEntry) {
+
+    final ChannelReference supplyChannel = inventoryEntry.getSupplyChannel();
+    return new InventoryEntryIdentifier(
+        inventoryEntry.getSku(), supplyChannel != null ? supplyChannel.getId() : null);
+  }
+
+  public String getSku() {
+    return sku;
+  }
+
+  public String getSupplyChannelId() {
+    return supplyChannelId;
+  }
+
+  @Override
+  public String toString() {
+    return format("{sku='%s', supplyChannelId='%s'}", sku, supplyChannelId);
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof InventoryEntryIdentifier)) {
+      return false;
+    }
+
+    final InventoryEntryIdentifier that = (InventoryEntryIdentifier) other;
+
+    return getSku().equals(that.getSku())
+        && Objects.equals(getSupplyChannelId(), that.getSupplyChannelId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getSku(), getSupplyChannelId());
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
@@ -212,8 +212,13 @@ public final class PriceReferenceResolver
           .thenCompose(
               createdChannelOptional -> {
                 if (createdChannelOptional.isPresent()) {
+                  final Channel channel = createdChannelOptional.get();
                   return completedFuture(
-                      draftBuilder.channel(createdChannelOptional.get().toResourceIdentifier()));
+                      draftBuilder.channel(
+                          ChannelResourceIdentifierBuilder.of()
+                              .key(channel.getKey())
+                              .id(channel.getId())
+                              .build()));
                 } else {
                   final ReferenceResolutionException referenceResolutionException =
                       new ReferenceResolutionException(format(CHANNEL_DOES_NOT_EXIST, channelKey));

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
@@ -4,6 +4,7 @@ import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFutur
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
+import com.commercetools.api.models.channel.Channel;
 import com.commercetools.api.models.channel.ChannelReference;
 import com.commercetools.api.models.channel.ChannelResourceIdentifier;
 import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
@@ -63,9 +64,9 @@ public final class PriceReferenceResolver
   }
 
   /**
-   * Given a {@link io.sphere.sdk.products.PriceDraft} this method attempts to resolve the custom
-   * type and channel references to return a {@link java.util.concurrent.CompletionStage} which
-   * contains a new instance of the draft with the resolved references.
+   * Given a {@link PriceDraft} this method attempts to resolve the custom type and channel
+   * references to return a {@link java.util.concurrent.CompletionStage} which contains a new
+   * instance of the draft with the resolved references.
    *
    * <p>The method then tries to fetch the key of the customer group, optimistically from a cache.
    * If the id is not found in cache nor the CTP project the {@link ReferenceResolutionException}
@@ -100,9 +101,9 @@ public final class PriceReferenceResolver
   }
 
   /**
-   * Given a {@link io.sphere.sdk.products.PriceDraftBuilder} this method attempts to resolve the
-   * supply channel reference to return a {@link java.util.concurrent.CompletionStage} which
-   * contains the same instance of draft builder with the resolved supply channel reference.
+   * Given a {@link PriceDraftBuilder} this method attempts to resolve the supply channel reference
+   * to return a {@link java.util.concurrent.CompletionStage} which contains the same instance of
+   * draft builder with the resolved supply channel reference.
    *
    * <p>The method then tries to fetch the key of the supply channel, optimistically from a cache.
    * If the id is not found in cache nor the CTP project and {@code ensureChannel} option is set to
@@ -181,19 +182,19 @@ public final class PriceReferenceResolver
   }
 
   /**
-   * Helper method that creates a new {@link io.sphere.sdk.channels.Channel} on the CTP project with
-   * the specified {@code channelKey} and of the role {@code "InventorySupply"}. Only if the {@code
-   * ensureChannels} options is set to {@code true} on the {@code options} instance of {@code this}
-   * class. Then it resolves the supply channel reference on the supplied {@code
-   * inventoryEntryDraft} by setting the id of it's supply channel reference with the newly created
-   * Channel.
+   * Helper method that creates a new {@link com.commercetools.api.models.channel.Channel} on the
+   * CTP project with the specified {@code channelKey} and of the role {@code "InventorySupply"}.
+   * Only if the {@code ensureChannels} options is set to {@code true} on the {@code options}
+   * instance of {@code this} class. Then it resolves the supply channel reference on the supplied
+   * {@code inventoryEntryDraft} by setting the id of it's supply channel reference with the newly
+   * created Channel.
    *
    * <p>If the {@code ensureChannels} options is set to {@code false} on the {@code options}
    * instance of {@code this} class, the future is completed exceptionally with a {@link
    * ReferenceResolutionException}.
    *
    * <p>The method then returns a CompletionStage with a resolved channel reference {@link
-   * io.sphere.sdk.products.PriceDraftBuilder} object.
+   * PriceDraftBuilder} object.
    *
    * @param channelKey the key to create the new channel with.
    * @param draftBuilder the inventory entry draft builder where to resolve it's supply channel
@@ -227,10 +228,9 @@ public final class PriceReferenceResolver
   }
 
   /**
-   * Given a {@link io.sphere.sdk.products.PriceDraftBuilder} this method attempts to resolve the
-   * customer group resource identifier to return a {@link java.util.concurrent.CompletionStage}
-   * which contains the same instance of draft builder with the resolved customer group resource
-   * identifier.
+   * Given a {@link PriceDraftBuilder} this method attempts to resolve the customer group resource
+   * identifier to return a {@link java.util.concurrent.CompletionStage} which contains the same
+   * instance of draft builder with the resolved customer group resource identifier.
    *
    * @param draftBuilder the priceDraftBuilder to resolve its customer group reference.
    * @return a {@link java.util.concurrent.CompletionStage} that contains as a result a new price

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolver.java
@@ -1,0 +1,296 @@
+package com.commercetools.sync.sdk2.products.helpers;
+
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelResourceIdentifier;
+import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
+import com.commercetools.api.models.common.PriceDraft;
+import com.commercetools.api.models.common.PriceDraftBuilder;
+import com.commercetools.api.models.customer_group.CustomerGroup;
+import com.commercetools.api.models.customer_group.CustomerGroupResourceIdentifier;
+import com.commercetools.api.models.customer_group.CustomerGroupResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.sdk2.commons.helpers.CustomReferenceResolver;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.services.ChannelService;
+import com.commercetools.sync.sdk2.services.CustomerGroupService;
+import com.commercetools.sync.sdk2.services.TypeService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.annotation.Nonnull;
+
+public final class PriceReferenceResolver
+    extends CustomReferenceResolver<PriceDraft, PriceDraftBuilder, ProductSyncOptions> {
+
+  private final ChannelService channelService;
+  private final CustomerGroupService customerGroupService;
+  static final String CHANNEL_DOES_NOT_EXIST = "Channel with key '%s' does not exist.";
+  static final String FAILED_TO_RESOLVE_CUSTOM_TYPE =
+      "Failed to resolve custom type reference on "
+          + "PriceDraft with country:'%s' and value: '%s'.";
+  static final String FAILED_TO_RESOLVE_REFERENCE =
+      "Failed to resolve '%s' reference on PriceDraft with "
+          + "country:'%s' and value: '%s'. Reason: %s";
+  static final String CUSTOMER_GROUP_DOES_NOT_EXIST =
+      "Customer Group with key '%s' does not exist.";
+
+  /**
+   * Takes a {@link com.commercetools.sync.products.ProductSyncOptions} instance, {@link
+   * com.commercetools.sync.services.TypeService}, a {@link
+   * com.commercetools.sync.services.ChannelService} and a {@link
+   * com.commercetools.sync.services.CustomerGroupService} to instantiate a {@link
+   * com.commercetools.sync.sdk2.products.helpers.PriceReferenceResolver} instance that could be
+   * used to resolve the prices of variant drafts in the CTP project specified in the injected
+   * {@link com.commercetools.sync.products.ProductSyncOptions} instance.
+   *
+   * @param options the container of all the options of the sync process including the CTP project
+   *     client and/or configuration and other sync-specific options.
+   * @param typeService the service to fetch the custom types for reference resolution.
+   * @param channelService the service to fetch the channels for reference resolution.
+   * @param customerGroupService the service to fetch the customer groups for reference resolution.
+   */
+  public PriceReferenceResolver(
+      @Nonnull final ProductSyncOptions options,
+      @Nonnull final TypeService typeService,
+      @Nonnull final ChannelService channelService,
+      @Nonnull final CustomerGroupService customerGroupService) {
+    super(options, typeService);
+    this.channelService = channelService;
+    this.customerGroupService = customerGroupService;
+  }
+
+  /**
+   * Given a {@link io.sphere.sdk.products.PriceDraft} this method attempts to resolve the custom
+   * type and channel references to return a {@link java.util.concurrent.CompletionStage} which
+   * contains a new instance of the draft with the resolved references.
+   *
+   * <p>The method then tries to fetch the key of the customer group, optimistically from a cache.
+   * If the id is not found in cache nor the CTP project the {@link ReferenceResolutionException}
+   * will be thrown.
+   *
+   * @param priceDraft the priceDraft to resolve it's references.
+   * @return a {@link java.util.concurrent.CompletionStage} that contains as a result a new
+   *     inventoryEntryDraft instance with resolved references or, in case an error occurs during
+   *     reference resolution a {@link ReferenceResolutionException}.
+   */
+  @Override
+  public CompletionStage<PriceDraft> resolveReferences(@Nonnull final PriceDraft priceDraft) {
+    return resolveCustomTypeReference(PriceDraftBuilder.of(priceDraft))
+        .thenCompose(this::resolveChannelReference)
+        .thenCompose(this::resolveCustomerGroupReference)
+        .thenApply(PriceDraftBuilder::build);
+  }
+
+  @Override
+  @Nonnull
+  protected CompletionStage<PriceDraftBuilder> resolveCustomTypeReference(
+      @Nonnull final PriceDraftBuilder draftBuilder) {
+
+    return resolveCustomTypeReference(
+        draftBuilder,
+        PriceDraftBuilder::getCustom,
+        PriceDraftBuilder::custom,
+        format(
+            FAILED_TO_RESOLVE_CUSTOM_TYPE,
+            draftBuilder.getCountry(),
+            draftBuilder.getValue().toMonetaryAmount()));
+  }
+
+  /**
+   * Given a {@link io.sphere.sdk.products.PriceDraftBuilder} this method attempts to resolve the
+   * supply channel reference to return a {@link java.util.concurrent.CompletionStage} which
+   * contains the same instance of draft builder with the resolved supply channel reference.
+   *
+   * <p>The method then tries to fetch the key of the supply channel, optimistically from a cache.
+   * If the id is not found in cache nor the CTP project and {@code ensureChannel} option is set to
+   * true, a new channel will be created with this key and the role {@code "InventorySupply"}.
+   * However, if the {@code ensureChannel} is set to false, the future is completed exceptionally
+   * with a {@link ReferenceResolutionException}.
+   *
+   * @param draftBuilder the PriceDraftBuilder to resolve its channel reference.
+   * @return a {@link java.util.concurrent.CompletionStage} that contains as a result a new price
+   *     draft builder instance with resolved supply channel or, in case an error occurs during
+   *     reference resolution, a {@link ReferenceResolutionException}.
+   */
+  @Nonnull
+  CompletionStage<PriceDraftBuilder> resolveChannelReference(
+      @Nonnull final PriceDraftBuilder draftBuilder) {
+    final ChannelResourceIdentifier channelResourceIdentifier = draftBuilder.getChannel();
+    if (channelResourceIdentifier != null && channelResourceIdentifier.getId() == null) {
+      String channelKey;
+      try {
+        channelKey = getKeyFromResourceIdentifier(channelResourceIdentifier);
+      } catch (ReferenceResolutionException referenceResolutionException) {
+        return exceptionallyCompletedFuture(
+            new ReferenceResolutionException(
+                format(
+                    FAILED_TO_RESOLVE_REFERENCE,
+                    ChannelResourceIdentifier.CHANNEL,
+                    draftBuilder.getCountry(),
+                    draftBuilder.getValue(),
+                    referenceResolutionException.getMessage())));
+      }
+
+      return fetchAndResolveChannelReference(draftBuilder, channelKey);
+    }
+    return completedFuture(draftBuilder);
+  }
+
+  @Nonnull
+  private CompletionStage<PriceDraftBuilder> fetchAndResolveChannelReference(
+      @Nonnull final PriceDraftBuilder draftBuilder, @Nonnull final String channelKey) {
+
+    return channelService
+        .fetchCachedChannelId(channelKey)
+        .thenCompose(
+            resolvedChannelIdOptional ->
+                resolvedChannelIdOptional
+                    .map(
+                        resolvedChannelId ->
+                            completedFuture(
+                                draftBuilder.channel(
+                                    ChannelResourceIdentifierBuilder.of()
+                                        .id(resolvedChannelId)
+                                        .build())))
+                    .orElseGet(
+                        () -> {
+                          final CompletableFuture<PriceDraftBuilder> result =
+                              new CompletableFuture<>();
+                          createChannelAndSetReference(channelKey, draftBuilder)
+                              .whenComplete(
+                                  (draftWithCreatedChannel, exception) -> {
+                                    if (exception != null) {
+                                      result.completeExceptionally(
+                                          new ReferenceResolutionException(
+                                              format(
+                                                  FAILED_TO_RESOLVE_REFERENCE,
+                                                  ChannelReference.CHANNEL,
+                                                  draftBuilder.getCountry(),
+                                                  draftBuilder.getValue(),
+                                                  exception.getMessage()),
+                                              exception));
+                                    } else {
+                                      result.complete(draftWithCreatedChannel);
+                                    }
+                                  });
+                          return result;
+                        }));
+  }
+
+  /**
+   * Helper method that creates a new {@link io.sphere.sdk.channels.Channel} on the CTP project with
+   * the specified {@code channelKey} and of the role {@code "InventorySupply"}. Only if the {@code
+   * ensureChannels} options is set to {@code true} on the {@code options} instance of {@code this}
+   * class. Then it resolves the supply channel reference on the supplied {@code
+   * inventoryEntryDraft} by setting the id of it's supply channel reference with the newly created
+   * Channel.
+   *
+   * <p>If the {@code ensureChannels} options is set to {@code false} on the {@code options}
+   * instance of {@code this} class, the future is completed exceptionally with a {@link
+   * ReferenceResolutionException}.
+   *
+   * <p>The method then returns a CompletionStage with a resolved channel reference {@link
+   * io.sphere.sdk.products.PriceDraftBuilder} object.
+   *
+   * @param channelKey the key to create the new channel with.
+   * @param draftBuilder the inventory entry draft builder where to resolve it's supply channel
+   *     reference to the newly created channel.
+   * @return a CompletionStage with the same {@code draftBuilder} instance having resolved channel
+   *     reference.
+   */
+  @Nonnull
+  private CompletionStage<PriceDraftBuilder> createChannelAndSetReference(
+      @Nonnull final String channelKey, @Nonnull final PriceDraftBuilder draftBuilder) {
+
+    if (options.shouldEnsurePriceChannels()) {
+      return channelService
+          .createAndCacheChannel(channelKey)
+          .thenCompose(
+              createdChannelOptional -> {
+                if (createdChannelOptional.isPresent()) {
+                  return completedFuture(
+                      draftBuilder.channel(createdChannelOptional.get().toResourceIdentifier()));
+                } else {
+                  final ReferenceResolutionException referenceResolutionException =
+                      new ReferenceResolutionException(format(CHANNEL_DOES_NOT_EXIST, channelKey));
+                  return exceptionallyCompletedFuture(referenceResolutionException);
+                }
+              });
+    } else {
+      final ReferenceResolutionException referenceResolutionException =
+          new ReferenceResolutionException(format(CHANNEL_DOES_NOT_EXIST, channelKey));
+      return exceptionallyCompletedFuture(referenceResolutionException);
+    }
+  }
+
+  /**
+   * Given a {@link io.sphere.sdk.products.PriceDraftBuilder} this method attempts to resolve the
+   * customer group resource identifier to return a {@link java.util.concurrent.CompletionStage}
+   * which contains the same instance of draft builder with the resolved customer group resource
+   * identifier.
+   *
+   * @param draftBuilder the priceDraftBuilder to resolve its customer group reference.
+   * @return a {@link java.util.concurrent.CompletionStage} that contains as a result a new price
+   *     draft builder instance with resolved customer group resource identifier or no customer
+   *     group resource identifier if the customer group doesn't exist or in case an error occurs
+   *     during reference resolution a {@link ReferenceResolutionException}.
+   */
+  @Nonnull
+  CompletionStage<PriceDraftBuilder> resolveCustomerGroupReference(
+      @Nonnull final PriceDraftBuilder draftBuilder) {
+    final CustomerGroupResourceIdentifier customerGroupResourceIdentifier =
+        draftBuilder.getCustomerGroup();
+    if (customerGroupResourceIdentifier != null
+        && customerGroupResourceIdentifier.getId() == null) {
+      String customerGroupKey = "";
+      try {
+        customerGroupKey = getKeyFromResourceIdentifier(customerGroupResourceIdentifier);
+      } catch (ReferenceResolutionException referenceResolutionException) {
+        return exceptionallyCompletedFuture(
+            new ReferenceResolutionException(
+                format(
+                    FAILED_TO_RESOLVE_REFERENCE,
+                    CustomerGroup.referenceTypeId(),
+                    draftBuilder.getCountry(),
+                    draftBuilder.getValue(),
+                    referenceResolutionException.getMessage())));
+      }
+      return fetchAndResolveCustomerGroupReference(draftBuilder, customerGroupKey);
+    }
+    return completedFuture(draftBuilder);
+  }
+
+  @Nonnull
+  private CompletionStage<PriceDraftBuilder> fetchAndResolveCustomerGroupReference(
+      @Nonnull final PriceDraftBuilder draftBuilder, @Nonnull final String customerGroupKey) {
+
+    return customerGroupService
+        .fetchCachedCustomerGroupId(customerGroupKey)
+        .thenCompose(
+            resolvedCustomerGroupIdOptional ->
+                resolvedCustomerGroupIdOptional
+                    .map(
+                        resolvedCustomerGroupId ->
+                            completedFuture(
+                                draftBuilder.customerGroup(
+                                    CustomerGroupResourceIdentifierBuilder.of()
+                                        .id(resolvedCustomerGroupId)
+                                        .build())))
+                    .orElseGet(
+                        () -> {
+                          final String errorMessage =
+                              format(CUSTOMER_GROUP_DOES_NOT_EXIST, customerGroupKey);
+                          return exceptionallyCompletedFuture(
+                              new ReferenceResolutionException(
+                                  format(
+                                      FAILED_TO_RESOLVE_REFERENCE,
+                                      CustomerGroup.referenceTypeId(),
+                                      draftBuilder.getCountry(),
+                                      draftBuilder.getValue(),
+                                      errorMessage)));
+                        }));
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/services/InventoryService.java
+++ b/src/main/java/com/commercetools/sync/sdk2/services/InventoryService.java
@@ -1,0 +1,51 @@
+package com.commercetools.sync.sdk2.services;
+
+import com.commercetools.api.models.inventory.InventoryEntry;
+import com.commercetools.api.models.inventory.InventoryEntryDraft;
+import com.commercetools.api.models.inventory.InventoryEntryUpdateAction;
+import com.commercetools.sync.sdk2.inventories.helpers.InventoryEntryIdentifier;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import javax.annotation.Nonnull;
+
+public interface InventoryService {
+
+  /**
+   * Queries existing {@link InventoryEntry}'s against set of sku and supply channels.
+   *
+   * @param inventoryEntryIdentifiers {@link java.util.Set} of unique inventory identifiers, used in
+   *     search predicate
+   * @return {@link java.util.List} of matching entries or empty list when there was no matching
+   *     resources.
+   */
+  @Nonnull
+  CompletionStage<Set<InventoryEntry>> fetchInventoryEntriesByIdentifiers(
+      @Nonnull final Set<InventoryEntryIdentifier> inventoryEntryIdentifiers);
+
+  /**
+   * Creates new inventory entry from {@code inventoryEntryDraft}.
+   *
+   * @param inventoryEntryDraft draft with data for new inventory entry
+   * @return {@link java.util.concurrent.CompletionStage} with created {@link InventoryEntry} or an
+   *     exception
+   */
+  @Nonnull
+  CompletionStage<Optional<InventoryEntry>> createInventoryEntry(
+      @Nonnull final InventoryEntryDraft inventoryEntryDraft);
+
+  /**
+   * Updates existing inventory entry with {@code updateActions}.
+   *
+   * @param inventoryEntry entry that should be updated
+   * @param updateActions {@link java.util.List} of actions that should be applied to {@code
+   *     inventoryEntry}
+   * @return {@link java.util.concurrent.CompletionStage} with updated {@link InventoryEntry} or an
+   *     exception
+   */
+  @Nonnull
+  CompletionStage<InventoryEntry> updateInventoryEntry(
+      @Nonnull final InventoryEntry inventoryEntry,
+      @Nonnull final List<InventoryEntryUpdateAction> updateActions);
+}

--- a/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
@@ -1,0 +1,142 @@
+package com.commercetools.sync.sdk2.inventories;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.channel.Channel;
+import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelReferenceBuilder;
+import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
+import com.commercetools.api.models.channel.ChannelRoleEnum;
+import com.commercetools.api.models.inventory.InventoryEntry;
+import com.commercetools.api.models.type.CustomFields;
+import com.commercetools.sync.sdk2.services.ChannelService;
+import com.commercetools.sync.sdk2.services.InventoryService;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.annotation.Nonnull;
+
+public class InventorySyncMockUtils {
+
+  /**
+   * Returns mock {@link io.sphere.sdk.channels.Channel} instance. Returned instance represents
+   * channel of passed {@code id}, {@code key} and of role {@link
+   * io.sphere.sdk.channels.ChannelRole#INVENTORY_SUPPLY}.
+   *
+   * @param id result of calling {@link io.sphere.sdk.channels.Channel#getId()}
+   * @param key result of calling {@link io.sphere.sdk.channels.Channel#getKey()}
+   * @return mock instance of {@link io.sphere.sdk.channels.Channel}
+   */
+  public static Channel getMockSupplyChannel(final String id, final String key) {
+    final Channel channel = mock(Channel.class);
+    when(channel.getId()).thenReturn(id);
+    when(channel.getKey()).thenReturn(key);
+    when(channel.getRoles()).thenReturn(singletonList(ChannelRoleEnum.INVENTORY_SUPPLY));
+    when(channel.toReference()).thenReturn(ChannelReferenceBuilder.of().id(id).build());
+    when(channel.toResourceIdentifier())
+        .thenReturn(ChannelResourceIdentifierBuilder.of().id(id).key(key).build());
+    return channel;
+  }
+
+  /**
+   * Returns mock {@link io.sphere.sdk.inventory.InventoryEntry} instance. Executing getters on
+   * returned instance will return values passed in parameters.
+   *
+   * @param sku result of calling {@link io.sphere.sdk.inventory.InventoryEntry#getSku()}
+   * @param quantityOnStock result of calling {@link
+   *     io.sphere.sdk.inventory.InventoryEntry#getQuantityOnStock()}
+   * @param restockableInDays result of calling {@link
+   *     io.sphere.sdk.inventory.InventoryEntry#getRestockableInDays()}
+   * @param expectedDelivery result of calling {@link
+   *     io.sphere.sdk.inventory.InventoryEntry#getExpectedDelivery()}
+   * @param supplyChannel result of calling {@link
+   *     io.sphere.sdk.inventory.InventoryEntry#getSupplyChannel()}
+   * @param customFields result of calling {@link
+   *     io.sphere.sdk.inventory.InventoryEntry#getCustom()}
+   * @return mock instance of {@link io.sphere.sdk.inventory.InventoryEntry}
+   */
+  public static InventoryEntry getMockInventoryEntry(
+      final String sku,
+      final Long quantityOnStock,
+      final Long restockableInDays,
+      final ZonedDateTime expectedDelivery,
+      final ChannelReference supplyChannel,
+      final CustomFields customFields) {
+    final InventoryEntry inventoryEntry = mock(InventoryEntry.class);
+    when(inventoryEntry.getSku()).thenReturn(sku);
+    when(inventoryEntry.getQuantityOnStock()).thenReturn(quantityOnStock);
+    when(inventoryEntry.getRestockableInDays()).thenReturn(restockableInDays);
+    when(inventoryEntry.getExpectedDelivery()).thenReturn(expectedDelivery);
+    when(inventoryEntry.getSupplyChannel()).thenReturn(supplyChannel);
+    when(inventoryEntry.getCustom()).thenReturn(customFields);
+    return inventoryEntry;
+  }
+
+  /**
+   * Returns mock instance of {@link InventoryService}. Executing any method with any parameter on
+   * this instance returns values passed in parameters, wrapped in {@link
+   * java.util.concurrent.CompletionStage}.
+   *
+   * @param inventoryEntries result of calling {@link
+   *     InventoryService#fetchInventoryEntriesByIdentifiers(java.util.Set)}
+   * @param createdInventoryEntry result of calling {@link
+   *     InventoryService#createInventoryEntry(com.commercetools.api.models.inventory.InventoryEntryDraft)}
+   * @param updatedInventoryEntry result of calling {@link
+   *     InventoryService#updateInventoryEntry(InventoryEntry, java.util.List)}
+   * @return mock instance of {@link InventoryService}
+   */
+  static InventoryService getMockInventoryService(
+      final Set<InventoryEntry> inventoryEntries,
+      final InventoryEntry createdInventoryEntry,
+      final InventoryEntry updatedInventoryEntry) {
+    final InventoryService inventoryService = mock(InventoryService.class);
+    when(inventoryService.fetchInventoryEntriesByIdentifiers(any()))
+        .thenReturn(completedFuture(inventoryEntries));
+    when(inventoryService.createInventoryEntry(any()))
+        .thenReturn(completedFuture(Optional.ofNullable(createdInventoryEntry)));
+    when(inventoryService.updateInventoryEntry(any(), any()))
+        .thenReturn(completedFuture(updatedInventoryEntry));
+    return inventoryService;
+  }
+
+  /**
+   * Returns mock instance of {@link InventoryService} with the specified parameters as mock results
+   * of calling the {@link ChannelService#createAndCacheChannel(String)} and {@link
+   * ChannelService#fetchCachedChannelId(String)} (String)} of the mock channel service.
+   *
+   * @param createdSupplyChannel result of future resulting from calling {@link
+   *     ChannelService#createAndCacheChannel(String)}
+   * @return mock instance of {@link InventoryService}.
+   */
+  public static ChannelService getMockChannelService(@Nonnull final Channel createdSupplyChannel) {
+    final String createdSupplyChannelId = createdSupplyChannel.getId();
+
+    final ChannelService channelService = mock(ChannelService.class);
+    when(channelService.fetchCachedChannelId(anyString()))
+        .thenReturn(completedFuture(Optional.of(createdSupplyChannelId)));
+    when(channelService.createAndCacheChannel(any()))
+        .thenReturn(completedFuture(Optional.of(createdSupplyChannel)));
+    return channelService;
+  }
+
+  /**
+   * Returns {@link java.util.concurrent.CompletionStage} completed exceptionally.
+   *
+   * @param <T> type of result that is supposed to be inside {@link
+   *     java.util.concurrent.CompletionStage}
+   * @return {@link java.util.concurrent.CompletionStage} instance that is completed exceptionally
+   *     with {@link RuntimeException}
+   */
+  static <T> CompletionStage<T> getCompletionStageWithException() {
+    final CompletableFuture<T> exceptionalStage = new CompletableFuture<>();
+    exceptionalStage.completeExceptionally(new RuntimeException());
+    return exceptionalStage;
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
@@ -26,13 +26,12 @@ import javax.annotation.Nonnull;
 public class InventorySyncMockUtils {
 
   /**
-   * Returns mock {@link io.sphere.sdk.channels.Channel} instance. Returned instance represents
-   * channel of passed {@code id}, {@code key} and of role {@link
-   * io.sphere.sdk.channels.ChannelRole#INVENTORY_SUPPLY}.
+   * Returns mock {@link Channel} instance. Returned instance represents channel of passed {@code
+   * id}, {@code key} and of role {@link ChannelRoleEnum#INVENTORY_SUPPLY}.
    *
-   * @param id result of calling {@link io.sphere.sdk.channels.Channel#getId()}
-   * @param key result of calling {@link io.sphere.sdk.channels.Channel#getKey()}
-   * @return mock instance of {@link io.sphere.sdk.channels.Channel}
+   * @param id result of calling {@link Channel#getId()}
+   * @param key result of calling {@link Channel#getKey()}
+   * @return mock instance of {@link Channel}
    */
   public static Channel getMockSupplyChannel(final String id, final String key) {
     final Channel channel = mock(Channel.class);
@@ -46,21 +45,16 @@ public class InventorySyncMockUtils {
   }
 
   /**
-   * Returns mock {@link io.sphere.sdk.inventory.InventoryEntry} instance. Executing getters on
-   * returned instance will return values passed in parameters.
+   * Returns mock {@link InventoryEntry} instance. Executing getters on returned instance will
+   * return values passed in parameters.
    *
-   * @param sku result of calling {@link io.sphere.sdk.inventory.InventoryEntry#getSku()}
-   * @param quantityOnStock result of calling {@link
-   *     io.sphere.sdk.inventory.InventoryEntry#getQuantityOnStock()}
-   * @param restockableInDays result of calling {@link
-   *     io.sphere.sdk.inventory.InventoryEntry#getRestockableInDays()}
-   * @param expectedDelivery result of calling {@link
-   *     io.sphere.sdk.inventory.InventoryEntry#getExpectedDelivery()}
-   * @param supplyChannel result of calling {@link
-   *     io.sphere.sdk.inventory.InventoryEntry#getSupplyChannel()}
-   * @param customFields result of calling {@link
-   *     io.sphere.sdk.inventory.InventoryEntry#getCustom()}
-   * @return mock instance of {@link io.sphere.sdk.inventory.InventoryEntry}
+   * @param sku result of calling {@link InventoryEntry#getSku()}
+   * @param quantityOnStock result of calling {@link InventoryEntry#getQuantityOnStock()}
+   * @param restockableInDays result of calling {@link InventoryEntry#getRestockableInDays()}
+   * @param expectedDelivery result of calling {@link InventoryEntry#getExpectedDelivery()}
+   * @param supplyChannel result of calling {@link InventoryEntry#getSupplyChannel()}
+   * @param customFields result of calling {@link InventoryEntry#getCustom()}
+   * @return mock instance of {@link InventoryEntry}
    */
   public static InventoryEntry getMockInventoryEntry(
       final String sku,

--- a/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/inventories/InventorySyncMockUtils.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.commercetools.api.models.channel.Channel;
 import com.commercetools.api.models.channel.ChannelReference;
-import com.commercetools.api.models.channel.ChannelReferenceBuilder;
-import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
 import com.commercetools.api.models.channel.ChannelRoleEnum;
 import com.commercetools.api.models.inventory.InventoryEntry;
 import com.commercetools.api.models.type.CustomFields;
@@ -38,9 +36,6 @@ public class InventorySyncMockUtils {
     when(channel.getId()).thenReturn(id);
     when(channel.getKey()).thenReturn(key);
     when(channel.getRoles()).thenReturn(singletonList(ChannelRoleEnum.INVENTORY_SUPPLY));
-    when(channel.toReference()).thenReturn(ChannelReferenceBuilder.of().id(id).build());
-    when(channel.toResourceIdentifier())
-        .thenReturn(ChannelResourceIdentifierBuilder.of().id(id).key(key).build());
     return channel;
   }
 

--- a/src/test/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/helpers/PriceReferenceResolverTest.java
@@ -1,0 +1,483 @@
+package com.commercetools.sync.sdk2.products.helpers;
+
+import static com.commercetools.sync.sdk2.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.sdk2.commons.helpers.BaseReferenceResolver.BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER;
+import static com.commercetools.sync.sdk2.commons.helpers.CustomReferenceResolver.TYPE_DOES_NOT_EXIST;
+import static com.commercetools.sync.sdk2.inventories.InventorySyncMockUtils.getMockChannelService;
+import static com.commercetools.sync.sdk2.inventories.InventorySyncMockUtils.getMockSupplyChannel;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.getMockCustomerGroup;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.getMockCustomerGroupService;
+import static com.commercetools.sync.sdk2.products.helpers.PriceReferenceResolver.*;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ByProjectKeyTypesGet;
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelResourceIdentifier;
+import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
+import com.commercetools.api.models.common.MoneyBuilder;
+import com.commercetools.api.models.common.PriceDraft;
+import com.commercetools.api.models.common.PriceDraftBuilder;
+import com.commercetools.api.models.type.CustomFieldsDraft;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.TypePagedQueryResponse;
+import com.commercetools.sync.sdk2.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.sdk2.commons.helpers.DefaultCurrencyUnits;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.services.ChannelService;
+import com.commercetools.sync.sdk2.services.CustomerGroupService;
+import com.commercetools.sync.sdk2.services.TypeService;
+import com.commercetools.sync.sdk2.services.impl.TypeServiceImpl;
+import com.neovisionaries.i18n.CountryCode;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PriceReferenceResolverTest {
+  private TypeService typeService;
+  private ChannelService channelService;
+  private CustomerGroupService customerGroupService;
+  private ProductSyncOptions syncOptions;
+
+  private static final String CHANNEL_KEY = "channel-key_1";
+  private static final String CHANNEL_ID = "1";
+
+  private static final String CUSTOMER_GROUP_KEY = "customer-group-key_1";
+  private static final String CUSTOMER_GROUP_ID = "1";
+
+  /** Sets up the services and the options needed for reference resolution. */
+  @BeforeEach
+  void setup() {
+    typeService = getMockTypeService();
+    channelService = getMockChannelService(getMockSupplyChannel(CHANNEL_ID, CHANNEL_KEY));
+    customerGroupService =
+        getMockCustomerGroupService(getMockCustomerGroup(CUSTOMER_GROUP_ID, CUSTOMER_GROUP_KEY));
+    syncOptions = ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+  }
+
+  @Test
+  void resolveCustomTypeReference_WithExceptionOnCustomTypeFetch_ShouldNotResolveReferences() {
+    // Preparation
+    final ProjectApiRoot ctpClient = mock(ProjectApiRoot.class);
+    final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(ctpClient).build();
+
+    final TypeService typeService = new TypeServiceImpl(productSyncOptions);
+
+    final CompletableFuture<ApiHttpResponse<TypePagedQueryResponse>> futureThrowingSphereException =
+        new CompletableFuture<>();
+    futureThrowingSphereException.completeExceptionally(new Exception("CTP error on fetch"));
+
+    final ByProjectKeyTypesGet byProjectKeyTypesGet = mock();
+    when(ctpClient.types()).thenReturn(mock());
+    when(ctpClient.types().get()).thenReturn(mock());
+    when(ctpClient.types().get().withWhere(anyString())).thenReturn(byProjectKeyTypesGet);
+    when(byProjectKeyTypesGet.withPredicateVar(anyString(), anyCollection()))
+        .thenReturn(byProjectKeyTypesGet);
+    when(byProjectKeyTypesGet.withLimit(anyInt())).thenReturn(byProjectKeyTypesGet);
+    when(byProjectKeyTypesGet.withWithTotal(anyBoolean())).thenReturn(byProjectKeyTypesGet);
+    when(byProjectKeyTypesGet.withSort(anyString())).thenReturn(byProjectKeyTypesGet);
+    when(byProjectKeyTypesGet.execute()).thenReturn(futureThrowingSphereException);
+
+    final String customTypeKey = "customTypeKey";
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .custom(
+                CustomFieldsDraftBuilder.of().type(builder -> builder.key(customTypeKey)).build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(
+            productSyncOptions, typeService, channelService, customerGroupService);
+
+    // Test and assertion
+    assertThat(priceReferenceResolver.resolveCustomTypeReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(Exception.class)
+        .withMessageContaining("CTP error on fetch");
+  }
+
+  @Test
+  void resolveCustomTypeReference_WithNonExistentCustomType_ShouldCompleteExceptionally() {
+    final String customTypeKey = "customTypeKey";
+    final CustomFieldsDraft customFieldsDraft =
+        CustomFieldsDraftBuilder.of().type(builder -> builder.key(customTypeKey)).build();
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .custom(customFieldsDraft);
+
+    when(typeService.fetchCachedTypeId(anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test and assertion
+    final String expectedExceptionMessage =
+        format(
+            FAILED_TO_RESOLVE_CUSTOM_TYPE,
+            priceBuilder.getCountry(),
+            priceBuilder.getValue().toMonetaryAmount());
+    final String expectedMessageWithCause =
+        format(
+            "%s Reason: %s", expectedExceptionMessage, format(TYPE_DOES_NOT_EXIST, customTypeKey));
+    ;
+    assertThat(priceReferenceResolver.resolveCustomTypeReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(ReferenceResolutionException.class)
+        .withMessageContaining(expectedMessageWithCause);
+  }
+
+  @Test
+  void resolveCustomTypeReference_WithEmptyKeyOnCustomTypeResId_ShouldCompleteExceptionally() {
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(typeResourceIdentifierBuilder -> typeResourceIdentifierBuilder.key(""))
+                    .build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    assertThat(priceReferenceResolver.resolveCustomTypeReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(ReferenceResolutionException.class)
+        .withMessageContaining(
+            format(
+                "Failed to resolve custom type reference on PriceDraft"
+                    + " with country:'DE' and value: 'EUR 10.00'. Reason: %s",
+                BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER));
+  }
+
+  @Test
+  void
+      resolveCustomTypeReference_WithNonNullIdOnCustomTypeResId_ShouldResolveCustomTypeReference() {
+    // Preparation
+    final String customTypeId = UUID.randomUUID().toString();
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .custom(
+                CustomFieldsDraftBuilder.of().type(builder -> builder.id(customTypeId)).build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver
+            .resolveCustomTypeReference(priceBuilder)
+            .toCompletableFuture()
+            .join();
+
+    // Assertion
+    assertThat(resolvedDraftBuilder.getCustom()).isNotNull();
+    assertThat(resolvedDraftBuilder.getCustom().getType().getId()).isEqualTo(customTypeId);
+  }
+
+  @Test
+  void
+      resolveCustomTypeReference_WithNonNullKeyOnCustomTypeResId_ShouldResolveCustomTypeReference() {
+    // Preparation
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(typeResourceIdentifierBuilder -> typeResourceIdentifierBuilder.key("foo"))
+                    .build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver
+            .resolveCustomTypeReference(priceBuilder)
+            .toCompletableFuture()
+            .join();
+    // Assertion
+    assertThat(resolvedDraftBuilder.getCustom()).isNotNull();
+    assertThat(resolvedDraftBuilder.getCustom().getType().getId()).isEqualTo("typeId");
+  }
+
+  @Test
+  void
+      resolveChannelReference_WithNonExistingChannelAndNotEnsureChannel_ShouldNotResolveChannelReference() {
+    // Preparation
+    when(channelService.fetchCachedChannelId(anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().key("channelKey").build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test and assertion
+    assertThat(priceReferenceResolver.resolveChannelReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(ReferenceResolutionException.class)
+        .withMessageContaining(
+            format(
+                FAILED_TO_RESOLVE_REFERENCE,
+                ChannelReference.CHANNEL,
+                priceBuilder.getCountry(),
+                priceBuilder.getValue(),
+                format(CHANNEL_DOES_NOT_EXIST, "channelKey")));
+  }
+
+  @Test
+  void
+      resolveChannelReference_WithNonExistingChannelAndEnsureChannel_ShouldResolveSupplyChannelReference() {
+    // Preparation
+    final ProductSyncOptions optionsWithEnsureChannels =
+        ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).ensurePriceChannels(true).build();
+    when(channelService.fetchCachedChannelId(anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().key("channelKey").build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(
+            optionsWithEnsureChannels, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver.resolveChannelReference(priceBuilder).toCompletableFuture().join();
+
+    // Assertion
+    assertThat(resolvedDraftBuilder.getChannel()).isNotNull();
+    assertThat(resolvedDraftBuilder.getChannel().getId()).isEqualTo(CHANNEL_ID);
+  }
+
+  @Test
+  void resolveChannelReference_WithEmptyChannelKey_ShouldNotResolveChannelReference() {
+    // Preparation
+    when(channelService.fetchCachedChannelId(anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().key("").build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test and assertion
+    assertThat(priceReferenceResolver.resolveChannelReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(ReferenceResolutionException.class)
+        .withMessageContaining(
+            format(
+                FAILED_TO_RESOLVE_REFERENCE,
+                ChannelReference.CHANNEL,
+                priceBuilder.getCountry(),
+                priceBuilder.getValue(),
+                BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER));
+  }
+
+  @Test
+  void resolveChannelReference_WithNullChannelKey_ShouldNotResolveChannelReference() {
+    // Preparation
+    when(channelService.fetchCachedChannelId(anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().key(null).build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    // Test and assertion
+    assertThat(priceReferenceResolver.resolveChannelReference(priceBuilder))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(ReferenceResolutionException.class)
+        .withMessageContaining(
+            format(
+                FAILED_TO_RESOLVE_REFERENCE,
+                ChannelReference.CHANNEL,
+                priceBuilder.getCountry(),
+                priceBuilder.getValue(),
+                BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER));
+  }
+
+  @Test
+  void resolveChannelReference_WithNonNullChannelKey_ShouldResolveSupplyChannelReference() {
+    // Preparation
+    final ProductSyncOptions optionsWithEnsureChannels =
+        ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().key("channelKey").build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(
+            optionsWithEnsureChannels, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver.resolveChannelReference(priceBuilder).toCompletableFuture().join();
+
+    // Assertion
+    assertThat(resolvedDraftBuilder.getChannel()).isNotNull();
+    assertThat(resolvedDraftBuilder.getChannel().getId()).isEqualTo(CHANNEL_ID);
+  }
+
+  @Test
+  void resolveReferences_WithNoReferences_ShouldNotResolveReferences() {
+    final PriceDraft priceDraft =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .build();
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(syncOptions, typeService, channelService, customerGroupService);
+
+    final PriceDraft referencesResolvedDraft =
+        priceReferenceResolver.resolveReferences(priceDraft).toCompletableFuture().join();
+
+    assertThat(referencesResolvedDraft.getCustom()).isNull();
+    assertThat(referencesResolvedDraft.getChannel()).isNull();
+    assertThat(referencesResolvedDraft.getCustomerGroup()).isNull();
+  }
+
+  @Test
+  void resolveChannelReference_WithNullChannelReference_ShouldNotResolveReference() {
+    final ProductSyncOptions optionsWithEnsureChannels =
+        ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel((ChannelResourceIdentifier) null);
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(
+            optionsWithEnsureChannels, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver.resolveChannelReference(priceBuilder).toCompletableFuture().join();
+
+    // Assertion
+    assertThat(resolvedDraftBuilder.getChannel()).isNull();
+  }
+
+  @Test
+  void resolveChannelReference_WithChannelReferenceWithId_ShouldNotResolveReference() {
+    final ProductSyncOptions optionsWithEnsureChannels =
+        ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    final PriceDraftBuilder priceBuilder =
+        PriceDraftBuilder.of()
+            .value(
+                MoneyBuilder.of()
+                    .centAmount(BigDecimal.TEN.longValue())
+                    .currencyCode(DefaultCurrencyUnits.EUR.getCurrencyCode())
+                    .build())
+            .country(CountryCode.DE.getAlpha2())
+            .channel(ChannelResourceIdentifierBuilder.of().id("existing-id").build());
+
+    final PriceReferenceResolver priceReferenceResolver =
+        new PriceReferenceResolver(
+            optionsWithEnsureChannels, typeService, channelService, customerGroupService);
+
+    // Test
+    final PriceDraftBuilder resolvedDraftBuilder =
+        priceReferenceResolver.resolveChannelReference(priceBuilder).toCompletableFuture().join();
+
+    // Assertion
+    assertThat(resolvedDraftBuilder.getChannel()).isNotNull();
+    assertThat(resolvedDraftBuilder.getChannel().getId()).isEqualTo("existing-id");
+  }
+}


### PR DESCRIPTION
#### Summary

Migrate price reference resolver and its tests to sdk v2. This is part of the preparation for migrating VariantReferenceResolver later.
