### PR TITLE
Add helper to convert  customField values to JsonNode

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/categories/CategorySyncIT.java
@@ -134,8 +134,6 @@ class CategorySyncIT {
     assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
   }
 
-  // TODO: Fix the mock for customFields or Adjust the CustomUpdateActionUtils comparison
-  @Disabled
   @Test
   void syncDrafts_WithCategoryWithNoChanges_ShouldNotUpdateCategory() {
     // Create a mock in the target project.
@@ -717,8 +715,6 @@ class CategorySyncIT {
     assertThat(syncStatistics).hasValues(6, 5, 1, 0, 0);
   }
 
-  // Needs the custom fields fix
-  @Disabled
   @Test
   void syncDrafts_WithSameSlugDraft_ShouldNotSyncIt() {
     // Create a mock in the target project.

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
@@ -331,7 +331,6 @@ public final class CustomUpdateActionUtils {
 
     final String oldCustomTypeId = oldCustomFields.getType().getId();
 
-    // Convert Object to JSONNode
     final Map<String, Object> oldCustomFieldsJsonMap = oldCustomFields.getFields().values();
     final String newCustomTypeId = newCustomFields.getType().getId();
     final FieldContainer fields = newCustomFields.getFields();
@@ -499,9 +498,10 @@ public final class CustomUpdateActionUtils {
     return newCustomFields.keySet().stream()
         .filter(
             newCustomFieldName -> {
-              final Object newCustomFieldValue =
+              // Convert Object to JSONNode
+              final JsonNode newCustomFieldValue =
                   convertFieldValuesToJsonNode(newCustomFields.get(newCustomFieldName));
-              final Object oldCustomFieldValue =
+              final JsonNode oldCustomFieldValue =
                   convertFieldValuesToJsonNode(oldCustomFields.get(newCustomFieldName));
               return !isNullJsonValue(newCustomFieldValue)
                   && !Objects.equals(newCustomFieldValue, oldCustomFieldValue);
@@ -516,8 +516,8 @@ public final class CustomUpdateActionUtils {
         .collect(Collectors.toList());
   }
 
-  private static boolean isNullJsonValue(@Nullable final Object value) {
-    return !Objects.nonNull(value) || (value instanceof JsonNode && ((JsonNode) value).isNull());
+  private static boolean isNullJsonValue(@Nullable final JsonNode value) {
+    return !Objects.nonNull(value) || value.isNull();
   }
 
   /**
@@ -558,9 +558,10 @@ public final class CustomUpdateActionUtils {
     return oldCustomFields.keySet().stream()
         .filter(
             oldCustomFieldsName -> {
-              final Object newCustomFieldValue =
+              // Convert Object to JSONNode
+              final JsonNode newCustomFieldValue =
                   convertFieldValuesToJsonNode(newCustomFields.get(oldCustomFieldsName));
-              final Object oldCustomFieldValue =
+              final JsonNode oldCustomFieldValue =
                   convertFieldValuesToJsonNode(oldCustomFields.get(oldCustomFieldsName));
               return isNullJsonValue(newCustomFieldValue)
                   && oldCustomFieldValue != newCustomFieldValue;

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
@@ -49,15 +49,14 @@ import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.sdk2.products.helpers.AssetCustomActionBuilder;
 import com.commercetools.sync.sdk2.products.helpers.PriceCustomActionBuilder;
 import com.commercetools.sync.sdk2.products.models.PriceCustomTypeAdapter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.Test;
 
 class CustomUpdateActionUtilsTest {
@@ -656,7 +655,9 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", Map.of("de", "rot", "es", "rojo"));
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("es", "rojo").put("de", "rot"));
+    newCustomFields.put(
+        "backgroundColor",
+        JsonNodeFactory.instance.objectNode().put("es", "rojo").put("de", "rot"));
 
     final Asset newAssetDraft =
         AssetBuilder.of().id("test").sources(emptyList()).name(ofEnglish("assetName")).build();
@@ -770,7 +771,8 @@ class CustomUpdateActionUtilsTest {
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
-    newCustomFieldsMap.put("setOfBooleans", new ObjectMapper().convertValue(Collections.emptyList(), List.class));
+    newCustomFieldsMap.put(
+        "setOfBooleans", new ObjectMapper().convertValue(Collections.emptyList(), List.class));
 
     // test
     final List<ProductUpdateAction> updateActions =

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
@@ -55,6 +55,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.Test;
 
 class CustomUpdateActionUtilsTest {
@@ -289,7 +292,7 @@ class CustomUpdateActionUtilsTest {
     // Mock new CustomFieldsDraft
     final CustomFieldsDraft newCustomFieldsMock = mock(CustomFieldsDraft.class);
     final Map<String, Object> newCustomFieldsJsonMapMock = new HashMap<>();
-    newCustomFieldsJsonMapMock.put("invisibleInShop", false);
+    newCustomFieldsJsonMapMock.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(false));
     when(newCustomFieldsMock.getType())
         .thenReturn(TypeResourceIdentifierBuilder.of().id("categoryAssetCustomTypeId").build());
     when(newCustomFieldsMock.getFields())
@@ -502,8 +505,8 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", Map.of("de", "rot", "en", "red"));
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("invisibleInShop", true);
-    newCustomFields.put("backgroundColor", Map.of("de", "rot"));
+    newCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
+    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
 
     // Mock new price
     final Price price =
@@ -540,8 +543,8 @@ class CustomUpdateActionUtilsTest {
     final Map<String, Object> oldCustomFields = new HashMap<>();
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("invisibleInShop", true);
-    newCustomFields.put("backgroundColor", Map.of("de", "rot"));
+    newCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
+    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
     newCustomFields.put("url", Map.of("domain", "domain.com"));
     newCustomFields.put("size", Map.of("cm", 34));
 
@@ -577,7 +580,7 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", Map.of("de", "rot", "en", "red"));
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("invisibleInShop", true);
+    newCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
 
     // Mock new price
     final Price price =
@@ -627,8 +630,8 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", Map.of("de", "rot"));
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("invisibleInShop", true);
-    newCustomFields.put("backgroundColor", Map.of("de", "rot"));
+    newCustomFields.put("invisibleInShop", JsonNodeFactory.instance.booleanNode(true));
+    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("de", "rot"));
 
     final Asset newAssetDraft =
         AssetBuilder.of().id("test").sources(emptyList()).name(ofEnglish("assetName")).build();
@@ -653,7 +656,7 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", Map.of("de", "rot", "es", "rojo"));
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("backgroundColor", Map.of("es", "rojo", "de", "rot"));
+    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.objectNode().put("es", "rojo").put("de", "rot"));
 
     final Asset newAssetDraft =
         AssetBuilder.of().id("test").sources(emptyList()).name(ofEnglish("assetName")).build();
@@ -677,7 +680,7 @@ class CustomUpdateActionUtilsTest {
     oldCustomFields.put("backgroundColor", "");
 
     final Map<String, Object> newCustomFields = new HashMap<>();
-    newCustomFields.put("backgroundColor", "");
+    newCustomFields.put("backgroundColor", JsonNodeFactory.instance.textNode(""));
 
     final Asset newAssetDraft =
         AssetBuilder.of().id("test").sources(emptyList()).name(ofEnglish("assetName")).build();
@@ -767,7 +770,7 @@ class CustomUpdateActionUtilsTest {
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
-    newCustomFieldsMap.put("setOfBooleans", Collections.emptyList());
+    newCustomFieldsMap.put("setOfBooleans", new ObjectMapper().convertValue(Collections.emptyList(), List.class));
 
     // test
     final List<ProductUpdateAction> updateActions =
@@ -959,7 +962,7 @@ class CustomUpdateActionUtilsTest {
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
-    newCustomFieldsMap.put("setOfBooleans", null);
+    newCustomFieldsMap.put("setOfBooleans", JsonNodeFactory.instance.nullNode());
 
     // test
     final List<ProductUpdateAction> updateActions =
@@ -996,7 +999,7 @@ class CustomUpdateActionUtilsTest {
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
-    newCustomFieldsMap.put("setOfBooleans", null);
+    newCustomFieldsMap.put("setOfBooleans", JsonNodeFactory.instance.nullNode());
 
     // test
     final List<ProductUpdateAction> updateActions =


### PR DESCRIPTION
**Problem**: To calculate updateActions for custom-fields the fields values of a Resource and a Draft needs to be comparable. As in jvm-sdk-v1 all fields values have been of type JsonNode, with java-sdk-v2 has changed to Object type. 
**Solution**: Convert all fields values to JsonNode and compare like before.

JIRA: https://commercetools.atlassian.net/browse/DEVX-169