### PR TITLE
migrate category sync

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/CategoryITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/CategoryITUtils.java
@@ -1,6 +1,8 @@
 package com.commercetools.sync.integration.sdk2.commons.utils;
 
+import static com.commercetools.sync.integration.sdk2.commons.utils.CustomObjectITUtils.deleteWaitingToBeResolvedCustomObjects;
 import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.createTypeIfNotAlreadyExisting;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.deleteTypes;
 import static io.vrap.rmf.base.client.utils.CompletableFutureUtils.listOfFuturesToFutureOfList;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -23,7 +25,6 @@ import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
 import com.commercetools.api.models.type.ResourceTypeId;
 import com.commercetools.api.models.type.Type;
 import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
-import io.sphere.sdk.models.ResourceIdentifier;
 import io.vrap.rmf.base.client.ApiHttpResponse;
 import io.vrap.rmf.base.client.error.NotFoundException;
 import java.util.ArrayList;
@@ -44,6 +45,9 @@ import javax.annotation.Nullable;
 public final class CategoryITUtils {
   public static final String OLD_CATEGORY_CUSTOM_TYPE_KEY = "oldCategoryCustomTypeKey";
   public static final String OLD_CATEGORY_CUSTOM_TYPE_NAME = "old_type_name";
+
+  public static final String CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY =
+      "commercetools-sync-java.UnresolvedReferencesService.categoryDrafts";
 
   /**
    * Builds a list of the supplied number ({@code numberOfCategories}) of CategoryDraft objects that
@@ -255,6 +259,17 @@ public final class CategoryITUtils {
   }
 
   /**
+   * Deletes all categories and types from the CTP project defined by the {@code ctpClient}.
+   *
+   * @param ctpClient defines the CTP project to delete the categories and types from.
+   */
+  public static void deleteCategorySyncTestData(@Nonnull final ProjectApiRoot ctpClient) {
+    deleteAllCategories(ctpClient);
+    deleteTypes(ctpClient);
+    deleteWaitingToBeResolvedCustomObjects(ctpClient, CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY);
+  }
+
+  /**
    * Deletes all categories from CTP projects defined by the {@code ctpClient}. Only issues delete
    * request action to a category in the case that none of its ancestors was already deleted or not
    * to avoid trying to delete a category which would have been already deleted, due to deletion of
@@ -315,9 +330,9 @@ public final class CategoryITUtils {
    * from the supplied {@link java.util.List} of {@link Category}.
    *
    * @param categories a {@link java.util.List} of {@link Category} from which the {@link
-   *     java.util.Set} of {@link ResourceIdentifier} will be built.
-   * @return a {@link java.util.Set} of {@link io.sphere.sdk.models.ResourceIdentifier} with keys in
-   *     place of ids from the supplied {@link java.util.List} of {@link Category}.
+   *     java.util.Set} of {@link CategoryResourceIdentifier} will be built.
+   * @return a {@link java.util.Set} of {@link CategoryResourceIdentifier} with keys in place of ids
+   *     from the supplied {@link java.util.List} of {@link Category}.
    */
   @Nonnull
   public static Set<CategoryResourceIdentifier> getResourceIdentifiersWithKeys(

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/ITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/ITUtils.java
@@ -7,11 +7,14 @@ import static java.util.Collections.*;
 
 import com.commercetools.api.client.ProjectApiRoot;
 import com.commercetools.api.client.QueryUtils;
+import com.commercetools.api.client.error.ConcurrentModificationException;
 import com.commercetools.api.models.common.AssetDraft;
 import com.commercetools.api.models.common.AssetDraftBuilder;
 import com.commercetools.api.models.common.AssetSourceBuilder;
 import com.commercetools.api.models.common.LocalizedString;
 import com.commercetools.api.models.common.LocalizedStringBuilder;
+import com.commercetools.api.models.error.ErrorResponse;
+import com.commercetools.api.models.error.ErrorResponseBuilder;
 import com.commercetools.api.models.type.CustomFieldBooleanType;
 import com.commercetools.api.models.type.CustomFieldBooleanTypeBuilder;
 import com.commercetools.api.models.type.CustomFieldLocalizedStringType;
@@ -27,9 +30,16 @@ import com.commercetools.api.models.type.ResourceTypeId;
 import com.commercetools.api.models.type.Type;
 import com.commercetools.api.models.type.TypeDraft;
 import com.commercetools.api.models.type.TypeDraftBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadGatewayException;
+import io.vrap.rmf.base.client.error.NotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -325,6 +335,45 @@ public final class ITUtils {
         .key(assetKey)
         .tags(singletonList(assetKey))
         .sources(singletonList(AssetSourceBuilder.of().uri("sourceUri").build()));
+  }
+
+  public static NotFoundException createNotFoundException() {
+    final String json = getErrorResponseJsonString(404);
+
+    return new NotFoundException(
+        404, "", null, "", new ApiHttpResponse<>(404, null, json.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  public static ConcurrentModificationException createConcurrentModificationException() {
+    final String json = getErrorResponseJsonString(409);
+
+    return new ConcurrentModificationException(
+        409, "", null, "", new ApiHttpResponse<>(409, null, json.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  public static BadGatewayException createBadGatewayException() {
+    final String json = getErrorResponseJsonString(500);
+    return new BadGatewayException(
+        500, "", null, "", new ApiHttpResponse<>(500, null, json.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private static String getErrorResponseJsonString(Integer errorCode) {
+    final ErrorResponse errorResponse =
+        ErrorResponseBuilder.of()
+            .statusCode(errorCode)
+            .errors(Collections.emptyList())
+            .message("test")
+            .build();
+
+    final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    String json;
+    try {
+      json = ow.writeValueAsString(errorResponse);
+    } catch (JsonProcessingException e) {
+      // ignore the error
+      json = null;
+    }
+    return json;
   }
 
   private ITUtils() {}

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
@@ -1,0 +1,506 @@
+package com.commercetools.sync.integration.sdk2.ctpprojectsource.categories;
+
+import static com.commercetools.sync.integration.sdk2.commons.utils.CategoryITUtils.*;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.createCustomFieldsJsonMap;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestClientUtils.CTP_SOURCE_CLIENT;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.client.error.BadRequestException;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.api.models.category.CategoryDraftBuilder;
+import com.commercetools.api.models.category.CategoryResourceIdentifierBuilder;
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.error.DuplicateFieldError;
+import com.commercetools.api.models.error.DuplicateFieldErrorBuilder;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.categories.CategorySync;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptionsBuilder;
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.sdk2.categories.utils.CategoryTransformUtils;
+import com.commercetools.sync.sdk2.commons.utils.CaffeineReferenceIdToKeyCacheImpl;
+import com.commercetools.sync.sdk2.commons.utils.ReferenceIdToKeyCache;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CategorySyncIT {
+  private CategorySync categorySync;
+
+  private List<String> callBackErrorResponses = new ArrayList<>();
+  private List<Throwable> callBackExceptions = new ArrayList<>();
+  private List<String> callBackWarningResponses = new ArrayList<>();
+  private ReferenceIdToKeyCache referenceIdToKeyCache;
+
+  /**
+   * Delete all categories and types from source and target project. Then create custom types for
+   * source and target CTP project categories.
+   */
+  @BeforeAll
+  static void setup() {
+    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
+    deleteCategorySyncTestData(CTP_SOURCE_CLIENT);
+    ensureCategoriesCustomType(
+        OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH, "anyName", CTP_TARGET_CLIENT);
+    ensureCategoriesCustomType(
+        OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH, "anyName", CTP_SOURCE_CLIENT);
+  }
+
+  /**
+   * Deletes Categories and Types from source and target CTP projects, then it populates target CTP
+   * project with category test data.
+   */
+  @BeforeEach
+  void setupTest() {
+    deleteAllCategories(CTP_TARGET_CLIENT);
+    deleteAllCategories(CTP_SOURCE_CLIENT);
+
+    ensureCategories(CTP_TARGET_CLIENT, getCategoryDrafts(null, 2));
+
+    callBackErrorResponses = new ArrayList<>();
+    callBackExceptions = new ArrayList<>();
+    callBackWarningResponses = new ArrayList<>();
+    categorySync = new CategorySync(buildCategorySyncOptions(50));
+    referenceIdToKeyCache = new CaffeineReferenceIdToKeyCacheImpl();
+  }
+
+  private CategorySyncOptions buildCategorySyncOptions(final int batchSize) {
+    return CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+        .batchSize(batchSize)
+        .errorCallback(
+            (exception, oldResource, newResource, updateActions) -> {
+              callBackErrorResponses.add(exception.getMessage());
+              callBackExceptions.add(exception.getCause());
+            })
+        .warningCallback(
+            (exception, oldResource, newResource) ->
+                callBackWarningResponses.add(exception.getMessage()))
+        .build();
+  }
+
+  /** Cleans up the target and source test data that were built in this test class. */
+  @AfterAll
+  static void tearDown() {
+    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
+    deleteCategorySyncTestData(CTP_SOURCE_CLIENT);
+  }
+
+  @Test
+  void syncDrafts_withChangesOnly_ShouldUpdateCategories() {
+    ensureCategories(
+        CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new", null, 2));
+
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 0, 2, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void syncDrafts_withNewCategories_ShouldCreateCategories() {
+    ensureCategories(
+        CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new", null, 3));
+
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(3, 1, 2, 0, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void syncDrafts_withNewShuffledBatchOfCategories_ShouldCreateCategories() {
+    // Create a total of 130 categories in the source project
+    final List<Category> subFamily = createChildren(5, null, "root", CTP_SOURCE_CLIENT);
+
+    for (final Category child : subFamily) {
+      final List<Category> subsubFamily =
+          createChildren(5, child, child.getName().get(Locale.ENGLISH), CTP_SOURCE_CLIENT);
+      for (final Category subChild : subsubFamily) {
+        createChildren(4, subChild, subChild.getName().get(Locale.ENGLISH), CTP_SOURCE_CLIENT);
+      }
+    }
+    // ---------------------------------------------------------------
+
+    // Fetch categories from source project
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .withLimit(500)
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+
+    // Make sure there is no hierarchical order
+    Collections.shuffle(categoryDrafts);
+
+    CategorySync categorySyncWith13BatchSize = new CategorySync(buildCategorySyncOptions(13));
+    final CategorySyncStatistics syncStatistics =
+        categorySyncWith13BatchSize.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(130, 130, 0, 0, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void
+      syncDrafts_withExistingShuffledCategoriesWithChangingCategoryHierarchy_ShouldUpdateCategories() {
+    // Create a total of 130 categories in the target project
+    final List<Category> subFamily = createChildren(5, null, "root", CTP_TARGET_CLIENT);
+
+    for (final Category child : subFamily) {
+      final List<Category> subsubFamily =
+          createChildren(5, child, child.getName().get(Locale.ENGLISH), CTP_TARGET_CLIENT);
+      for (final Category subChild : subsubFamily) {
+        createChildren(4, subChild, subChild.getName().get(Locale.ENGLISH), CTP_TARGET_CLIENT);
+      }
+    }
+    // ---------------------------------------------------------------
+
+    // Create a total of 130 categories in the source project
+    final List<Category> sourceSubFamily = createChildren(5, null, "root", CTP_SOURCE_CLIENT);
+
+    for (final Category child : sourceSubFamily) {
+      final List<Category> subsubFamily =
+          createChildren(
+              5, sourceSubFamily.get(0), child.getName().get(Locale.ENGLISH), CTP_SOURCE_CLIENT);
+      for (final Category subChild : subsubFamily) {
+        createChildren(
+            4, sourceSubFamily.get(0), subChild.getName().get(Locale.ENGLISH), CTP_SOURCE_CLIENT);
+      }
+    }
+    // ---------------------------------------------------------------
+
+    // Fetch categories from source project
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .withLimit(500)
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+    Collections.shuffle(categoryDrafts);
+
+    CategorySync categorySyncWith13BatcheSize = new CategorySync(buildCategorySyncOptions(13));
+    final CategorySyncStatistics syncStatistics =
+        categorySyncWith13BatcheSize.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(130, 0, 120, 0, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void syncDrafts_withExistingCategoriesThatChangeParents_ShouldUpdateCategories() {
+    // Create a total of 3 categories in the target project (2 roots and 1 child to the first root)
+    final List<Category> subFamily = createChildren(2, null, "root", CTP_TARGET_CLIENT);
+
+    final Category firstRoot = subFamily.get(0);
+    createChildren(1, firstRoot, "child", CTP_TARGET_CLIENT);
+
+    // ---------------------------------------------------------------
+
+    // Create a total of 2 categories in the source project (2 roots and 1 child to the second root)
+    final List<Category> sourceSubFamily = createChildren(2, null, "root", CTP_SOURCE_CLIENT);
+
+    final Category secondRoot = sourceSubFamily.get(1);
+    createChildren(1, secondRoot, "child", CTP_SOURCE_CLIENT);
+    // ---------------------------------------------------------------
+
+    // Fetch categories from source project
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+    Collections.shuffle(categoryDrafts);
+
+    CategorySync categorySyncWith1BatchSize = new CategorySync(buildCategorySyncOptions(1));
+    final CategorySyncStatistics syncStatistics =
+        categorySyncWith1BatchSize.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(3, 0, 1, 0, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void syncDrafts_withANonExistingNewParent_ShouldUpdateCategories() {
+    String parentKey = "parent";
+    // Create a total of 2 categories in the target project.
+    final CategoryDraft parentDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "parent"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "parent"))
+            .key(parentKey)
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(
+                        TypeResourceIdentifierBuilder.of()
+                            .key(OLD_CATEGORY_CUSTOM_TYPE_KEY)
+                            .build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    CTP_TARGET_CLIENT.categories().create(parentDraft).execute().toCompletableFuture().join();
+
+    final CategoryDraft childDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "child"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "child"))
+            .key("child")
+            .parent(CategoryResourceIdentifierBuilder.of().key(parentKey).build())
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(
+                        TypeResourceIdentifierBuilder.of()
+                            .key(OLD_CATEGORY_CUSTOM_TYPE_KEY)
+                            .build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    CTP_TARGET_CLIENT.categories().create(childDraft).execute().toCompletableFuture().join();
+    // ------------------------------------------------------------------------------------------------------------
+    // Create a total of 2 categories in the source project
+    String newParentKey = "new-parent";
+    final CategoryDraft sourceParentDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "new-parent"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "new-parent"))
+            .key(newParentKey)
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(
+                        TypeResourceIdentifierBuilder.of()
+                            .key(OLD_CATEGORY_CUSTOM_TYPE_KEY)
+                            .build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    CTP_SOURCE_CLIENT.categories().create(sourceParentDraft).execute().toCompletableFuture().join();
+
+    final CategoryDraft sourceChildDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "new-child"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "child"))
+            .key("child")
+            .parent(CategoryResourceIdentifierBuilder.of().key(newParentKey).build())
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(
+                        TypeResourceIdentifierBuilder.of()
+                            .key(OLD_CATEGORY_CUSTOM_TYPE_KEY)
+                            .build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    CTP_SOURCE_CLIENT.categories().create(sourceChildDraft).execute().toCompletableFuture().join();
+    // ---------------------------------------------------------------
+
+    // Fetch categories from source project
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .withSort("createdAt asc")
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+
+    // To simulate the new parent coming in a later draft
+    Collections.reverse(categoryDrafts);
+
+    CategorySync categorySyncWith1BatchSize = new CategorySync(buildCategorySyncOptions(13));
+    final CategorySyncStatistics syncStatistics =
+        categorySyncWith1BatchSize.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 1, 1, 0, 0);
+    assertThat(callBackErrorResponses).isEmpty();
+    assertThat(callBackExceptions).isEmpty();
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+
+  @Test
+  void syncDrafts_fromCategoriesWithoutKeys_ShouldNotUpdateCategories() {
+    final CategoryDraft oldCategoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat1"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture1"))
+            .key("newKey1")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft oldCategoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat2"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture2"))
+            .key("newKey2")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    // Create two categories in the source with Keys.
+    List<CompletableFuture<ApiHttpResponse<Category>>> futureCreations = new ArrayList<>();
+    futureCreations.add(
+        CTP_SOURCE_CLIENT.categories().create(oldCategoryDraft1).execute().toCompletableFuture());
+    futureCreations.add(
+        CTP_SOURCE_CLIENT.categories().create(oldCategoryDraft2).execute().toCompletableFuture());
+    CompletableFuture.allOf(futureCreations.toArray(new CompletableFuture[futureCreations.size()]))
+        .join();
+
+    // Create two categories in the target without Keys.
+    futureCreations = new ArrayList<>();
+    final CategoryDraft newCategoryDraft1 =
+        CategoryDraftBuilder.of(oldCategoryDraft1).key(null).build();
+    final CategoryDraft newCategoryDraft2 =
+        CategoryDraftBuilder.of(oldCategoryDraft2).key(null).build();
+    futureCreations.add(
+        CTP_TARGET_CLIENT.categories().create(newCategoryDraft1).execute().toCompletableFuture());
+    futureCreations.add(
+        CTP_TARGET_CLIENT.categories().create(newCategoryDraft2).execute().toCompletableFuture());
+
+    CompletableFuture.allOf(futureCreations.toArray(new CompletableFuture[futureCreations.size()]))
+        .join();
+
+    // ---------
+
+    final List<Category> categories =
+        CTP_SOURCE_CLIENT
+            .categories()
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody()
+            .getResults();
+
+    final List<CategoryDraft> categoryDrafts =
+        CategoryTransformUtils.toCategoryDrafts(
+                CTP_SOURCE_CLIENT, referenceIdToKeyCache, categories)
+            .join();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 0, 0, 2, 0);
+
+    assertThat(callBackErrorResponses)
+        .hasSize(2)
+        .allSatisfy(
+            errorMessage -> {
+              assertThat(errorMessage).contains("\"code\" : \"DuplicateField\"");
+              assertThat(errorMessage).contains("\"field\" : \"slug.en\"");
+            });
+
+    assertThat(callBackExceptions)
+        .hasSize(2)
+        .allSatisfy(
+            throwable -> {
+              assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+              assertThat(throwable).hasCauseExactlyInstanceOf(BadRequestException.class);
+              final BadRequestException errorResponse = (BadRequestException) throwable.getCause();
+
+              final List<DuplicateFieldError> fieldErrors =
+                  errorResponse.getErrorResponse().getErrors().stream()
+                      .map(
+                          sphereError -> {
+                            assertThat(sphereError.getCode()).isEqualTo(DuplicateFieldError.DUPLICATE_FIELD);
+                            return DuplicateFieldErrorBuilder.of((DuplicateFieldError) sphereError)
+                                .build();
+                          })
+                      .collect(toList());
+              assertThat(fieldErrors).hasSize(1);
+              assertThat(fieldErrors)
+                  .allSatisfy(error -> assertThat(error.getField()).isEqualTo("slug.en"));
+            });
+
+    assertThat(callBackWarningResponses).isEmpty();
+  }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
@@ -126,7 +126,8 @@ class CategorySyncIT {
   }
 
   @Test
-  void syncDrafts_withChangesInExistingCategoriesAndNewCategories_ShouldUpdate2CategoriesAndCreate1Category() {
+  void
+      syncDrafts_withChangesInExistingCategoriesAndNewCategories_ShouldUpdate2CategoriesAndCreate1Category() {
     ensureCategories(
         CTP_SOURCE_CLIENT, getCategoryDraftsWithPrefix(Locale.ENGLISH, "new", null, 3));
 
@@ -247,7 +248,8 @@ class CategorySyncIT {
             .join();
     Collections.shuffle(categoryDrafts);
 
-    final CategorySync categorySyncWith13BatcheSize = new CategorySync(buildCategorySyncOptions(13));
+    final CategorySync categorySyncWith13BatcheSize =
+        new CategorySync(buildCategorySyncOptions(13));
     final CategorySyncStatistics syncStatistics =
         categorySyncWith13BatcheSize.sync(categoryDrafts).toCompletableFuture().join();
 

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
@@ -491,7 +491,8 @@ class CategorySyncIT {
                   errorResponse.getErrorResponse().getErrors().stream()
                       .map(
                           sphereError -> {
-                            assertThat(sphereError.getCode()).isEqualTo(DuplicateFieldError.DUPLICATE_FIELD);
+                            assertThat(sphereError.getCode())
+                                .isEqualTo(DuplicateFieldError.DUPLICATE_FIELD);
                             return DuplicateFieldErrorBuilder.of((DuplicateFieldError) sphereError)
                                 .build();
                           })

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/ctpprojectsource/categories/CategorySyncIT.java
@@ -51,8 +51,6 @@ class CategorySyncIT {
    */
   @BeforeAll
   static void setup() {
-    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
-    deleteCategorySyncTestData(CTP_SOURCE_CLIENT);
     ensureCategoriesCustomType(
         OLD_CATEGORY_CUSTOM_TYPE_KEY, Locale.ENGLISH, "anyName", CTP_TARGET_CLIENT);
     ensureCategoriesCustomType(
@@ -472,7 +470,7 @@ class CategorySyncIT {
     assertThat(syncStatistics).hasValues(2, 0, 0, 2, 0);
 
     assertThat(callBackErrorResponses)
-        .hasSize(2)
+        .hasSize(1)
         .allSatisfy(
             errorMessage -> {
               assertThat(errorMessage).contains("\"code\" : \"DuplicateField\"");

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
@@ -44,7 +44,6 @@ class CategorySyncIT {
    */
   @BeforeAll
   static void setup() {
-    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
     ensureCategoriesCustomType(
         OLD_CATEGORY_CUSTOM_TYPE_KEY,
         Locale.ENGLISH,

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
@@ -66,7 +66,6 @@ class CategorySyncIT {
                 })
             .build();
     categorySync = new CategorySync(categorySyncOptions);
-
   }
 
   /** Cleans up the target test data that were built in each test. */
@@ -85,12 +84,12 @@ class CategorySyncIT {
   void syncDrafts_WithANewCategoryWithNewSlug_ShouldCreateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -112,12 +111,12 @@ class CategorySyncIT {
   void syncDrafts_WithANewCategoryWithDuplicateSlug_ShouldNotCreateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -141,12 +140,12 @@ class CategorySyncIT {
   void syncDrafts_WithCategoryWithNoChanges_ShouldNotUpdateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -168,12 +167,12 @@ class CategorySyncIT {
   void syncDrafts_WithChangesInExistingCategoryNameAndSlug_ShouldUpdateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -195,15 +194,17 @@ class CategorySyncIT {
   void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewCategoryWithSuccess() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
-    final Category oldCategory = ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+    final Category oldCategory =
+        ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
     // Preparation
-    final ProjectApiRoot mockClient = buildClientWithConcurrentModificationUpdate(oldCategory.getId());
+    final ProjectApiRoot mockClient =
+        buildClientWithConcurrentModificationUpdate(oldCategory.getId());
 
     final LocalizedString newCategoryName = LocalizedString.of(Locale.ENGLISH, "Modern Furniture");
     final CategoryDraft categoryDraft =
@@ -242,7 +243,8 @@ class CategorySyncIT {
   }
 
   @Nonnull
-  private ProjectApiRoot buildClientWithConcurrentModificationUpdate(@Nonnull final String oldCategoryId) {
+  private ProjectApiRoot buildClientWithConcurrentModificationUpdate(
+      @Nonnull final String oldCategoryId) {
 
     // Helps to count invocation of a request and used to decide execution or mocking response
     final AtomicInteger requestInvocationCounter = new AtomicInteger(0);
@@ -269,13 +271,14 @@ class CategorySyncIT {
   void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
-    final Category oldCategory = ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+    final Category oldCategory =
+        ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Preparation
     final ProjectApiRoot mockClient =
@@ -332,8 +335,7 @@ class CategorySyncIT {
                       return CompletableFutureUtils.exceptionallyCompletedFuture(
                           createBadGatewayException());
                     }
-                  }
-                  else if (uri.contains("categories/" + oldCategory.getId())
+                  } else if (uri.contains("categories/" + oldCategory.getId())
                       && ApiHttpMethod.POST.equals(method)) {
                     return CompletableFutureUtils.exceptionallyCompletedFuture(
                         createConcurrentModificationException());
@@ -350,13 +352,14 @@ class CategorySyncIT {
       syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
-    final Category oldCategory = ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+    final Category oldCategory =
+        ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
     // Preparation
     final ProjectApiRoot mockClient =
         buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry(oldCategory);
@@ -430,12 +433,12 @@ class CategorySyncIT {
   void syncDrafts_WithNewCategoryWithExistingParent_ShouldCreateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -458,12 +461,12 @@ class CategorySyncIT {
   void syncDraft_withARemovedCustomType_ShouldUpdateCategory() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -484,12 +487,12 @@ class CategorySyncIT {
   void syncDrafts_WithMultipleBatchSyncing_ShouldSync() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Existing array of [1, 2, 3, oldCategoryKey]
@@ -585,12 +588,12 @@ class CategorySyncIT {
   void syncDrafts_WithMultipleBatchSyncingWithAlreadyProcessedDrafts_ShouldSync() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.
@@ -639,12 +642,12 @@ class CategorySyncIT {
   void syncDrafts_WithOneBatchSyncing_ShouldSync() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
@@ -720,12 +723,12 @@ class CategorySyncIT {
   void syncDrafts_WithSameSlugDraft_ShouldNotSyncIt() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
@@ -800,12 +803,12 @@ class CategorySyncIT {
   void syncDrafts_WithValidAndInvalidCustomTypeKeys_ShouldSyncCorrectly() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
@@ -853,12 +856,12 @@ class CategorySyncIT {
   void syncDrafts_WithValidCustomFieldsChange_ShouldSyncIt() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
@@ -897,12 +900,12 @@ class CategorySyncIT {
   void syncDrafts_WithDraftWithAMissingParentKey_ShouldNotSyncIt() {
     // Create a mock in the target project.
     final CategoryDraft oldCategoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
-                    .key(oldCategoryKey)
-                    .custom(getCustomFieldsDraft())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
     ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
 
     // Category draft coming from external source.

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
@@ -1,0 +1,789 @@
+package com.commercetools.sync.integration.sdk2.externalsource.categories;
+
+import static com.commercetools.sync.integration.sdk2.commons.utils.CategoryITUtils.*;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.*;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.sdk2.commons.helpers.CustomReferenceResolver.TYPE_DOES_NOT_EXIST;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.defaultconfig.ApiRootBuilder;
+import com.commercetools.api.models.category.*;
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.FieldContainerBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.categories.CategorySync;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptionsBuilder;
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.vrap.rmf.base.client.ApiHttpMethod;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadGatewayException;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
+import java.util.*;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.*;
+
+class CategorySyncIT {
+  private CategorySync categorySync;
+  private static final String oldCategoryKey = "oldCategoryKey";
+  private List<String> errorCallBackMessages = new ArrayList<>();
+  private List<Throwable> errorCallBackExceptions = new ArrayList<>();
+  private Category oldCategory = null;
+  // Helps to count invocation of a request and used to decide execution or mocking response
+  private int requestInvocationCounter = 0;
+
+  /**
+   * Delete all categories and types from target project. Then create custom types for target CTP
+   * project categories.
+   */
+  @BeforeAll
+  static void setup() {
+    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
+    ensureCategoriesCustomType(
+        OLD_CATEGORY_CUSTOM_TYPE_KEY,
+        Locale.ENGLISH,
+        OLD_CATEGORY_CUSTOM_TYPE_NAME,
+        CTP_TARGET_CLIENT);
+  }
+
+  /**
+   * Deletes Categories and Types from target CTP project, then it populates it with category test
+   * data.
+   */
+  @BeforeEach
+  void setupTest() {
+    deleteAllCategories(CTP_TARGET_CLIENT);
+    this.requestInvocationCounter = 0;
+
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+    categorySync = new CategorySync(categorySyncOptions);
+
+    // Create a mock in the target project.
+    final CategoryDraft oldCategoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+    oldCategory = ensureCategories(CTP_TARGET_CLIENT, singletonList(oldCategoryDraft)).get(0);
+  }
+
+  /** Cleans up the target test data that were built in each test. */
+  @AfterEach
+  void tearDownTest() {
+    deleteAllCategories(CTP_TARGET_CLIENT);
+    this.requestInvocationCounter = 0;
+  }
+
+  /** Cleans up the entire target test data that were built in this test class. */
+  @AfterAll
+  static void tearDown() {
+    deleteCategorySyncTestData(CTP_TARGET_CLIENT);
+  }
+
+  @Test
+  void syncDrafts_WithANewCategoryWithNewSlug_ShouldCreateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "new-furniture"))
+            .key("newCategoryKey")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithANewCategoryWithDuplicateSlug_ShouldNotCreateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key("newCategoryKey")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
+  }
+
+  // TODO: Fix the mock for customFields or Adjust the CustomUpdateActionUtils comparison
+  @Disabled
+  @Test
+  void syncDrafts_WithCategoryWithNoChanges_ShouldNotUpdateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithChangedCategory_ShouldUpdateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithConcurrentModificationException_ShouldRetryToUpdateNewCategoryWithSuccess() {
+    // Preparation
+    final ProjectApiRoot spyClient = buildClientWithConcurrentModificationUpdate();
+
+    final LocalizedString newCategoryName = LocalizedString.of(Locale.ENGLISH, "Modern Furniture");
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(newCategoryName)
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(spyClient).build();
+
+    final CategorySync categorySync = new CategorySync(categorySyncOptions);
+
+    // Test
+    final CategorySyncStatistics statistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    // Assertion
+    assertThat(statistics).hasValues(1, 0, 1, 0);
+
+    // Assert CTP state.
+
+    final ApiHttpResponse<Category> queryResult =
+        CTP_TARGET_CLIENT
+            .categories()
+            .withKey(categoryDraft.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join();
+
+    assertThat(queryResult.getBody()).isNotNull();
+    assertThat(queryResult.getBody().getName()).isEqualTo(newCategoryName);
+  }
+
+  @Nonnull
+  private ProjectApiRoot buildClientWithConcurrentModificationUpdate() {
+    final ProjectApiRoot testClient =
+        ApiRootBuilder.of(
+                request -> {
+                  final String uri = request.getUri() != null ? request.getUri().toString() : "";
+                  final ApiHttpMethod method = request.getMethod();
+                  if (uri.contains("categories/" + this.oldCategory.getId())
+                      && ApiHttpMethod.POST.equals(method)) {
+                    if (this.requestInvocationCounter == 0) {
+                      this.requestInvocationCounter++;
+                      return CompletableFutureUtils.exceptionallyCompletedFuture(
+                          createConcurrentModificationException());
+                    }
+                  }
+                  return CTP_TARGET_CLIENT.getApiHttpClient().execute(request);
+                })
+            .withApiBaseUrl(CTP_TARGET_CLIENT.getApiHttpClient().getBaseUri())
+            .build(CTP_TARGET_CLIENT.getProjectKey());
+    return testClient;
+  }
+
+  @Test
+  void syncDrafts_WithConcurrentModificationExceptionAndFailedFetch_ShouldFailToReFetchAndUpdate() {
+    // Preparation
+    final ProjectApiRoot spyClient =
+        buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry(oldCategoryKey);
+
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> errors = new ArrayList<>();
+
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(spyClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  errors.add(exception.getCause());
+                })
+            .build();
+
+    final CategorySync categorySync = new CategorySync(categorySyncOptions);
+    final CategorySyncStatistics statistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    // Test and assertion
+    assertThat(statistics).hasValues(1, 0, 0, 1);
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errors).hasSize(1);
+
+    assertThat(errors.get(0).getCause()).isExactlyInstanceOf(BadGatewayException.class);
+    assertThat(errorMessages.get(0))
+        .contains(
+            "Reason: Failed to fetch from CTP while retrying after concurrency modification.");
+  }
+
+  @Nonnull
+  private ProjectApiRoot buildClientWithConcurrentModificationUpdateAndFailedFetchOnRetry(
+      final String categoryKey) {
+    final ProjectApiRoot testClient =
+        ApiRootBuilder.of(
+                request -> {
+                  final String uri = request.getUri() != null ? request.getUri().toString() : "";
+                  final ApiHttpMethod method = request.getMethod();
+                  if (uri.contains("categories/key=" + categoryKey)
+                      && ApiHttpMethod.GET.equals(method)) {
+                    if (this.requestInvocationCounter > 0) {
+                      return CompletableFutureUtils.exceptionallyCompletedFuture(
+                          createBadGatewayException());
+                    }
+                    this.requestInvocationCounter++;
+                  }
+                  if (uri.contains("categories/" + this.oldCategory.getId())
+                      && ApiHttpMethod.POST.equals(method)) {
+                    return CompletableFutureUtils.exceptionallyCompletedFuture(
+                        createConcurrentModificationException());
+                  }
+                  return CTP_TARGET_CLIENT.getApiHttpClient().execute(request);
+                })
+            .withApiBaseUrl(CTP_TARGET_CLIENT.getApiHttpClient().getBaseUri())
+            .build(CTP_TARGET_CLIENT.getProjectKey());
+    return testClient;
+  }
+
+  @Test
+  void
+      syncDrafts_WithConcurrentModificationExceptionAndUnexpectedDelete_ShouldFailToReFetchAndUpdate() {
+    // Preparation
+    final ProjectApiRoot spyClient =
+        buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry(oldCategoryKey);
+
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> errors = new ArrayList<>();
+
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(spyClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  errors.add(exception.getCause());
+                })
+            .build();
+
+    final CategorySync categorySync = new CategorySync(categorySyncOptions);
+    final CategorySyncStatistics statistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    // Test and assertion
+    assertThat(statistics).hasValues(1, 0, 0, 1);
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errors).hasSize(1);
+
+    assertThat(errorMessages.get(0))
+        .contains(
+            format(
+                "Failed to update Category with key: '%s'. Reason: Not found when attempting to fetch while"
+                    + " retrying after concurrency modification.",
+                categoryDraft.getKey()));
+  }
+
+  @Nonnull
+  private ProjectApiRoot buildClientWithConcurrentModificationUpdateAndNotFoundFetchOnRetry(
+      final String categoryKey) {
+    final ProjectApiRoot testClient =
+        ApiRootBuilder.of(
+                request -> {
+                  final String uri = request.getUri() != null ? request.getUri().toString() : "";
+                  final ApiHttpMethod method = request.getMethod();
+                  if (uri.contains("categories/key=" + categoryKey)
+                      && ApiHttpMethod.GET.equals(method)) {
+                    if (this.requestInvocationCounter > 0) {
+                      return CompletableFutureUtils.exceptionallyCompletedFuture(
+                          createNotFoundException());
+                    }
+                    this.requestInvocationCounter++;
+                  }
+                  if (uri.contains("categories/" + this.oldCategory.getId())
+                      && ApiHttpMethod.POST.equals(method)) {
+                    return CompletableFutureUtils.exceptionallyCompletedFuture(
+                        createConcurrentModificationException());
+                  }
+                  return CTP_TARGET_CLIENT.getApiHttpClient().execute(request);
+                })
+            .withApiBaseUrl(CTP_TARGET_CLIENT.getApiHttpClient().getBaseUri())
+            .build(CTP_TARGET_CLIENT.getProjectKey());
+    return testClient;
+  }
+
+  @Test
+  void syncDrafts_WithNewCategoryWithExistingParent_ShouldCreateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key("newCategory")
+            .custom(getCustomFieldsDraft())
+            .parent(CategoryResourceIdentifierBuilder.of().key(oldCategoryKey).build())
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+  }
+
+  @Test
+  void syncDraft_withARemovedCustomType_ShouldUpdateCategory() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .key(oldCategoryKey)
+            .build();
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithMultipleBatchSyncing_ShouldSync() {
+    // Existing array of [1, 2, 3, oldCategoryKey]
+    final CategoryDraft oldCategoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat1"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture1"))
+            .key("cat1")
+            .custom(getCustomFieldsDraft())
+            .build();
+    CTP_TARGET_CLIENT.categories().post(oldCategoryDraft1).execute().toCompletableFuture().join();
+    final CategoryDraft oldCategoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat2"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture2"))
+            .key("cat2")
+            .custom(getCustomFieldsDraft())
+            .build();
+    CTP_TARGET_CLIENT.categories().post(oldCategoryDraft2).execute().toCompletableFuture().join();
+    final CategoryDraft oldCategoryDraft3 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat3"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "furniture3"))
+            .key("cat3")
+            .custom(getCustomFieldsDraft())
+            .build();
+    CTP_TARGET_CLIENT.categories().post(oldCategoryDraft3).execute().toCompletableFuture().join();
+
+    // _-----_-----_-----_-----_-----_PREPARE BATCHES FROM EXTERNAL
+    // SOURCE-----_-----_-----_-----_-----_-----
+    // _-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----_-----
+
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "oldCategoryKey"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat7").build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> batch1 = new ArrayList<>();
+    batch1.add(categoryDraft1);
+
+    final CategoryDraft categoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat7"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture1"))
+            .key("cat7")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> batch2 = new ArrayList<>();
+    batch2.add(categoryDraft2);
+
+    final CategoryDraft categoryDraft3 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat6"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
+            .key("cat6")
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat5").build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> batch3 = new ArrayList<>();
+    batch3.add(categoryDraft3);
+
+    final CategoryDraft categoryDraft4 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat5"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
+            .key("cat5")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> batch4 = new ArrayList<>();
+    batch4.add(categoryDraft4);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync
+            .sync(batch1)
+            .thenCompose(result -> categorySync.sync(batch2))
+            .thenCompose(result -> categorySync.sync(batch3))
+            .thenCompose(result -> categorySync.sync(batch4))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(syncStatistics).hasValues(4, 3, 1, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithMultipleBatchSyncingWithAlreadyProcessedDrafts_ShouldSync() {
+    // Category draft coming from external source.
+    CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "new name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "new-slug"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> batch1 = new ArrayList<>();
+    batch1.add(categoryDraft1);
+
+    // Process same draft again in a different batch but with a different name.
+    final LocalizedString anotherNewName = LocalizedString.of(Locale.ENGLISH, "another new name");
+    categoryDraft1 = CategoryDraftBuilder.of(categoryDraft1).name(anotherNewName).build();
+
+    final List<CategoryDraft> batch2 = new ArrayList<>();
+    batch2.add(categoryDraft1);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync
+            .sync(batch1)
+            .thenCompose(result -> categorySync.sync(batch2))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(syncStatistics).hasValues(2, 0, 2, 0, 0);
+
+    final CategoryPagedQueryResponse queryResponse =
+        CTP_TARGET_CLIENT
+            .categories()
+            .get()
+            .withQueryParam("slug", categoryDraft1.getSlug().get(Locale.ENGLISH))
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+    assertThat(queryResponse).isNotNull();
+    assertThat(queryResponse.getResults()).hasSize(1);
+    assertThat(queryResponse.getResults().get(0).getName()).isEqualTo(anotherNewName);
+  }
+
+  @Test
+  void syncDrafts_WithOneBatchSyncing_ShouldSync() {
+    final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
+
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat1"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture1"))
+            .key("cat1")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft3 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat2"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
+            .key("cat2")
+            .custom(getCustomFieldsDraft())
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat1").build())
+            .build();
+
+    final CategoryDraft categoryDraft4 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat3"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
+            .key("cat3")
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat1").build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft5 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat4"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture4"))
+            .key("cat4")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft6 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat5"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
+            .key("cat5")
+            .custom(getCustomFieldsDraft())
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat4").build())
+            .build();
+
+    newCategoryDrafts.add(categoryDraft1);
+    newCategoryDrafts.add(categoryDraft2);
+    newCategoryDrafts.add(categoryDraft3);
+    newCategoryDrafts.add(categoryDraft4);
+    newCategoryDrafts.add(categoryDraft5);
+    newCategoryDrafts.add(categoryDraft6);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(newCategoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(6, 5, 1, 0, 0);
+  }
+
+  // Needs the custom fields fix
+  @Disabled
+  @Test
+  void syncDrafts_WithSameSlugDraft_ShouldNotSyncIt() {
+    final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
+
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    // Same slug draft
+    final CategoryDraft categoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat1"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key("cat1")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft3 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat2"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture2"))
+            .key("cat2")
+            .custom(getCustomFieldsDraft())
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat1").build())
+            .build();
+
+    final CategoryDraft categoryDraft4 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat3"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture3"))
+            .key("cat3")
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat1").build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft5 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat4"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture4"))
+            .key("cat4")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final CategoryDraft categoryDraft6 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "cat5"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture5"))
+            .key("cat5")
+            .parent(CategoryResourceIdentifierBuilder.of().key("cat4").build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    newCategoryDrafts.add(categoryDraft1);
+    newCategoryDrafts.add(categoryDraft2);
+    newCategoryDrafts.add(categoryDraft3);
+    newCategoryDrafts.add(categoryDraft4);
+    newCategoryDrafts.add(categoryDraft5);
+    newCategoryDrafts.add(categoryDraft6);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(newCategoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(6, 5, 0, 1, 0);
+  }
+
+  @Test
+  void syncDrafts_WithValidAndInvalidCustomTypeKeys_ShouldSyncCorrectly() {
+    final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
+    final String newCustomTypeKey = "newKey";
+    ensureCategoriesCustomType(
+        newCustomTypeKey, Locale.ENGLISH, "newCustomTypeName", CTP_TARGET_CLIENT);
+
+    final CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(TypeResourceIdentifierBuilder.of().key("nonExistingKey").build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    final CategoryDraft categoryDraft2 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture-2"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture-2"))
+            .key("newCategoryKey")
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(TypeResourceIdentifierBuilder.of().key(newCustomTypeKey).build())
+                    .fields(createCustomFieldsJsonMap())
+                    .build())
+            .build();
+
+    newCategoryDrafts.add(categoryDraft1);
+    newCategoryDrafts.add(categoryDraft2);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(newCategoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 1, 0, 1, 0);
+
+    final String expectedMessage = format(TYPE_DOES_NOT_EXIST, "nonExistingKey");
+    assertThat(errorCallBackMessages.get(0)).contains(expectedMessage);
+  }
+
+  @Test
+  void syncDrafts_WithValidCustomFieldsChange_ShouldSyncIt() {
+    final List<CategoryDraft> newCategoryDrafts = new ArrayList<>();
+
+    final FieldContainerBuilder fieldContainerBuilder = FieldContainerBuilder.of();
+    fieldContainerBuilder.addValue(
+        BOOLEAN_CUSTOM_FIELD_NAME, JsonNodeFactory.instance.booleanNode(false));
+    fieldContainerBuilder.addValue(
+        LOCALISED_STRING_CUSTOM_FIELD_NAME,
+        JsonNodeFactory.instance.objectNode().put("de", "rot").put("en", "red").put("it", "rosso"));
+
+    final CategoryDraft categoryDraft1 =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "Modern Furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "modern-furniture"))
+            .key(oldCategoryKey)
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(
+                        TypeResourceIdentifierBuilder.of()
+                            .key(OLD_CATEGORY_CUSTOM_TYPE_KEY)
+                            .build())
+                    .fields(fieldContainerBuilder.build())
+                    .build())
+            .build();
+
+    newCategoryDrafts.add(categoryDraft1);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(newCategoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+  }
+
+  @Test
+  void syncDrafts_WithDraftWithAMissingParentKey_ShouldNotSyncIt() {
+    // Category draft coming from external source.
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "new-furniture"))
+            .key("newCategoryKey")
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final String nonExistingParentKey = "nonExistingParent";
+    final CategoryDraft categoryDraftWithMissingParent =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "furniture"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "new-furniture1"))
+            .key("cat1")
+            .parent(CategoryResourceIdentifierBuilder.of().key(nonExistingParentKey).build())
+            .custom(getCustomFieldsDraft())
+            .build();
+
+    final List<CategoryDraft> categoryDrafts = new ArrayList<>();
+    categoryDrafts.add(categoryDraft);
+    categoryDrafts.add(categoryDraftWithMissingParent);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 1, 0, 0, 1);
+  }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/products/ProductSyncIT.java
@@ -1,6 +1,7 @@
 package com.commercetools.sync.integration.sdk2.externalsource.products;
 
 import static com.commercetools.sync.integration.sdk2.commons.utils.CategoryITUtils.*;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.*;
 import static com.commercetools.sync.integration.sdk2.commons.utils.ProductITUtils.deleteAllProducts;
 import static com.commercetools.sync.integration.sdk2.commons.utils.ProductITUtils.deleteProductSyncTestData;
 import static com.commercetools.sync.integration.sdk2.commons.utils.ProductTypeITUtils.ensureProductType;
@@ -29,7 +30,6 @@ import com.commercetools.api.client.ByProjectKeyProductsByIDRequestBuilder;
 import com.commercetools.api.client.ByProjectKeyProductsRequestBuilder;
 import com.commercetools.api.client.ProjectApiRoot;
 import com.commercetools.api.client.error.BadRequestException;
-import com.commercetools.api.client.error.ConcurrentModificationException;
 import com.commercetools.api.models.category.Category;
 import com.commercetools.api.models.category.CategoryDraft;
 import com.commercetools.api.models.category.CategoryReference;
@@ -42,8 +42,6 @@ import com.commercetools.api.models.common.Price;
 import com.commercetools.api.models.common.PriceDraft;
 import com.commercetools.api.models.common.PriceDraftBuilder;
 import com.commercetools.api.models.error.DuplicateFieldError;
-import com.commercetools.api.models.error.ErrorResponse;
-import com.commercetools.api.models.error.ErrorResponseBuilder;
 import com.commercetools.api.models.product.Attribute;
 import com.commercetools.api.models.product.AttributeBuilder;
 import com.commercetools.api.models.product.CategoryOrderHints;
@@ -77,14 +75,9 @@ import com.commercetools.sync.sdk2.products.ProductSync;
 import com.commercetools.sync.sdk2.products.ProductSyncOptions;
 import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import io.vrap.rmf.base.client.ApiHttpResponse;
 import io.vrap.rmf.base.client.error.BadGatewayException;
-import io.vrap.rmf.base.client.error.NotFoundException;
 import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1224,44 +1217,5 @@ class ProductSyncIT {
         .thenReturn(CompletableFutureUtils.exceptionallyCompletedFuture(createNotFoundException()));
 
     return spyClient;
-  }
-
-  private NotFoundException createNotFoundException() {
-    final String json = getErrorResponseJsonString(404);
-
-    return new NotFoundException(
-        404, "", null, "", new ApiHttpResponse<>(404, null, json.getBytes(StandardCharsets.UTF_8)));
-  }
-
-  private ConcurrentModificationException createConcurrentModificationException() {
-    final String json = getErrorResponseJsonString(409);
-
-    return new ConcurrentModificationException(
-        409, "", null, "", new ApiHttpResponse<>(409, null, json.getBytes(StandardCharsets.UTF_8)));
-  }
-
-  private BadGatewayException createBadGatewayException() {
-    final String json = getErrorResponseJsonString(500);
-    return new BadGatewayException(
-        500, "", null, "", new ApiHttpResponse<>(500, null, json.getBytes(StandardCharsets.UTF_8)));
-  }
-
-  private String getErrorResponseJsonString(Integer errorCode) {
-    final ErrorResponse errorResponse =
-        ErrorResponseBuilder.of()
-            .statusCode(errorCode)
-            .errors(Collections.emptyList())
-            .message("test")
-            .build();
-
-    final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
-    String json;
-    try {
-      json = ow.writeValueAsString(errorResponse);
-    } catch (JsonProcessingException e) {
-      // ignore the error
-      json = null;
-    }
-    return json;
   }
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/services/impl/UnresolvedReferencesServiceImplIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/services/impl/UnresolvedReferencesServiceImplIT.java
@@ -1,0 +1,258 @@
+package com.commercetools.sync.integration.sdk2.services.impl;
+
+import static com.commercetools.sync.integration.sdk2.commons.utils.CustomObjectITUtils.deleteWaitingToBeResolvedCustomObjects;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestUtils.readObjectFromResource;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_KEY_1_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_KEY_SPECIAL_CHARS_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY;
+import static java.util.Collections.singleton;
+import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedProducts;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.services.UnresolvedReferencesService;
+import com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl;
+import java.util.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UnresolvedReferencesServiceImplIT {
+
+  private static final String CUSTOM_OBJECT_CONTAINER_KEY =
+      "commercetools-sync-java.UnresolvedReferencesService.productDrafts";
+  private UnresolvedReferencesService<WaitingToBeResolvedProducts> unresolvedReferencesService;
+  private List<String> errorCallBackMessages;
+  private List<String> warningCallBackMessages;
+  private List<Throwable> errorCallBackExceptions;
+
+  @AfterEach
+  void tearDown() {
+    deleteWaitingToBeResolvedCustomObjects(CTP_TARGET_CLIENT, CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY);
+  }
+
+  @BeforeEach
+  void setupTest() {
+    deleteWaitingToBeResolvedCustomObjects(CTP_TARGET_CLIENT, CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY);
+    errorCallBackMessages = new ArrayList<>();
+    errorCallBackExceptions = new ArrayList<>();
+    warningCallBackMessages = new ArrayList<>();
+
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+            .errorCallback(
+                (exception, oldResource, newResource, actions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception);
+                })
+            .warningCallback(
+                (syncException, productDraft, product) ->
+                    warningCallBackMessages.add(syncException.getMessage()))
+            .build();
+
+    unresolvedReferencesService = new UnresolvedReferencesServiceImpl<>(productSyncOptions);
+  }
+
+  @Test
+  void saveFetchAndDelete_WithoutExceptions_shouldWorkCorrectly() {
+    // preparation
+    final ProductDraft productDraft =
+        readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, ProductDraft.class);
+
+    final Set<String> missingKeysSet = new HashSet<>();
+    missingKeysSet.add("foo");
+    missingKeysSet.add("bar");
+    final WaitingToBeResolvedProducts productDraftWithUnresolvedRefs =
+        new WaitingToBeResolvedProducts(productDraft, missingKeysSet);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> result =
+        unresolvedReferencesService
+            .save(
+                productDraftWithUnresolvedRefs,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(result)
+        .hasValueSatisfying(
+            waitingToBeResolved ->
+                assertThat(waitingToBeResolved.getProductDraft()).isEqualTo(productDraft));
+
+    // test
+    final Set<WaitingToBeResolvedProducts> waitingDrafts =
+        unresolvedReferencesService
+            .fetch(
+                singleton(productDraft.getKey()),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(waitingDrafts).containsExactly(productDraftWithUnresolvedRefs);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> deletionResult =
+        unresolvedReferencesService
+            .delete(
+                productDraft.getKey(),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(deletionResult)
+        .hasValueSatisfying(
+            waitingToBeResolved ->
+                assertThat(waitingToBeResolved.getProductDraft()).isEqualTo(productDraft));
+
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(errorCallBackExceptions).isEmpty();
+  }
+
+  @Test
+  void saveFetchAndDelete_WithKeyWithSpecialCharacter_shouldWorkCorrectly() {
+    // preparation
+    final ProductDraft productDraft =
+        readObjectFromResource(PRODUCT_KEY_SPECIAL_CHARS_RESOURCE_PATH, ProductDraft.class);
+
+    final Set<String> missingKeysSet = new HashSet<>();
+    missingKeysSet.add("foo");
+    missingKeysSet.add("bar");
+    final WaitingToBeResolvedProducts productDraftWithUnresolvedRefs =
+        new WaitingToBeResolvedProducts(productDraft, missingKeysSet);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> result =
+        unresolvedReferencesService
+            .save(
+                productDraftWithUnresolvedRefs,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(result)
+        .hasValueSatisfying(
+            waitingToBeResolved ->
+                assertThat(waitingToBeResolved.getProductDraft()).isEqualTo(productDraft));
+
+    // test
+    CustomObject customObject =
+        CTP_TARGET_CLIENT
+            .customObjects()
+            .withContainerAndKey(CUSTOM_OBJECT_CONTAINER_KEY, sha1Hex(productDraft.getKey()))
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+    // assertions
+    assertThat(customObject.getKey()).isEqualTo(sha1Hex(productDraft.getKey()));
+
+    // test
+    final Set<WaitingToBeResolvedProducts> waitingDrafts =
+        unresolvedReferencesService
+            .fetch(
+                singleton(productDraft.getKey()),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(waitingDrafts).containsExactly(productDraftWithUnresolvedRefs);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> deletionResult =
+        unresolvedReferencesService
+            .delete(
+                productDraft.getKey(),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(deletionResult)
+        .hasValueSatisfying(
+            waitingToBeResolved ->
+                assertThat(waitingToBeResolved.getProductDraft()).isEqualTo(productDraft));
+
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(errorCallBackExceptions).isEmpty();
+  }
+
+  @Test
+  void save_ExistingProductDraftWithoutException_overwritesOldCustomObjectValue() {
+    // preparation
+    final ProductDraft productDraft =
+        readObjectFromResource(PRODUCT_KEY_1_RESOURCE_PATH, ProductDraft.class);
+
+    final Set<String> missingKeysSet = new HashSet<>();
+    missingKeysSet.add("foo");
+    missingKeysSet.add("bar");
+    final WaitingToBeResolvedProducts productDraftWithUnresolvedRefs =
+        new WaitingToBeResolvedProducts(productDraft, missingKeysSet);
+
+    unresolvedReferencesService
+        .save(
+            productDraftWithUnresolvedRefs,
+            CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+            WaitingToBeResolvedProducts.class)
+        .toCompletableFuture()
+        .join();
+
+    final Set<String> missingKeysSet123 = new HashSet<>();
+    missingKeysSet.add("foo123");
+    missingKeysSet.add("bar123");
+    final WaitingToBeResolvedProducts productDraftWithUnresolvedNewRefs =
+        new WaitingToBeResolvedProducts(productDraft, missingKeysSet123);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> latestResult =
+        unresolvedReferencesService
+            .save(
+                productDraftWithUnresolvedNewRefs,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(latestResult)
+        .hasValueSatisfying(
+            waitingToBeResolved -> {
+              assertThat(waitingToBeResolved.getProductDraft()).isEqualTo(productDraft);
+              assertThat(waitingToBeResolved.getMissingReferencedProductKeys())
+                  .isEqualTo(productDraftWithUnresolvedNewRefs.getMissingReferencedProductKeys());
+            });
+
+    CustomObject customObject =
+        CTP_TARGET_CLIENT
+            .customObjects()
+            .withContainerAndKey(CUSTOM_OBJECT_CONTAINER_KEY, sha1Hex(productDraft.getKey()))
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    assertThat((Map) customObject.getValue()).hasSize(3);
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
@@ -1,5 +1,17 @@
 package com.commercetools.sync.sdk2.categories;
 
+import static com.commercetools.sync.sdk2.categories.utils.CategorySyncUtils.buildActions;
+import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.areResourceIdentifiersEqual;
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.batchElements;
+import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY;
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
 import com.commercetools.api.models.category.CategoryUpdateAction;
 import com.commercetools.api.models.common.ResourceIdentifier;
 import com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator;
@@ -13,30 +25,22 @@ import com.commercetools.sync.sdk2.services.UnresolvedReferencesService;
 import com.commercetools.sync.sdk2.services.impl.CategoryServiceImpl;
 import com.commercetools.sync.sdk2.services.impl.TypeServiceImpl;
 import com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl;
-import com.commercetools.api.models.category.Category;
-import com.commercetools.api.models.category.CategoryDraft;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import static com.commercetools.sync.sdk2.categories.utils.CategorySyncUtils.buildActions;
-import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.areResourceIdentifiersEqual;
-import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.batchElements;
-import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY;
-import static java.lang.String.format;
-import static java.util.concurrent.CompletableFuture.allOf;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class CategorySync
-    extends BaseSync<Category, CategoryDraft, CategoryUpdateAction, CategorySyncStatistics, CategorySyncOptions> {
+    extends BaseSync<
+        Category,
+        CategoryDraft,
+        CategoryUpdateAction,
+        CategorySyncStatistics,
+        CategorySyncOptions> {
 
   private static final String FAILED_TO_FETCH =
       "Failed to fetch existing categories with keys: '%s'. Reason: %s";
@@ -321,14 +325,14 @@ public class CategorySync
 
   /**
    * Compares the parent references of a {@link Category} and a {@link CategoryDraft} to check
-   * whether a {@link com.commercetools.api.models.category.CategoryChangeParentAction} update action is
-   * required to sync the draft to the category or not
+   * whether a {@link com.commercetools.api.models.category.CategoryChangeParentAction} update
+   * action is required to sync the draft to the category or not
    *
    * @param category the old category to sync to.
    * @param categoryDraft the new category draft to sync.
    * @return true or false whether a {@link
-   *     com.commercetools.api.models.category.CategoryChangeParentAction} is needed to sync the draft
-   *     to the category.
+   *     com.commercetools.api.models.category.CategoryChangeParentAction} is needed to sync the
+   *     draft to the category.
    */
   static boolean requiresChangeParentUpdateAction(
       @Nonnull final Category category, @Nonnull final CategoryDraft categoryDraft) {
@@ -338,8 +342,7 @@ public class CategorySync
   private CompletionStage<Void> updateCategory(
       @Nonnull final Category oldCategory,
       @Nonnull final CategoryDraft newCategory,
-      @Nonnull final List<CategoryUpdateAction
-              > updateActions) {
+      @Nonnull final List<CategoryUpdateAction> updateActions) {
     final String categoryKey = oldCategory.getKey();
     return categoryService
         .updateCategory(oldCategory, updateActions)

--- a/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
@@ -1,0 +1,478 @@
+package com.commercetools.sync.sdk2.categories;
+
+import com.commercetools.api.models.category.CategoryUpdateAction;
+import com.commercetools.api.models.common.ResourceIdentifier;
+import com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator;
+import com.commercetools.sync.sdk2.categories.helpers.CategoryReferenceResolver;
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.sdk2.commons.BaseSync;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedCategories;
+import com.commercetools.sync.sdk2.services.CategoryService;
+import com.commercetools.sync.sdk2.services.TypeService;
+import com.commercetools.sync.sdk2.services.UnresolvedReferencesService;
+import com.commercetools.sync.sdk2.services.impl.CategoryServiceImpl;
+import com.commercetools.sync.sdk2.services.impl.TypeServiceImpl;
+import com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.commercetools.sync.sdk2.categories.utils.CategorySyncUtils.buildActions;
+import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.areResourceIdentifiersEqual;
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.batchElements;
+import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY;
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+public class CategorySync
+    extends BaseSync<Category, CategoryDraft, CategoryUpdateAction, CategorySyncStatistics, CategorySyncOptions> {
+
+  private static final String FAILED_TO_FETCH =
+      "Failed to fetch existing categories with keys: '%s'. Reason: %s";
+  private static final String FAILED_TO_PROCESS =
+      "Failed to process the CategoryDraft with key: '%s'. Reason: %s";
+  private static final String UPDATE_FAILED =
+      "Failed to update Category with key: '%s'. Reason: %s";
+  private static final String FAILED_TO_FETCH_WAITING_DRAFTS =
+      "Failed to fetch CategoryDraft waiting to be resolved with parent keys: '%s'.";
+  private final CategoryService categoryService;
+  private final UnresolvedReferencesService<WaitingToBeResolvedCategories>
+      unresolvedReferencesService;
+  private final CategoryReferenceResolver referenceResolver;
+  private final CategoryBatchValidator batchValidator;
+
+  private ConcurrentHashMap.KeySetView<String, Boolean> readyToResolve;
+  private ConcurrentHashMap<CategoryDraft, Category> categoryDraftsToUpdateSequentially;
+
+  /**
+   * Takes a {@link CategorySyncOptions} instance to instantiate a new {@link CategorySync} instance
+   * that could be used to sync category drafts with the given categories in the CTP project
+   * specified in the injected {@link CategorySyncOptions} instance.
+   *
+   * @param syncOptions the container of all the options of the sync process including the CTP
+   *     project client and/or configuration and other sync-specific options.
+   */
+  public CategorySync(@Nonnull final CategorySyncOptions syncOptions) {
+    this(
+        syncOptions,
+        new TypeServiceImpl(syncOptions),
+        new CategoryServiceImpl(syncOptions),
+        new UnresolvedReferencesServiceImpl<>(syncOptions));
+  }
+
+  CategorySync(
+      @Nonnull final CategorySyncOptions syncOptions,
+      @Nonnull final TypeService typeService,
+      @Nonnull final CategoryService categoryService,
+      @Nonnull
+          final UnresolvedReferencesService<WaitingToBeResolvedCategories>
+              unresolvedReferencesService) {
+    super(new CategorySyncStatistics(), syncOptions);
+    this.categoryService = categoryService;
+    this.unresolvedReferencesService = unresolvedReferencesService;
+    this.referenceResolver =
+        new CategoryReferenceResolver(getSyncOptions(), typeService, categoryService);
+    this.batchValidator = new CategoryBatchValidator(getSyncOptions(), getStatistics());
+  }
+
+  @Override
+  protected CompletionStage<CategorySyncStatistics> process(
+      @Nonnull final List<CategoryDraft> categoryDrafts) {
+    final List<List<CategoryDraft>> batches =
+        batchElements(categoryDrafts, syncOptions.getBatchSize());
+    return syncBatches(batches, completedFuture(statistics));
+  }
+
+  @Override
+  protected CompletionStage<CategorySyncStatistics> processBatch(
+      @Nonnull final List<CategoryDraft> categoryDrafts) {
+
+    setBatchState();
+
+    final ImmutablePair<Set<CategoryDraft>, CategoryBatchValidator.ReferencedKeys> result =
+        batchValidator.validateAndCollectReferencedKeys(categoryDrafts);
+
+    final Set<CategoryDraft> validDrafts = result.getLeft();
+    if (validDrafts.isEmpty()) {
+      statistics.incrementProcessed(categoryDrafts.size());
+      return completedFuture(statistics);
+    }
+
+    return referenceResolver
+        .populateKeyToIdCachesForReferencedKeys(result.getRight())
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            cachingResponse -> {
+              final Throwable cachingException = cachingResponse.getValue();
+              if (cachingException != null) {
+                handleError(
+                    "Failed to build a cache of keys to ids.",
+                    cachingException,
+                    null,
+                    null,
+                    null,
+                    validDrafts.size());
+                return completedFuture(null);
+              }
+
+              final Map<String, String> keyToIdCache = cachingResponse.getKey();
+              return syncBatch(validDrafts, keyToIdCache);
+            })
+        .thenApply(
+            ignoredResult -> {
+              statistics.incrementProcessed(categoryDrafts.size());
+              return statistics;
+            });
+  }
+
+  private void setBatchState() {
+    readyToResolve = ConcurrentHashMap.newKeySet();
+    categoryDraftsToUpdateSequentially = new ConcurrentHashMap<>();
+  }
+
+  @Nonnull
+  private CompletionStage<Void> syncBatch(
+      @Nonnull final Set<CategoryDraft> categoryDrafts,
+      @Nonnull final Map<String, String> keyToIdCache) {
+
+    final Set<String> categoryDraftKeys =
+        categoryDrafts.stream().map(CategoryDraft::getKey).collect(Collectors.toSet());
+
+    return categoryService
+        .fetchMatchingCategoriesByKeys(categoryDraftKeys)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchResponse -> {
+              final Throwable fetchException = fetchResponse.getValue();
+              if (fetchException != null) {
+                final String errorMessage =
+                    format(FAILED_TO_FETCH, categoryDraftKeys, fetchException.getMessage());
+                handleError(
+                    errorMessage, fetchException, null, null, null, categoryDraftKeys.size());
+                return CompletableFuture.completedFuture(null);
+              } else {
+                final Set<Category> matchingCategories = fetchResponse.getKey();
+                return syncOrKeepTrack(categoryDrafts, matchingCategories, keyToIdCache)
+                    .thenCompose(
+                        aVoid -> updateCategoriesSequentially(categoryDraftsToUpdateSequentially))
+                    .thenCompose(aVoid -> resolveNowReadyReferences(keyToIdCache));
+              }
+            });
+  }
+
+  /**
+   * Given a set of category drafts, for each new draft: if it doesn't have any parent category
+   * reference which are missing, it syncs the new draft. However, if it does have missing parent
+   * category reference, it keeps track of it by persisting it.
+   *
+   * @param oldCategories old category types.
+   * @param newCategories drafts that need to be synced.
+   * @return a {@link CompletionStage} which contains an empty result after execution of the update
+   */
+  @Nonnull
+  private CompletionStage<Void> syncOrKeepTrack(
+      @Nonnull final Set<CategoryDraft> newCategories,
+      @Nonnull final Set<Category> oldCategories,
+      @Nonnull final Map<String, String> keyToIdCache) {
+
+    return allOf(
+        newCategories.stream()
+            .map(
+                newDraft -> {
+                  final Optional<String> missingReferencedParentCategoryKey =
+                      getMissingReferencedParentCategoryKey(newDraft, keyToIdCache);
+
+                  if (missingReferencedParentCategoryKey.isPresent()) {
+                    return keepTrackOfMissingReference(
+                        newDraft, missingReferencedParentCategoryKey.get());
+                  } else {
+                    return syncDraft(oldCategories, newDraft);
+                  }
+                })
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+  }
+
+  private Optional<String> getMissingReferencedParentCategoryKey(
+      @Nonnull final CategoryDraft newCategory, @Nonnull final Map<String, String> keyToIdCache) {
+
+    final String parentCategoryKey =
+        Optional.ofNullable(newCategory.getParent()).map(ResourceIdentifier::getKey).orElse(null);
+
+    if (StringUtils.isBlank(parentCategoryKey) || keyToIdCache.containsKey(parentCategoryKey)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(parentCategoryKey);
+  }
+
+  private CompletionStage<Optional<WaitingToBeResolvedCategories>> keepTrackOfMissingReference(
+      @Nonnull final CategoryDraft newCategory, @Nonnull final String parentCategoryKey) {
+
+    statistics.addMissingDependency(parentCategoryKey, newCategory.getKey());
+    return unresolvedReferencesService.save(
+        new WaitingToBeResolvedCategories(newCategory, Collections.singleton(parentCategoryKey)),
+        CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+        WaitingToBeResolvedCategories.class);
+  }
+
+  @Nonnull
+  private CompletionStage<Void> syncDraft(
+      @Nonnull final Set<Category> oldCategories, @Nonnull final CategoryDraft newCategory) {
+
+    final Map<String, Category> oldCategoryMap =
+        oldCategories.stream().collect(toMap(Category::getKey, identity()));
+
+    return referenceResolver
+        .resolveReferences(newCategory)
+        .thenCompose(
+            resolvedDraft -> {
+              final Category oldCategory = oldCategoryMap.get(newCategory.getKey());
+
+              if (oldCategory != null) {
+                return fetchAndUpdate(oldCategory, resolvedDraft);
+              } else {
+                return applyCallbackAndCreate(resolvedDraft);
+              }
+            })
+        .exceptionally(
+            completionException -> {
+              final String errorMessage =
+                  format(FAILED_TO_PROCESS, newCategory.getKey(), completionException.getMessage());
+              handleError(errorMessage, completionException, null, newCategory, null, 1);
+              return null;
+            });
+  }
+
+  @Nonnull
+  private CompletionStage<Void> applyCallbackAndCreate(@Nonnull final CategoryDraft categoryDraft) {
+    return syncOptions
+        .applyBeforeCreateCallback(categoryDraft)
+        .map(
+            draft ->
+                categoryService
+                    .createCategory(draft)
+                    .thenAccept(
+                        categoryOptional -> {
+                          if (categoryOptional.isPresent()) {
+                            readyToResolve.add(categoryDraft.getKey());
+                            statistics.incrementCreated();
+                          } else {
+                            statistics.incrementFailed();
+                          }
+                        }))
+        .orElse(completedFuture(null));
+  }
+
+  @Nonnull
+  private CompletionStage<Void> fetchAndUpdate(
+      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
+
+    String key = oldCategory.getKey();
+    return categoryService
+        .fetchCategory(key)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchResponse -> {
+              Optional<Category> fetchedCategoryOptional = fetchResponse.getKey();
+              final Throwable exception = fetchResponse.getValue();
+
+              if (exception != null) {
+                final String errorMessage =
+                    format(
+                        FAILED_TO_FETCH,
+                        key,
+                        "Failed to fetch from CTP while retrying after concurrency modification.");
+                handleError(errorMessage, exception, oldCategory, newCategory, null, 1);
+                return completedFuture(null);
+              }
+
+              if (requiresChangeParentUpdateAction(oldCategory, newCategory)) {
+                categoryDraftsToUpdateSequentially.putIfAbsent(newCategory, oldCategory);
+                return completedFuture(null);
+              }
+
+              return fetchedCategoryOptional
+                  .map(fetchedCategory -> buildUpdateActionsAndUpdate(fetchedCategory, newCategory))
+                  .orElseGet(
+                      () -> {
+                        final String errorMessage =
+                            format(
+                                UPDATE_FAILED,
+                                key,
+                                "Not found when attempting to fetch while retrying "
+                                    + "after concurrency modification.");
+                        handleError(errorMessage, null, oldCategory, newCategory, null, 1);
+                        return completedFuture(null);
+                      });
+            });
+  }
+
+  /**
+   * Compares the parent references of a {@link Category} and a {@link CategoryDraft} to check
+   * whether a {@link com.commercetools.api.models.category.CategoryChangeParentAction} update action is
+   * required to sync the draft to the category or not
+   *
+   * @param category the old category to sync to.
+   * @param categoryDraft the new category draft to sync.
+   * @return true or false whether a {@link
+   *     com.commercetools.api.models.category.CategoryChangeParentAction} is needed to sync the draft
+   *     to the category.
+   */
+  static boolean requiresChangeParentUpdateAction(
+      @Nonnull final Category category, @Nonnull final CategoryDraft categoryDraft) {
+    return !areResourceIdentifiersEqual(category.getParent(), categoryDraft.getParent());
+  }
+
+  private CompletionStage<Void> updateCategory(
+      @Nonnull final Category oldCategory,
+      @Nonnull final CategoryDraft newCategory,
+      @Nonnull final List<CategoryUpdateAction
+              > updateActions) {
+    final String categoryKey = oldCategory.getKey();
+    return categoryService
+        .updateCategory(oldCategory, updateActions)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            updateResponse -> {
+              final Throwable sphereException = updateResponse.getValue();
+
+              if (sphereException != null) {
+                return executeSupplierIfConcurrentModificationException(
+                    sphereException,
+                    () -> fetchAndUpdate(oldCategory, newCategory),
+                    () -> {
+                      final String errorMessage =
+                          format(UPDATE_FAILED, categoryKey, sphereException.getMessage());
+                      handleError(
+                          errorMessage,
+                          sphereException,
+                          oldCategory,
+                          newCategory,
+                          updateActions,
+                          1);
+
+                      categoryDraftsToUpdateSequentially.remove(newCategory);
+                      return completedFuture(null);
+                    });
+              } else {
+                categoryDraftsToUpdateSequentially.remove(newCategory);
+                statistics.incrementUpdated();
+                return completedFuture(null);
+              }
+            });
+  }
+
+  @Nonnull
+  private CompletionStage<Void> resolveNowReadyReferences(
+      @Nonnull final Map<String, String> keyToIdCache) {
+
+    final Set<String> referencingDraftKeys =
+        readyToResolve.stream()
+            .map(statistics::getChildrenKeys)
+            .filter(Objects::nonNull)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+
+    if (referencingDraftKeys.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final Set<CategoryDraft> readyToSync = new HashSet<>();
+
+    return unresolvedReferencesService
+        .fetch(
+            referencingDraftKeys,
+            CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+            WaitingToBeResolvedCategories.class)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchResponse -> {
+              final Set<WaitingToBeResolvedCategories> waitingDrafts = fetchResponse.getKey();
+              final Throwable fetchException = fetchResponse.getValue();
+
+              if (fetchException != null) {
+                final String errorMessage =
+                    format(FAILED_TO_FETCH_WAITING_DRAFTS, referencingDraftKeys);
+                handleError(
+                    errorMessage, fetchException, null, null, null, referencingDraftKeys.size());
+                return CompletableFuture.completedFuture(null);
+              }
+
+              waitingDrafts.forEach(
+                  waitingDraft -> {
+                    waitingDraft
+                        .getMissingReferencedCategoriesKeys()
+                        .forEach(
+                            parentKey -> {
+                              statistics.removeChildCategoryKeyFromMissingParentsMap(
+                                  parentKey, waitingDraft.getKey());
+                            });
+                    readyToSync.add(waitingDraft.getCategoryDraft());
+                  });
+
+              return syncBatch(readyToSync, keyToIdCache)
+                  .thenCompose(aVoid -> removeFromWaiting(readyToSync));
+            });
+  }
+
+  @Nonnull
+  private CompletableFuture<Void> removeFromWaiting(@Nonnull final Set<CategoryDraft> drafts) {
+    return allOf(
+        drafts.stream()
+            .map(CategoryDraft::getKey)
+            .map(
+                key ->
+                    unresolvedReferencesService.delete(
+                        key,
+                        CUSTOM_OBJECT_CATEGORY_CONTAINER_KEY,
+                        WaitingToBeResolvedCategories.class))
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+  }
+
+  private CompletionStage<Void> buildUpdateActionsAndUpdate(
+      @Nonnull final Category oldCategory, @Nonnull final CategoryDraft newCategory) {
+
+    final List<CategoryUpdateAction> updateActions =
+        buildActions(oldCategory, newCategory, syncOptions);
+
+    final List<CategoryUpdateAction> beforeUpdateCallBackApplied =
+        syncOptions.applyBeforeUpdateCallback(updateActions, newCategory, oldCategory);
+
+    if (!beforeUpdateCallBackApplied.isEmpty()) {
+      return updateCategory(oldCategory, newCategory, beforeUpdateCallBackApplied);
+    }
+
+    return completedFuture(null);
+  }
+
+  /**
+   * Given a {@link Map} of categoryDrafts to Categories that require syncing, this method updates
+   * only categories which need a {@link
+   * com.commercetools.api.models.category.CategoryChangeParentAction} update action, and in turn
+   * performs the sync on them in a sequential/blocking fashion as advised by the CTP documentation:
+   * https://docs.commercetools.com/api/projects/categories#change-parent
+   *
+   * @param matchingCategories a {@link Map} of categoryDrafts to Categories that require syncing.
+   */
+  private CompletableFuture<Void> updateCategoriesSequentially(
+      @Nonnull final Map<CategoryDraft, Category> matchingCategories) {
+    matchingCategories.entrySet().stream()
+        .map(entry -> buildUpdateActionsAndUpdate(entry.getValue(), entry.getKey()))
+        .map(CompletionStage::toCompletableFuture)
+        .forEach(CompletableFuture::join);
+    return completedFuture(null);
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/CategorySync.java
@@ -349,22 +349,17 @@ public class CategorySync
         .handle(ImmutablePair::new)
         .thenCompose(
             updateResponse -> {
-              final Throwable sphereException = updateResponse.getValue();
+              final Throwable ctpException = updateResponse.getValue();
 
-              if (sphereException != null) {
+              if (ctpException != null) {
                 return executeSupplierIfConcurrentModificationException(
-                    sphereException,
+                    ctpException,
                     () -> fetchAndUpdate(oldCategory, newCategory),
                     () -> {
                       final String errorMessage =
-                          format(UPDATE_FAILED, categoryKey, sphereException.getMessage());
+                          format(UPDATE_FAILED, categoryKey, ctpException.getMessage());
                       handleError(
-                          errorMessage,
-                          sphereException,
-                          oldCategory,
-                          newCategory,
-                          updateActions,
-                          1);
+                          errorMessage, ctpException, oldCategory, newCategory, updateActions, 1);
 
                       categoryDraftsToUpdateSequentially.remove(newCategory);
                       return completedFuture(null);

--- a/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidator.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryBatchValidator.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class CategoryBatchValidator
     extends BaseBatchValidator<CategoryDraft, CategorySyncOptions, CategorySyncStatistics> {
 
-  static final String CATEGORY_DRAFT_KEY_NOT_SET =
+  public static final String CATEGORY_DRAFT_KEY_NOT_SET =
       "CategoryDraft with name: %s doesn't have a key. "
           + "Please make sure all category drafts have keys.";
   static final String CATEGORY_DRAFT_IS_NULL = "CategoryDraft is null.";

--- a/src/main/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategories.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategories.java
@@ -1,10 +1,9 @@
 package com.commercetools.sync.sdk2.commons.models;
 
 import com.commercetools.api.models.category.CategoryDraft;
-
-import javax.annotation.Nonnull;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 public final class WaitingToBeResolvedCategories implements WaitingToBeResolved {
   private CategoryDraft categoryDraft;

--- a/src/main/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategories.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategories.java
@@ -1,0 +1,62 @@
+package com.commercetools.sync.sdk2.commons.models;
+
+import com.commercetools.api.models.category.CategoryDraft;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.Set;
+
+public final class WaitingToBeResolvedCategories implements WaitingToBeResolved {
+  private CategoryDraft categoryDraft;
+  private Set<String> missingReferencedCategoriesKeys;
+
+  public Set<String> getMissingReferencedCategoriesKeys() {
+    return missingReferencedCategoriesKeys;
+  }
+
+  public void setMissingReferencedCategoriesKeys(Set<String> missingReferencedCategoriesKeys) {
+    this.missingReferencedCategoriesKeys = missingReferencedCategoriesKeys;
+  }
+
+  // Needed for the 'com.fasterxml.jackson' deserialization, for example, when fetching
+  // from CTP custom objects.
+  public WaitingToBeResolvedCategories() {}
+
+  public WaitingToBeResolvedCategories(
+      @Nonnull final CategoryDraft draft,
+      @Nonnull final Set<String> missingReferencedCategoriesKeys) {
+    this.categoryDraft = draft;
+    this.setMissingReferencedCategoriesKeys(missingReferencedCategoriesKeys);
+  }
+
+  public void setCategoryDraft(@Nonnull final CategoryDraft draft) {
+    categoryDraft = draft;
+  }
+
+  public CategoryDraft getCategoryDraft() {
+    return categoryDraft;
+  }
+
+  @Override
+  public String getKey() {
+    return getCategoryDraft().getKey();
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof WaitingToBeResolvedCategories)) {
+      return false;
+    }
+    final WaitingToBeResolvedCategories that = (WaitingToBeResolvedCategories) other;
+    return Objects.equals(getCategoryDraft().getKey(), that.getCategoryDraft().getKey())
+        && getMissingReferencedCategoriesKeys().equals(that.getMissingReferencedCategoriesKeys());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getCategoryDraft().getKey(), getMissingReferencedCategoriesKeys());
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
@@ -499,7 +499,7 @@ public final class CustomUpdateActionUtils {
             newCustomFieldName -> {
               final Object newCustomFieldValue = newCustomFields.get(newCustomFieldName);
               final Object oldCustomFieldValue = oldCustomFields.get(newCustomFieldName);
-
+              // TODO: This comparison doesn't work when newFieldValue is passed as JSON string.
               return !isNullJsonValue(newCustomFieldValue)
                   && !Objects.equals(newCustomFieldValue, oldCustomFieldValue);
             })

--- a/src/main/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImpl.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
 
 import com.commercetools.api.client.ByProjectKeyCustomObjectsByContainerGet;
+import com.commercetools.api.models.custom_object.CustomObject;
 import com.commercetools.api.models.custom_object.CustomObjectDraft;
 import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
 import com.commercetools.sync.sdk2.commons.BaseSyncOptions;
@@ -15,7 +16,6 @@ import com.commercetools.sync.sdk2.commons.utils.ChunkUtils;
 import com.commercetools.sync.sdk2.services.UnresolvedReferencesService;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vrap.rmf.base.client.ApiHttpResponse;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -120,11 +120,12 @@ public class UnresolvedReferencesServiceImpl<WaitingToBeResolvedT extends Waitin
         .customObjects()
         .post(customObjectDraft)
         .execute()
-        .thenApply(ApiHttpResponse::getBody)
         .handle(
             (resource, exception) -> {
               if (exception == null) {
-                return Optional.of(OBJECT_MAPPER.convertValue(resource.getValue(), clazz));
+                final CustomObject customObject = resource.getBody();
+                return Optional.ofNullable(customObject)
+                    .map(co -> OBJECT_MAPPER.convertValue(co.getValue(), clazz));
               } else {
                 syncOptions.applyErrorCallback(
                     new SyncException(

--- a/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncMockUtils.java
@@ -71,10 +71,12 @@ public class CategorySyncMockUtils {
     return category;
   }
 
-  public static Category getMockCategory(@Nonnull final String id, @Nonnull final String key) {
+  public static Category getMockCategory(@Nonnull final String id, @Nonnull final String key, @Nonnull String name, @Nonnull String slug, @Nonnull Locale locale) {
     final Category category = mock(Category.class);
     when(category.getKey()).thenReturn(key);
     when(category.getId()).thenReturn(id);
+    when(category.getName()).thenReturn(LocalizedString.of(locale, name));
+    when(category.getSlug()).thenReturn(LocalizedString.of(locale, slug));
     when(category.toReference()).thenReturn(CategoryReferenceBuilder.of().id(id).build());
     return category;
   }
@@ -240,5 +242,20 @@ public class CategorySyncMockUtils {
                         typeResourceIdentifierBuilder.key(customTypeKey))
                 .fields(fieldContainerBuilder -> fieldContainerBuilder.values(customFields))
                 .build());
+  }
+
+  public static CategoryDraft getCategoryDraftFromCategory(
+          @Nonnull final Category category) {
+    return CategoryDraftBuilder.of()
+            .key(category.getKey())
+            .name(category.getName())
+            .slug(category.getSlug())
+            .externalId(category.getExternalId())
+            .description(category.getDescription())
+            .metaDescription(category.getMetaDescription())
+            .metaTitle(category.getMetaTitle())
+            .metaKeywords(category.getMetaKeywords())
+            .orderHint(category.getOrderHint())
+            .build();
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncMockUtils.java
@@ -71,7 +71,12 @@ public class CategorySyncMockUtils {
     return category;
   }
 
-  public static Category getMockCategory(@Nonnull final String id, @Nonnull final String key, @Nonnull String name, @Nonnull String slug, @Nonnull Locale locale) {
+  public static Category getMockCategory(
+      @Nonnull final String id,
+      @Nonnull final String key,
+      @Nonnull String name,
+      @Nonnull String slug,
+      @Nonnull Locale locale) {
     final Category category = mock(Category.class);
     when(category.getKey()).thenReturn(key);
     when(category.getId()).thenReturn(id);
@@ -244,18 +249,17 @@ public class CategorySyncMockUtils {
                 .build());
   }
 
-  public static CategoryDraft getCategoryDraftFromCategory(
-          @Nonnull final Category category) {
+  public static CategoryDraft getCategoryDraftFromCategory(@Nonnull final Category category) {
     return CategoryDraftBuilder.of()
-            .key(category.getKey())
-            .name(category.getName())
-            .slug(category.getSlug())
-            .externalId(category.getExternalId())
-            .description(category.getDescription())
-            .metaDescription(category.getMetaDescription())
-            .metaTitle(category.getMetaTitle())
-            .metaKeywords(category.getMetaKeywords())
-            .orderHint(category.getOrderHint())
-            .build();
+        .key(category.getKey())
+        .name(category.getName())
+        .slug(category.getSlug())
+        .externalId(category.getExternalId())
+        .description(category.getDescription())
+        .metaDescription(category.getMetaDescription())
+        .metaTitle(category.getMetaTitle())
+        .metaKeywords(category.getMetaKeywords())
+        .orderHint(category.getOrderHint())
+        .build();
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
@@ -61,7 +61,8 @@ class CategorySyncTest {
   private CategorySyncOptions categorySyncOptions;
   private List<String> errorCallBackMessages;
   private List<Throwable> errorCallBackExceptions;
-  private UnresolvedReferencesService mockUnresolvedReferencesService;
+  private UnresolvedReferencesService<WaitingToBeResolvedCategories>
+      mockUnresolvedReferencesService;
 
   // protected method access helper
   private static class CategorySyncMock extends CategorySync {
@@ -69,7 +70,9 @@ class CategorySyncTest {
         @Nonnull final CategorySyncOptions syncOptions,
         @Nonnull final TypeService typeService,
         @Nonnull final CategoryService categoryService,
-        @Nonnull final UnresolvedReferencesService unresolvedReferencesService) {
+        @Nonnull
+            final UnresolvedReferencesService<WaitingToBeResolvedCategories>
+                unresolvedReferencesService) {
       super(syncOptions, typeService, categoryService, unresolvedReferencesService);
     }
 

--- a/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
@@ -1,44 +1,15 @@
 package com.commercetools.sync.sdk2.categories;
 
-import com.commercetools.api.client.ByProjectKeyGraphqlPost;
-import com.commercetools.api.models.category.*;
-import com.commercetools.api.models.graph_ql.GraphQLRequest;
-import com.commercetools.api.models.graph_ql.GraphQLResponse;
-import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
-import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
-import com.commercetools.sync.commons.models.ResourceKeyId;
-import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
-import com.commercetools.sync.sdk2.commons.exceptions.ReferenceResolutionException;
-import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedCategories;
-import com.commercetools.sync.sdk2.services.*;
-import com.commercetools.sync.sdk2.services.impl.CategoryServiceImpl;
-import com.commercetools.api.client.ProjectApiRoot;
-import com.commercetools.api.models.common.LocalizedString;
-import io.vrap.rmf.base.client.ApiHttpException;
-import io.vrap.rmf.base.client.ApiHttpHeaders;
-import io.vrap.rmf.base.client.ApiHttpResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import javax.annotation.Nonnull;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.getMockCategory;
+import static com.commercetools.sync.products.ProductSyncMockUtils.CATEGORY_KEY_1_RESOURCE_PATH;
 import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.*;
+import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.getMockCategory;
 import static com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.CATEGORY_DRAFT_KEY_NOT_SET;
 import static com.commercetools.sync.sdk2.commons.MockUtils.getMockTypeService;
 import static com.commercetools.sync.sdk2.commons.MockUtils.mockCategoryService;
 import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.sdk2.commons.helpers.BaseReferenceResolver.BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER;
-import static com.commercetools.sync.products.ProductSyncMockUtils.CATEGORY_KEY_1_RESOURCE_PATH;
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.mockGraphQLResponse;
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.readObjectFromResource;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.mockGraphQLResponse;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.readObjectFromResource;
 import static java.lang.String.format;
 import static java.util.Collections.*;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -50,6 +21,33 @@ import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.*;
+
+import com.commercetools.api.client.ByProjectKeyGraphqlPost;
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.category.*;
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.graph_ql.GraphQLRequest;
+import com.commercetools.api.models.graph_ql.GraphQLResponse;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.sdk2.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedCategories;
+import com.commercetools.sync.sdk2.services.*;
+import com.commercetools.sync.sdk2.services.impl.CategoryServiceImpl;
+import io.vrap.rmf.base.client.ApiHttpException;
+import io.vrap.rmf.base.client.ApiHttpHeaders;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @SuppressWarnings("unchecked")
 class CategorySyncTest {
@@ -150,9 +148,9 @@ class CategorySyncTest {
             getMockTypeService(),
             mockCategoryService,
             mockUnresolvedReferencesService);
-    final CategoryDraft categoryDraft = getMockCategoryDraft(Locale.ENGLISH, "noKeyDraft", "no-key-id-draft", null);
-    final List<CategoryDraft> categoryDrafts =
-        singletonList(categoryDraft);
+    final CategoryDraft categoryDraft =
+        getMockCategoryDraft(Locale.ENGLISH, "noKeyDraft", "no-key-id-draft", null);
+    final List<CategoryDraft> categoryDrafts = singletonList(categoryDraft);
 
     final CategorySyncStatistics syncStatistics =
         mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
@@ -167,8 +165,11 @@ class CategorySyncTest {
 
   @Test
   void sync_WithNoExistingCategory_ShouldCreateCategory() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "newKey", "name", "slug", Locale.ENGLISH);
-    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "newKey", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory =
+        getMockCategory(
+            UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
     final CategoryService mockCategoryService =
         mockCategoryService(singleton(mockParentCategory), mockCategory);
     when(mockCategoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
@@ -194,8 +195,11 @@ class CategorySyncTest {
 
   @Test
   void sync_WithErrorOnFetchingUnresolvableCategory_ShouldNotCreateCategory() {
-    final Category mockRootCategory = getMockCategory(UUID.randomUUID().toString(), "root", "name", "slug", Locale.ENGLISH);
-    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final Category mockRootCategory =
+        getMockCategory(UUID.randomUUID().toString(), "root", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory =
+        getMockCategory(
+            UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
     final CategoryService mockCategoryService =
         mockCategoryService(Collections.singleton(mockRootCategory), mockParentCategory);
 
@@ -233,8 +237,11 @@ class CategorySyncTest {
 
   @Test
   void sync_WithExistingCategory_ShouldUpdateCategory() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
-    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory =
+        getMockCategory(
+            UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
     HashSet<Category> existingCategories = new HashSet<>();
     existingCategories.add(mockCategory);
     existingCategories.add(mockParentCategory);
@@ -267,7 +274,8 @@ class CategorySyncTest {
   @Test
   void sync_WithIdenticalExistingCategory_ShouldNotUpdateCategory() {
     final String categoryKey = "key";
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), categoryKey, "name", "slug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), categoryKey, "name", "slug", Locale.ENGLISH);
     final CategoryDraft identicalCategoryDraft = getCategoryDraftFromCategory(mockCategory);
     final CategoryService mockCategoryService =
         mockCategoryService(singleton(mockCategory), null, mockCategory);
@@ -292,7 +300,8 @@ class CategorySyncTest {
 
   @Test
   void sync_WithExistingCategoryButWithNullParentReference_ShouldFailSync() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
     final CategoryService mockCategoryService =
         mockCategoryService(singleton(mockCategory), null, mockCategory);
     final CategorySync categorySync =
@@ -317,7 +326,8 @@ class CategorySyncTest {
 
   @Test
   void sync_WithExistingCategoryButWithNoCustomType_ShouldSync() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
     final CategoryService mockCategoryService =
         mockCategoryService(singleton(mockCategory), null, mockCategory);
     when(mockCategoryService.fetchCategory(Mockito.eq("key")))
@@ -348,7 +358,8 @@ class CategorySyncTest {
 
   @Test
   void sync_WithExistingCategoryButWithEmptyParentReference_ShouldFailSync() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
     final CategoryService mockCategoryService =
         mockCategoryService(singleton(mockCategory), null, mockCategory);
     when(mockCategoryService.fetchCategory(Mockito.eq("key")))
@@ -375,8 +386,11 @@ class CategorySyncTest {
 
   @Test
   void sync_WithExistingCategoryButWithEmptyCustomTypeReference_ShouldFailSync() {
-    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
-    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final Category mockCategory =
+        getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory =
+        getMockCategory(
+            UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
     Set<Category> existingCategories = new HashSet<>();
     existingCategories.add(mockCategory);
     existingCategories.add(mockParentCategory);
@@ -438,11 +452,11 @@ class CategorySyncTest {
     when(category.getParent()).thenReturn(CategoryReferenceBuilder.of().id(parentId).build());
 
     final CategoryDraft categoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "name"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
-                    .parent(CategoryResourceIdentifierBuilder.of().id(parentId).key(parentKey).build())
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .parent(CategoryResourceIdentifierBuilder.of().id(parentId).key(parentKey).build())
+            .build();
 
     // checking with ids (on draft reference id will be resolved, but in test it's given)
     final boolean doesRequire =
@@ -456,10 +470,10 @@ class CategorySyncTest {
     when(category.getParent()).thenReturn(null);
 
     final CategoryDraft categoryDraft =
-            CategoryDraftBuilder.of()
-                    .name(LocalizedString.of(Locale.ENGLISH, "name"))
-                    .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
-                    .build();
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .build();
     final boolean doesRequire =
         CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
     assertThat(doesRequire).isFalse();
@@ -481,7 +495,10 @@ class CategorySyncTest {
     final int numberOfCategoryDrafts = 160;
     final List<Category> mockedCreatedCategories =
         IntStream.range(0, numberOfCategoryDrafts)
-            .mapToObj(i -> getMockCategory(UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
+            .mapToObj(
+                i ->
+                    getMockCategory(
+                        UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
             .collect(Collectors.toList());
     final List<CategoryDraft> categoryDrafts =
         mockedCreatedCategories.stream()
@@ -518,7 +535,10 @@ class CategorySyncTest {
     final int numberOfCategoryDrafts = 160;
     final List<Category> mockedCreatedCategories =
         IntStream.range(0, numberOfCategoryDrafts)
-            .mapToObj(i -> getMockCategory(UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
+            .mapToObj(
+                i ->
+                    getMockCategory(
+                        UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
             .collect(Collectors.toList());
     final List<CategoryDraft> categoryDrafts =
         mockedCreatedCategories.stream()
@@ -563,11 +583,11 @@ class CategorySyncTest {
     final ByProjectKeyGraphqlPost byProjectKeyGraphqlPost = mock();
     when(mockClient.graphql().post(any(GraphQLRequest.class))).thenReturn(byProjectKeyGraphqlPost);
     when(byProjectKeyGraphqlPost.execute())
-            .thenReturn(
-                    supplyAsync(
-                            () -> {
-                              throw new ApiHttpException(500, "", new ApiHttpHeaders());
-                            }));
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new ApiHttpException(500, "", new ApiHttpHeaders());
+                }));
 
     final CategorySyncOptions syncOptions =
         CategorySyncOptionsBuilder.of(mockClient)
@@ -610,20 +630,23 @@ class CategorySyncTest {
   }
 
   @Test
-  void sync_WithFailOnFetchingCategories_ShouldTriggerErrorCallbackAndReturnProperStats() throws Exception {
+  void sync_WithFailOnFetchingCategories_ShouldTriggerErrorCallbackAndReturnProperStats()
+      throws Exception {
     // preparation
     final ProjectApiRoot mockClient = mock(ProjectApiRoot.class);
 
     final String categoryKey = "key";
-    final String categoryJsonResponse = "{ \"categories\": {\"results\":[{\"id\":\"foo\",\"key\":\"key\"}"
-            + "]}}";;
-    final ApiHttpResponse<GraphQLResponse> graphQLResponseApiHttpResponse = mockGraphQLResponse(categoryJsonResponse);
+    final String categoryJsonResponse =
+        "{ \"categories\": {\"results\":[{\"id\":\"foo\",\"key\":\"key\"}" + "]}}";
+    ;
+    final ApiHttpResponse<GraphQLResponse> graphQLResponseApiHttpResponse =
+        mockGraphQLResponse(categoryJsonResponse);
 
     when(mockClient.graphql()).thenReturn(mock());
     final ByProjectKeyGraphqlPost byProjectKeyGraphqlPost = mock();
     when(mockClient.graphql().post(any(GraphQLRequest.class))).thenReturn(byProjectKeyGraphqlPost);
     when(byProjectKeyGraphqlPost.execute())
-            .thenReturn(CompletableFuture.completedFuture(graphQLResponseApiHttpResponse));
+        .thenReturn(CompletableFuture.completedFuture(graphQLResponseApiHttpResponse));
 
     final CategorySyncOptions syncOptions =
         CategorySyncOptionsBuilder.of(mockClient)
@@ -634,14 +657,15 @@ class CategorySyncTest {
                 })
             .build();
 
-    final CategoryService categoryServiceSpy = mock(CategoryService.class);
+    final CategoryService categoryServiceSpy = spy(new CategoryServiceImpl(syncOptions));
 
-    when(categoryServiceSpy.fetchCategory(Mockito.eq(categoryKey)))
-            .thenReturn(
-                    supplyAsync(
-                            () -> { throw new RuntimeException("Error when fetching category"); }
-                    )
-            );
+    doReturn(
+            supplyAsync(
+                () -> {
+                  throw new RuntimeException("Error when fetching category");
+                }))
+        .when(categoryServiceSpy)
+        .fetchMatchingCategoriesByKeys(anySet());
 
     final CategorySync mockCategorySync =
         new CategorySync(
@@ -672,7 +696,7 @@ class CategorySyncTest {
     assertThat(errorCallBackExceptions)
         .hasSize(1)
         .singleElement(as(THROWABLE))
-        .hasCauseExactlyInstanceOf(ApiHttpException.class);
+        .hasCauseExactlyInstanceOf(RuntimeException.class);
   }
 
   @Test

--- a/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/CategorySyncTest.java
@@ -1,0 +1,761 @@
+package com.commercetools.sync.sdk2.categories;
+
+import com.commercetools.api.client.ByProjectKeyGraphqlPost;
+import com.commercetools.api.models.category.*;
+import com.commercetools.api.models.graph_ql.GraphQLRequest;
+import com.commercetools.api.models.graph_ql.GraphQLResponse;
+import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
+import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.sync.commons.models.ResourceKeyId;
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
+import com.commercetools.sync.sdk2.commons.exceptions.ReferenceResolutionException;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedCategories;
+import com.commercetools.sync.sdk2.services.*;
+import com.commercetools.sync.sdk2.services.impl.CategoryServiceImpl;
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.common.LocalizedString;
+import io.vrap.rmf.base.client.ApiHttpException;
+import io.vrap.rmf.base.client.ApiHttpHeaders;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.getMockCategory;
+import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.*;
+import static com.commercetools.sync.sdk2.categories.helpers.CategoryBatchValidator.CATEGORY_DRAFT_KEY_NOT_SET;
+import static com.commercetools.sync.sdk2.commons.MockUtils.getMockTypeService;
+import static com.commercetools.sync.sdk2.commons.MockUtils.mockCategoryService;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.sdk2.commons.helpers.BaseReferenceResolver.BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER;
+import static com.commercetools.sync.products.ProductSyncMockUtils.CATEGORY_KEY_1_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.mockGraphQLResponse;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.readObjectFromResource;
+import static java.lang.String.format;
+import static java.util.Collections.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class CategorySyncTest {
+  private CategorySyncOptions categorySyncOptions;
+  private List<String> errorCallBackMessages;
+  private List<Throwable> errorCallBackExceptions;
+  private UnresolvedReferencesService mockUnresolvedReferencesService;
+
+  // protected method access helper
+  private static class CategorySyncMock extends CategorySync {
+    CategorySyncMock(
+        @Nonnull final CategorySyncOptions syncOptions,
+        @Nonnull final TypeService typeService,
+        @Nonnull final CategoryService categoryService,
+        @Nonnull final UnresolvedReferencesService unresolvedReferencesService) {
+      super(syncOptions, typeService, categoryService, unresolvedReferencesService);
+    }
+
+    @Override
+    protected CompletionStage<CategorySyncStatistics> syncBatches(
+        @Nonnull final List<List<CategoryDraft>> batches,
+        @Nonnull final CompletionStage<CategorySyncStatistics> result) {
+      return super.syncBatches(batches, result);
+    }
+  }
+
+  /**
+   * Initializes instances of {@link CategorySyncOptions} and {@link CategorySync} which will be
+   * used by some of the unit test methods in this test class.
+   */
+  @BeforeEach
+  void setup() {
+    errorCallBackMessages = new ArrayList<>();
+    errorCallBackExceptions = new ArrayList<>();
+    mockUnresolvedReferencesService = mock(UnresolvedReferencesService.class);
+    final ProjectApiRoot ctpClient = mock(ProjectApiRoot.class);
+    categorySyncOptions =
+        CategorySyncOptionsBuilder.of(ctpClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    when(mockUnresolvedReferencesService.save(any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+    when(mockUnresolvedReferencesService.fetch(any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(emptySet()));
+    when(mockUnresolvedReferencesService.delete(any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+  }
+
+  @Test
+  void sync_WithEmptyListOfDrafts_ShouldNotProcessAnyCategories() {
+    final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(emptyList()).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(0, 0, 0, 0);
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(errorCallBackExceptions).isEmpty();
+  }
+
+  @Test
+  void sync_WithANullDraft_ShouldBeCountedAsFailed() {
+    final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(singletonList(null)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0)).isEqualTo("CategoryDraft is null.");
+    assertThat(errorCallBackExceptions).hasSize(1);
+    assertThat(errorCallBackExceptions.get(0)).isEqualTo(null);
+  }
+
+  @Test
+  void sync_WithADraftWithNoSetKey_ShouldFailSync() {
+    final CategoryService mockCategoryService = mockCategoryService(emptySet(), null);
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final CategoryDraft categoryDraft = getMockCategoryDraft(Locale.ENGLISH, "noKeyDraft", "no-key-id-draft", null);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(categoryDraft);
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(format(CATEGORY_DRAFT_KEY_NOT_SET, categoryDraft.getName()));
+    assertThat(errorCallBackExceptions).hasSize(1);
+    assertThat(errorCallBackExceptions.get(0)).isEqualTo(null);
+  }
+
+  @Test
+  void sync_WithNoExistingCategory_ShouldCreateCategory() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "newKey", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final CategoryService mockCategoryService =
+        mockCategoryService(singleton(mockParentCategory), mockCategory);
+    when(mockCategoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of("parentId")));
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(
+            getMockCategoryDraft(
+                Locale.ENGLISH, "name", "newKey", "parentKey", "customTypeId", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0);
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+  }
+
+  @Test
+  void sync_WithErrorOnFetchingUnresolvableCategory_ShouldNotCreateCategory() {
+    final Category mockRootCategory = getMockCategory(UUID.randomUUID().toString(), "root", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    final CategoryService mockCategoryService =
+        mockCategoryService(Collections.singleton(mockRootCategory), mockParentCategory);
+
+    when(mockCategoryService.fetchCachedCategoryId(Mockito.eq("root")))
+        .thenReturn(completedFuture(Optional.of("rootID")));
+    final CompletableFuture<Set<WaitingToBeResolvedCategories>> futureThrowingSphereException =
+        new CompletableFuture<>();
+    futureThrowingSphereException.completeExceptionally(new RuntimeException("CTP error on fetch"));
+    when(mockUnresolvedReferencesService.fetch(any(), any(), any()))
+        .thenReturn(futureThrowingSphereException);
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts = new ArrayList<>();
+    categoryDrafts.add(
+        getMockCategoryDraft(
+            Locale.ENGLISH, "name", "child", "parentKey", "customTypeId", new HashMap<>()));
+    categoryDrafts.add(
+        getMockCategoryDraft(
+            Locale.ENGLISH, "name", "parentKey", "root", "customTypeId", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 1, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackExceptions).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(
+            "Failed to fetch CategoryDraft waiting to be resolved with parent keys: '[child]'.");
+  }
+
+  @Test
+  void sync_WithExistingCategory_ShouldUpdateCategory() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    HashSet<Category> existingCategories = new HashSet<>();
+    existingCategories.add(mockCategory);
+    existingCategories.add(mockParentCategory);
+    final CategoryService mockCategoryService =
+        mockCategoryService(existingCategories, null, mockCategory);
+    when(mockCategoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of("parentId")));
+    when(mockCategoryService.fetchCategory(Mockito.eq("key")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(mockCategory)));
+
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(
+            getMockCategoryDraft(
+                Locale.ENGLISH, "name", "key", "parentKey", "customTypeId", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+  }
+
+  @Test
+  void sync_WithIdenticalExistingCategory_ShouldNotUpdateCategory() {
+    final String categoryKey = "key";
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), categoryKey, "name", "slug", Locale.ENGLISH);
+    final CategoryDraft identicalCategoryDraft = getCategoryDraftFromCategory(mockCategory);
+    final CategoryService mockCategoryService =
+        mockCategoryService(singleton(mockCategory), null, mockCategory);
+    when(mockCategoryService.fetchCategory(Mockito.eq(categoryKey)))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(mockCategory)));
+
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts = singletonList(identicalCategoryDraft);
+
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0);
+  }
+
+  @Test
+  void sync_WithExistingCategoryButWithNullParentReference_ShouldFailSync() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final CategoryService mockCategoryService =
+        mockCategoryService(singleton(mockCategory), null, mockCategory);
+    final CategorySync categorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(
+            getMockCategoryDraft(
+                Locale.ENGLISH, "name", "key", null, "customTypeId", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0)).contains(BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER);
+    assertThat(errorCallBackExceptions).hasSize(1);
+  }
+
+  @Test
+  void sync_WithExistingCategoryButWithNoCustomType_ShouldSync() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final CategoryService mockCategoryService =
+        mockCategoryService(singleton(mockCategory), null, mockCategory);
+    when(mockCategoryService.fetchCategory(Mockito.eq("key")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(mockCategory)));
+
+    final CategorySync categorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+
+    final CategoryDraft categoryDraft = mock(CategoryDraft.class);
+    when(categoryDraft.getName()).thenReturn(LocalizedString.of(Locale.ENGLISH, "new-name"));
+    when(categoryDraft.getKey()).thenReturn("key");
+    when(categoryDraft.getSlug()).thenReturn(LocalizedString.of(Locale.ENGLISH, "slug"));
+    when(categoryDraft.getCustom()).thenReturn(null);
+
+    final List<CategoryDraft> categoryDrafts = singletonList(categoryDraft);
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0);
+  }
+
+  @Test
+  void sync_WithExistingCategoryButWithEmptyParentReference_ShouldFailSync() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final CategoryService mockCategoryService =
+        mockCategoryService(singleton(mockCategory), null, mockCategory);
+    when(mockCategoryService.fetchCategory(Mockito.eq("key")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(mockCategory)));
+    final CategorySync categorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(
+            getMockCategoryDraft(
+                Locale.ENGLISH, "name", "key", "", "customTypeId", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0)).contains(BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER);
+    assertThat(errorCallBackExceptions).hasSize(1);
+  }
+
+  @Test
+  void sync_WithExistingCategoryButWithEmptyCustomTypeReference_ShouldFailSync() {
+    final Category mockCategory = getMockCategory(UUID.randomUUID().toString(), "key", "name", "slug", Locale.ENGLISH);
+    final Category mockParentCategory = getMockCategory(UUID.randomUUID().toString(), "parentKey", "parentName", "parentSlug", Locale.ENGLISH);
+    Set<Category> existingCategories = new HashSet<>();
+    existingCategories.add(mockCategory);
+    existingCategories.add(mockParentCategory);
+    final CategoryService mockCategoryService =
+        mockCategoryService(existingCategories, null, mockCategory);
+    when(mockCategoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of("parentId")));
+    final CategorySync categorySync =
+        new CategorySync(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final List<CategoryDraft> categoryDrafts =
+        singletonList(
+            getMockCategoryDraft(Locale.ENGLISH, "name", "key", "parentKey", "", new HashMap<>()));
+
+    final CategorySyncStatistics syncStatistics =
+        categorySync.sync(categoryDrafts).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0))
+        .isEqualTo(
+            format(
+                "Failed to process the CategoryDraft with"
+                    + " key: 'key'. Reason: %s: Failed to resolve custom type reference on CategoryDraft "
+                    + "with key:'key'. Reason: %s",
+                ReferenceResolutionException.class.getCanonicalName(),
+                BLANK_KEY_VALUE_ON_RESOURCE_IDENTIFIER));
+    assertThat(errorCallBackExceptions).hasSize(1);
+    assertThat(errorCallBackExceptions.get(0)).isExactlyInstanceOf(CompletionException.class);
+    assertThat(errorCallBackExceptions.get(0).getCause())
+        .isExactlyInstanceOf(ReferenceResolutionException.class);
+  }
+
+  @Test
+  void requiresChangeParentUpdateAction_WithTwoDifferentParents_ShouldReturnTrue() {
+    final String parentId = "parentId";
+    final Category category = mock(Category.class);
+    when(category.getParent()).thenReturn(CategoryReferenceBuilder.of().id(parentId).build());
+
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .parent(CategoryResourceIdentifierBuilder.of().id("differentParent").build())
+            .build();
+    final boolean doesRequire =
+        CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
+    assertThat(doesRequire).isTrue();
+  }
+
+  @Test
+  void requiresChangeParentUpdateAction_WithTwoIdenticalParents_ShouldReturnFalse() {
+    final String parentId = "parentId";
+    final String parentKey = "parentkey";
+    final Category category = mock(Category.class);
+    when(category.getParent()).thenReturn(CategoryReferenceBuilder.of().id(parentId).build());
+
+    final CategoryDraft categoryDraft =
+            CategoryDraftBuilder.of()
+                    .name(LocalizedString.of(Locale.ENGLISH, "name"))
+                    .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+                    .parent(CategoryResourceIdentifierBuilder.of().id(parentId).key(parentKey).build())
+                    .build();
+
+    // checking with ids (on draft reference id will be resolved, but in test it's given)
+    final boolean doesRequire =
+        CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
+    assertThat(doesRequire).isFalse();
+  }
+
+  @Test
+  void requiresChangeParentUpdateAction_WithNonExistingParents_ShouldReturnFalse() {
+    final Category category = mock(Category.class);
+    when(category.getParent()).thenReturn(null);
+
+    final CategoryDraft categoryDraft =
+            CategoryDraftBuilder.of()
+                    .name(LocalizedString.of(Locale.ENGLISH, "name"))
+                    .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+                    .build();
+    final boolean doesRequire =
+        CategorySync.requiresChangeParentUpdateAction(category, categoryDraft);
+    assertThat(doesRequire).isFalse();
+  }
+
+  @Test
+  void sync_WithBatchSizeSet_ShouldCallSyncOnEachBatch() {
+    // preparation
+    final int batchSize = 1;
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .batchSize(batchSize)
+            .build();
+    final int numberOfCategoryDrafts = 160;
+    final List<Category> mockedCreatedCategories =
+        IntStream.range(0, numberOfCategoryDrafts)
+            .mapToObj(i -> getMockCategory(UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
+            .collect(Collectors.toList());
+    final List<CategoryDraft> categoryDrafts =
+        mockedCreatedCategories.stream()
+            .map(category -> getCategoryDraftFromCategory(category))
+            .collect(Collectors.toList());
+
+    final Category createdCategory = mock(Category.class);
+    when(createdCategory.getKey()).thenReturn("foo");
+    when(createdCategory.getId()).thenReturn(UUID.randomUUID().toString());
+
+    final CategoryService mockCategoryService = mockCategoryService(emptySet(), createdCategory);
+
+    final CategorySyncMock categorySync =
+        new CategorySyncMock(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+    final CategorySyncMock syncSpy = spy(categorySync);
+
+    // test
+    syncSpy.sync(categoryDrafts).toCompletableFuture().join();
+
+    // assertion
+    int expectedNumberOfCalls = (int) (Math.ceil(numberOfCategoryDrafts / batchSize) + 1);
+    verify(syncSpy, times(expectedNumberOfCalls)).syncBatches(any(), any());
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+  }
+
+  @Test
+  void sync_WithDefaultBatchSize_ShouldCallSyncOnEachBatch() {
+    // preparation
+    final int numberOfCategoryDrafts = 160;
+    final List<Category> mockedCreatedCategories =
+        IntStream.range(0, numberOfCategoryDrafts)
+            .mapToObj(i -> getMockCategory(UUID.randomUUID().toString(), "key" + i, "name", "slug", Locale.ENGLISH))
+            .collect(Collectors.toList());
+    final List<CategoryDraft> categoryDrafts =
+        mockedCreatedCategories.stream()
+            .map(category -> getCategoryDraftFromCategory(category))
+            .collect(Collectors.toList());
+
+    final Category createdCategory = mock(Category.class);
+    when(createdCategory.getKey()).thenReturn("foo");
+    when(createdCategory.getId()).thenReturn(UUID.randomUUID().toString());
+
+    final CategoryService mockCategoryService = mockCategoryService(emptySet(), createdCategory);
+
+    final CategorySyncMock categorySync =
+        new CategorySyncMock(
+            categorySyncOptions,
+            getMockTypeService(),
+            mockCategoryService,
+            mockUnresolvedReferencesService);
+
+    final CategorySyncMock syncSpy = spy(categorySync);
+
+    // test
+    syncSpy.sync(categoryDrafts).toCompletableFuture().join();
+
+    // assertion
+    final int expectedNumberOfCalls =
+        (int)
+            (Math.ceil(
+                    numberOfCategoryDrafts / (double) CategorySyncOptionsBuilder.BATCH_SIZE_DEFAULT)
+                + 1);
+    verify(syncSpy, times(expectedNumberOfCalls)).syncBatches(any(), any());
+    assertThat(errorCallBackMessages).hasSize(0);
+    assertThat(errorCallBackExceptions).hasSize(0);
+  }
+
+  @Test
+  void sync_WithFailOnCachingKeysToIds_ShouldTriggerErrorCallbackAndReturnProperStats() {
+    // preparation
+    final ProjectApiRoot mockClient = mock(ProjectApiRoot.class);
+
+    when(mockClient.graphql()).thenReturn(mock());
+    final ByProjectKeyGraphqlPost byProjectKeyGraphqlPost = mock();
+    when(mockClient.graphql().post(any(GraphQLRequest.class))).thenReturn(byProjectKeyGraphqlPost);
+    when(byProjectKeyGraphqlPost.execute())
+            .thenReturn(
+                    supplyAsync(
+                            () -> {
+                              throw new ApiHttpException(500, "", new ApiHttpHeaders());
+                            }));
+
+    final CategorySyncOptions syncOptions =
+        CategorySyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CategoryService categoryServiceSpy = spy(new CategoryServiceImpl(syncOptions));
+
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            syncOptions, getMockTypeService(), categoryServiceSpy, mockUnresolvedReferencesService);
+
+    CategoryDraft categoryDraft =
+        getMockCategoryDraft(
+            Locale.ENGLISH, "name", "newKey", "parentKey", "customTypeId", new HashMap<>());
+
+    // test
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    // assertions
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+
+    assertThat(errorCallBackMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains("Failed to build a cache of keys to ids.");
+
+    assertThat(errorCallBackExceptions)
+        .hasSize(1)
+        .singleElement()
+        .matches(
+            throwable ->
+                throwable instanceof CompletionException
+                    && throwable.getCause() instanceof RuntimeException);
+  }
+
+  @Test
+  void sync_WithFailOnFetchingCategories_ShouldTriggerErrorCallbackAndReturnProperStats() throws Exception {
+    // preparation
+    final ProjectApiRoot mockClient = mock(ProjectApiRoot.class);
+
+    final String categoryKey = "key";
+    final String categoryJsonResponse = "{ \"categories\": {\"results\":[{\"id\":\"foo\",\"key\":\"key\"}"
+            + "]}}";;
+    final ApiHttpResponse<GraphQLResponse> graphQLResponseApiHttpResponse = mockGraphQLResponse(categoryJsonResponse);
+
+    when(mockClient.graphql()).thenReturn(mock());
+    final ByProjectKeyGraphqlPost byProjectKeyGraphqlPost = mock();
+    when(mockClient.graphql().post(any(GraphQLRequest.class))).thenReturn(byProjectKeyGraphqlPost);
+    when(byProjectKeyGraphqlPost.execute())
+            .thenReturn(CompletableFuture.completedFuture(graphQLResponseApiHttpResponse));
+
+    final CategorySyncOptions syncOptions =
+        CategorySyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CategoryService categoryServiceSpy = mock(CategoryService.class);
+
+    when(categoryServiceSpy.fetchCategory(Mockito.eq(categoryKey)))
+            .thenReturn(
+                    supplyAsync(
+                            () -> { throw new RuntimeException("Error when fetching category"); }
+                    )
+            );
+
+    final CategorySync mockCategorySync =
+        new CategorySync(
+            syncOptions, getMockTypeService(), categoryServiceSpy, mockUnresolvedReferencesService);
+
+    final CategoryDraft categoryDraft =
+        CategoryDraftBuilder.of()
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .key(categoryKey)
+            .custom(
+                CustomFieldsDraftBuilder.of()
+                    .type(TypeResourceIdentifierBuilder.of().key("customType").build())
+                    .build())
+            .build();
+    // test
+    final CategorySyncStatistics syncStatistics =
+        mockCategorySync.sync(singletonList(categoryDraft)).toCompletableFuture().join();
+
+    // assertions
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1);
+
+    assertThat(errorCallBackMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains("Failed to fetch existing categories");
+
+    assertThat(errorCallBackExceptions)
+        .hasSize(1)
+        .singleElement(as(THROWABLE))
+        .hasCauseExactlyInstanceOf(ApiHttpException.class);
+  }
+
+  @Test
+  void sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback() {
+    // preparation
+    final CategoryDraft categoryDraft =
+        getMockCategoryDraft(
+            Locale.ENGLISH, "name", "foo", "parentKey", "customTypeId", new HashMap<>());
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    final Category createdCategory = mock(Category.class);
+    when(createdCategory.getKey()).thenReturn(categoryDraft.getKey());
+
+    final CategoryService categoryService = mockCategoryService(emptySet(), createdCategory);
+    when(categoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of("parentId")));
+
+    Map<String, String> cache = new HashMap<>();
+    cache.put("1", UUID.randomUUID().toString());
+    cache.put("parentKey", UUID.randomUUID().toString());
+
+    when(categoryService.cacheKeysToIds(anySet())).thenReturn(completedFuture(cache));
+    final CategorySyncOptions spyCategorySyncOptions = spy(categorySyncOptions);
+
+    // test
+    new CategorySync(
+            spyCategorySyncOptions,
+            getMockTypeService(),
+            categoryService,
+            mockUnresolvedReferencesService)
+        .sync(singletonList(categoryDraft))
+        .toCompletableFuture()
+        .join();
+
+    // assertion
+    verify(spyCategorySyncOptions).applyBeforeCreateCallback(any());
+    verify(spyCategorySyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
+  }
+
+  @Test
+  void sync_WithOnlyDraftsToUpdate_ShouldOnlyCallBeforeUpdateCallback() {
+    // preparation
+    final CategoryDraft categoryDraft =
+        getMockCategoryDraft(
+            Locale.ENGLISH, "name", "categoryKey1", "parentKey", "customTypeId", new HashMap<>());
+
+    final Category mockedExistingCategory =
+        readObjectFromResource(CATEGORY_KEY_1_RESOURCE_PATH, Category.class);
+
+    final CategorySyncOptions categorySyncOptions =
+        CategorySyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    final CategoryService categoryService =
+        mockCategoryService(
+            singleton(mockedExistingCategory), mockedExistingCategory, mockedExistingCategory);
+
+    Map<String, String> cache = new HashMap<>();
+    cache.put("categoryKey1", mockedExistingCategory.getId());
+    cache.put("parentKey", mockedExistingCategory.getParent().getId());
+    when(categoryService.cacheKeysToIds(anySet())).thenReturn(completedFuture(cache));
+
+    when(categoryService.fetchCachedCategoryId(Mockito.eq("parentKey")))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Optional.of(mockedExistingCategory.getParent().getId())));
+    when(categoryService.fetchCategory(Mockito.eq("categoryKey1")))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(mockedExistingCategory)));
+
+    final CategorySyncOptions spyCategorySyncOptions = spy(categorySyncOptions);
+
+    // test
+    new CategorySync(
+            spyCategorySyncOptions,
+            getMockTypeService(),
+            categoryService,
+            mockUnresolvedReferencesService)
+        .sync(singletonList(categoryDraft))
+        .toCompletableFuture()
+        .join();
+
+    // assertion
+    verify(spyCategorySyncOptions).applyBeforeUpdateCallback(any(), any(), any());
+    verify(spyCategorySyncOptions, never()).applyBeforeCreateCallback(any());
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/categories/utils/CategoryUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/utils/CategoryUpdateActionUtilsTest.java
@@ -2,8 +2,8 @@ package com.commercetools.sync.sdk2.categories.utils;
 
 import static com.commercetools.sync.sdk2.categories.CategorySyncMockUtils.getMockCategory;
 import static com.commercetools.sync.sdk2.categories.utils.CategoryUpdateActionUtils.*;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.readObjectFromResource;
 import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.CATEGORY_KEY_1_RESOURCE_PATH;
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.readObjectFromResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/commercetools/sync/sdk2/categories/utils/categoryupdateactionutils/BuildAssetsUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/categories/utils/categoryupdateactionutils/BuildAssetsUpdateActionsTest.java
@@ -3,7 +3,7 @@ package com.commercetools.sync.sdk2.categories.utils.categoryupdateactionutils;
 import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
 import static com.commercetools.sync.sdk2.categories.utils.CategoryUpdateActionUtils.buildAssetsUpdateActions;
 import static com.commercetools.sync.sdk2.commons.utils.AssetsUpdateActionUtils.ASSET_KEY_NOT_SET;
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.readObjectFromResource;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.readObjectFromResource;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.sdk2.commons.asserts.statistics;
 
+import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.sdk2.customers.helpers.CustomerSyncStatistics;
 import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
 import javax.annotation.Nonnull;
@@ -30,5 +31,17 @@ public final class AssertionsForStatistics {
   public static ProductSyncStatisticsAssert assertThat(
       @Nullable final ProductSyncStatistics statistics) {
     return new ProductSyncStatisticsAssert(statistics);
+  }
+
+  /**
+   * Create assertion for {@link CategorySyncStatistics}.
+   *
+   * @param statistics the actual value.
+   * @return the created assertion object.
+   */
+  @Nonnull
+  public static CategorySyncStatisticsAssert assertThat(
+          @Nullable final CategorySyncStatistics statistics) {
+    return new CategorySyncStatisticsAssert(statistics);
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
@@ -41,7 +41,7 @@ public final class AssertionsForStatistics {
    */
   @Nonnull
   public static CategorySyncStatisticsAssert assertThat(
-          @Nullable final CategorySyncStatistics statistics) {
+      @Nullable final CategorySyncStatistics statistics) {
     return new CategorySyncStatisticsAssert(statistics);
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategoriesTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategoriesTest.java
@@ -1,0 +1,241 @@
+package com.commercetools.sync.sdk2.commons.models;
+
+import com.commercetools.api.models.category.CategoryDraft;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WaitingToBeResolvedCategoriesTest {
+
+  @Test
+  void setCategoryDraft_WithNonNullCategoryDraft_ShouldSetCategoryDraft() {
+    // preparation
+    final CategoryDraft CategoryDraft = mock(CategoryDraft.class);
+    final WaitingToBeResolvedCategories waitingToBeResolved = new WaitingToBeResolvedCategories();
+
+    // test
+    waitingToBeResolved.setCategoryDraft(CategoryDraft);
+
+    // assertions
+    assertThat(waitingToBeResolved.getCategoryDraft()).isEqualTo(CategoryDraft);
+  }
+
+  @Test
+  void setMissingReferencedProductKeys_WithNonNullSet_ShouldSetTheSet() {
+    // preparation
+    final WaitingToBeResolvedCategories waitingToBeResolved = new WaitingToBeResolvedCategories();
+
+    // test
+    waitingToBeResolved.setMissingReferencedCategoriesKeys(emptySet());
+
+    // assertions
+    assertThat(waitingToBeResolved.getMissingReferencedCategoriesKeys()).isEqualTo(emptySet());
+  }
+
+  @Test
+  void equals_WithSameRef_ShouldReturnTrue() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other = waitingToBeResolved;
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertTrue(result);
+  }
+
+  @Test
+  void equals_WithDiffType_ShouldReturnFalse() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final Object other = new Object();
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertFalse(result);
+  }
+
+  @Test
+  void equals_WithEqualObjects_ShouldReturnTrue() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertTrue(result);
+  }
+
+  @Test
+  void equals_WithDifferentMissingRefKeys_ShouldReturnFalse() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), singleton("foo"));
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertFalse(result);
+  }
+
+  @Test
+  void equals_WithDifferentCategoryDraft_ShouldReturnFalse() {
+    // preparation
+    final CategoryDraft CategoryDraft = mock(CategoryDraft.class);
+    final CategoryDraft CategoryDraft1 = mock(CategoryDraft.class);
+    when(CategoryDraft1.getKey()).thenReturn("foo");
+
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(CategoryDraft, new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(CategoryDraft1, new HashSet<>());
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertFalse(result);
+  }
+
+  @Test
+  void equals_WithCompletelyDifferentFieldValues_ShouldReturnFalse() {
+    // preparation
+    final CategoryDraft CategoryDraft = mock(CategoryDraft.class);
+    final CategoryDraft CategoryDraft1 = mock(CategoryDraft.class);
+    when(CategoryDraft1.getKey()).thenReturn("foo");
+
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(CategoryDraft, singleton("foo"));
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(CategoryDraft1, singleton("bar"));
+
+    // test
+    boolean result = waitingToBeResolved.equals(other);
+
+    // assertions
+    assertFalse(result);
+  }
+
+  @Test
+  void hashCode_withSameInstances_ShouldBeEquals() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other = waitingToBeResolved;
+
+    // test
+    final int hash1 = waitingToBeResolved.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withSameProductKeyAndSameRefSet_ShouldBeEquals() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+
+    // test
+    final int hash1 = waitingToBeResolved.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withDifferentProductKeyAndSameRefSet_ShouldNotBeEquals() {
+    // preparation
+    final CategoryDraft CategoryDraft = mock(CategoryDraft.class);
+    final CategoryDraft CategoryDraft1 = mock(CategoryDraft.class);
+    when(CategoryDraft1.getKey()).thenReturn("foo");
+
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(CategoryDraft, new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(CategoryDraft1, new HashSet<>());
+
+    // test
+    final int hash1 = waitingToBeResolved.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertNotEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withSameProductKeyAndDiffRefSet_ShouldNotBeEquals() {
+    // preparation
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), new HashSet<>());
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(mock(CategoryDraft.class), singleton("foo"));
+
+    // test
+    final int hash1 = waitingToBeResolved.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertNotEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withCompletelyDifferentFields_ShouldNotBeEquals() {
+    // preparation
+    final CategoryDraft CategoryDraft = mock(CategoryDraft.class);
+    final CategoryDraft CategoryDraft1 = mock(CategoryDraft.class);
+    when(CategoryDraft1.getKey()).thenReturn("foo");
+
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(CategoryDraft, singleton("foo"));
+    final WaitingToBeResolved other =
+        new WaitingToBeResolvedCategories(CategoryDraft1, singleton("bar"));
+
+    // test
+    final int hash1 = waitingToBeResolved.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertNotEquals(hash1, hash2);
+  }
+
+  @Test
+  void getKey_withValidCategoryDraftKey_ShouldReturnKey() {
+    // preparation
+    String key = "anyKey";
+    final CategoryDraft CategoryDraft1 = mock(CategoryDraft.class);
+    when(CategoryDraft1.getKey()).thenReturn(key);
+
+    final WaitingToBeResolved waitingToBeResolved =
+        new WaitingToBeResolvedCategories(CategoryDraft1, singleton("bar"));
+
+    // test
+    final String resolvedKey = waitingToBeResolved.getKey();
+
+    // assertions
+    assertEquals(resolvedKey, key);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategoriesTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/models/WaitingToBeResolvedCategoriesTest.java
@@ -1,16 +1,15 @@
 package com.commercetools.sync.sdk2.commons.models;
 
-import com.commercetools.api.models.category.CategoryDraft;
-import org.junit.jupiter.api.Test;
-
-import java.util.HashSet;
-
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.category.CategoryDraft;
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
 
 class WaitingToBeResolvedCategoriesTest {
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/TestUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/TestUtils.java
@@ -1,13 +1,34 @@
 package com.commercetools.sync.sdk2.commons.utils;
 
 import static io.vrap.rmf.base.client.utils.json.JsonUtils.fromInputStream;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.commercetools.api.models.graph_ql.GraphQLResponse;
+import com.commercetools.api.models.graph_ql.GraphQLResponseBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.utils.json.JsonUtils;
 import java.io.InputStream;
+import java.util.Map;
+import javax.annotation.Nonnull;
 
 public class TestUtils {
   public static <T> T readObjectFromResource(final String resourcePath, final Class<T> objectType) {
     final InputStream resourceAsStream =
         Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath);
     return fromInputStream(resourceAsStream, objectType);
+  }
+
+  @Nonnull
+  public static ApiHttpResponse<GraphQLResponse> mockGraphQLResponse(
+      final String jsonResponseString) throws JsonProcessingException {
+    ObjectMapper objectMapper = JsonUtils.getConfiguredObjectMapper();
+    final Map responseMap = objectMapper.readValue(jsonResponseString, Map.class);
+    final ApiHttpResponse<GraphQLResponse> apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody())
+        .thenReturn(GraphQLResponseBuilder.of().data(responseMap).build());
+    return apiHttpResponse;
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/customers/utils/CustomerTransformUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customers/utils/CustomerTransformUtilsTest.java
@@ -1,6 +1,6 @@
 package com.commercetools.sync.sdk2.customers.utils;
 
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.mockGraphQLResponse;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.mockGraphQLResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncMockUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncMockUtils.java
@@ -25,8 +25,6 @@ import com.commercetools.api.models.customer.CustomerReference;
 import com.commercetools.api.models.customer.CustomerReferenceBuilder;
 import com.commercetools.api.models.customer_group.CustomerGroup;
 import com.commercetools.api.models.customer_group.CustomerGroupReference;
-import com.commercetools.api.models.graph_ql.GraphQLResponse;
-import com.commercetools.api.models.graph_ql.GraphQLResponseBuilder;
 import com.commercetools.api.models.product.*;
 import com.commercetools.api.models.product_type.ProductTypeReference;
 import com.commercetools.api.models.product_type.ProductTypeReferenceBuilder;
@@ -50,10 +48,6 @@ import com.commercetools.sync.sdk2.services.ProductService;
 import com.commercetools.sync.sdk2.services.ProductTypeService;
 import com.commercetools.sync.sdk2.services.StateService;
 import com.commercetools.sync.sdk2.services.TaxCategoryService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vrap.rmf.base.client.ApiHttpResponse;
-import io.vrap.rmf.base.client.utils.json.JsonUtils;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
@@ -644,16 +638,5 @@ public class ProductSyncMockUtils {
     when(customerService.fetchCachedCustomerId(anyString()))
         .thenReturn(CompletableFuture.completedFuture(Optional.of(id)));
     return customerService;
-  }
-
-  @Nonnull
-  public static ApiHttpResponse<GraphQLResponse> mockGraphQLResponse(
-      final String jsonResponseString) throws JsonProcessingException {
-    ObjectMapper objectMapper = JsonUtils.getConfiguredObjectMapper();
-    final Map responseMap = objectMapper.readValue(jsonResponseString, Map.class);
-    final ApiHttpResponse<GraphQLResponse> apiHttpResponse = mock(ApiHttpResponse.class);
-    when(apiHttpResponse.getBody())
-        .thenReturn(GraphQLResponseBuilder.of().data(responseMap).build());
-    return apiHttpResponse;
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/helpers/productreferenceresolver/CategoryReferenceResolverTest.java
@@ -56,7 +56,7 @@ class CategoryReferenceResolverTest {
     final List<Category> categories =
         IntStream.range(0, nCategories)
             .mapToObj(i -> i + "")
-            .map(key -> getMockCategory(key, key))
+            .map(key -> getMockCategory(key, key, "name" + key, "slug" + key, Locale.ENGLISH))
             .collect(Collectors.toList());
 
     final CategoryService mockCategoryService =
@@ -109,7 +109,7 @@ class CategoryReferenceResolverTest {
     final List<Category> categories =
         IntStream.range(0, nCategories)
             .mapToObj(i -> i + "")
-            .map(key -> getMockCategory(key, key))
+            .map(key -> getMockCategory(key, key, "name" + key, "slug" + key, Locale.ENGLISH))
             .collect(Collectors.toList());
     final CategoryService mockCategoryService =
         mockCategoryService(new HashSet<>(categories), null);
@@ -153,7 +153,7 @@ class CategoryReferenceResolverTest {
     final List<Category> categories =
         IntStream.range(0, nCategories)
             .mapToObj(i -> i + "")
-            .map(key -> getMockCategory(key, key))
+            .map(key -> getMockCategory(key, key, "name" + key, "slug" + key, Locale.ENGLISH))
             .collect(Collectors.toList());
     final CategoryService mockCategoryService =
         mockCategoryService(new HashSet<>(categories), null);
@@ -326,7 +326,8 @@ class CategoryReferenceResolverTest {
 
   @Test
   void resolveCategoryReferences_WithExceptionCategoryFetch_ShouldNotResolveReference() {
-    final Category category = getMockCategory("categoryKey", "categoryKey");
+    final Category category =
+        getMockCategory("categoryKey", "categoryKey", "name", "slug", Locale.ENGLISH);
     final List<Category> categories = Collections.singletonList(category);
 
     final List<CategoryResourceIdentifier> categoryResourceIdentifiers =

--- a/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductTransformUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductTransformUtilsTest.java
@@ -1,7 +1,7 @@
 package com.commercetools.sync.sdk2.products.utils;
 
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.mockGraphQLResponse;
 import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.createProductFromJson;
-import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.mockGraphQLResponse;
 import static com.commercetools.sync.sdk2.services.impl.BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImplTest.java
@@ -1,0 +1,523 @@
+package com.commercetools.sync.sdk2.services.impl;
+
+import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY;
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.commercetools.api.client.*;
+import com.commercetools.api.client.error.BadRequestException;
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectPagedQueryResponse;
+import com.commercetools.api.models.custom_object.CustomObjectPagedQueryResponseBuilder;
+import com.commercetools.api.models.error.ErrorResponse;
+import com.commercetools.api.models.error.ErrorResponseBuilder;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductDraftBuilder;
+import com.commercetools.api.models.product_type.ProductTypeResourceIdentifierBuilder;
+import com.commercetools.api.models.state.State;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedProducts;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@SuppressWarnings("unchecked")
+class UnresolvedReferencesServiceImplTest {
+
+  private UnresolvedReferencesServiceImpl<WaitingToBeResolvedProducts> service;
+  private ProductSyncOptions productSyncOptions;
+  private List<String> errorMessages;
+  private List<Throwable> errorExceptions;
+
+  @BeforeEach
+  void setUp() {
+    final ProjectApiRoot apiRoot = mock(ProjectApiRoot.class);
+    when(apiRoot.customObjects()).thenReturn(mock());
+    when(apiRoot.customObjects().withContainer(anyString())).thenReturn(mock());
+    when(apiRoot.customObjects().withContainerAndKey(anyString(), anyString())).thenReturn(mock());
+    errorMessages = new ArrayList<>();
+    errorExceptions = new ArrayList<>();
+    productSyncOptions =
+        ProductSyncOptionsBuilder.of(apiRoot)
+            .errorCallback(
+                (exception, oldResource, newResource, actions) -> {
+                  errorMessages.add(exception.getMessage());
+                  errorExceptions.add(exception);
+                })
+            .build();
+
+    service = new UnresolvedReferencesServiceImpl<>(productSyncOptions);
+  }
+
+  @Test
+  void fetch_WithEmptyKeySet_ShouldReturnEmptySet() {
+    // preparation
+    final Set<String> keys = new HashSet<>();
+
+    // test
+    final Set<WaitingToBeResolvedProducts> result =
+        service
+            .fetch(keys, CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY, WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(result).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void fetch_OnSuccess_ShouldReturnMock() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+
+    final WaitingToBeResolvedProducts waitingToBeResolved =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingToBeResolved);
+
+    final ApiHttpResponse<CustomObjectPagedQueryResponse> result =
+        getMockCustomObjectPagedQueryResponse(singletonList(customObjectMock));
+    final ByProjectKeyCustomObjectsByContainerGet customObjectGet =
+        mock(ByProjectKeyCustomObjectsByContainerGet.class);
+    when(customObjectGet.withWhere(anyString())).thenReturn(customObjectGet);
+    when(customObjectGet.withPredicateVar(anyString(), anyCollection()))
+        .thenReturn(customObjectGet);
+    when(customObjectGet.execute()).thenReturn(CompletableFuture.completedFuture(result));
+    when(productSyncOptions.getCtpClient().customObjects().withContainer(anyString()).get())
+        .thenReturn(customObjectGet);
+
+    // test
+    final Set<WaitingToBeResolvedProducts> toBeResolvedOptional =
+        service
+            .fetch(
+                singleton("product-draft-key"),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(toBeResolvedOptional).containsOnly(waitingToBeResolved);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void fetch_OnSuccess_ShouldRequestHashedKeys() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+
+    final WaitingToBeResolvedProducts waitingToBeResolved =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingToBeResolved);
+
+    final ApiHttpResponse<CustomObjectPagedQueryResponse> result =
+        getMockCustomObjectPagedQueryResponse(singletonList(customObjectMock));
+    final ByProjectKeyCustomObjectsByContainerGet customObjectGet =
+        mock(ByProjectKeyCustomObjectsByContainerGet.class);
+    when(customObjectGet.withWhere(anyString())).thenReturn(customObjectGet);
+    when(customObjectGet.withPredicateVar(anyString(), anyCollection()))
+        .thenReturn(customObjectGet);
+    when(customObjectGet.execute()).thenReturn(CompletableFuture.completedFuture(result));
+    when(productSyncOptions.getCtpClient().customObjects().withContainer(anyString()).get())
+        .thenReturn(customObjectGet);
+
+    final ArgumentCaptor<List<String>> requestArgumentCaptor = ArgumentCaptor.forClass(List.class);
+
+    // test
+    final Set<String> setOfSpecialCharKeys = new HashSet<>();
+    setOfSpecialCharKeys.addAll(
+        Arrays.asList(
+            "Get a $100 Visa® Reward Card because you’re ordering TV",
+            "product$",
+            "Visa®",
+            "Visa©"));
+    final Set<WaitingToBeResolvedProducts> toBeResolvedOptional =
+        service
+            .fetch(
+                setOfSpecialCharKeys,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    verify(customObjectGet).withPredicateVar(anyString(), requestArgumentCaptor.capture());
+    assertThat(toBeResolvedOptional).containsOnly(waitingToBeResolved);
+    setOfSpecialCharKeys.forEach(
+        key -> assertThat(requestArgumentCaptor.getValue()).contains(sha1Hex(key)));
+  }
+
+  @Test
+  void save_OnSuccess_ShouldSaveMock() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+
+    final WaitingToBeResolvedProducts waitingToBeResolved =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingToBeResolved);
+
+    final ApiHttpResponse<CustomObject> coResponse = getMockCustomObjectResponse(customObjectMock);
+    final ByProjectKeyCustomObjectsPost customObjectsPost =
+        mock(ByProjectKeyCustomObjectsPost.class);
+    when(customObjectsPost.execute()).thenReturn(CompletableFuture.completedFuture(coResponse));
+    when(productSyncOptions.getCtpClient().customObjects().post(any(CustomObjectDraft.class)))
+        .thenReturn(customObjectsPost);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> result =
+        service
+            .save(
+                waitingToBeResolved,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(result).contains(waitingToBeResolved);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void save_OnSuccess_ShouldSaveMockWithSha1HashedKey() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+
+    final WaitingToBeResolvedProducts waitingToBeResolved =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingToBeResolved);
+
+    final ApiHttpResponse<CustomObject> coResponse = getMockCustomObjectResponse(customObjectMock);
+    final ByProjectKeyCustomObjectsPost customObjectsPost =
+        mock(ByProjectKeyCustomObjectsPost.class);
+    when(customObjectsPost.execute()).thenReturn(CompletableFuture.completedFuture(coResponse));
+    final ByProjectKeyCustomObjectsRequestBuilder requestBuilder =
+        mock(ByProjectKeyCustomObjectsRequestBuilder.class);
+    when(requestBuilder.post(any(CustomObjectDraft.class))).thenReturn(customObjectsPost);
+    when(productSyncOptions.getCtpClient().customObjects()).thenReturn(requestBuilder);
+
+    final ArgumentCaptor<CustomObjectDraft> requestArgumentCaptor =
+        ArgumentCaptor.forClass(CustomObjectDraft.class);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> result =
+        service
+            .save(
+                waitingToBeResolved,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    verify(requestBuilder).post(requestArgumentCaptor.capture());
+    assertThat(result).contains(waitingToBeResolved);
+    assertThat(requestArgumentCaptor.getValue().getKey())
+        .isEqualTo(sha1Hex(productDraftMock.getKey()));
+  }
+
+  @Test
+  void save_WithUnsuccessfulMockCtpResponse_ShouldNotSaveMock() throws JsonProcessingException {
+    // preparation
+    final String productKey = "product-draft-key";
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key(productKey)
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+    final WaitingToBeResolvedProducts waitingToBeResolved =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+
+    final ApiHttpResponse<State> apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(mock());
+    final ErrorResponse errorResponse =
+        ErrorResponseBuilder.of()
+            .statusCode(400)
+            .errors(Collections.emptyList())
+            .message("test")
+            .build();
+
+    final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    final String json = ow.writeValueAsString(errorResponse);
+
+    final ByProjectKeyCustomObjectsPost customObjectsPost =
+        mock(ByProjectKeyCustomObjectsPost.class);
+    when(customObjectsPost.execute())
+        .thenReturn(
+            CompletableFutureUtils.failed(
+                new BadRequestException(
+                    400,
+                    "",
+                    null,
+                    "bad request",
+                    new ApiHttpResponse<>(400, null, json.getBytes(StandardCharsets.UTF_8)))));
+    when(productSyncOptions.getCtpClient().customObjects().post(any(CustomObjectDraft.class)))
+        .thenReturn(customObjectsPost);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> result =
+        service
+            .save(
+                waitingToBeResolved,
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(result).isEmpty();
+    assertThat(errorMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains(
+            format(
+                "Failed to save CustomObject with key: '%s' (hash of product key: '%s').",
+                sha1Hex(productKey), productKey));
+
+    assertThat(errorExceptions)
+        .hasSize(1)
+        .singleElement(as(THROWABLE))
+        .isExactlyInstanceOf(SyncException.class)
+        .hasCauseExactlyInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  void delete_WithUnsuccessfulMockCtpResponse_ShouldReturnProperException()
+      throws JsonProcessingException {
+    // preparation
+    final String key = "product-draft-key";
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key(key)
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+
+    final ApiHttpResponse<State> apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(mock());
+    final ErrorResponse errorResponse =
+        ErrorResponseBuilder.of()
+            .statusCode(400)
+            .errors(Collections.emptyList())
+            .message("test")
+            .build();
+
+    final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    final String json = ow.writeValueAsString(errorResponse);
+
+    final ByProjectKeyCustomObjectsByContainerByKeyDelete customObjectsDelete =
+        mock(ByProjectKeyCustomObjectsByContainerByKeyDelete.class);
+    when(customObjectsDelete.execute())
+        .thenReturn(
+            CompletableFutureUtils.failed(
+                new BadRequestException(
+                    400,
+                    "",
+                    null,
+                    "bad request",
+                    new ApiHttpResponse<>(400, null, json.getBytes(StandardCharsets.UTF_8)))));
+    when(productSyncOptions
+            .getCtpClient()
+            .customObjects()
+            .withContainerAndKey(anyString(), anyString())
+            .delete())
+        .thenReturn(customObjectsDelete);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> toBeResolvedOptional =
+        service
+            .delete(
+                "product-draft-key",
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(toBeResolvedOptional).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errorExceptions).hasSize(1);
+    assertThat(errorMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains(
+            format(
+                "Failed to delete CustomObject with key: '%s' (hash of product key: '%s')",
+                sha1Hex(key), key));
+    assertThat(errorExceptions)
+        .hasSize(1)
+        .singleElement(as(THROWABLE))
+        .isExactlyInstanceOf(SyncException.class)
+        .hasCauseExactlyInstanceOf(BadRequestException.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void delete_OnSuccess_ShouldRemoveTheResourceObject() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+    final WaitingToBeResolvedProducts waitingDraft =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingDraft);
+
+    ApiHttpResponse<CustomObject> mockCustomObjectResponse =
+        getMockCustomObjectResponse(customObjectMock);
+    final ByProjectKeyCustomObjectsByContainerByKeyDelete customObjectsDelete =
+        mock(ByProjectKeyCustomObjectsByContainerByKeyDelete.class);
+    when(customObjectsDelete.execute())
+        .thenReturn(CompletableFuture.completedFuture(mockCustomObjectResponse));
+    when(productSyncOptions
+            .getCtpClient()
+            .customObjects()
+            .withContainerAndKey(anyString(), anyString())
+            .delete())
+        .thenReturn(customObjectsDelete);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> toBeResolvedOptional =
+        service
+            .delete(
+                "product-draft-key",
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    assertThat(toBeResolvedOptional).contains(waitingDraft);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void delete_OnSuccess_ShouldMakeRequestWithSha1HashedKey() {
+    // preparation
+    final CustomObject customObjectMock = mock(CustomObject.class);
+
+    final ProductDraft productDraftMock =
+        ProductDraftBuilder.of()
+            .productType(ProductTypeResourceIdentifierBuilder.of().key("product-type").build())
+            .key("product-draft-key")
+            .name(LocalizedString.ofEnglish("product-name"))
+            .slug(LocalizedString.ofEnglish("product-slug"))
+            .build();
+    final WaitingToBeResolvedProducts waitingDraft =
+        new WaitingToBeResolvedProducts(productDraftMock, singleton("test-ref"));
+    when(customObjectMock.getValue()).thenReturn(waitingDraft);
+
+    ApiHttpResponse<CustomObject> mockCustomObjectResponse =
+        getMockCustomObjectResponse(customObjectMock);
+    final ByProjectKeyCustomObjectsByContainerByKeyDelete customObjectsDelete =
+        mock(ByProjectKeyCustomObjectsByContainerByKeyDelete.class);
+    when(customObjectsDelete.execute())
+        .thenReturn(CompletableFuture.completedFuture(mockCustomObjectResponse));
+    final ByProjectKeyCustomObjectsRequestBuilder requestBuilder =
+        mock(ByProjectKeyCustomObjectsRequestBuilder.class);
+    final ByProjectKeyCustomObjectsByContainerByKeyRequestBuilder requestBuilderByContainerByKey =
+        mock(ByProjectKeyCustomObjectsByContainerByKeyRequestBuilder.class);
+    when(requestBuilderByContainerByKey.delete()).thenReturn(customObjectsDelete);
+    when(requestBuilder.withContainerAndKey(anyString(), anyString()))
+        .thenReturn(requestBuilderByContainerByKey);
+    when(productSyncOptions.getCtpClient().customObjects()).thenReturn(requestBuilder);
+
+    final ArgumentCaptor<String> requestArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+    // test
+    final Optional<WaitingToBeResolvedProducts> toBeResolvedOptional =
+        service
+            .delete(
+                "product-draft-key",
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    // assertions
+    verify(requestBuilder).withContainerAndKey(anyString(), requestArgumentCaptor.capture());
+    assertThat(toBeResolvedOptional).contains(waitingDraft);
+    assertThat(requestArgumentCaptor.getValue()).contains(sha1Hex(productDraftMock.getKey()));
+  }
+
+  @Nonnull
+  private ApiHttpResponse<CustomObjectPagedQueryResponse> getMockCustomObjectPagedQueryResponse(
+      @Nonnull final List<CustomObject> results) {
+    final ApiHttpResponse<CustomObjectPagedQueryResponse> apiHttpResponse =
+        mock(ApiHttpResponse.class);
+    final CustomObjectPagedQueryResponse pagedQueryResponse =
+        CustomObjectPagedQueryResponseBuilder.of()
+            .results(results)
+            .limit(1L)
+            .offset(0L)
+            .count(1L)
+            .build();
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    return apiHttpResponse;
+  }
+
+  @Nonnull
+  private ApiHttpResponse<CustomObject> getMockCustomObjectResponse(
+      @Nonnull final CustomObject result) {
+    final ApiHttpResponse<CustomObject> apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(result);
+    return apiHttpResponse;
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/UnresolvedReferencesServiceImplTest.java
@@ -492,7 +492,11 @@ class UnresolvedReferencesServiceImplTest {
             .join();
 
     // assertions
-    verify(requestBuilder).withContainerAndKey(anyString(), requestArgumentCaptor.capture());
+    // Solve spotbugs @ChangeReturnValue violation
+    final ByProjectKeyCustomObjectsByContainerByKeyRequestBuilder
+        byProjectKeyCustomObjectsByContainerByKeyRequestBuilder =
+            verify(requestBuilder)
+                .withContainerAndKey(anyString(), requestArgumentCaptor.capture());
     assertThat(toBeResolvedOptional).contains(waitingDraft);
     assertThat(requestArgumentCaptor.getValue()).contains(sha1Hex(productDraftMock.getKey()));
   }


### PR DESCRIPTION
Additional changes:
- Add IT for `UnresolvedReferenceResolverService` and adjustments for the service
- Add model `WaitingToBeResolvedCategories` incl. unittests
- Move utility function `mockGraphQLResponse` to common test package
- Extract helper to create different Exceptions used in IT to `ITUtils`

Follow-up:
- Adjust calculation of updateActions for customFields in `CustomUpdateActionUtils`
- JIRA: https://commercetools.atlassian.net/browse/DEVX-169

JIRA: https://commercetools.atlassian.net/browse/DEVX-83