### PR TITLE
DEVX-78 migrate category sync statistics

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidator.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidator.java
@@ -1,0 +1,102 @@
+package com.commercetools.sync.sdk2.categories.helpers;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.commons.helpers.BaseBatchValidator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+public class CategoryBatchValidator
+    extends BaseBatchValidator<CategoryDraft, CategorySyncOptions, CategorySyncStatistics> {
+
+  static final String CATEGORY_DRAFT_KEY_NOT_SET =
+      "CategoryDraft with name: %s doesn't have a key. "
+          + "Please make sure all category drafts have keys.";
+  static final String CATEGORY_DRAFT_IS_NULL = "CategoryDraft is null.";
+
+  public CategoryBatchValidator(
+      @Nonnull final CategorySyncOptions syncOptions,
+      @Nonnull final CategorySyncStatistics syncStatistics) {
+
+    super(syncOptions, syncStatistics);
+  }
+
+  /**
+   * Given the {@link java.util.List}&lt;{@link CategoryDraft}&gt; of drafts this method attempts to
+   * validate drafts and collect referenced keys from the draft and return an {@link
+   * org.apache.commons.lang3.tuple.ImmutablePair}&lt;{@link java.util.Set}&lt;{@link
+   * CategoryDraft}&gt;,{@link
+   * com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.ReferencedKeys}&gt; which
+   * contains the {@link java.util.Set} of valid drafts and referenced keys within a wrapper.
+   *
+   * <p>A valid category draft is one which satisfies the following conditions:
+   *
+   * <ol>
+   *   <li>It is not null
+   *   <li>It has a key which is not blank (null/empty)
+   * </ol>
+   *
+   * @param categoryDrafts the category drafts to validate and collect referenced keys.
+   * @return {@link org.apache.commons.lang3.tuple.ImmutablePair}&lt;{@link java.util.Set}&lt;{@link
+   *     CategoryDraft}&gt;,{@link
+   *     com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.ReferencedKeys}&gt;
+   *     which contains the {@link java.util.Set} of valid drafts and referenced keys within a
+   *     wrapper.
+   */
+  @Override
+  public ImmutablePair<Set<CategoryDraft>, ReferencedKeys> validateAndCollectReferencedKeys(
+      @Nonnull final List<CategoryDraft> categoryDrafts) {
+    final ReferencedKeys referencedKeys = new ReferencedKeys();
+    final Set<CategoryDraft> validDrafts =
+        categoryDrafts.stream()
+            .filter(this::isValidCategoryDraft)
+            .peek(categoryDraft -> collectReferencedKeys(referencedKeys, categoryDraft))
+            .collect(Collectors.toSet());
+
+    return ImmutablePair.of(validDrafts, referencedKeys);
+  }
+
+  private boolean isValidCategoryDraft(@Nullable final CategoryDraft categoryDraft) {
+    if (categoryDraft == null) {
+      handleError(CATEGORY_DRAFT_IS_NULL);
+    } else if (isBlank(categoryDraft.getKey())) {
+      handleError(format(CATEGORY_DRAFT_KEY_NOT_SET, categoryDraft.getName()));
+    } else {
+      return true;
+    }
+
+    return false;
+  }
+
+  private void collectReferencedKeys(
+      @Nonnull final ReferencedKeys referencedKeys, @Nonnull final CategoryDraft categoryDraft) {
+
+    referencedKeys.categoryKeys.add(categoryDraft.getKey());
+    collectReferencedKeyFromResourceIdentifier(
+        categoryDraft.getParent(), referencedKeys.categoryKeys::add);
+    collectReferencedKeyFromCustomFieldsDraft(
+        categoryDraft.getCustom(), referencedKeys.typeKeys::add);
+    collectReferencedKeysFromAssetDrafts(categoryDraft.getAssets(), referencedKeys.typeKeys::add);
+  }
+
+  public static class ReferencedKeys {
+    private final Set<String> categoryKeys = new HashSet<>();
+    private final Set<String> typeKeys = new HashSet<>();
+
+    public Set<String> getCategoryKeys() {
+      return categoryKeys;
+    }
+
+    public Set<String> getTypeKeys() {
+      return typeKeys;
+    }
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategorySyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategorySyncStatistics.java
@@ -1,0 +1,116 @@
+package com.commercetools.sync.sdk2.categories.helpers;
+
+import static java.lang.String.format;
+
+import com.commercetools.sync.sdk2.commons.helpers.BaseSyncStatistics;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class CategorySyncStatistics extends BaseSyncStatistics {
+
+  /**
+   * The following {@link java.util.Map} ({@code categoryKeysWithMissingParents}) represents
+   * categories with missing parents.
+   *
+   * <ul>
+   *   <li>key: key of the missing parent category
+   *   <li>value: a set of the parent's children category keys
+   * </ul>
+   *
+   * <p>The map is thread-safe (by instantiating it with {@link
+   * java.util.concurrent.ConcurrentHashMap}).
+   */
+  private final ConcurrentHashMap<String, Set<String>> categoryKeysWithMissingParents =
+      new ConcurrentHashMap<>();
+
+  public CategorySyncStatistics() {
+    super();
+  }
+
+  /**
+   * Builds a summary of the category sync statistics instance that looks like the following
+   * example:
+   *
+   * <p>"Summary: 2 categories were processed in total (1 created, 1 updated and 0 categories failed
+   * to sync and 0 categories with a missing parent)."
+   *
+   * @return a summary message of the category sync statistics instance.
+   */
+  @Override
+  public String getReportMessage() {
+    return format(
+        "Summary: %s categories were processed in total "
+            + "(%s created, %s updated, %s failed to sync and %s categories with a missing parent).",
+        getProcessed(),
+        getCreated(),
+        getUpdated(),
+        getFailed(),
+        getNumberOfCategoriesWithMissingParents());
+  }
+
+  /**
+   * Returns the total number of categories with missing parents.
+   *
+   * @return the total number of categories with missing parents.
+   */
+  public int getNumberOfCategoriesWithMissingParents() {
+    return (int)
+        categoryKeysWithMissingParents.values().stream()
+            .flatMap(Collection::stream)
+            .distinct()
+            .count();
+  }
+
+  /**
+   * This method checks if there is an entry with the key of the {@code missingParentCategoryKey} in
+   * the {@code categoryKeysWithMissingParents}, if there isn't it creates a new entry with this
+   * parent key and as a value a new set containing the {@code childKey}. Otherwise, if there is
+   * already, it just adds the {@code childKey} to the existing set.
+   *
+   * @param missingParentCategoryKey the key of the missing parent.
+   * @param childKey the key of the state with a missing parent.
+   */
+  public void addMissingDependency(
+      @Nonnull final String missingParentCategoryKey, @Nonnull final String childKey) {
+
+    categoryKeysWithMissingParents
+        .computeIfAbsent(missingParentCategoryKey, ign -> new HashSet<>())
+        .add(childKey);
+  }
+
+  /**
+   * Given a child {@code childKey} this method removes its occurrences from the map {@code
+   * categoryKeysWithMissingParents}.
+   *
+   * <p>NOTE: When all the children keys of a missing parent are removed, the value of the map entry
+   * will be removed.
+   *
+   * @param parentKey the key of the missing parent.
+   * @param childKey the child category key to remove from {@code categoryKeysWithMissingParents}
+   */
+  public void removeChildCategoryKeyFromMissingParentsMap(
+      @Nonnull final String parentKey, @Nonnull final String childKey) {
+
+    categoryKeysWithMissingParents.computeIfPresent(
+        parentKey,
+        (key, values) -> {
+          values.remove(childKey);
+          return values.isEmpty() ? null : values;
+        });
+  }
+
+  /**
+   * Returns the children keys of given {@code parentKey}.
+   *
+   * @param parentKey parent category key
+   * @return Returns the children keys of given {@code parentKey}.
+   */
+  @Nullable
+  public Set<String> getChildrenKeys(@Nonnull final String parentKey) {
+    return categoryKeysWithMissingParents.get(parentKey);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidatorTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidatorTest.java
@@ -1,0 +1,135 @@
+package com.commercetools.sync.sdk2.categories.helpers;
+
+import static com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.CATEGORY_DRAFT_IS_NULL;
+import static com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.CATEGORY_DRAFT_KEY_NOT_SET;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.api.models.category.CategoryResourceIdentifierBuilder;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.FieldContainerBuilder;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptionsBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CategoryBatchValidatorTest {
+
+  private CategorySyncOptions syncOptions;
+  private CategorySyncStatistics syncStatistics;
+  private List<String> errorCallBackMessages;
+
+  @BeforeEach
+  void setup() {
+    errorCallBackMessages = new ArrayList<>();
+    final ProjectApiRoot ctpClient = mock(ProjectApiRoot.class);
+
+    syncOptions =
+        CategorySyncOptionsBuilder.of(ctpClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) ->
+                    errorCallBackMessages.add(exception.getMessage()))
+            .build();
+    syncStatistics = mock(CategorySyncStatistics.class);
+  }
+
+  @Test
+  void validateAndCollectReferencedKeys_WithEmptyDraft_ShouldHaveEmptyResult() {
+    final Set<CategoryDraft> validDrafts = getValidDrafts(Collections.emptyList());
+
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(validDrafts).isEmpty();
+  }
+
+  @Test
+  void
+      validateAndCollectReferencedKeys_WithNullCategoryDraft_ShouldHaveValidationErrorAndEmptyResult() {
+    final Set<CategoryDraft> validDrafts = getValidDrafts(Collections.singletonList(null));
+
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0)).isEqualTo(CATEGORY_DRAFT_IS_NULL);
+    assertThat(validDrafts).isEmpty();
+  }
+
+  @Test
+  void
+      validateAndCollectReferencedKeys_WithCategoryDraftWithNullKey_ShouldHaveValidationErrorAndEmptyResult() {
+    final CategoryDraft categoryDraft = mock(CategoryDraft.class);
+    final Set<CategoryDraft> validDrafts = getValidDrafts(Collections.singletonList(categoryDraft));
+
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(format(CATEGORY_DRAFT_KEY_NOT_SET, categoryDraft.getName()));
+    assertThat(validDrafts).isEmpty();
+  }
+
+  @Test
+  void
+      validateAndCollectReferencedKeys_WithCategoryDraftWithEmptyKey_ShouldHaveValidationErrorAndEmptyResult() {
+    final CategoryDraft categoryDraft = mock(CategoryDraft.class);
+    when(categoryDraft.getKey()).thenReturn(EMPTY);
+    final Set<CategoryDraft> validDrafts = getValidDrafts(Collections.singletonList(categoryDraft));
+
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(format(CATEGORY_DRAFT_KEY_NOT_SET, categoryDraft.getName()));
+    assertThat(validDrafts).isEmpty();
+  }
+
+  @Test
+  void validateAndCollectReferencedKeys_WithValidDrafts_ShouldReturnCorrectResults() {
+    final CategoryDraft validCategoryDraft = mock(CategoryDraft.class);
+    when(validCategoryDraft.getKey()).thenReturn("validDraftKey");
+    when(validCategoryDraft.getParent())
+        .thenReturn(CategoryResourceIdentifierBuilder.of().key("validParentKey").build());
+    when(validCategoryDraft.getCustom())
+        .thenReturn(
+            CustomFieldsDraftBuilder.of()
+                .type(typeResourceIdentifierBuilder -> typeResourceIdentifierBuilder.key("typeKey"))
+                .fields(FieldContainerBuilder.of().values(Collections.emptyMap()).build())
+                .build());
+
+    final CategoryDraft validMainCategoryDraft = mock(CategoryDraft.class);
+    when(validMainCategoryDraft.getKey()).thenReturn("validDraftKey1");
+
+    final CategoryDraft invalidCategoryDraft = mock(CategoryDraft.class);
+    when(invalidCategoryDraft.getParent())
+        .thenReturn(CategoryResourceIdentifierBuilder.of().key("key").build());
+
+    final CategoryBatchValidator categoryBatchValidator =
+        new CategoryBatchValidator(syncOptions, syncStatistics);
+    final ImmutablePair<Set<CategoryDraft>, CategoryBatchValidator.ReferencedKeys> pair =
+        categoryBatchValidator.validateAndCollectReferencedKeys(
+            Arrays.asList(validCategoryDraft, invalidCategoryDraft, validMainCategoryDraft));
+
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(format(CATEGORY_DRAFT_KEY_NOT_SET, invalidCategoryDraft.getName()));
+    assertThat(pair.getLeft())
+        .containsExactlyInAnyOrder(validCategoryDraft, validMainCategoryDraft);
+    assertThat(pair.getRight().getCategoryKeys())
+        .containsExactlyInAnyOrder("validDraftKey", "validParentKey", "validDraftKey1");
+    assertThat(pair.getRight().getTypeKeys()).containsExactlyInAnyOrder("typeKey");
+  }
+
+  @Nonnull
+  private Set<CategoryDraft> getValidDrafts(@Nonnull final List<CategoryDraft> categoryDrafts) {
+    final CategoryBatchValidator categoryBatchValidator =
+        new CategoryBatchValidator(syncOptions, syncStatistics);
+    final ImmutablePair<Set<CategoryDraft>, CategoryBatchValidator.ReferencedKeys> pair =
+        categoryBatchValidator.validateAndCollectReferencedKeys(categoryDrafts);
+    return pair.getLeft();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/categories/helpers/CategorySyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/helpers/CategorySyncStatisticsTest.java
@@ -1,0 +1,153 @@
+package com.commercetools.sync.sdk2.categories.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CategorySyncStatisticsTest {
+
+  private CategorySyncStatistics categorySyncStatistics;
+
+  @BeforeEach
+  void setup() {
+    categorySyncStatistics = new CategorySyncStatistics();
+  }
+
+  @Test
+  void getUpdated_WithNoUpdated_ShouldReturnZero() {
+    assertThat(categorySyncStatistics.getUpdated()).hasValue(0);
+  }
+
+  @Test
+  void incrementUpdated_ShouldIncrementUpdatedValue() {
+    categorySyncStatistics.incrementUpdated();
+    assertThat(categorySyncStatistics.getUpdated()).hasValue(1);
+  }
+
+  @Test
+  void getCreated_WithNoCreated_ShouldReturnZero() {
+    assertThat(categorySyncStatistics.getCreated()).hasValue(0);
+  }
+
+  @Test
+  void incrementCreated_ShouldIncrementCreatedValue() {
+    categorySyncStatistics.incrementCreated();
+    assertThat(categorySyncStatistics.getCreated()).hasValue(1);
+  }
+
+  @Test
+  void getProcessed_WithNoProcessed_ShouldReturnZero() {
+    assertThat(categorySyncStatistics.getProcessed()).hasValue(0);
+  }
+
+  @Test
+  void incrementProcessed_ShouldIncrementProcessedValue() {
+    categorySyncStatistics.incrementProcessed();
+    assertThat(categorySyncStatistics.getProcessed()).hasValue(1);
+  }
+
+  @Test
+  void getFailed_WithNoFailed_ShouldReturnZero() {
+    assertThat(categorySyncStatistics.getFailed()).hasValue(0);
+  }
+
+  @Test
+  void incrementFailed_ShouldIncrementFailedValue() {
+    categorySyncStatistics.incrementFailed();
+    assertThat(categorySyncStatistics.getFailed()).hasValue(1);
+  }
+
+  @Test
+  void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    categorySyncStatistics.incrementCreated(1);
+    categorySyncStatistics.incrementFailed(1);
+    categorySyncStatistics.incrementUpdated(1);
+    categorySyncStatistics.incrementProcessed(3);
+
+    assertThat(categorySyncStatistics.getReportMessage())
+        .isEqualTo(
+            "Summary: 3 categories were processed in total "
+                + "(1 created, 1 updated, 1 failed to sync and 0 categories with a missing parent).");
+  }
+
+  @Test
+  void getNumberOfProductsWithMissingParents_WithEmptyMap_ShouldReturn0() {
+    final int result = categorySyncStatistics.getNumberOfCategoriesWithMissingParents();
+
+    assertThat(result).isZero();
+  }
+
+  @Test
+  void
+      getNumberOfCategoriesWithMissingParents_WithNonEmptyNonDuplicateKeyMap_ShouldReturnCorrectValue() {
+    // preparation
+    categorySyncStatistics.addMissingDependency("parent1", "key1");
+    categorySyncStatistics.addMissingDependency("parent1", "key2");
+
+    categorySyncStatistics.addMissingDependency("parent1", "key3");
+    categorySyncStatistics.addMissingDependency("parent2", "key4");
+
+    // test
+    final int result = categorySyncStatistics.getNumberOfCategoriesWithMissingParents();
+
+    // assert
+    assertThat(result).isEqualTo(4);
+  }
+
+  @Test
+  void
+      getNumberOfCategoriesWithMissingParents_WithNonEmptyDuplicateKeyMap_ShouldReturnCorrectValue() {
+    // preparation
+    categorySyncStatistics.addMissingDependency("parent1", "key1");
+    categorySyncStatistics.addMissingDependency("parent1", "key2");
+
+    categorySyncStatistics.addMissingDependency("parent1", "key3");
+    categorySyncStatistics.addMissingDependency("parent2", "key1");
+
+    // test
+    final int result = categorySyncStatistics.getNumberOfCategoriesWithMissingParents();
+
+    // assert
+    assertThat(result).isEqualTo(3);
+  }
+
+  @Test
+  void addMissingDependency_WithEmptyParentsAndChildren_ShouldAddKeys() {
+    // preparation
+    categorySyncStatistics.addMissingDependency("", "");
+    categorySyncStatistics.addMissingDependency("foo", "");
+    categorySyncStatistics.addMissingDependency("", "");
+
+    // test
+    final int result = categorySyncStatistics.getNumberOfCategoriesWithMissingParents();
+
+    // assert
+    assertThat(result).isOne();
+  }
+
+  @Test
+  void removeChildCategoryKeyFromMissingParentsMap_WithExistingKey_ShouldRemoveKey() {
+    // preparation
+    categorySyncStatistics.addMissingDependency("foo", "a");
+    categorySyncStatistics.addMissingDependency("foo", "b");
+
+    // test
+    categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("foo", "a");
+
+    // assert
+    assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isEqualTo(1);
+  }
+
+  @Test
+  void removeChildCategoryKeyFromMissingParentsMap_WithExistingKey_ShouldRemoveParentMap() {
+    // preparation
+    categorySyncStatistics.addMissingDependency("foo", "a");
+
+    // test
+    categorySyncStatistics.removeChildCategoryKeyFromMissingParentsMap("foo", "a");
+
+    // assert
+    assertThat(categorySyncStatistics.getNumberOfCategoriesWithMissingParents()).isEqualTo(0);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CategorySyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CategorySyncStatisticsAssert.java
@@ -13,9 +13,8 @@ public final class CategorySyncStatisticsAssert
   }
 
   /**
-   * Verifies that the actual {@link
-   * CategorySyncStatistics} value has identical
-   * statistics counters as the ones supplied.
+   * Verifies that the actual {@link CategorySyncStatistics} value has identical statistics counters
+   * as the ones supplied.
    *
    * @param processed the number of processed categories.
    * @param created the number of created categories.

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CategorySyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CategorySyncStatisticsAssert.java
@@ -1,0 +1,40 @@
+package com.commercetools.sync.sdk2.commons.asserts.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import javax.annotation.Nullable;
+
+public final class CategorySyncStatisticsAssert
+    extends AbstractSyncStatisticsAssert<CategorySyncStatisticsAssert, CategorySyncStatistics> {
+
+  CategorySyncStatisticsAssert(@Nullable final CategorySyncStatistics actual) {
+    super(actual, CategorySyncStatisticsAssert.class);
+  }
+
+  /**
+   * Verifies that the actual {@link
+   * CategorySyncStatistics} value has identical
+   * statistics counters as the ones supplied.
+   *
+   * @param processed the number of processed categories.
+   * @param created the number of created categories.
+   * @param updated the number of updated categories.
+   * @param failed the number of failed categories.
+   * @param numberOfCategoriesWithMissingParents the number of categories with missing parents.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual statistics do not match the supplied values.
+   */
+  public CategorySyncStatisticsAssert hasValues(
+      final int processed,
+      final int created,
+      final int updated,
+      final int failed,
+      final int numberOfCategoriesWithMissingParents) {
+    super.hasValues(processed, created, updated, failed);
+    assertThat(actual.getNumberOfCategoriesWithMissingParents())
+        .isEqualTo(numberOfCategoriesWithMissingParents);
+    return myself;
+  }
+}


### PR DESCRIPTION
#### Summary

JIRA: https://commercetools.atlassian.net/browse/DEVX-78

**Note:** 

The following classes were already migrated in the previous PRs:
```
src/test/java/com/commercetools/sync/sdk2/commons/helpers/BaseSyncStatisticsTest.java
src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
```