### PR TITLE
Migrate missing unittests for common utility classes

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/ResourceIdentifierUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/ResourceIdentifierUtils.java
@@ -7,6 +7,7 @@ import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.common.ResourceIdentifier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 public final class ResourceIdentifierUtils {
 
@@ -28,6 +29,22 @@ public final class ResourceIdentifierUtils {
   }
 
   /**
+   * Given a {@link Reference}, if it is not null, this method applies the {@link
+   * Reference#toResourceIdentifier()} method to return it as a {@link ResourceIdentifiable}. If it
+   * is {@code null}, this method returns {@code null}.
+   *
+   * @param reference represents the reference to return as a {@link ResourceIdentifier} if not
+   *     {@code null}.
+   * @return the supplied reference as a {@link ResourceIdentifier} if not {@code null}. If it is
+   *     {@code null}, this method returns {@code null}.
+   */
+  @Nullable
+  public static <ReferenceT extends Reference> ResourceIdentifier toResourceIdentifierIfNotNull(
+      @Nullable final ReferenceT reference) {
+    return ofNullable(reference).map(ReferenceT::toResourceIdentifier).orElse(null);
+  }
+
+  /**
    * Given a {@link Reference} {@code referenceValue} which is the representation of CTP Reference
    * object, this method checks if it has a {@code typeId} with the value equal to {@code
    * referenceTypeId}.
@@ -39,7 +56,9 @@ public final class ResourceIdentifierUtils {
    */
   public static boolean isReferenceOfType(
       @Nonnull final Reference referenceValue, final String referenceTypeId) {
-    return referenceValue.getTypeId().getJsonName().equals(referenceTypeId);
+    return referenceValue.getTypeId() != null
+        && StringUtils.isNotBlank(referenceValue.getTypeId().getJsonName())
+        && referenceValue.getTypeId().getJsonName().equals(referenceTypeId);
   }
 
   private ResourceIdentifierUtils() {}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/ChunkUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/ChunkUtilsTest.java
@@ -1,0 +1,119 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import com.commercetools.api.client.ApiRoot;
+import com.commercetools.api.client.ByProjectKeyCategoriesGet;
+import com.commercetools.api.client.ByProjectKeyGraphqlPost;
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.defaultconfig.ApiRootBuilder;
+import com.commercetools.api.models.PagedQueryResourceRequest;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryPagedQueryResponse;
+import com.commercetools.api.models.graph_ql.GraphQLRequest;
+import com.commercetools.api.models.graph_ql.GraphQLResponse;
+import com.commercetools.api.models.graph_ql.GraphQLResponseBuilder;
+import com.commercetools.sync.commons.models.ResourceKeyId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.sphere.sdk.client.SphereClient;
+import io.vrap.rmf.base.client.ApiHttpClientImpl;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.utils.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ChunkUtilsTest {
+
+  @Test
+  void chunk_WithEmptyList_ShouldNotChunkItems() {
+    final List<List<Object>> chunk = ChunkUtils.chunk(emptyList(), 5);
+
+    assertThat(chunk).isEmpty();
+  }
+
+  @Test
+  void chunk_WithList_ShouldChunkItemsIntoMultipleLists() {
+    final List<List<String>> chunks =
+        ChunkUtils.chunk(asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), 3);
+
+    assertThat(chunks).hasSize(4);
+    assertThat(chunks)
+        .isEqualTo(
+            asList(
+                asList("1", "2", "3"),
+                asList("4", "5", "6"),
+                asList("7", "8", "9"),
+                singletonList("10")));
+  }
+
+  @Test
+  void executeChunks_withEmptyRequestList_ShouldReturnEmptyList() {
+    List<ByProjectKeyCategoriesGet> queries = new ArrayList<>();
+    final List<ApiHttpResponse<CategoryPagedQueryResponse>> results =
+        ChunkUtils.executeChunks(queries).join();
+
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  void executeChunks_withQueryBuilderRequests_ShouldReturnResults() {
+    @SuppressWarnings("unchecked")
+    String jsonStringCategories =
+        "{\"results\":[{\"id\":\"catId1\", \"key\":\"catKey1\"},"
+            + "{\"id\":\"catId2\", \"key\":\"catKey2\"},"
+            + "{\"id\":\"catId3\", \"key\":\"catKey3\"}]}";
+
+    final List<ApiHttpResponse<CategoryPagedQueryResponse>> results =
+        ChunkUtils.executeChunks(
+                asList(getCategoryQueryGetWithWhereKeyInList(asList("1", "2", "3"), jsonStringCategories),
+                    getCategoryQueryGetWithWhereKeyInList(asList("4", "5", "6"), jsonStringCategories)))
+            .join();
+
+    assertThat(results).hasSize(2);
+    List<Category> categories = results.stream().map(ApiHttpResponse::getBody).map(CategoryPagedQueryResponse::getResults).flatMap(Collection::stream).collect(Collectors.toList());
+    assertThat(categories).hasSize(6);
+  }
+
+  @Test
+  void executeChunks_withGraphqlRequests_ShouldReturnResults() {
+
+    String jsonStringKeyToId =
+        "{\"data\": {\"categories\": {\"results\":[{\"id\":\"coId1\", \"key\":\"coKey1\"},"
+            + "{\"id\":\"coId2\", \"key\":\"coKey2\"}]}}}";
+
+    ProjectApiRoot client = ApiRootBuilder.of(request -> {
+      if (request.getUri() != null && request.getUri().toString().contains("graphql")) {
+        return completedFuture(new ApiHttpResponse<>(200, null, jsonStringKeyToId.getBytes(StandardCharsets.UTF_8)));
+      }
+      return completedFuture(new ApiHttpResponse<>(404, null, "".getBytes(StandardCharsets.UTF_8)));
+    }).withApiBaseUrl("baseUrl").build("testClient");
+
+    final List<ApiHttpResponse<GraphQLResponse>> results =
+        ChunkUtils.executeChunks(client, asList(mock(GraphQLRequest.class), mock(GraphQLRequest.class), mock(GraphQLRequest.class))).join();
+
+    assertThat(results).hasSize(3);
+  }
+
+  private ByProjectKeyCategoriesGet getCategoryQueryGetWithWhereKeyInList(final List<String> keylist, final String response) {
+    return ApiRootBuilder.of(request -> completedFuture(new ApiHttpResponse<>(200, null, response.getBytes(StandardCharsets.UTF_8)))
+    )
+            .withApiBaseUrl("baseURl")
+            .build()
+            .withProjectKey("projectKey")
+            .categories()
+            .get()
+            .withWhere("key in :keys")
+            .withPredicateVar("keys", keylist);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CollectionUtilsTest.java
@@ -1,14 +1,13 @@
 package com.commercetools.sync.sdk2.commons.utils;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Test;
-
-import java.util.*;
-
 import static com.commercetools.sync.sdk2.commons.utils.CollectionUtils.*;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+
+import java.util.*;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
 
 class CollectionUtilsTest {
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CollectionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CollectionUtilsTest.java
@@ -1,0 +1,201 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static com.commercetools.sync.sdk2.commons.utils.CollectionUtils.*;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class CollectionUtilsTest {
+
+  @Test
+  void filterCollection_emptyCases() {
+    assertThat(filterCollection(null, i -> true)).isEmpty();
+    assertThat(filterCollection(Collections.emptyList(), i -> true)).isEmpty();
+  }
+
+  @Test
+  void filterCollection_normalCases() {
+    List<String> abcd = asList("a", "b", "c", "d");
+    assertThat(filterCollection(abcd, s -> true)).containsExactlyInAnyOrder("a", "b", "c", "d");
+    assertThat(filterCollection(abcd, s -> false)).isEmpty();
+    assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b')).containsExactlyInAnyOrder("c", "d");
+  }
+
+  @Test
+  void filterCollection_duplicates() {
+    List<String> abcd = asList("a", "b", "c", "d", "d", "c", "g", "a");
+    assertThat(filterCollection(abcd, s -> true))
+        .containsExactlyInAnyOrder("a", "a", "b", "c", "c", "d", "d", "g");
+    assertThat(filterCollection(abcd, s -> false)).isEmpty();
+    assertThat(filterCollection(abcd, s -> s.charAt(0) > 'b'))
+        .containsExactlyInAnyOrder("c", "c", "d", "d", "g");
+  }
+
+  @Test
+  void collectionToSet_emptyCases() {
+    assertThat(collectionToSet(null, i -> i)).isEmpty();
+    assertThat(collectionToSet(Collections.emptyList(), i -> i)).isEmpty();
+  }
+
+  @Test
+  void collectionToSet_normalCases() {
+    List<Pair<String, Integer>> abcd =
+        asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
+    assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+    assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4);
+  }
+
+  @Test
+  void collectionToSet_duplicates() {
+    List<Pair<String, Integer>> abcd =
+        asList(
+            Pair.of("a", 1),
+            Pair.of("b", 2),
+            Pair.of("c", 3),
+            Pair.of("d", 4),
+            Pair.of("d", 5),
+            Pair.of("b", 6));
+    // 2 duplicate keys should be suppressed
+    assertThat(collectionToSet(abcd, Pair::getKey)).containsExactlyInAnyOrder("a", "b", "c", "d");
+    // no duplicate values - nothing should be suppressed
+    assertThat(collectionToSet(abcd, Pair::getValue)).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+  }
+
+  @Test
+  void collectionToMap_emptyCases() {
+    assertThat(collectionToMap(null, k -> k)).isEmpty();
+    assertThat(collectionToMap(null, k -> k, v -> v)).isEmpty();
+    assertThat(collectionToMap(Collections.emptyList(), k -> k)).isEmpty();
+    assertThat(collectionToMap(Collections.emptyList(), k -> k, v -> v)).isEmpty();
+  }
+
+  @Test
+  void collectionToMap_normalCases() {
+    List<Pair<String, Integer>> abcd =
+        asList(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
+
+    assertThat(collectionToMap(abcd, Pair::getKey, Pair::getValue))
+        .containsOnly(Pair.of("a", 1), Pair.of("b", 2), Pair.of("c", 3), Pair.of("d", 4));
+
+    assertThat(collectionToMap(abcd, Pair::getValue, Pair::getKey))
+        .containsOnly(Pair.of(1, "a"), Pair.of(2, "b"), Pair.of(3, "c"), Pair.of(4, "d"));
+
+    assertThat(collectionToMap(abcd, Pair::getKey)) // with default value mapper
+        .containsOnly(
+            Pair.of("a", Pair.of("a", 1)),
+            Pair.of("b", Pair.of("b", 2)),
+            Pair.of("c", Pair.of("c", 3)),
+            Pair.of("d", Pair.of("d", 4)));
+
+    assertThat(collectionToMap(abcd, Pair::getValue)) // with default value mapper
+        .containsOnly(
+            Pair.of(1, Pair.of("a", 1)),
+            Pair.of(2, Pair.of("b", 2)),
+            Pair.of(3, Pair.of("c", 3)),
+            Pair.of(4, Pair.of("d", 4)));
+  }
+
+  @Test
+  void collectionToMap_duplicates() {
+    List<Pair<String, Integer>> abcd =
+        asList(
+            Pair.of("a", 1),
+            Pair.of("b", 2),
+            Pair.of("c", 3),
+            Pair.of("d", 4),
+            Pair.of("d", 5),
+            Pair.of("b", 6));
+
+    // 2 duplicate keys should be suppressed
+    assertThat(collectionToMap(abcd, Pair::getKey, Pair::getValue))
+        .containsOnlyKeys("a", "b", "c", "d");
+    assertThat(collectionToMap(abcd, Pair::getKey)) // with default value mapper
+        .containsOnlyKeys("a", "b", "c", "d");
+
+    // no duplicate values - nothing should be suppressed
+    assertThat(collectionToMap(abcd, Pair::getValue, Pair::getKey))
+        .containsOnly(
+            Pair.of(1, "a"),
+            Pair.of(2, "b"),
+            Pair.of(3, "c"),
+            Pair.of(4, "d"),
+            Pair.of(5, "d"),
+            Pair.of(6, "b"));
+
+    assertThat(collectionToMap(abcd, Pair::getValue)) // with default value mapper
+        .containsOnly(
+            Pair.of(1, Pair.of("a", 1)),
+            Pair.of(2, Pair.of("b", 2)),
+            Pair.of(3, Pair.of("c", 3)),
+            Pair.of(4, Pair.of("d", 4)),
+            Pair.of(5, Pair.of("d", 5)),
+            Pair.of(6, Pair.of("b", 6)));
+  }
+
+  @Test
+  void emptyIfNull_withNullInstances_returnsNonNullInstances() {
+    Collection<String> nonNullEmptyCollection = emptyIfNull((Collection<String>) null);
+    assertThat(nonNullEmptyCollection).isNotNull();
+    assertThat(nonNullEmptyCollection).isEmpty();
+
+    Set<Exception> nonNullEmptySet = emptyIfNull((Set<Exception>) null);
+    assertThat(nonNullEmptySet).isNotNull();
+    assertThat(nonNullEmptySet).isEmpty();
+
+    List<Integer> nonNullEmptyList = emptyIfNull((List<Integer>) null);
+    assertThat(nonNullEmptyList).isNotNull();
+    assertThat(nonNullEmptyList).isEmpty();
+
+    Map<Double, CharSequence> nonNullEmptyMap = emptyIfNull((Map<Double, CharSequence>) null);
+    assertThat(nonNullEmptyMap).isNotNull();
+    assertThat(nonNullEmptyMap).isEmpty();
+  }
+
+  @Test
+  void emptyIfNull_withArrayList_returnsSameInstance() {
+    ArrayList<String> arrayListCollection = new ArrayList<>();
+    arrayListCollection.add("a");
+    arrayListCollection.add("b");
+
+    List<String> actualCollection = emptyIfNull(arrayListCollection);
+    assertThat(actualCollection).isSameAs(arrayListCollection);
+    assertThat(actualCollection).containsExactly("a", "b"); // verify ArrayList is not mutated
+  }
+
+  @Test
+  void emptyIfNull_withHashSet_returnsSameInstance() {
+    HashSet<String> arrayListCollection = new HashSet<>();
+    arrayListCollection.add("woot");
+    arrayListCollection.add("hack");
+
+    Set<String> actualCollection = emptyIfNull(arrayListCollection);
+    assertThat(actualCollection).isSameAs(arrayListCollection);
+    assertThat(actualCollection)
+        .containsExactlyInAnyOrder("woot", "hack"); // verify HashSet is not mutated
+  }
+
+  @Test
+  void emptyIfNull_withListInstances_returnsNonNullList() {
+    List<String> originalListToTest = asList("a", "b");
+
+    List<String> actualListToTest = emptyIfNull(originalListToTest);
+    assertThat(actualListToTest).isSameAs(originalListToTest);
+    assertThat(actualListToTest).containsExactly("a", "b"); // verify list is not mutated
+  }
+
+  @Test
+  void emptyIfNull_withMapInstances_returnsNonNullMap() {
+    Map<String, Integer> mapToTest = new HashMap<>();
+    mapToTest.put("X", 10);
+    mapToTest.put("Y", 11);
+
+    assertThat(emptyIfNull(mapToTest)).isSameAs(mapToTest);
+    assertThat(mapToTest)
+        .containsExactly(entry("X", 10), entry("Y", 11)); // verify map is not mutated
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/FilterUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/FilterUtilsTest.java
@@ -1,0 +1,119 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.FilterUtils.executeSupplierIfPassesFilter;
+import static com.commercetools.sync.sdk2.products.ActionGroup.*;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.models.common.ImageBuilder;
+import com.commercetools.api.models.common.ImageDimensionsBuilder;
+import com.commercetools.api.models.product.*;
+import com.commercetools.sync.sdk2.products.SyncFilter;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FilterUtilsTest {
+
+  private final ProductAddExternalImageAction addExternalImageAction =
+      ProductAddExternalImageActionBuilder.of()
+          .image(
+              ImageBuilder.of()
+                  .url("url2")
+                  .dimensions(ImageDimensionsBuilder.of().h(10).w(10).build())
+                  .build())
+          .build();
+
+  private final List<ProductUpdateAction> passingUpdateActions =
+      Arrays.asList(addExternalImageAction, addExternalImageAction);
+
+  private static final ProductRemoveImageAction removeImageAction =
+      ProductRemoveImageActionBuilder.of().imageUrl("anyUrl").build();
+
+  private static final List<ProductUpdateAction> defaultActions = singletonList(removeImageAction);
+
+  @Test
+  void executeSupplierIfPassesFilter_WithGroupInBlackList_ShouldFilterOutOnlyThisGroup() {
+    final SyncFilter syncFilter = SyncFilter.ofBlackList(IMAGES);
+
+    final List<ProductUpdateAction> updateActionsAfterImagesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, IMAGES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterImagesFilter).hasSize(1);
+    assertThat(updateActionsAfterImagesFilter).isSameAs(defaultActions);
+
+    final List<ProductUpdateAction> updateActionsAfterPricesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, PRICES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterPricesFilter).hasSize(2);
+    assertThat(updateActionsAfterPricesFilter).isSameAs(passingUpdateActions);
+
+    final List<ProductUpdateAction> updateActionsAfterCategoriesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, CATEGORIES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterCategoriesFilter).hasSize(2);
+    assertThat(updateActionsAfterCategoriesFilter).isSameAs(passingUpdateActions);
+  }
+
+  @Test
+  void executeSupplierIfPassesFilter_WithGroupNotInBlackList_ShouldFilterInThisGroup() {
+    final SyncFilter syncFilter = SyncFilter.ofBlackList(PRICES);
+    final List<ProductUpdateAction> updateActionsAfterImagesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, IMAGES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterImagesFilter).hasSize(2);
+    assertThat(updateActionsAfterImagesFilter).isSameAs(passingUpdateActions);
+
+    final List<ProductUpdateAction> updateActionsAfterPricesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, PRICES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterPricesFilter).hasSize(1);
+    assertThat(updateActionsAfterPricesFilter).isSameAs(defaultActions);
+  }
+
+  @Test
+  void executeSupplierIfPassesFilter_WithGroupInWhiteList_ShouldFilterInOnlyThisGroup() {
+    final SyncFilter syncFilter = SyncFilter.ofWhiteList(PRICES);
+
+    final List<ProductUpdateAction> updateActionsAfterPricesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, PRICES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterPricesFilter).hasSize(2);
+    assertThat(updateActionsAfterPricesFilter).isSameAs(passingUpdateActions);
+
+    final List<ProductUpdateAction> updateActionsAfterImagesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, IMAGES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterImagesFilter).hasSize(1);
+    assertThat(updateActionsAfterImagesFilter).isSameAs(defaultActions);
+
+    final List<ProductUpdateAction> updateActionsAfterCategoriesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, CATEGORIES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterCategoriesFilter).hasSize(1);
+    assertThat(updateActionsAfterCategoriesFilter).isSameAs(defaultActions);
+  }
+
+  @Test
+  void executeSupplierIfPassesFilter_WithDefault_ShouldFilterInEveryThing() {
+    final SyncFilter syncFilter = SyncFilter.of();
+
+    final List<ProductUpdateAction> updateActionsAfterPricesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, PRICES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterPricesFilter).hasSize(2);
+    assertThat(updateActionsAfterPricesFilter).isSameAs(passingUpdateActions);
+
+    final List<ProductUpdateAction> updateActionsAfterImagesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, IMAGES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterImagesFilter).hasSize(2);
+    assertThat(updateActionsAfterImagesFilter).isSameAs(passingUpdateActions);
+
+    final List<ProductUpdateAction> updateActionsAfterCategoriesFilter =
+        executeSupplierIfPassesFilter(
+            syncFilter, CATEGORIES, () -> passingUpdateActions, () -> defaultActions);
+    assertThat(updateActionsAfterCategoriesFilter).hasSize(2);
+    assertThat(updateActionsAfterCategoriesFilter).isSameAs(passingUpdateActions);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/OptionalUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/OptionalUtilsTest.java
@@ -1,0 +1,100 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.OptionalUtils.filterEmptyOptionals;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OptionalUtilsTest {
+
+  @Test
+  void filterEmptyOptionals_withEmptyCollection_ShouldReturnEmptyList() {
+    // preparation
+    final List<Optional<String>> optionalStrings = emptyList();
+
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(optionalStrings);
+
+    // assertion
+    assertEquals(emptyList(), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withNoEmptyOptionals_ShouldReturnOptionalContentsAsList() {
+    // preparation
+    final List<Optional<String>> optionalStrings = asList(Optional.of("foo"), Optional.of("bar"));
+
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(optionalStrings);
+
+    // assertion
+    assertEquals(asList("foo", "bar"), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withAllEmptyOptionals_ShouldReturnEmptyList() {
+    // preparation
+    final List<Optional<String>> optionalStrings = asList(empty(), empty());
+
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(optionalStrings);
+
+    // assertion
+    assertEquals(emptyList(), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withSomeEmptyOptionals_ShouldFilterEmptyOptionals() {
+    // preparation
+    final List<Optional<String>> optionalStrings = asList(Optional.of("foo"), empty());
+
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(optionalStrings);
+
+    // assertion
+    assertEquals(singletonList("foo"), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withNoVarArgs_ShouldReturnEmptyList() {
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals();
+
+    // assertion
+    assertEquals(emptyList(), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withVarArgsAllEmptyOptionals_ShouldReturnEmptyList() {
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(empty(), empty());
+
+    // assertion
+    assertEquals(emptyList(), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withVarArgsAllNonEmptyOptionals_ShouldReturnAllElementsInList() {
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(of("foo"), of("bar"));
+
+    // assertion
+    assertEquals(asList("foo", "bar"), filteredOptionals);
+  }
+
+  @Test
+  void filterEmptyOptionals_withVarArgsSomeEmptyOptionals_ShouldFilterEmptyOptionals() {
+    // test
+    final List<String> filteredOptionals = filterEmptyOptionals(of("foo"), empty());
+
+    // assertion
+    assertEquals(singletonList("foo"), filteredOptionals);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/ResourceIdentifierUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/ResourceIdentifierUtilsTest.java
@@ -1,0 +1,94 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.ResourceIdentifierUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.category.*;
+import com.commercetools.api.models.common.ReferenceImpl;
+import com.commercetools.api.models.common.ResourceIdentifier;
+import com.commercetools.api.models.product.ProductReference;
+import com.commercetools.api.models.product.ProductReferenceBuilder;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ResourceIdentifierUtilsTest {
+
+  @Test
+  void toResourceIdentifierIfNotNull_WithNullResource_ShouldReturnNull() {
+    assertThat(toResourceIdentifierIfNotNull((Category) null)).isNull();
+  }
+
+  @Test
+  void toResourceIdentifierIfNotNull_WithNonNullResource_ShouldReturnCorrectResourceIdentifier() {
+    final Category category = mock(Category.class);
+    when(category.getId()).thenReturn(UUID.randomUUID().toString());
+    when(category.toResourceIdentifier()).thenCallRealMethod();
+    when(category.toReference()).thenCallRealMethod();
+
+    final CategoryResourceIdentifier categoryResourceIdentifier =
+        (CategoryResourceIdentifier) toResourceIdentifierIfNotNull(category);
+
+    assertThat(categoryResourceIdentifier).isNotNull();
+    assertThat(categoryResourceIdentifier.getId()).isEqualTo(category.getId());
+    assertThat(categoryResourceIdentifier.getTypeId().getJsonName())
+        .isEqualTo(CategoryResourceIdentifier.CATEGORY);
+  }
+
+  @Test
+  void toResourceIdentifierIfNotNull_WithNonNullReference_ShouldReturnCorrectResourceIdentifier() {
+    final CategoryReference categoryReference = CategoryReferenceBuilder.of().id("foo").build();
+
+    final ResourceIdentifier categoryResourceIdentifier =
+        toResourceIdentifierIfNotNull(categoryReference);
+
+    assertThat(categoryResourceIdentifier).isNotNull();
+    assertThat(categoryResourceIdentifier.getId()).isEqualTo("foo");
+    assertThat(categoryResourceIdentifier.getTypeId().getJsonName())
+        .isEqualTo(CategoryResourceIdentifier.CATEGORY);
+  }
+
+  @Test
+  void isReferenceOfType_WithReferenceValueVsEmptyStringAsReferenceTypeId_ShouldReturnFalse() {
+    // test
+    final boolean isReference =
+        isReferenceOfType(ProductReferenceBuilder.of().id("id").build(), "");
+
+    // assertion
+    assertThat(isReference).isFalse();
+  }
+
+  @Test
+  void isReferenceOfType_WithEmptyObjectNodeValueVsProductReferenceTypeId_ShouldReturnFalse() {
+    // test
+    final boolean isReference = isReferenceOfType(new ReferenceImpl(), ProductReference.PRODUCT);
+
+    // assertion
+    assertThat(isReference).isFalse();
+  }
+
+  @Test
+  void isReferenceOfType_WithCategoryReferenceVsProductReferenceTypeId_ShouldReturnFalse() {
+    // preparation
+    final CategoryReference categoryReference = CategoryReferenceBuilder.of().id("id").build();
+
+    // test
+    final boolean isReference = isReferenceOfType(categoryReference, ProductReference.PRODUCT);
+
+    // assertion
+    assertThat(isReference).isFalse();
+  }
+
+  @Test
+  void isReferenceOfType_WithCategoryReferenceVsCategoryReferenceTypeId_ShouldReturnTrue() {
+    // preparation
+    final CategoryReference categoryReference = CategoryReferenceBuilder.of().id("id").build();
+
+    // test
+    final boolean isReference = isReferenceOfType(categoryReference, CategoryReference.CATEGORY);
+
+    // assertion
+    assertThat(isReference).isTrue();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/StreamUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/StreamUtilsTest.java
@@ -1,13 +1,12 @@
 package com.commercetools.sync.sdk2.commons.utils;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 import static com.commercetools.sync.sdk2.commons.utils.StreamUtils.filterNullAndMap;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 
 class StreamUtilsTest {
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/StreamUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/StreamUtilsTest.java
@@ -1,0 +1,62 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.commercetools.sync.sdk2.commons.utils.StreamUtils.filterNullAndMap;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamUtilsTest {
+
+  @Test
+  void filterNullAndMap_emptyStream_ShouldReturnAnEmptyStream() {
+    final Stream<Integer> mappedStream = filterNullAndMap(Stream.empty(), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isEmpty();
+  }
+
+  @Test
+  void filterNullAndMap_streamWithOnlyNullElements_ShouldReturnAnEmptyStream() {
+    final Stream<Integer> mappedStream =
+        filterNullAndMap(Stream.of(null, null, null), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isEmpty();
+  }
+
+  @Test
+  void filterNullAndMap_streamWithOneNullElement_ShouldReturnAnEmptyStream() {
+    final String nullString = null;
+    final Stream<Integer> mappedStream = filterNullAndMap(Stream.of(nullString), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isEmpty();
+  }
+
+  @Test
+  void filterNullAndMap_singleElementStream_ShouldReturnMappedStream() {
+    final Stream<Integer> mappedStream = filterNullAndMap(Stream.of("foo"), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isNotEmpty();
+    assertThat(mappedList).containsExactly(3);
+  }
+
+  @Test
+  void filterNullAndMap_multipleElementsStream_ShouldReturnMappedStream() {
+    final Stream<Integer> mappedStream =
+        filterNullAndMap(Stream.of("james", "hetfield"), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isNotEmpty();
+    assertThat(mappedList).containsExactly(5, 8);
+  }
+
+  @Test
+  void filterNullAndMap_nonEmptyStreamWithNullElements_ShouldReturnMappedStream() {
+    final Stream<Integer> mappedStream =
+        filterNullAndMap(Stream.of("james", "hetfield", null), String::length);
+    final List<Integer> mappedList = mappedStream.collect(toList());
+    assertThat(mappedList).isNotEmpty();
+    assertThat(mappedList).containsExactly(5, 8);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/TriFunctionTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/TriFunctionTest.java
@@ -1,0 +1,89 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.createObjectFromResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.product.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class TriFunctionTest {
+
+  @Test
+  void apply_WithUpdateActionLocaleFilter_ShouldReturnCorrectResult() {
+    final TriFunction<List<ProductUpdateAction>, ProductDraft, Product, List<ProductUpdateAction>>
+        updateActionFilter = TriFunctionTest::filterEnglishNameChangesOnly;
+
+    final Product oldProduct = createObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, Product.class);
+    final LocalizedString oldName = oldProduct.getMasterData().getStaged().getName();
+
+    final ProductDraft newDraftWithNoEnglishNameChange = mock(ProductDraft.class);
+    final LocalizedString newNameWithSameEnglishLocale = oldName.plus(Locale.GERMAN, "bar");
+    when(newDraftWithNoEnglishNameChange.getName()).thenReturn(newNameWithSameEnglishLocale);
+
+    final ProductChangeNameAction changeNameAction =
+        ProductChangeNameActionBuilder.of().name(newNameWithSameEnglishLocale).build();
+    final ProductSetSkuAction setSkuAction =
+        ProductSetSkuActionBuilder.of().variantId(1L).sku("sku").build();
+
+    List<ProductUpdateAction> updateActions = Arrays.asList(changeNameAction, setSkuAction);
+
+    assertThat(updateActionFilter.apply(updateActions, newDraftWithNoEnglishNameChange, oldProduct))
+        .isEmpty();
+
+    final ProductDraft newDraftWithEnglishNameChange = mock(ProductDraft.class);
+    final LocalizedString newNameWithDiffEnglishLocale = LocalizedString.ofEnglish("foo");
+    when(newDraftWithEnglishNameChange.getName()).thenReturn(newNameWithDiffEnglishLocale);
+
+    final ProductChangeNameAction changeNameDiffAction =
+        ProductChangeNameActionBuilder.of().name(newNameWithSameEnglishLocale).build();
+
+    updateActions = Arrays.asList(changeNameDiffAction, setSkuAction);
+
+    final List<ProductUpdateAction> filteredActions =
+        updateActionFilter.apply(updateActions, newDraftWithEnglishNameChange, oldProduct);
+    assertThat(filteredActions).isNotEmpty();
+    assertThat(filteredActions).isEqualTo(updateActions);
+  }
+
+  private static List<ProductUpdateAction> filterEnglishNameChangesOnly(
+      @Nonnull final List<ProductUpdateAction> updateActions,
+      @Nonnull final ProductDraft newDraft,
+      @Nonnull final Product oldProduct) {
+    return updateActions.stream()
+        .filter(
+            action -> {
+              final String englishOldName =
+                  oldProduct.getMasterData().getStaged().getName().get(Locale.ENGLISH);
+              final String englishNewName = newDraft.getName().get(Locale.ENGLISH);
+              return !Objects.equals(englishOldName, englishNewName);
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  void apply_WithIntegerParams_ShouldReturnCorrectResult() {
+    final TriFunction<Integer, Integer, Integer, String> sumToString =
+        (num1, num2, num3) -> {
+          num1 = num1 != null ? num1 : 0;
+          num2 = num2 != null ? num2 : 0;
+          num3 = num3 != null ? num3 : 0;
+          return String.format("The sum is: %d", num1 + num2 + num3);
+        };
+
+    final String threeOnes = sumToString.apply(1, 1, 1);
+    final String threeNulls = sumToString.apply(null, null, null);
+
+    assertThat(threeOnes).isEqualTo(String.format("The sum is: %d", 3));
+    assertThat(threeNulls).isEqualTo(String.format("The sum is: %d", 0));
+  }
+}


### PR DESCRIPTION
Migrate unittests for classes in package `com.commercetools.sync.sdk2.common.utils`. 

