### PR TITLE
generate a build info class with version property

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
       - name: benchmark test
         if: ${{ success() }}
-        run: ./gradlew clean setLibraryVersion benchmark
+        run: ./gradlew clean benchmark
         env:
           GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}
   deployment:
@@ -52,7 +52,7 @@ jobs:
       - name: Publish GitHub Pages
         run: ./gradlew --info -Dbuild.version="${{ steps.vars.outputs.tag }}" mkdocsPublish
       - name: deploy to sonatype and publish to maven central
-        run: ./gradlew setLibraryVersion -Dbuild.version="${{ steps.vars.outputs.tag }}" publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew -Dbuild.version="${{ steps.vars.outputs.tag }}" publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
           GITHUB_TAG: ${{ steps.vars.outputs.tag }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: 11
           distribution: 'zulu'
       - name: Build with Gradle
-        run: ./gradlew clean setLibraryVersion test integrationTest jacocoTestCoverageVerification jacocoTestReport
+        run: ./gradlew clean test integrationTest jacocoTestCoverageVerification jacocoTestReport
         env:
           SOURCE_PROJECT_KEY: java-sync-source
           SOURCE_CLIENT_ID:  ${{ secrets.SOURCE_CLIENT_ID }}
@@ -63,6 +63,6 @@ jobs:
         run: echo ::set-output name=libVersion::${GITHUB_REF#refs/*/}
       - name: benchmark test
         if: ${{ success() }}
-        run: ./gradlew clean setLibraryVersion benchmark
+        run: ./gradlew clean benchmark
         env:
           GITHUB_TAG: ${{ steps.vars.outputs.libVersion }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ If you have push access to the repository you can fix them directly otherwise ju
 
 ##### Build and publish to Maven Central
 ````bash
-./gradlew clean setLibraryVersion -Dbuild.version={version} publishToSonatype closeAndReleaseSonatypeStagingRepository
+./gradlew clean -Dbuild.version={version} publishToSonatype closeAndReleaseSonatypeStagingRepository
 ````
 
 For more detailed information on the build and the release process, see [Build and Release](BUILD.md) documentation.

--- a/gradle-scripts/execution-order.gradle
+++ b/gradle-scripts/execution-order.gradle
@@ -41,7 +41,6 @@ check.dependsOn jacocoTestReport
 // Ensure jacocoTestCoverageVerification and jacocoTestReport run after integrationTest
 jacocoTestCoverageVerification.mustRunAfter integrationTest
 jacocoTestReport.mustRunAfter integrationTest
-// Ensure build runs after setLibraryVersion
-build.mustRunAfter setLibraryVersion
+compileJava.dependsOn versionTxt
 // Ensure benchmark results are only committed runs after the benchmarks are run
 benchmarkCommit.mustRunAfter benchmark

--- a/gradle-scripts/set-library-version.gradle
+++ b/gradle-scripts/set-library-version.gradle
@@ -1,32 +1,20 @@
-task setLibraryVersion {
-    description 'If the env var "GITHUB_TAG" is set, injects the value in the ' +
-            'src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java. Otherwise, if the env var is not ' +
-            'set it sets the version to the value "dev-version". Note: Should only be executed before compilation in ' +
-            'the CI tool (e.g. github action.)'
+sourceSets {
+    main {
+        java {
+            srcDir 'build/generated/src/main/java'
+        }
+    }
+}
+
+task versionTxt()  {
     doLast {
-        def versionFile = 'src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java'
-        def versionFileContents = new File(versionFile).text
-        def versionPlaceholder = '#{LIB_VERSION}'
-        def libVersion = 'dev-version'
-        def tagName = System.getenv('GITHUB_TAG')
+        new File(projectDir, "build/generated/src/main/java/com/commercetools/sync/").mkdirs()
+        new File(projectDir, "build/generated/src/main/java/com/commercetools/sync/BuildInfo.java").text = """
+package com.commercetools.sync;
 
-        if (!versionFileContents.contains(versionPlaceholder)) {
-            throw new InvalidUserCodeException("$versionFile does not contain the placeholder: $versionPlaceholder. " +
-                    "Please make sure the file contains the placeholder, in order for the version to be injected " +
-                    "correctly.")
-        }
-
-        // if build was triggered by a git tag, set version to tag name
-        if (tagName) {
-            libVersion = tagName
-        }
-
-        if (libVersion) {
-            println "Injecting the version: '$libVersion' in $versionFile"
-            ant.replace(file: versionFile, token: versionPlaceholder, value: libVersion)
-        } else {
-            throw new InvalidUserDataException("Unable to set library version in $versionFile. Please make sure the" +
-                    " var 'libVersion' is set correctly.")
-        }
+public class BuildInfo {
+    public static final String VERSION = "$version";
+}
+"""
     }
 }

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncSolutionInfo.java
@@ -1,11 +1,12 @@
 package com.commercetools.sync.commons.utils;
 
+import com.commercetools.sync.BuildInfo;
 import io.sphere.sdk.client.SolutionInfo;
 
 public final class SyncSolutionInfo extends SolutionInfo {
   private static final String LIB_NAME = "commercetools-sync-java";
   /** This value is injected by the script at gradle-scripts/set-library-version.gradle. */
-  public static final String LIB_VERSION = "#{LIB_VERSION}";
+  public static final String LIB_VERSION = BuildInfo.VERSION;
 
   /**
    * Extends {@link SolutionInfo} class of the JVM SDK to append to the User-Agent header with


### PR DESCRIPTION
#### Summary

Generates a BuildInfo class file with the version of the library

#### Description

At the moment the SyncSolutionInfo file is updated by a task which uses ant to replace a placeholder with the actual build version number.

By generating a class file before the compilation step we can ensure that this file is always there and holds the version of the package. So the error prone pattern matching can be dropped.
