### PR TITLE
DEVX-172 Migrate ProductTypeActionUtils and all related classes

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateNameException.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateNameException.java
@@ -1,0 +1,17 @@
+package com.commercetools.sync.sdk2.commons.exceptions;
+
+import javax.annotation.Nonnull;
+
+public class DuplicateNameException extends RuntimeException {
+  public DuplicateNameException(@Nonnull final String message) {
+    super(message);
+  }
+
+  public DuplicateNameException(@Nonnull final Throwable cause) {
+    super(cause);
+  }
+
+  public DuplicateNameException(@Nonnull final String message, @Nonnull final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -353,9 +353,16 @@ final class AttributeDefinitionUpdateActionUtils {
               newAttributeConstraint.name()));
     }
 
+    if (AttributeConstraintEnum.NONE.equals(oldAttributeConstraint)
+        && newAttributeConstraint == null) {
+      // attribute constraint is optional and by default attribute constraint is NONE:
+      // https://docs.commercetools.com/api/projects/productTypes#ctp:api:type:AttributeDefinitionDraft
+      return Optional.empty();
+    }
+
     return buildUpdateAction(
-        oldAttributeDefinition.getAttributeConstraint(),
-        newAttributeDefinition.getAttributeConstraint(),
+        oldAttributeConstraint,
+        newAttributeConstraint,
         () ->
             ProductTypeChangeAttributeConstraintActionBuilder.of()
                 .attributeName(oldAttributeDefinition.getName())

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -52,7 +52,7 @@ final class AttributeDefinitionUpdateActionUtils {
   static List<ProductTypeUpdateAction> buildActions(
       @Nonnull final AttributeDefinition oldAttributeDefinition,
       @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft)
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
 
     final List<ProductTypeUpdateAction> updateActions =
         filterEmptyOptionals(
@@ -338,7 +338,7 @@ final class AttributeDefinitionUpdateActionUtils {
   static Optional<ProductTypeUpdateAction> buildChangeAttributeConstraintUpdateAction(
       @Nonnull final AttributeDefinition oldAttributeDefinition,
       @Nonnull final AttributeDefinitionDraft newAttributeDefinition)
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
 
     final AttributeConstraintEnum newAttributeConstraint =
         newAttributeDefinition.getAttributeConstraint();
@@ -347,7 +347,7 @@ final class AttributeDefinitionUpdateActionUtils {
     if (newAttributeConstraint != null
         && !newAttributeConstraint.equals(oldAttributeConstraint)
         && !AttributeConstraintEnum.NONE.equals(newAttributeConstraint)) {
-      throw new BuildUpdateActionException(
+      throw new UnsupportedOperationException(
           format(
               "Invalid AttributeConstraint update to %s. Only following updates are allowed: SameForAll to None and Unique to None.",
               newAttributeConstraint.name()));

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -1,0 +1,367 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static com.commercetools.sync.sdk2.commons.utils.OptionalUtils.filterEmptyOptionals;
+import static com.commercetools.sync.sdk2.producttypes.utils.LocalizedEnumValueUpdateActionUtils.buildLocalizedEnumValuesUpdateActions;
+import static com.commercetools.sync.sdk2.producttypes.utils.PlainEnumValueUpdateActionUtils.buildEnumValuesUpdateActions;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+
+import com.commercetools.api.models.product_type.AttributeConstraintEnum;
+import com.commercetools.api.models.product_type.AttributeConstraintEnumDraft;
+import com.commercetools.api.models.product_type.AttributeDefinition;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeEnumType;
+import com.commercetools.api.models.product_type.AttributeLocalizedEnumType;
+import com.commercetools.api.models.product_type.AttributePlainEnumValue;
+import com.commercetools.api.models.product_type.AttributeSetType;
+import com.commercetools.api.models.product_type.AttributeType;
+import com.commercetools.api.models.product_type.ProductTypeChangeAttributeConstraintActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeInputHintActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeIsSearchableActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeSetInputTipActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.api.models.product_type.TextInputHint;
+import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/** This class is only meant for the internal use of the commercetools-sync-java library. */
+final class AttributeDefinitionUpdateActionUtils {
+  /**
+   * Compares all the fields of an {@link AttributeDefinition} and an {@link
+   * AttributeDefinitionDraft} and returns a list of {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result. If both the
+   * {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have identical fields,
+   * then no update action is needed and hence an empty {@link java.util.List} is returned.
+   *
+   * @param oldAttributeDefinition the old attribute definition which should be updated.
+   * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new
+   *     fields.
+   * @return A list with the update actions or an empty list if the attribute definition fields are
+   *     identical.
+   * @throws com.commercetools.sync.sdk2.commons.exceptions.DuplicateKeyException in case there are
+   *     localized enum values with duplicate keys.
+   * @throws com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException in case of
+   *     any other update action errors.
+   */
+  @Nonnull
+  static List<ProductTypeUpdateAction> buildActions(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft)
+      throws BuildUpdateActionException {
+
+    final List<ProductTypeUpdateAction> updateActions =
+        filterEmptyOptionals(
+            buildChangeLabelUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildSetInputTipUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeIsSearchableUpdateAction(
+                oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeInputHintUpdateAction(oldAttributeDefinition, newAttributeDefinitionDraft),
+            buildChangeAttributeConstraintUpdateAction(
+                oldAttributeDefinition, newAttributeDefinitionDraft));
+
+    updateActions.addAll(
+        buildEnumUpdateActions(oldAttributeDefinition, newAttributeDefinitionDraft));
+    return updateActions;
+  }
+
+  /**
+   * Checks if both the supplied {@code oldAttributeDefinition} and {@code
+   * newAttributeDefinitionDraft} have an {@link AttributeType} that is either an {@link
+   * AttributeEnumType} or a {@link AttributeLocalizedEnumType} or a {@link AttributeSetType} with a
+   * subtype that is either an {@link AttributeEnumType} or a {@link AttributeLocalizedEnumType}.
+   *
+   * <p>The method compares all the {@link AttributePlainEnumValue} and {@link
+   * com.commercetools.api.models.product_type.AttributeLocalizedEnumValue} values of the {@link
+   * AttributeDefinition} and the {@link AttributeDefinitionDraft} attribute types and returns a
+   * list of {@link com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result.
+   * If both the {@link AttributeDefinition} and the {@link AttributeDefinitionDraft} have identical
+   * enum values, then no update action is needed and hence an empty {@link java.util.List} is
+   * returned.
+   *
+   * <p>Note: This method expects the supplied {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} to have the same {@link AttributeType}. Otherwise, the behaviour is
+   * not guaranteed.
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinitionDraft the new attribute definition draft where we get the new
+   *     fields.
+   * @return A list with the update actions or an empty list if the attribute definition enums are
+   *     identical.
+   * @throws com.commercetools.sync.sdk2.commons.exceptions.DuplicateKeyException in case there are
+   *     enum values with duplicate keys.
+   */
+  @Nonnull
+  static List<ProductTypeUpdateAction> buildEnumUpdateActions(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
+
+    final AttributeType oldAttributeType = oldAttributeDefinition.getType();
+    final AttributeType newAttributeType = newAttributeDefinitionDraft.getType();
+
+    return getAttributeEnumType(oldAttributeType)
+        .map(
+            oldEnumAttributeType ->
+                getAttributeEnumType(newAttributeType)
+                    .map(
+                        newEnumAttributeType ->
+                            buildEnumValuesUpdateActions(
+                                oldAttributeDefinition.getName(),
+                                oldEnumAttributeType.getValues(),
+                                newEnumAttributeType.getValues()))
+                    .orElseGet(Collections::emptyList))
+        .orElseGet(
+            () ->
+                getLocalizedEnumAttributeType(oldAttributeType)
+                    .map(
+                        oldLocalizedEnumAttributeType ->
+                            getLocalizedEnumAttributeType(newAttributeType)
+                                .map(
+                                    newLocalizedEnumAttributeType ->
+                                        buildLocalizedEnumValuesUpdateActions(
+                                            oldAttributeDefinition.getName(),
+                                            oldLocalizedEnumAttributeType.getValues(),
+                                            newLocalizedEnumAttributeType.getValues()))
+                                .orElseGet(Collections::emptyList))
+                    .orElseGet(Collections::emptyList));
+  }
+
+  /**
+   * Returns an optional containing the attribute type if is an {@link AttributeEnumType} or if the
+   * {@link AttributeType} is a {@link AttributeSetType} with an {@link AttributeEnumType} as a
+   * subtype, it returns this subtype in the optional. Otherwise, an empty optional.
+   *
+   * @param attributeType the attribute type.
+   * @return an optional containing the attribute type if is an {@link AttributeEnumType} or if the
+   *     {@link AttributeType} is a {@link AttributeSetType} with an {@link AttributeEnumType} as a
+   *     subtype, it returns this subtype in the optional. Otherwise, an empty optional.
+   */
+  private static Optional<AttributeEnumType> getAttributeEnumType(
+      @Nonnull final AttributeType attributeType) {
+
+    if (attributeType instanceof AttributeEnumType) {
+      return Optional.of((AttributeEnumType) attributeType);
+    }
+
+    if (attributeType instanceof AttributeSetType) {
+      final AttributeSetType setFieldType = (AttributeSetType) attributeType;
+      final AttributeType subType = setFieldType.getElementType();
+
+      if (subType instanceof AttributeEnumType) {
+        return Optional.of((AttributeEnumType) subType);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Returns an optional containing the attribute type if is an {@link AttributeLocalizedEnumType}
+   * or if the {@link AttributeType} is a {@link AttributeSetType} with an {@link
+   * AttributeLocalizedEnumType} as a subtype, it returns this subtype in the optional. Otherwise,
+   * an empty optional.
+   *
+   * @param attributeType the attribute type.
+   * @return an optional containing the attribute type if is an {@link AttributeLocalizedEnumType}
+   *     or if the {@link AttributeType} is a {@link AttributeSetType} with an {@link
+   *     AttributeLocalizedEnumType} as a subtype, it returns this subtype in the optional.
+   *     Otherwise, an empty optional.
+   */
+  private static Optional<AttributeLocalizedEnumType> getLocalizedEnumAttributeType(
+      @Nonnull final AttributeType attributeType) {
+
+    if (attributeType instanceof AttributeLocalizedEnumType) {
+      return Optional.of((AttributeLocalizedEnumType) attributeType);
+    }
+
+    if (attributeType instanceof AttributeSetType) {
+      final AttributeSetType setFieldType = (AttributeSetType) attributeType;
+      final AttributeType subType = setFieldType.getElementType();
+
+      if (subType instanceof AttributeLocalizedEnumType) {
+        return Optional.of((AttributeLocalizedEnumType) subType);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Compares the {@link com.commercetools.api.models.common.LocalizedString} labels of an {@link
+   * AttributeDefinition} and an {@link AttributeDefinitionDraft} and returns an {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result in an {@link
+   * java.util.Optional}. If both the {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} have the same label, then no update action is needed and hence an
+   * empty {@link java.util.Optional} is returned.
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinition the attribute definition draft where we get the new label.
+   * @return A filled optional with the update action or an empty optional if the labels are
+   *     identical.
+   */
+  @Nonnull
+  static Optional<ProductTypeUpdateAction> buildChangeLabelUpdateAction(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+    return buildUpdateAction(
+        oldAttributeDefinition.getLabel(),
+        newAttributeDefinition.getLabel(),
+        () ->
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(oldAttributeDefinition.getName())
+                .label(newAttributeDefinition.getLabel())
+                .build());
+  }
+
+  /**
+   * Compares the {@link com.commercetools.api.models.common.LocalizedString} input tips of an
+   * {@link AttributeDefinition} and an {@link AttributeDefinitionDraft} and returns an {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result in an {@link
+   * java.util.Optional}. If both the {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} have the same input tip, then no update action is needed and hence an
+   * empty {@link java.util.Optional} is returned.
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinition the attribute definition draft where we get the new input tip.
+   * @return A filled optional with the update action or an empty optional if the labels are
+   *     identical.
+   */
+  @Nonnull
+  static Optional<ProductTypeUpdateAction> buildSetInputTipUpdateAction(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+    return buildUpdateAction(
+        oldAttributeDefinition.getInputTip(),
+        newAttributeDefinition.getInputTip(),
+        () ->
+            ProductTypeSetInputTipActionBuilder.of()
+                .attributeName(oldAttributeDefinition.getName())
+                .inputTip(newAttributeDefinition.getInputTip())
+                .build());
+  }
+
+  /**
+   * Compares the 'isSearchable' fields of an {@link AttributeDefinition} and an {@link
+   * AttributeDefinitionDraft} and returns an {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result in an {@link
+   * java.util.Optional}. If both the {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} have the same 'isSearchable' field, then no update action is needed
+   * and hence an empty {@link java.util.Optional} is returned.
+   *
+   * <p>Note: A {@code null} {@code isSearchable} value in the {@link AttributeDefinitionDraft} is
+   * treated as a {@code true} value which is the default value of CTP.
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinition the attribute definition draft where we get the new
+   *     'isSearchable' field.
+   * @return A filled optional with the update action or an empty optional if the 'isSearchable'
+   *     fields are identical.
+   */
+  @Nonnull
+  static Optional<ProductTypeUpdateAction> buildChangeIsSearchableUpdateAction(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+    final Boolean searchable = ofNullable(newAttributeDefinition.getIsSearchable()).orElse(true);
+
+    return buildUpdateAction(
+        oldAttributeDefinition.getIsSearchable(),
+        searchable,
+        () ->
+            ProductTypeChangeIsSearchableActionBuilder.of()
+                .attributeName(oldAttributeDefinition.getName())
+                .isSearchable(searchable)
+                .build());
+  }
+
+  /**
+   * Compares the input hints of an {@link AttributeDefinition} and an {@link
+   * AttributeDefinitionDraft} and returns an {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result in an {@link
+   * java.util.Optional}. If both the {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} have the same input hints, then no update action is needed and hence
+   * an empty {@link java.util.Optional} is returned.
+   *
+   * <p>Note: A {@code null} {@code inputHint} value in the {@link AttributeDefinitionDraft} is
+   * treated as a {@code TextInputHint#SINGLE_LINE} value which is the default value of CTP.
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinition the attribute definition draft where we get the new input hint.
+   * @return A filled optional with the update action or an empty optional if the input hints are
+   *     identical.
+   */
+  @Nonnull
+  static Optional<ProductTypeUpdateAction> buildChangeInputHintUpdateAction(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinition) {
+
+    final TextInputHint inputHint =
+        ofNullable(newAttributeDefinition.getInputHint()).orElse(TextInputHint.SINGLE_LINE);
+
+    return buildUpdateAction(
+        oldAttributeDefinition.getInputHint(),
+        inputHint,
+        () ->
+            ProductTypeChangeInputHintActionBuilder.of()
+                .attributeName(oldAttributeDefinition.getName())
+                .newValue(inputHint)
+                .build());
+  }
+
+  /**
+   * Compares the attribute constraints of an {@link AttributeDefinition} and an {@link
+   * AttributeDefinitionDraft} and returns an {@link
+   * com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result in an {@link
+   * java.util.Optional}. If both the {@link AttributeDefinition} and the {@link
+   * AttributeDefinitionDraft} have the same attribute constraints, then no update action is needed
+   * and hence an empty {@link java.util.Optional} is returned.
+   *
+   * <p>Note: Only following changes are supported: SameForAll to None and Unique to None. See the
+   * docs:
+   * https://docs.commercetools.com/api/projects/productTypes#change-attributedefinition-attributeconstraint
+   *
+   * @param oldAttributeDefinition the attribute definition which should be updated.
+   * @param newAttributeDefinition the attribute definition draft where we get the new attribute
+   *     constraint.
+   * @return A filled optional with the update action or an empty optional if the attribute
+   *     constraints are identical.
+   * @throws BuildUpdateActionException If newAttributeDefinition has other values than {@code
+   *     AttributeConstraintEnum.NONE}
+   */
+  @Nonnull
+  static Optional<ProductTypeUpdateAction> buildChangeAttributeConstraintUpdateAction(
+      @Nonnull final AttributeDefinition oldAttributeDefinition,
+      @Nonnull final AttributeDefinitionDraft newAttributeDefinition)
+      throws BuildUpdateActionException {
+
+    final AttributeConstraintEnum newAttributeConstraint =
+        newAttributeDefinition.getAttributeConstraint();
+    final AttributeConstraintEnum oldAttributeConstraint =
+        oldAttributeDefinition.getAttributeConstraint();
+    if (newAttributeConstraint != null
+        && !newAttributeConstraint.equals(oldAttributeConstraint)
+        && !AttributeConstraintEnum.NONE.equals(newAttributeConstraint)) {
+      throw new BuildUpdateActionException(
+          format(
+              "Invalid AttributeConstraint update to %s. Only following updates are allowed: SameForAll to None and Unique to None.",
+              newAttributeConstraint.name()));
+    }
+
+    return buildUpdateAction(
+        oldAttributeDefinition.getAttributeConstraint(),
+        newAttributeDefinition.getAttributeConstraint(),
+        () ->
+            ProductTypeChangeAttributeConstraintActionBuilder.of()
+                .attributeName(oldAttributeDefinition.getName())
+                .newValue(AttributeConstraintEnumDraft.NONE)
+                .build());
+  }
+
+  private AttributeDefinitionUpdateActionUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtils.java
@@ -99,52 +99,37 @@ final class AttributeDefinitionUpdateActionUtils {
   static List<ProductTypeUpdateAction> buildEnumUpdateActions(
       @Nonnull final AttributeDefinition oldAttributeDefinition,
       @Nonnull final AttributeDefinitionDraft newAttributeDefinitionDraft) {
-
     final AttributeType oldAttributeType = oldAttributeDefinition.getType();
     final AttributeType newAttributeType = newAttributeDefinitionDraft.getType();
+    final AttributeEnumType oldEnumAttributeType = getAttributeEnumType(oldAttributeType);
+    final AttributeEnumType newEnumAttributeType = getAttributeEnumType(newAttributeType);
+    if (oldEnumAttributeType != null && newEnumAttributeType != null) {
+      return buildEnumValuesUpdateActions(
+          oldAttributeDefinition.getName(),
+          oldEnumAttributeType.getValues(),
+          newEnumAttributeType.getValues());
+    } else {
+      final AttributeLocalizedEnumType oldLocalizedEnumAttributeType =
+          getLocalizedEnumAttributeType(oldAttributeType);
+      final AttributeLocalizedEnumType newLocalizedEnumAttributeType =
+          getLocalizedEnumAttributeType(newAttributeType);
+      if (oldLocalizedEnumAttributeType != null && newLocalizedEnumAttributeType != null) {
+        return buildLocalizedEnumValuesUpdateActions(
+            oldAttributeDefinition.getName(),
+            oldLocalizedEnumAttributeType.getValues(),
+            newLocalizedEnumAttributeType.getValues());
 
-    return getAttributeEnumType(oldAttributeType)
-        .map(
-            oldEnumAttributeType ->
-                getAttributeEnumType(newAttributeType)
-                    .map(
-                        newEnumAttributeType ->
-                            buildEnumValuesUpdateActions(
-                                oldAttributeDefinition.getName(),
-                                oldEnumAttributeType.getValues(),
-                                newEnumAttributeType.getValues()))
-                    .orElseGet(Collections::emptyList))
-        .orElseGet(
-            () ->
-                getLocalizedEnumAttributeType(oldAttributeType)
-                    .map(
-                        oldLocalizedEnumAttributeType ->
-                            getLocalizedEnumAttributeType(newAttributeType)
-                                .map(
-                                    newLocalizedEnumAttributeType ->
-                                        buildLocalizedEnumValuesUpdateActions(
-                                            oldAttributeDefinition.getName(),
-                                            oldLocalizedEnumAttributeType.getValues(),
-                                            newLocalizedEnumAttributeType.getValues()))
-                                .orElseGet(Collections::emptyList))
-                    .orElseGet(Collections::emptyList));
+      } else {
+        return Collections.emptyList();
+      }
+    }
   }
 
-  /**
-   * Returns an optional containing the attribute type if is an {@link AttributeEnumType} or if the
-   * {@link AttributeType} is a {@link AttributeSetType} with an {@link AttributeEnumType} as a
-   * subtype, it returns this subtype in the optional. Otherwise, an empty optional.
-   *
-   * @param attributeType the attribute type.
-   * @return an optional containing the attribute type if is an {@link AttributeEnumType} or if the
-   *     {@link AttributeType} is a {@link AttributeSetType} with an {@link AttributeEnumType} as a
-   *     subtype, it returns this subtype in the optional. Otherwise, an empty optional.
-   */
-  private static Optional<AttributeEnumType> getAttributeEnumType(
+  private static AttributeEnumType getAttributeEnumType(
       @Nonnull final AttributeType attributeType) {
 
     if (attributeType instanceof AttributeEnumType) {
-      return Optional.of((AttributeEnumType) attributeType);
+      return (AttributeEnumType) attributeType;
     }
 
     if (attributeType instanceof AttributeSetType) {
@@ -152,30 +137,18 @@ final class AttributeDefinitionUpdateActionUtils {
       final AttributeType subType = setFieldType.getElementType();
 
       if (subType instanceof AttributeEnumType) {
-        return Optional.of((AttributeEnumType) subType);
+        return (AttributeEnumType) subType;
       }
     }
 
-    return Optional.empty();
+    return null;
   }
 
-  /**
-   * Returns an optional containing the attribute type if is an {@link AttributeLocalizedEnumType}
-   * or if the {@link AttributeType} is a {@link AttributeSetType} with an {@link
-   * AttributeLocalizedEnumType} as a subtype, it returns this subtype in the optional. Otherwise,
-   * an empty optional.
-   *
-   * @param attributeType the attribute type.
-   * @return an optional containing the attribute type if is an {@link AttributeLocalizedEnumType}
-   *     or if the {@link AttributeType} is a {@link AttributeSetType} with an {@link
-   *     AttributeLocalizedEnumType} as a subtype, it returns this subtype in the optional.
-   *     Otherwise, an empty optional.
-   */
-  private static Optional<AttributeLocalizedEnumType> getLocalizedEnumAttributeType(
+  private static AttributeLocalizedEnumType getLocalizedEnumAttributeType(
       @Nonnull final AttributeType attributeType) {
 
     if (attributeType instanceof AttributeLocalizedEnumType) {
-      return Optional.of((AttributeLocalizedEnumType) attributeType);
+      return (AttributeLocalizedEnumType) attributeType;
     }
 
     if (attributeType instanceof AttributeSetType) {
@@ -183,11 +156,11 @@ final class AttributeDefinitionUpdateActionUtils {
       final AttributeType subType = setFieldType.getElementType();
 
       if (subType instanceof AttributeLocalizedEnumType) {
-        return Optional.of((AttributeLocalizedEnumType) subType);
+        return (AttributeLocalizedEnumType) subType;
       }
     }
 
-    return Optional.empty();
+    return null;
   }
 
   /**

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionsUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionsUpdateActionUtils.java
@@ -1,0 +1,325 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static com.commercetools.sync.sdk2.producttypes.utils.AttributeDefinitionUpdateActionUtils.buildActions;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.commercetools.api.models.product_type.AttributeDefinition;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeEnumType;
+import com.commercetools.api.models.product_type.AttributeLocalizedEnumType;
+import com.commercetools.api.models.product_type.AttributeReferenceType;
+import com.commercetools.api.models.product_type.AttributeSetType;
+import com.commercetools.api.models.product_type.AttributeType;
+import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeAttributeOrderByNameActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeRemoveAttributeDefinitionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.sdk2.commons.exceptions.DuplicateKeyException;
+import com.commercetools.sync.sdk2.commons.exceptions.DuplicateNameException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** This class is only meant for the internal use of the commercetools-sync-java library. */
+final class AttributeDefinitionsUpdateActionUtils {
+
+  /**
+   * Compares a list of {@link AttributeDefinition}s with a list of {@link
+   * AttributeDefinitionDraft}s to returns a {@link java.util.List} of {@link
+   * ProductTypeUpdateAction}. If both lists have identical AttributeDefinitions, then no update
+   * actions are needed and hence an empty {@link java.util.List} is returned.
+   *
+   * <p>If the list of new {@link AttributeDefinitionDraft}s is {@code null}, then remove actions
+   * are built for every existing attribute definition in the {@code oldAttributeDefinitions} list.
+   *
+   * <p>Note: The method will ignore/filter out {@code null} attribute definitions drafts from the
+   * passed {@code newAttributeDefinitionDrafts}.
+   *
+   * @param oldAttributeDefinitions the old list of attribute definitions.
+   * @param newAttributeDefinitionsDrafts the new list of attribute definitions drafts.
+   * @return a list of attribute definitions update actions if the list of attribute definitions are
+   *     not identical. Otherwise, if the attribute definitions are identical, an empty list is
+   *     returned.
+   * @throws BuildUpdateActionException in case there are attribute definitions drafts with
+   *     duplicate names or enums duplicate keys.
+   */
+  @Nonnull
+  static List<ProductTypeUpdateAction> buildAttributeDefinitionsUpdateActions(
+      @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
+      @Nullable final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts)
+      throws BuildUpdateActionException {
+
+    if (newAttributeDefinitionsDrafts != null) {
+      return buildUpdateActions(
+          oldAttributeDefinitions,
+          newAttributeDefinitionsDrafts.stream().filter(Objects::nonNull).collect(toList()));
+    } else {
+      return oldAttributeDefinitions.stream()
+          .map(AttributeDefinition::getName)
+          .map(name -> ProductTypeRemoveAttributeDefinitionActionBuilder.of().name(name).build())
+          .collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * Compares a list of {@link AttributeDefinition}s with a list of {@link
+   * AttributeDefinitionDraft}s. The method serves as an implementation for attribute definitions
+   * syncing. The method takes in functions for building the required update actions (AddAttribute,
+   * RemoveAttribute, ChangeAttributeOrder and 1-1 update actions on attribute definitions (e.g.
+   * changeAttributeName, changeAttributeLabel, etc..) for the required resource.
+   *
+   * @param oldAttributeDefinitions the old list of attribute definitions.
+   * @param newAttributeDefinitionsDrafts the new list of attribute definitions drafts.
+   * @return a list of attribute definitions update actions if the list of attribute definitions is
+   *     not identical. Otherwise, if the attribute definitions are identical, an empty list is
+   *     returned.
+   * @throws BuildUpdateActionException in case there are attribute definitions drafts with
+   *     duplicate names, enums duplicate keys or unsupported attribute definition type change.
+   */
+  @Nonnull
+  private static List<ProductTypeUpdateAction> buildUpdateActions(
+      @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
+      @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts)
+      throws BuildUpdateActionException {
+
+    try {
+      final List<ProductTypeUpdateAction> updateActions =
+          buildRemoveAttributeDefinitionOrAttributeDefinitionUpdateActions(
+              oldAttributeDefinitions, newAttributeDefinitionsDrafts);
+
+      updateActions.addAll(
+          buildAddAttributeDefinitionUpdateActions(
+              oldAttributeDefinitions, newAttributeDefinitionsDrafts));
+
+      buildChangeAttributeDefinitionOrderUpdateAction(
+              oldAttributeDefinitions, newAttributeDefinitionsDrafts)
+          .ifPresent(updateActions::add);
+
+      return updateActions;
+
+    } catch (final DuplicateNameException
+        | DuplicateKeyException
+        | UnsupportedOperationException exception) {
+      throw new BuildUpdateActionException(exception);
+    }
+  }
+
+  /**
+   * Checks if there are any attribute definitions which are not existing in the {@code
+   * newAttributeDefinitionsDrafts}. If there are, then "remove" attribute definition update actions
+   * are built. Otherwise, if the attribute definition still exists in the new draft, then compare
+   * the attribute definition fields (name, label, etc..), and add the computed actions to the list
+   * of update actions.
+   *
+   * @param oldAttributeDefinitions the list of old {@link AttributeDefinition}s.
+   * @param newAttributeDefinitionsDrafts the list of new {@link AttributeDefinitionDraft}s.
+   * @return a list of attribute definition update actions if there are attribute definitions that
+   *     are not existing in the new draft. If the attribute definition still exists in the new
+   *     draft, then compare the attribute definition fields (name, label, etc..), and add the
+   *     computed actions to the list of update actions. Otherwise, if the attribute definitions are
+   *     identical, an empty optional is returned.
+   * @throws DuplicateNameException in case there are attribute definitions drafts with duplicate
+   *     names.
+   * @throws DuplicateKeyException in case there are enum values with duplicate keys.
+   * @throws UnsupportedOperationException in case the attribute type field changes.
+   */
+  @Nonnull
+  private static List<ProductTypeUpdateAction>
+      buildRemoveAttributeDefinitionOrAttributeDefinitionUpdateActions(
+          @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
+          @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionsDrafts) {
+
+    final Map<String, AttributeDefinitionDraft> newAttributesDefinitionsDraftsNameMap =
+        newAttributeDefinitionsDrafts.stream()
+            .collect(
+                toMap(
+                    AttributeDefinitionDraft::getName,
+                    attributeDefinitionDraft -> attributeDefinitionDraft,
+                    (attributeDefinitionDraftA, attributeDefinitionDraftB) -> {
+                      throw new DuplicateNameException(
+                          format(
+                              "Attribute definitions drafts have duplicated names. "
+                                  + "Duplicated attribute definition name: '%s'. "
+                                  + "Attribute definitions names are expected to be unique inside their product type.",
+                              attributeDefinitionDraftA.getName()));
+                    }));
+
+    return oldAttributeDefinitions.stream()
+        .map(
+            oldAttributeDefinition -> {
+              final String oldAttributeDefinitionName = oldAttributeDefinition.getName();
+              final AttributeDefinitionDraft matchingNewAttributeDefinitionDraft =
+                  newAttributesDefinitionsDraftsNameMap.get(oldAttributeDefinitionName);
+              if (matchingNewAttributeDefinitionDraft == null) {
+                return singletonList(
+                    ProductTypeRemoveAttributeDefinitionActionBuilder.of()
+                        .name(oldAttributeDefinitionName)
+                        .build());
+              } else {
+                // attribute type is required so if null we let commercetools to throw
+                // exception
+                if (matchingNewAttributeDefinitionDraft.getType() != null) {
+                  if (haveSameAttributeType(
+                      oldAttributeDefinition.getType(),
+                      matchingNewAttributeDefinitionDraft.getType())) {
+                    return buildActions(
+                        oldAttributeDefinition, matchingNewAttributeDefinitionDraft);
+                  } else {
+                    throw new UnsupportedOperationException(
+                        format(
+                            "Due to eventual consistency of 'removeAttributeDefinition' action, "
+                                + "changing the attribute definition type (attribute name='%s') is not "
+                                + "supported programmatically. "
+                                + "Please apply the attribute definition type changes "
+                                + "manually through commercetools API or merchant center. "
+                                + "For more information please check: https://github.com/commercetools/commercetools-sync-java/blob/master/docs/adr/0003-syncing-attribute-type-changes.md",
+                            oldAttributeDefinitionName));
+                  }
+                } else {
+                  return new ArrayList<ProductTypeUpdateAction>();
+                }
+              }
+            })
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Compares the attribute types of the {@code attributeDefinitionA} and the {@code
+   * attributeDefinitionB} and returns true if both attribute definitions have the same attribute
+   * type, false otherwise.
+   *
+   * <p>Note:
+   *
+   * <ul>
+   *   <li>It returns true if both attribute types are of {@link AttributeEnumType} type, regardless
+   *       of the enum values.
+   *   <li>It returns true if both attribute types are of {@link AttributeLocalizedEnumType} type,
+   *       regardless of the localized enum values.
+   * </ul>
+   *
+   * @param attributeTypeA the first attribute type to compare.
+   * @param attributeTypeB the second attribute type to compare.
+   * @return true if both attribute definitions have the same attribute type, false otherwise.
+   */
+  private static boolean haveSameAttributeType(
+      @Nonnull final AttributeType attributeTypeA, @Nonnull final AttributeType attributeTypeB) {
+    if (attributeTypeA instanceof AttributeSetType && attributeTypeB instanceof AttributeSetType) {
+      return haveSameAttributeType(
+          ((AttributeSetType) attributeTypeA).getElementType(),
+          ((AttributeSetType) attributeTypeB).getElementType());
+    }
+
+    if (attributeTypeA instanceof AttributeReferenceType
+        && attributeTypeB instanceof AttributeReferenceType) {
+      return attributeTypeA.equals(attributeTypeB);
+    }
+
+    if (attributeTypeA instanceof AttributeEnumType
+        && attributeTypeB instanceof AttributeEnumType) {
+      return true;
+    }
+
+    if (attributeTypeA instanceof AttributeLocalizedEnumType
+        && attributeTypeB instanceof AttributeLocalizedEnumType) {
+      return true;
+    }
+
+    return Objects.equals(attributeTypeA, attributeTypeB);
+  }
+
+  /**
+   * Compares the order of a list of old {@link AttributeDefinition}s and a list of new {@link
+   * AttributeDefinitionDraft}s. If there is a change in order, then a change attribute definition
+   * order (with the new order) is built. If there are no changes in order an empty optional is
+   * returned.
+   *
+   * @param oldAttributeDefinitions the list of old {@link AttributeDefinition}s
+   * @param newAttributeDefinitionDrafts the list of new {@link AttributeDefinitionDraft}s
+   * @return a list of attribute definition update actions if the order of attribute definitions is
+   *     not identical. Otherwise, if the attribute definitions order is identical, an empty
+   *     optional is returned.
+   */
+  @Nonnull
+  private static Optional<ProductTypeUpdateAction> buildChangeAttributeDefinitionOrderUpdateAction(
+      @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
+      @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionDrafts) {
+
+    final List<String> newNames =
+        newAttributeDefinitionDrafts.stream()
+            .map(AttributeDefinitionDraft::getName)
+            .collect(toList());
+
+    final List<String> existingNames =
+        oldAttributeDefinitions.stream()
+            .map(AttributeDefinition::getName)
+            .filter(newNames::contains)
+            .collect(toList());
+
+    final List<String> notExistingNames =
+        newNames.stream().filter(newName -> !existingNames.contains(newName)).collect(toList());
+
+    final List<String> newAttributeDefinitionsOrder =
+        newAttributeDefinitionDrafts.stream()
+            .map(AttributeDefinitionDraft::getName)
+            .collect(toList());
+
+    final List<String> allNames =
+        Stream.concat(existingNames.stream(), notExistingNames.stream()).collect(toList());
+
+    return buildUpdateAction(
+        allNames,
+        newNames,
+        () ->
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(newAttributeDefinitionsOrder)
+                .build());
+  }
+
+  /**
+   * Checks if there are any new attribute definition drafts which are not existing in the {@code
+   * oldAttributeDefinitions}. If there are, then "add" attribute definition update actions are
+   * built. Otherwise, if there are no new attribute definitions, then an empty list is returned.
+   *
+   * @param oldAttributeDefinitions the list of old {@link AttributeDefinition}s.
+   * @param newAttributeDefinitionDrafts the list of new {@link AttributeDefinitionDraft}s.
+   * @return a list of attribute definition update actions if there are new attribute definition
+   *     that should be added. Otherwise, if the attribute definitions are identical, an empty
+   *     optional is returned.
+   */
+  @Nonnull
+  private static List<ProductTypeUpdateAction> buildAddAttributeDefinitionUpdateActions(
+      @Nonnull final List<AttributeDefinition> oldAttributeDefinitions,
+      @Nonnull final List<AttributeDefinitionDraft> newAttributeDefinitionDrafts) {
+
+    final Map<String, AttributeDefinition> oldAttributeDefinitionNameMap =
+        oldAttributeDefinitions.stream()
+            .collect(
+                toMap(AttributeDefinition::getName, attributeDefinition -> attributeDefinition));
+
+    return newAttributeDefinitionDrafts.stream()
+        .filter(
+            attributeDefinitionDraft ->
+                !oldAttributeDefinitionNameMap.containsKey(attributeDefinitionDraft.getName()))
+        .map(
+            attributeDefinitionDraft ->
+                ProductTypeAddAttributeDefinitionActionBuilder.of()
+                    .attribute(attributeDefinitionDraft)
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  private AttributeDefinitionsUpdateActionUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeSyncUtils.java
@@ -1,0 +1,48 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.OptionalUtils.filterEmptyOptionals;
+import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.*;
+
+import com.commercetools.api.models.product_type.ProductType;
+import com.commercetools.api.models.product_type.ProductTypeDraft;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.sync.sdk2.producttypes.ProductTypeSyncOptions;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public final class ProductTypeSyncUtils {
+
+  /**
+   * Compares all the fields (including the attributes see {@link
+   * ProductTypeUpdateActionUtils#buildAttributesUpdateActions}) of a {@link ProductType} and a
+   * {@link ProductTypeDraft}. It returns a {@link java.util.List} of {@link
+   * ProductTypeUpdateAction} as a result. If no update action is needed, for example in case where
+   * both the {@link ProductType} and the {@link ProductTypeDraft} have the same fields, an empty
+   * {@link java.util.List} is returned.
+   *
+   * @param oldProductType the {@link ProductType} which should be updated.
+   * @param newProductType the {@link ProductTypeDraft} where we get the new data.
+   * @param syncOptions the sync options wrapper which contains options related to the sync process
+   *     supplied by the user. For example, custom callbacks to call in case of warnings or errors
+   *     occurring on the build update action process. And other options (See {@link
+   *     ProductTypeSyncOptions} for more info.
+   * @return A list of productType-specific update actions.
+   */
+  @Nonnull
+  public static List<ProductTypeUpdateAction> buildActions(
+      @Nonnull final ProductType oldProductType,
+      @Nonnull final ProductTypeDraft newProductType,
+      @Nonnull final ProductTypeSyncOptions syncOptions) {
+
+    final List<ProductTypeUpdateAction> updateActions =
+        filterEmptyOptionals(
+            buildChangeNameAction(oldProductType, newProductType),
+            buildChangeDescriptionAction(oldProductType, newProductType));
+
+    updateActions.addAll(buildAttributesUpdateActions(oldProductType, newProductType, syncOptions));
+
+    return updateActions;
+  }
+
+  private ProductTypeSyncUtils() {}
+}

--- a/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtils.java
@@ -1,0 +1,105 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CommonTypeUpdateActionUtils.buildUpdateAction;
+import static com.commercetools.sync.sdk2.producttypes.utils.AttributeDefinitionsUpdateActionUtils.buildAttributeDefinitionsUpdateActions;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+import com.commercetools.api.models.product_type.ProductType;
+import com.commercetools.api.models.product_type.ProductTypeChangeDescriptionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeNameActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeDraft;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.producttypes.ProductTypeSyncOptions;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+public final class ProductTypeUpdateActionUtils {
+  /**
+   * Compares the {@code name} values of a {@link ProductType} and a {@link ProductTypeDraft} and
+   * returns an {@link java.util.Optional} of update action, which would contain the {@code
+   * "changeName"} {@link com.commercetools.api.models.product_type.ProductTypeChangeNameAction}. If
+   * both {@link ProductType} and {@link ProductTypeDraft} have the same {@code name} values, then
+   * no update action is needed and empty optional will be returned.
+   *
+   * @param oldProductType the product type that should be updated.
+   * @param newProductType the product type draft which contains the new name.
+   * @return optional containing update action or empty optional if names are identical.
+   */
+  @Nonnull
+  public static Optional<ProductTypeUpdateAction> buildChangeNameAction(
+      @Nonnull final ProductType oldProductType, @Nonnull final ProductTypeDraft newProductType) {
+
+    return buildUpdateAction(
+        oldProductType.getName(),
+        newProductType.getName(),
+        () -> ProductTypeChangeNameActionBuilder.of().name(newProductType.getName()).build());
+  }
+
+  /**
+   * Compares the {@code description} values of a {@link ProductType} and a {@link ProductTypeDraft}
+   * and returns an {@link java.util.Optional} of update action, which would contain the {@link
+   * com.commercetools.api.models.product_type.ProductTypeChangeDescriptionAction}. If both {@link
+   * ProductType} and {@link ProductTypeDraft} have the same {@code description} values, then no
+   * update action is needed and empty optional will be returned.
+   *
+   * @param oldProductType the product type that should be updated.
+   * @param newProductType the product type draft which contains the new description.
+   * @return optional containing update action or empty optional if descriptions are identical.
+   */
+  @Nonnull
+  public static Optional<ProductTypeUpdateAction> buildChangeDescriptionAction(
+      @Nonnull final ProductType oldProductType, @Nonnull final ProductTypeDraft newProductType) {
+
+    return buildUpdateAction(
+        oldProductType.getDescription(),
+        newProductType.getDescription(),
+        () ->
+            ProductTypeChangeDescriptionActionBuilder.of()
+                .description(newProductType.getDescription())
+                .build());
+  }
+
+  /**
+   * Compares the attributes of a {@link ProductType} and a {@link ProductTypeDraft} and returns a
+   * list of {@link com.commercetools.api.models.product_type.ProductTypeUpdateAction} as a result.
+   * If both the {@link ProductType} and the {@link ProductTypeDraft} have identical attributes,
+   * then no update action is needed and hence an empty {@link java.util.List} is returned. In case,
+   * the new product type draft has a list of attributes in which a duplicate name exists, the error
+   * callback is triggered and an empty list is returned.
+   *
+   * @param oldProductType the product type which should be updated.
+   * @param newProductType the product type draft where we get the key.
+   * @param syncOptions responsible for supplying the sync options to the sync utility method. It is
+   *     used for triggering the error callback within the utility, in case of errors.
+   * @return A list with the update actions or an empty list if the attributes are identical.
+   */
+  @Nonnull
+  public static List<ProductTypeUpdateAction> buildAttributesUpdateActions(
+      @Nonnull final ProductType oldProductType,
+      @Nonnull final ProductTypeDraft newProductType,
+      @Nonnull final ProductTypeSyncOptions syncOptions) {
+
+    try {
+      return buildAttributeDefinitionsUpdateActions(
+          oldProductType.getAttributes(), newProductType.getAttributes());
+    } catch (final BuildUpdateActionException exception) {
+      syncOptions.applyErrorCallback(
+          new SyncException(
+              format(
+                  "Failed to build update actions for the attributes definitions "
+                      + "of the product type with the key '%s'. Reason: %s",
+                  oldProductType.getKey(), exception),
+              exception),
+          oldProductType,
+          newProductType,
+          null);
+      return emptyList();
+    }
+  }
+
+  private ProductTypeUpdateActionUtils() {}
+}

--- a/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/producttypes/utils/producttypeactionutils/BuildLocalizedEnumUpdateActionsTest.java
@@ -19,6 +19,9 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+// NOTE: All the tests were migrated to java SDK v2 already. They're in this test file:
+// LocalizedEnumValueUpdateActionUtilsTest
+// Reason: it's easier to navigate to the test file if we have 1 unit test file per class.
 class BuildLocalizedEnumUpdateActionsTest {
 
   @Test

--- a/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateNameExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateNameExceptionTest.java
@@ -1,0 +1,47 @@
+package com.commercetools.sync.sdk2.commons.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class DuplicateNameExceptionTest {
+  @Test
+  void duplicateNameException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateNameException(message);
+            })
+        .isExactlyInstanceOf(DuplicateNameException.class)
+        .hasNoCause()
+        .hasMessage(message);
+  }
+
+  @Test
+  void duplicateNameException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateNameException(message, cause);
+            })
+        .isExactlyInstanceOf(DuplicateNameException.class)
+        .hasCause(cause)
+        .hasMessage(message);
+  }
+
+  @Test
+  void duplicateNameException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateNameException(cause);
+            })
+        .isExactlyInstanceOf(DuplicateNameException.class)
+        .hasCause(cause)
+        .hasMessage(cause.toString());
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/MockBuilderUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/MockBuilderUtils.java
@@ -6,10 +6,28 @@ import com.commercetools.api.models.product_type.AttributeConstraintEnum;
 import com.commercetools.api.models.product_type.AttributeDefinitionBuilder;
 import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
 import com.commercetools.api.models.product_type.AttributeTypeBuilder;
+import com.commercetools.api.models.product_type.ProductTypeBuilder;
+import com.commercetools.api.models.product_type.ProductTypeDraftBuilder;
 import com.commercetools.api.models.product_type.TextInputHint;
+import java.time.ZonedDateTime;
 
-public class TestBuilderUtils {
-  public static AttributeDefinitionDraftBuilder createDefaultAttributeDefinitionDraftBuilder() {
+public class MockBuilderUtils {
+
+  public static ProductTypeBuilder createMockProductTypeBuilder() {
+    return ProductTypeBuilder.of()
+        .id("test")
+        .version(1L)
+        .createdAt(ZonedDateTime.now())
+        .lastModifiedAt(ZonedDateTime.now())
+        .name("foo")
+        .description("foo");
+  }
+
+  public static ProductTypeDraftBuilder createMockProductTypeDraftBuilder() {
+    return ProductTypeDraftBuilder.of().name("foo").description("foo");
+  }
+
+  public static AttributeDefinitionDraftBuilder createMockAttributeDefinitionDraftBuilder() {
     return AttributeDefinitionDraftBuilder.of()
         .name("foo")
         .label(ofEnglish("x"))
@@ -20,7 +38,7 @@ public class TestBuilderUtils {
         .isSearchable(false);
   }
 
-  public static AttributeDefinitionBuilder createDefaultAttributeDefinitionBuilder() {
+  public static AttributeDefinitionBuilder createMockAttributeDefinitionBuilder() {
     return AttributeDefinitionBuilder.of()
         .name("foo")
         .label(ofEnglish("x"))

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/TestBuilderUtils.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/TestBuilderUtils.java
@@ -1,0 +1,33 @@
+package com.commercetools.sync.sdk2.producttypes;
+
+import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+
+import com.commercetools.api.models.product_type.AttributeConstraintEnum;
+import com.commercetools.api.models.product_type.AttributeDefinitionBuilder;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
+import com.commercetools.api.models.product_type.AttributeTypeBuilder;
+import com.commercetools.api.models.product_type.TextInputHint;
+
+public class TestBuilderUtils {
+  public static AttributeDefinitionDraftBuilder createDefaultAttributeDefinitionDraftBuilder() {
+    return AttributeDefinitionDraftBuilder.of()
+        .name("foo")
+        .label(ofEnglish("x"))
+        .type(AttributeTypeBuilder::textBuilder)
+        .inputHint(TextInputHint.MULTI_LINE)
+        .attributeConstraint(AttributeConstraintEnum.NONE)
+        .isRequired(true)
+        .isSearchable(false);
+  }
+
+  public static AttributeDefinitionBuilder createDefaultAttributeDefinitionBuilder() {
+    return AttributeDefinitionBuilder.of()
+        .name("foo")
+        .label(ofEnglish("x"))
+        .type(AttributeTypeBuilder::textBuilder)
+        .inputHint(TextInputHint.MULTI_LINE)
+        .attributeConstraint(AttributeConstraintEnum.NONE)
+        .isRequired(true)
+        .isSearchable(false);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -67,7 +67,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
             .isRequired(false)
             .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
             .inputTip(ofEnglish("inputTip1"))
-            .inputHint(TextInputHint.TextInputHintEnum.SINGLE_LINE)
+            .inputHint(TextInputHint.SINGLE_LINE)
             .isSearchable(false)
             .build();
 

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -1,6 +1,8 @@
 package com.commercetools.sync.sdk2.producttypes.utils;
 
 import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionBuilder;
+import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionDraftBuilder;
 import static com.commercetools.sync.sdk2.producttypes.utils.AttributeDefinitionUpdateActionUtils.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -33,7 +35,6 @@ import com.commercetools.api.models.product_type.ProductTypeRemoveEnumValuesActi
 import com.commercetools.api.models.product_type.ProductTypeSetInputTipActionBuilder;
 import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
 import com.commercetools.api.models.product_type.TextInputHint;
-import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
 import com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters;
 import java.util.List;
 import java.util.Optional;
@@ -74,7 +75,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
     newDifferent =
         AttributeDefinitionDraftBuilder.of()
-            .type(attributeTypeBuilder -> attributeTypeBuilder.textBuilder())
+            .type(AttributeTypeBuilder::textBuilder)
             .name("attributeName1")
             .label(ofEnglish("label2"))
             .isRequired(true)
@@ -356,7 +357,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldBuildAction()
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
         createDefaultAttributeDefinitionDraftBuilder()
@@ -382,7 +383,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional()
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
         createDefaultAttributeDefinitionDraftBuilder()
@@ -404,7 +405,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void
       buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldBuildAction()
-          throws BuildUpdateActionException {
+          throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
         createDefaultAttributeDefinitionDraftBuilder().attributeConstraint(null).build();
@@ -443,7 +444,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
     try {
       buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
       fail("Expected an exception to be thrown");
-    } catch (BuildUpdateActionException e) {
+    } catch (UnsupportedOperationException e) {
       assertThat(e)
           .hasMessage(
               "Invalid AttributeConstraint update to COMBINATION_UNIQUE. Only following updates are allowed: SameForAll to None and Unique to None.");
@@ -451,7 +452,8 @@ class AttributeDefinitionUpdateActionUtilsTest {
   }
 
   @Test
-  void buildActions_WithNewDifferentValues_ShouldReturnActions() throws BuildUpdateActionException {
+  void buildActions_WithNewDifferentValues_ShouldReturnActions()
+      throws UnsupportedOperationException {
     final List<ProductTypeUpdateAction> result = buildActions(old, newDifferent);
 
     assertThat(result)
@@ -479,7 +481,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
   }
 
   @Test
-  void buildActions_WithSameValues_ShouldReturnEmpty() throws BuildUpdateActionException {
+  void buildActions_WithSameValues_ShouldReturnEmpty() throws UnsupportedOperationException {
     final List<ProductTypeUpdateAction> result = buildActions(old, newSame);
 
     assertThat(result).isEmpty();
@@ -487,7 +489,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildActions_WithStringAttributeTypesWithLabelChanges_ShouldBuildChangeLabelAction()
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
     final AttributeDefinition attributeDefinition =
         createDefaultAttributeDefinitionBuilder().label(ofEnglish("label1")).build();
 
@@ -507,7 +509,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildActions_WithChangedSetOfEnumAttributeTypes_ShouldBuildEnumActions()
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
     // preparation
     final AttributeDefinition oldDefinition =
         createDefaultAttributeDefinitionBuilder()
@@ -590,7 +592,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildActions_WithChangedSetOfLocalizedEnumAttributeTypes_ShouldBuildEnumActions()
-      throws BuildUpdateActionException {
+      throws UnsupportedOperationException {
     // preparation
     final AttributeDefinition oldDefinition =
         createDefaultAttributeDefinitionBuilder()
@@ -835,27 +837,5 @@ class AttributeDefinitionUpdateActionUtilsTest {
                 .attributeName(attributeDefinition.getName())
                 .newValue(localizedEnumValueDiffLabel)
                 .build());
-  }
-
-  private AttributeDefinitionDraftBuilder createDefaultAttributeDefinitionDraftBuilder() {
-    return AttributeDefinitionDraftBuilder.of()
-        .name("foo")
-        .label(ofEnglish("x"))
-        .type(AttributeTypeBuilder::textBuilder)
-        .inputHint(TextInputHint.MULTI_LINE)
-        .attributeConstraint(AttributeConstraintEnum.NONE)
-        .isRequired(true)
-        .isSearchable(false);
-  }
-
-  private AttributeDefinitionBuilder createDefaultAttributeDefinitionBuilder() {
-    return AttributeDefinitionBuilder.of()
-        .name("foo")
-        .label(ofEnglish("x"))
-        .type(AttributeTypeBuilder::textBuilder)
-        .inputHint(TextInputHint.MULTI_LINE)
-        .attributeConstraint(AttributeConstraintEnum.NONE)
-        .isRequired(true)
-        .isSearchable(false);
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -1,0 +1,861 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.sdk2.producttypes.utils.AttributeDefinitionUpdateActionUtils.*;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.product_type.AttributeConstraintEnum;
+import com.commercetools.api.models.product_type.AttributeConstraintEnumDraft;
+import com.commercetools.api.models.product_type.AttributeDefinition;
+import com.commercetools.api.models.product_type.AttributeDefinitionBuilder;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
+import com.commercetools.api.models.product_type.AttributeLocalizedEnumValue;
+import com.commercetools.api.models.product_type.AttributeLocalizedEnumValueBuilder;
+import com.commercetools.api.models.product_type.AttributePlainEnumValue;
+import com.commercetools.api.models.product_type.AttributePlainEnumValueBuilder;
+import com.commercetools.api.models.product_type.AttributeTypeBuilder;
+import com.commercetools.api.models.product_type.ProductTypeAddLocalizedEnumValueActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeAddPlainEnumValueActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeAttributeConstraintActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeInputHintActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeIsSearchableActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLocalizedEnumValueLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLocalizedEnumValueOrderActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangePlainEnumValueLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangePlainEnumValueOrderActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeRemoveEnumValuesActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeSetInputTipActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.api.models.product_type.TextInputHint;
+import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class AttributeDefinitionUpdateActionUtilsTest {
+  private static AttributeDefinition old;
+  private static AttributeDefinitionDraft newSame;
+  private static AttributeDefinitionDraft newDifferent;
+
+  private static final AttributePlainEnumValue ENUM_VALUE_A =
+      AttributePlainEnumValueBuilder.of().key("a").label("label_a").build();
+  private static final AttributePlainEnumValue ENUM_VALUE_B =
+      AttributePlainEnumValueBuilder.of().key("b").label("label_b").build();
+
+  private static final AttributeLocalizedEnumValue LOCALIZED_ENUM_VALUE_A =
+      AttributeLocalizedEnumValueBuilder.of().key("a").label(ofEnglish("label_a")).build();
+  private static final AttributeLocalizedEnumValue LOCALIZED_ENUM_VALUE_B =
+      AttributeLocalizedEnumValueBuilder.of().key("b").label(ofEnglish("label_b")).build();
+
+  /** Initialises test data. */
+  @BeforeAll
+  static void setup() {
+    old =
+        AttributeDefinitionBuilder.of()
+            .name("attributeName1")
+            .label(ofEnglish("label1"))
+            .type(AttributeTypeBuilder::textBuilder)
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
+            .inputTip(ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.TextInputHintEnum.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+    newSame = ResourceToDraftConverters.toAttributeDefinitionDraftBuilder(old).build();
+
+    newDifferent =
+        AttributeDefinitionDraftBuilder.of()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.textBuilder())
+            .name("attributeName1")
+            .label(ofEnglish("label2"))
+            .isRequired(true)
+            .attributeConstraint(AttributeConstraintEnum.NONE)
+            .inputTip(ofEnglish("inputTip2"))
+            .inputHint(TextInputHint.MULTI_LINE)
+            .isSearchable(true)
+            .build();
+  }
+
+  @Test
+  void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().label(ofEnglish("x")).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().label(ofEnglish("y")).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeLabelUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result)
+        .contains(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .label(ofEnglish("x"))
+                .build());
+  }
+
+  @Test
+  void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
+    // Preparation
+    final AttributeDefinitionDraft draft = createDefaultAttributeDefinitionDraftBuilder().build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeLabelUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("bar")).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result)
+        .contains(
+            ProductTypeSetInputTipActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .inputTip(ofEnglish("foo"))
+                .build());
+  }
+
+  @Test
+  void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputTip((LocalizedString) null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result)
+        .contains(
+            ProductTypeSetInputTipActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .inputTip((LocalizedString) null)
+                .build());
+  }
+
+  @Test
+  void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputTip((LocalizedString) null).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildSetInputTipUpdateAction(attributeDefinition, draft);
+
+    // assertion
+    assertThat(result)
+        .contains(
+            ProductTypeSetInputTipActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .inputTip(ofEnglish("foo"))
+                .build());
+  }
+
+  @Test
+  void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().isSearchable(true).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().isSearchable(false).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeIsSearchableActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .isSearchable(true)
+                .build());
+  }
+
+  @Test
+  void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().isSearchable(true).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().isSearchable(true).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldBuildAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().isSearchable(null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().isSearchable(false).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeIsSearchableActionBuilder.of()
+                .attributeName("foo")
+                .isSearchable(true)
+                .build());
+  }
+
+  @Test
+  void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotBuildAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().isSearchable(null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().isSearchable(true).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeIsSearchableUpdateAction(attributeDefinition, draft);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeInputHintActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .newValue(TextInputHint.MULTI_LINE)
+                .build());
+  }
+
+  @Test
+  void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldBuildAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputHint(null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeInputHintActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .newValue(TextInputHint.SINGLE_LINE)
+                .build());
+  }
+
+  @Test
+  void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldNotBuildAction() {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().inputHint(null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeInputHintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildChangeAttributeConstraintAction_WithDifferentValues_ShouldBuildAction()
+      throws BuildUpdateActionException {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .attributeConstraint(AttributeConstraintEnum.NONE)
+            .build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
+            .build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeAttributeConstraintActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .newValue(AttributeConstraintEnumDraft.NONE)
+                .build());
+  }
+
+  @Test
+  void buildChangeAttributeConstraintAction_WithSameValues_ShouldReturnEmptyOptional()
+      throws BuildUpdateActionException {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
+            .build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
+            .build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void
+      buildChangeAttributeConstraintAction_WithSourceNullValuesAndNonDefaultTarget_ShouldBuildAction()
+          throws BuildUpdateActionException {
+    // Preparation
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder().attributeConstraint(null).build();
+
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
+            .build();
+
+    // test
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+
+    assertThat(result)
+        .contains(
+            ProductTypeChangeAttributeConstraintActionBuilder.of()
+                .attributeName(draft.getName())
+                .newValue(AttributeConstraintEnumDraft.NONE)
+                .build());
+  }
+
+  @Test
+  void
+      buildChangeAttributeConstraintAction_WithSourceSameForAllAndTargetCombinationUnique_ShouldThrowException() {
+    // Preparation
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
+            .build();
+
+    final AttributeDefinitionDraft draft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
+            .build();
+    // test
+    try {
+      buildChangeAttributeConstraintUpdateAction(attributeDefinition, draft);
+      fail("Expected an exception to be thrown");
+    } catch (BuildUpdateActionException e) {
+      assertThat(e)
+          .hasMessage(
+              "Invalid AttributeConstraint update to COMBINATION_UNIQUE. Only following updates are allowed: SameForAll to None and Unique to None.");
+    }
+  }
+
+  @Test
+  void buildActions_WithNewDifferentValues_ShouldReturnActions() throws BuildUpdateActionException {
+    final List<ProductTypeUpdateAction> result = buildActions(old, newDifferent);
+
+    assertThat(result)
+        .containsExactlyInAnyOrder(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(old.getName())
+                .label(newDifferent.getLabel())
+                .build(),
+            ProductTypeSetInputTipActionBuilder.of()
+                .attributeName(old.getName())
+                .inputTip(newDifferent.getInputTip())
+                .build(),
+            ProductTypeChangeAttributeConstraintActionBuilder.of()
+                .attributeName(old.getName())
+                .newValue(AttributeConstraintEnumDraft.NONE)
+                .build(),
+            ProductTypeChangeInputHintActionBuilder.of()
+                .attributeName(old.getName())
+                .newValue(newDifferent.getInputHint())
+                .build(),
+            ProductTypeChangeIsSearchableActionBuilder.of()
+                .attributeName(old.getName())
+                .isSearchable(newDifferent.getIsSearchable())
+                .build());
+  }
+
+  @Test
+  void buildActions_WithSameValues_ShouldReturnEmpty() throws BuildUpdateActionException {
+    final List<ProductTypeUpdateAction> result = buildActions(old, newSame);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildActions_WithStringAttributeTypesWithLabelChanges_ShouldBuildChangeLabelAction()
+      throws BuildUpdateActionException {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder().label(ofEnglish("label1")).build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder().label(ofEnglish("label2")).build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName("foo")
+                .label(ofEnglish("label2"))
+                .build());
+  }
+
+  @Test
+  void buildActions_WithChangedSetOfEnumAttributeTypes_ShouldBuildEnumActions()
+      throws BuildUpdateActionException {
+    // preparation
+    final AttributeDefinition oldDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        AttributePlainEnumValueBuilder.of()
+                                            .key("c")
+                                            .label("c")
+                                            .build(),
+                                        AttributePlainEnumValueBuilder.of()
+                                            .key("d")
+                                            .label("d")
+                                            .build(),
+                                        ENUM_VALUE_B)))
+            .build();
+
+    final AttributeDefinitionDraft newDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        ENUM_VALUE_A,
+                                        AttributePlainEnumValueBuilder.of()
+                                            .key(ENUM_VALUE_B.getKey())
+                                            .label("newLabel")
+                                            .build(),
+                                        AttributePlainEnumValueBuilder.of()
+                                            .key("c")
+                                            .label("c")
+                                            .build())))
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> result = buildActions(oldDefinition, newDraft);
+
+    // assertion
+    assertThat(result)
+        .containsExactly(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .keys("d")
+                .build(),
+            ProductTypeChangePlainEnumValueLabelActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .newValue(
+                    AttributePlainEnumValueBuilder.of()
+                        .key(ENUM_VALUE_B.getKey())
+                        .label("newLabel")
+                        .build())
+                .build(),
+            ProductTypeAddPlainEnumValueActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .value(ENUM_VALUE_A)
+                .build(),
+            ProductTypeChangePlainEnumValueOrderActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .values(
+                    asList(
+                        ENUM_VALUE_A,
+                        AttributePlainEnumValueBuilder.of()
+                            .key(ENUM_VALUE_B.getKey())
+                            .label("newLabel")
+                            .build(),
+                        AttributePlainEnumValueBuilder.of().key("c").label("c").build()))
+                .build());
+  }
+
+  @Test
+  void buildActions_WithChangedSetOfLocalizedEnumAttributeTypes_ShouldBuildEnumActions()
+      throws BuildUpdateActionException {
+    // preparation
+    final AttributeDefinition oldDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        asList(
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("c")
+                                                .label(ofEnglish("c"))
+                                                .build(),
+                                            LOCALIZED_ENUM_VALUE_B,
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("d")
+                                                .label(ofEnglish("d"))
+                                                .build()))))
+            .build();
+
+    final AttributeDefinitionDraft newDefinition =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        asList(
+                                            LOCALIZED_ENUM_VALUE_A,
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key(LOCALIZED_ENUM_VALUE_B.getKey())
+                                                .label(ofEnglish("newLabel"))
+                                                .build(),
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("c")
+                                                .label(ofEnglish("c"))
+                                                .build()))))
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> result = buildActions(oldDefinition, newDefinition);
+
+    // assertion
+    assertThat(result)
+        .containsExactly(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .keys("d")
+                .build(),
+            ProductTypeChangeLocalizedEnumValueLabelActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .newValue(
+                    AttributeLocalizedEnumValueBuilder.of()
+                        .key(LOCALIZED_ENUM_VALUE_B.getKey())
+                        .label(ofEnglish("newLabel"))
+                        .build())
+                .build(),
+            ProductTypeAddLocalizedEnumValueActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .value(LOCALIZED_ENUM_VALUE_A)
+                .build(),
+            ProductTypeChangeLocalizedEnumValueOrderActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .values(
+                    asList(
+                        LOCALIZED_ENUM_VALUE_A,
+                        AttributeLocalizedEnumValueBuilder.of()
+                            .key(LOCALIZED_ENUM_VALUE_B.getKey())
+                            .label(ofEnglish("newLabel"))
+                            .build(),
+                        AttributeLocalizedEnumValueBuilder.of()
+                            .key("c")
+                            .label(ofEnglish("c"))
+                            .build()))
+                .build());
+  }
+
+  @Test
+  void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
+            .build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A, ENUM_VALUE_B))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeAddPlainEnumValueActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .value(ENUM_VALUE_B)
+                .build());
+  }
+
+  @Test
+  void buildActions_WithoutOldPlainEnum_ShouldReturnRemoveEnumValueAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
+            .build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(emptyList()))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .keys("a")
+                .build());
+  }
+
+  @Test
+  void buildActions_WitDifferentPlainEnumValueLabel_ShouldReturnChangeEnumValueLabelAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
+            .build();
+
+    final AttributePlainEnumValue enumValueDiffLabel =
+        AttributePlainEnumValueBuilder.of().key("a").label("label_a_different").build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.enumBuilder().values(enumValueDiffLabel))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeChangePlainEnumValueLabelActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .newValue(enumValueDiffLabel)
+                .build());
+  }
+
+  @Test
+  void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
+            .build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .lenumBuilder()
+                        .values(LOCALIZED_ENUM_VALUE_A, LOCALIZED_ENUM_VALUE_B))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeAddLocalizedEnumValueActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .value(LOCALIZED_ENUM_VALUE_B)
+                .build());
+  }
+
+  @Test
+  void buildActions_WithoutOldLocalizedEnum_ShouldReturnRemoveLocalizedEnumValueAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
+            .build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.lenumBuilder().values(emptyList()))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .keys("a")
+                .build());
+  }
+
+  @Test
+  void
+      buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
+            .build();
+
+    final AttributeLocalizedEnumValue localizedEnumValueDiffLabel =
+        AttributeLocalizedEnumValueBuilder.of().key("a").label(ofEnglish("label_a_diff")).build();
+
+    final AttributeDefinitionDraft attributeDefinitionDraft =
+        createDefaultAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder.lenumBuilder().values(localizedEnumValueDiffLabel))
+            .build();
+
+    final List<ProductTypeUpdateAction> result =
+        buildEnumUpdateActions(attributeDefinition, attributeDefinitionDraft);
+
+    assertThat(result)
+        .containsExactly(
+            ProductTypeChangeLocalizedEnumValueLabelActionBuilder.of()
+                .attributeName(attributeDefinition.getName())
+                .newValue(localizedEnumValueDiffLabel)
+                .build());
+  }
+
+  private AttributeDefinitionDraftBuilder createDefaultAttributeDefinitionDraftBuilder() {
+    return AttributeDefinitionDraftBuilder.of()
+        .name("foo")
+        .label(ofEnglish("x"))
+        .type(AttributeTypeBuilder::textBuilder)
+        .inputHint(TextInputHint.MULTI_LINE)
+        .attributeConstraint(AttributeConstraintEnum.NONE)
+        .isRequired(true)
+        .isSearchable(false);
+  }
+
+  private AttributeDefinitionBuilder createDefaultAttributeDefinitionBuilder() {
+    return AttributeDefinitionBuilder.of()
+        .name("foo")
+        .label(ofEnglish("x"))
+        .type(AttributeTypeBuilder::textBuilder)
+        .inputHint(TextInputHint.MULTI_LINE)
+        .attributeConstraint(AttributeConstraintEnum.NONE)
+        .isRequired(true)
+        .isSearchable(false);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -1,8 +1,8 @@
 package com.commercetools.sync.sdk2.producttypes.utils;
 
 import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
-import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionBuilder;
-import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionDraftBuilder;
+import static com.commercetools.sync.sdk2.producttypes.MockBuilderUtils.createMockAttributeDefinitionBuilder;
+import static com.commercetools.sync.sdk2.producttypes.MockBuilderUtils.createMockAttributeDefinitionDraftBuilder;
 import static com.commercetools.sync.sdk2.producttypes.utils.AttributeDefinitionUpdateActionUtils.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -90,10 +90,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().label(ofEnglish("x")).build();
+        createMockAttributeDefinitionDraftBuilder().label(ofEnglish("x")).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().label(ofEnglish("y")).build();
+        createMockAttributeDefinitionBuilder().label(ofEnglish("y")).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -111,10 +111,9 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildChangeLabelAction_WithSameValues_ShouldReturnEmptyOptional() {
     // Preparation
-    final AttributeDefinitionDraft draft = createDefaultAttributeDefinitionDraftBuilder().build();
+    final AttributeDefinitionDraft draft = createMockAttributeDefinitionDraftBuilder().build();
 
-    final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().build();
+    final AttributeDefinition attributeDefinition = createMockAttributeDefinitionBuilder().build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -128,10 +127,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildSetInputTipAction_WithDifferentValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+        createMockAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("bar")).build();
+        createMockAttributeDefinitionBuilder().inputTip(ofEnglish("bar")).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -150,10 +149,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildSetInputTipAction_WithSameValues_ShouldReturnEmptyOptional() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+        createMockAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
+        createMockAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -167,10 +166,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildSetInputTipAction_WithSourceNullValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputTip((LocalizedString) null).build();
+        createMockAttributeDefinitionDraftBuilder().inputTip((LocalizedString) null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
+        createMockAttributeDefinitionBuilder().inputTip(ofEnglish("foo")).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -189,10 +188,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildSetInputTipAction_WithTargetNullValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
+        createMockAttributeDefinitionDraftBuilder().inputTip(ofEnglish("foo")).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputTip((LocalizedString) null).build();
+        createMockAttributeDefinitionBuilder().inputTip((LocalizedString) null).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -211,10 +210,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeIsSearchableAction_WithDifferentValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().isSearchable(true).build();
+        createMockAttributeDefinitionDraftBuilder().isSearchable(true).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().isSearchable(false).build();
+        createMockAttributeDefinitionBuilder().isSearchable(false).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -232,10 +231,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeIsSearchableAction_WithSameValues_ShouldReturnEmptyOptional() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().isSearchable(true).build();
+        createMockAttributeDefinitionDraftBuilder().isSearchable(true).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().isSearchable(true).build();
+        createMockAttributeDefinitionBuilder().isSearchable(true).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -248,10 +247,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeIsSearchableAction_WithNullSourceAndNonDefaultTarget_ShouldBuildAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().isSearchable(null).build();
+        createMockAttributeDefinitionDraftBuilder().isSearchable(null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().isSearchable(false).build();
+        createMockAttributeDefinitionBuilder().isSearchable(false).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -269,10 +268,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeIsSearchableAction_WithNullSourceAndDefaultTarget_ShouldNotBuildAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().isSearchable(null).build();
+        createMockAttributeDefinitionDraftBuilder().isSearchable(null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().isSearchable(true).build();
+        createMockAttributeDefinitionBuilder().isSearchable(true).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -285,10 +284,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeInputHintAction_WithDifferentValues_ShouldReturnAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+        createMockAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
+        createMockAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -306,10 +305,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeInputHintAction_WithSameValues_ShouldReturnEmptyOptional() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+        createMockAttributeDefinitionDraftBuilder().inputHint(TextInputHint.MULTI_LINE).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+        createMockAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -322,10 +321,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeInputHintAction_WithSourceNullValuesAndNonDefaultTargetValue_ShouldBuildAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputHint(null).build();
+        createMockAttributeDefinitionDraftBuilder().inputHint(null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
+        createMockAttributeDefinitionBuilder().inputHint(TextInputHint.MULTI_LINE).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -343,10 +342,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildChangeInputHintAction_WithSourceNullValuesAndDefaultTargetValue_ShouldNotBuildAction() {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().inputHint(null).build();
+        createMockAttributeDefinitionDraftBuilder().inputHint(null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
+        createMockAttributeDefinitionBuilder().inputHint(TextInputHint.SINGLE_LINE).build();
 
     // test
     final Optional<ProductTypeUpdateAction> result =
@@ -360,12 +359,12 @@ class AttributeDefinitionUpdateActionUtilsTest {
       throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .attributeConstraint(AttributeConstraintEnum.NONE)
             .build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
             .build();
 
@@ -386,12 +385,12 @@ class AttributeDefinitionUpdateActionUtilsTest {
       throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
             .build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
             .build();
 
@@ -408,10 +407,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
           throws UnsupportedOperationException {
     // Preparation
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder().attributeConstraint(null).build();
+        createMockAttributeDefinitionDraftBuilder().attributeConstraint(null).build();
 
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
             .build();
 
@@ -432,12 +431,12 @@ class AttributeDefinitionUpdateActionUtilsTest {
       buildChangeAttributeConstraintAction_WithSourceSameForAllAndTargetCombinationUnique_ShouldThrowException() {
     // Preparation
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
             .build();
 
     final AttributeDefinitionDraft draft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .attributeConstraint(AttributeConstraintEnum.COMBINATION_UNIQUE)
             .build();
     // test
@@ -491,10 +490,10 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void buildActions_WithStringAttributeTypesWithLabelChanges_ShouldBuildChangeLabelAction()
       throws UnsupportedOperationException {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder().label(ofEnglish("label1")).build();
+        createMockAttributeDefinitionBuilder().label(ofEnglish("label1")).build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder().label(ofEnglish("label2")).build();
+        createMockAttributeDefinitionDraftBuilder().label(ofEnglish("label2")).build();
 
     final List<ProductTypeUpdateAction> result =
         buildActions(attributeDefinition, attributeDefinitionDraft);
@@ -512,7 +511,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
       throws UnsupportedOperationException {
     // preparation
     final AttributeDefinition oldDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder
@@ -534,7 +533,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
             .build();
 
     final AttributeDefinitionDraft newDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder
@@ -595,7 +594,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
       throws UnsupportedOperationException {
     // preparation
     final AttributeDefinition oldDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder
@@ -618,7 +617,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
             .build();
 
     final AttributeDefinitionDraft newDefinition =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder
@@ -681,12 +680,12 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WithNewPlainEnum_ShouldReturnAddEnumValueAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
             .build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A, ENUM_VALUE_B))
@@ -706,12 +705,12 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WithoutOldPlainEnum_ShouldReturnRemoveEnumValueAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
             .build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(emptyList()))
             .build();
 
@@ -729,7 +728,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WitDifferentPlainEnumValueLabel_ShouldReturnChangeEnumValueLabelAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(attributeTypeBuilder -> attributeTypeBuilder.enumBuilder().values(ENUM_VALUE_A))
             .build();
 
@@ -737,7 +736,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
         AttributePlainEnumValueBuilder.of().key("a").label("label_a_different").build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.enumBuilder().values(enumValueDiffLabel))
@@ -757,14 +756,14 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WithNewLocalizedEnum_ShouldReturnAddLocalizedEnumValueAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
             .build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder
@@ -786,14 +785,14 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WithoutOldLocalizedEnum_ShouldReturnRemoveLocalizedEnumValueAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
             .build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(attributeTypeBuilder -> attributeTypeBuilder.lenumBuilder().values(emptyList()))
             .build();
 
@@ -812,7 +811,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
   void
       buildActions_WithDifferentLocalizedEnumValueLabel_ShouldReturnChangeLocalizedEnumValueLabelAction() {
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.lenumBuilder().values(LOCALIZED_ENUM_VALUE_A))
@@ -822,7 +821,7 @@ class AttributeDefinitionUpdateActionUtilsTest {
         AttributeLocalizedEnumValueBuilder.of().key("a").label(ofEnglish("label_a_diff")).build();
 
     final AttributeDefinitionDraft attributeDefinitionDraft =
-        createDefaultAttributeDefinitionDraftBuilder()
+        createMockAttributeDefinitionDraftBuilder()
             .type(
                 attributeTypeBuilder ->
                     attributeTypeBuilder.lenumBuilder().values(localizedEnumValueDiffLabel))

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java
@@ -13,14 +13,11 @@ import com.commercetools.api.models.common.LocalizedString;
 import com.commercetools.api.models.product_type.AttributeConstraintEnum;
 import com.commercetools.api.models.product_type.AttributeConstraintEnumDraft;
 import com.commercetools.api.models.product_type.AttributeDefinition;
-import com.commercetools.api.models.product_type.AttributeDefinitionBuilder;
 import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
-import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
 import com.commercetools.api.models.product_type.AttributeLocalizedEnumValue;
 import com.commercetools.api.models.product_type.AttributeLocalizedEnumValueBuilder;
 import com.commercetools.api.models.product_type.AttributePlainEnumValue;
 import com.commercetools.api.models.product_type.AttributePlainEnumValueBuilder;
-import com.commercetools.api.models.product_type.AttributeTypeBuilder;
 import com.commercetools.api.models.product_type.ProductTypeAddLocalizedEnumValueActionBuilder;
 import com.commercetools.api.models.product_type.ProductTypeAddPlainEnumValueActionBuilder;
 import com.commercetools.api.models.product_type.ProductTypeChangeAttributeConstraintActionBuilder;
@@ -38,13 +35,9 @@ import com.commercetools.api.models.product_type.TextInputHint;
 import com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class AttributeDefinitionUpdateActionUtilsTest {
-  private static AttributeDefinition old;
-  private static AttributeDefinitionDraft newSame;
-  private static AttributeDefinitionDraft newDifferent;
 
   private static final AttributePlainEnumValue ENUM_VALUE_A =
       AttributePlainEnumValueBuilder.of().key("a").label("label_a").build();
@@ -55,36 +48,6 @@ class AttributeDefinitionUpdateActionUtilsTest {
       AttributeLocalizedEnumValueBuilder.of().key("a").label(ofEnglish("label_a")).build();
   private static final AttributeLocalizedEnumValue LOCALIZED_ENUM_VALUE_B =
       AttributeLocalizedEnumValueBuilder.of().key("b").label(ofEnglish("label_b")).build();
-
-  /** Initialises test data. */
-  @BeforeAll
-  static void setup() {
-    old =
-        AttributeDefinitionBuilder.of()
-            .name("attributeName1")
-            .label(ofEnglish("label1"))
-            .type(AttributeTypeBuilder::textBuilder)
-            .isRequired(false)
-            .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
-            .inputTip(ofEnglish("inputTip1"))
-            .inputHint(TextInputHint.SINGLE_LINE)
-            .isSearchable(false)
-            .build();
-
-    newSame = ResourceToDraftConverters.toAttributeDefinitionDraftBuilder(old).build();
-
-    newDifferent =
-        AttributeDefinitionDraftBuilder.of()
-            .type(AttributeTypeBuilder::textBuilder)
-            .name("attributeName1")
-            .label(ofEnglish("label2"))
-            .isRequired(true)
-            .attributeConstraint(AttributeConstraintEnum.NONE)
-            .inputTip(ofEnglish("inputTip2"))
-            .inputHint(TextInputHint.MULTI_LINE)
-            .isSearchable(true)
-            .build();
-  }
 
   @Test
   void buildChangeLabelAction_WithDifferentValues_ShouldReturnAction() {
@@ -453,6 +416,26 @@ class AttributeDefinitionUpdateActionUtilsTest {
   @Test
   void buildActions_WithNewDifferentValues_ShouldReturnActions()
       throws UnsupportedOperationException {
+    final AttributeDefinition old =
+        createMockAttributeDefinitionBuilder()
+            .label(ofEnglish("label1"))
+            .isRequired(false)
+            .attributeConstraint(AttributeConstraintEnum.SAME_FOR_ALL)
+            .inputTip(ofEnglish("inputTip1"))
+            .inputHint(TextInputHint.SINGLE_LINE)
+            .isSearchable(false)
+            .build();
+
+    final AttributeDefinitionDraft newDifferent =
+        createMockAttributeDefinitionDraftBuilder()
+            .label(ofEnglish("label2"))
+            .isRequired(true)
+            .attributeConstraint(AttributeConstraintEnum.NONE)
+            .inputTip(ofEnglish("inputTip2"))
+            .inputHint(TextInputHint.MULTI_LINE)
+            .isSearchable(true)
+            .build();
+
     final List<ProductTypeUpdateAction> result = buildActions(old, newDifferent);
 
     assertThat(result)
@@ -481,6 +464,11 @@ class AttributeDefinitionUpdateActionUtilsTest {
 
   @Test
   void buildActions_WithSameValues_ShouldReturnEmpty() throws UnsupportedOperationException {
+    final AttributeDefinition old = createMockAttributeDefinitionBuilder().build();
+
+    final AttributeDefinitionDraft newSame =
+        ResourceToDraftConverters.toAttributeDefinitionDraftBuilder(old).build();
+
     final List<ProductTypeUpdateAction> result = buildActions(old, newSame);
 
     assertThat(result).isEmpty();

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
@@ -1,0 +1,109 @@
+package com.commercetools.sync.sdk2.producttypes.utils;
+
+import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionBuilder;
+import static com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters.toAttributeDefinitionDraftBuilder;
+import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeDescriptionAction;
+import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeNameAction;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.product_type.AttributeDefinition;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeTypeBuilder;
+import com.commercetools.api.models.product_type.ProductType;
+import com.commercetools.api.models.product_type.ProductTypeChangeDescriptionAction;
+import com.commercetools.api.models.product_type.ProductTypeChangeDescriptionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeNameAction;
+import com.commercetools.api.models.product_type.ProductTypeChangeNameActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeDraft;
+import com.commercetools.api.models.product_type.ProductTypeDraftBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ProductTypeUpdateActionUtilsTest {
+  private static ProductType old;
+  private static ProductTypeDraft newSame;
+  private static ProductTypeDraft newDifferent;
+
+  /** Initialises test data. */
+  @BeforeAll
+  static void setup() {
+    final LocalizedString label = LocalizedString.of(Locale.ENGLISH, "label1");
+    final AttributeDefinition attributeDefinition =
+        createDefaultAttributeDefinitionBuilder()
+            .name("attributeName1")
+            .label(label)
+            .type(AttributeTypeBuilder::textBuilder)
+            .build();
+
+    final List<AttributeDefinition> oldAttributeDefinitions = singletonList(attributeDefinition);
+
+    final List<AttributeDefinitionDraft> sameAttributeDefinitionDrafts =
+        singletonList(toAttributeDefinitionDraftBuilder(attributeDefinition).build());
+
+    old = mock(ProductType.class);
+    when(old.getKey()).thenReturn("key1");
+    when(old.getName()).thenReturn("name1");
+    when(old.getDescription()).thenReturn("description 1");
+    when(old.getAttributes()).thenReturn(oldAttributeDefinitions);
+
+    newSame =
+        ProductTypeDraftBuilder.of()
+            .key("key1")
+            .name("name1")
+            .description("description 1")
+            .attributes(sameAttributeDefinitionDrafts)
+            .build();
+
+    newDifferent =
+        ProductTypeDraftBuilder.of()
+            .key("key2")
+            .name("name2")
+            .description("description 2")
+            .attributes(sameAttributeDefinitionDrafts)
+            .build();
+  }
+
+  @Test
+  void buildChangeNameAction_WithDifferentValues_ShouldReturnAction() {
+    final Optional<ProductTypeUpdateAction> result = buildChangeNameAction(old, newDifferent);
+
+    assertThat(result).containsInstanceOf(ProductTypeChangeNameAction.class);
+    assertThat(result)
+        .contains(ProductTypeChangeNameActionBuilder.of().name(newDifferent.getName()).build());
+  }
+
+  @Test
+  void buildChangeNameAction_WithSameValues_ShouldReturnEmptyOptional() {
+    final Optional<ProductTypeUpdateAction> result = buildChangeNameAction(old, newSame);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void buildChangeDescriptionAction_WithDifferentValues_ShouldReturnAction() {
+    final Optional<ProductTypeUpdateAction> result =
+        buildChangeDescriptionAction(old, newDifferent);
+
+    assertThat(result).containsInstanceOf(ProductTypeChangeDescriptionAction.class);
+    assertThat(result)
+        .contains(
+            ProductTypeChangeDescriptionActionBuilder.of()
+                .description(newDifferent.getDescription())
+                .build());
+  }
+
+  @Test
+  void buildChangeDescriptionAction_WithSameValues_ShouldReturnEmptyOptional() {
+    final Optional<ProductTypeUpdateAction> result = buildChangeDescriptionAction(old, newSame);
+
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/ProductTypeUpdateActionUtilsTest.java
@@ -1,6 +1,6 @@
 package com.commercetools.sync.sdk2.producttypes.utils;
 
-import static com.commercetools.sync.sdk2.producttypes.TestBuilderUtils.createDefaultAttributeDefinitionBuilder;
+import static com.commercetools.sync.sdk2.producttypes.MockBuilderUtils.createMockAttributeDefinitionBuilder;
 import static com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters.toAttributeDefinitionDraftBuilder;
 import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeDescriptionAction;
 import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.buildChangeNameAction;
@@ -37,7 +37,7 @@ class ProductTypeUpdateActionUtilsTest {
   static void setup() {
     final LocalizedString label = LocalizedString.of(Locale.ENGLISH, "label1");
     final AttributeDefinition attributeDefinition =
-        createDefaultAttributeDefinitionBuilder()
+        createMockAttributeDefinitionBuilder()
             .name("attributeName1")
             .label(label)
             .type(AttributeTypeBuilder::textBuilder)

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -133,17 +133,13 @@ class BuildAttributeDefinitionUpdateActionsTest {
   @Test
   void
       buildAttributesUpdateActions_WithNullNewAttributesAndNoOldAttributes_ShouldNotBuildActions() {
-    final ProductType oldProductType = mock(ProductType.class);
-    when(oldProductType.getAttributes()).thenReturn(emptyList());
-    when(oldProductType.getKey()).thenReturn("product_type_key_1");
+    final ProductType oldProductType =
+        createMockProductTypeBuilder().attributes(emptyList()).build();
 
     final List<ProductTypeUpdateAction> updateActions =
         buildAttributesUpdateActions(
             oldProductType,
-            ProductTypeDraftBuilder.of()
-                .key("key")
-                .name("name")
-                .description("description")
+            createMockProductTypeDraftBuilder()
                 .attributes((List<AttributeDefinitionDraft>) null)
                 .build(),
             SYNC_OPTIONS);

--- a/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/producttypes/utils/producttypeactionutils/BuildAttributeDefinitionUpdateActionsTest.java
@@ -1,0 +1,1516 @@
+package com.commercetools.sync.sdk2.producttypes.utils.producttypeactionutils;
+
+import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.readObjectFromResource;
+import static com.commercetools.sync.sdk2.producttypes.MockBuilderUtils.*;
+import static com.commercetools.sync.sdk2.producttypes.helpers.ResourceToDraftConverters.toAttributeDefinitionDraftBuilder;
+import static com.commercetools.sync.sdk2.producttypes.utils.ProductTypeUpdateActionUtils.buildAttributesUpdateActions;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.product_type.AttributeConstraintEnum;
+import com.commercetools.api.models.product_type.AttributeDefinition;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
+import com.commercetools.api.models.product_type.AttributeLocalizedEnumValueBuilder;
+import com.commercetools.api.models.product_type.AttributePlainEnumValueBuilder;
+import com.commercetools.api.models.product_type.AttributeTypeBuilder;
+import com.commercetools.api.models.product_type.ProductType;
+import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionAction;
+import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeAddLocalizedEnumValueActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeAddPlainEnumValueActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeAttributeOrderByNameActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeInputHintActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeIsSearchableActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLocalizedEnumValueLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangeLocalizedEnumValueOrderActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangePlainEnumValueLabelActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeChangePlainEnumValueOrderActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeDraft;
+import com.commercetools.api.models.product_type.ProductTypeDraftBuilder;
+import com.commercetools.api.models.product_type.ProductTypeReferenceBuilder;
+import com.commercetools.api.models.product_type.ProductTypeRemoveAttributeDefinitionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeRemoveEnumValuesActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.api.models.product_type.TextInputHint;
+import com.commercetools.sync.sdk2.commons.exceptions.BuildUpdateActionException;
+import com.commercetools.sync.sdk2.commons.exceptions.DuplicateNameException;
+import com.commercetools.sync.sdk2.producttypes.ProductTypeSyncOptions;
+import com.commercetools.sync.sdk2.producttypes.ProductTypeSyncOptionsBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BuildAttributeDefinitionUpdateActionsTest {
+  private static final String RES_ROOT =
+      "com/commercetools/sync/producttypes/utils/updateattributedefinitions/attributes/";
+
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_AB =
+      RES_ROOT + "product-type-with-attribute-definitions-ab.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ABB =
+      RES_ROOT + "product-type-with-attribute-definitions-abb.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ABC =
+      RES_ROOT + "product-type-with-attribute-definitions-abc.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ABCD =
+      RES_ROOT + "product-type-with-attribute-definitions-abcd.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ABD =
+      RES_ROOT + "product-type-with-attribute-definitions-abd.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_CAB =
+      RES_ROOT + "product-type-with-attribute-definitions-cab.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_CB =
+      RES_ROOT + "product-type-with-attribute-definitions-cb.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ACBD =
+      RES_ROOT + "product-type-with-attribute-definitions-acbd.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_ADBC =
+      RES_ROOT + "product-type-with-attribute-definitions-adbc.json";
+  private static final String PRODUCT_TYPE_WITH_ATTRIBUTES_CBD =
+      RES_ROOT + "product-type-with-attribute-definitions-cbd.json";
+
+  private static final ProductTypeSyncOptions SYNC_OPTIONS =
+      ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+  private static final AttributeDefinition ATTRIBUTE_DEFINITION_A =
+      createMockAttributeDefinitionBuilder()
+          .name("a")
+          .label(ofEnglish("label_en"))
+          .type(AttributeTypeBuilder::textBuilder)
+          .build();
+
+  private static final AttributeDefinition ATTRIBUTE_DEFINITION_B =
+      createMockAttributeDefinitionBuilder()
+          .name("b")
+          .label(ofEnglish("label_en"))
+          .type(AttributeTypeBuilder::textBuilder)
+          .build();
+
+  private static final AttributeDefinition ATTRIBUTE_DEFINITION_C =
+      createMockAttributeDefinitionBuilder()
+          .name("c")
+          .label(ofEnglish("label_en"))
+          .type(AttributeTypeBuilder::textBuilder)
+          .build();
+
+  private static final AttributeDefinition ATTRIBUTE_DEFINITION_D =
+      createMockAttributeDefinitionBuilder()
+          .name("d")
+          .label(ofEnglish("label_en"))
+          .type(AttributeTypeBuilder::textBuilder)
+          .isRequired(false)
+          .build();
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithNullNewAttributesAndExistingAttributes_ShouldBuild3RemoveActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(
+            oldProductType,
+            ProductTypeDraftBuilder.of()
+                .key("key")
+                .name("name")
+                .description("description")
+                .attributes((List<AttributeDefinitionDraft>) null)
+                .build(),
+            SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("a").build(),
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("b").build(),
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("c").build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithNullNewAttributesAndNoOldAttributes_ShouldNotBuildActions() {
+    final ProductType oldProductType = mock(ProductType.class);
+    when(oldProductType.getAttributes()).thenReturn(emptyList());
+    when(oldProductType.getKey()).thenReturn("product_type_key_1");
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(
+            oldProductType,
+            ProductTypeDraftBuilder.of()
+                .key("key")
+                .name("name")
+                .description("description")
+                .attributes((List<AttributeDefinitionDraft>) null)
+                .build(),
+            SYNC_OPTIONS);
+
+    assertThat(updateActions).isEmpty();
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithNewAttributesAndNoOldAttributes_ShouldBuild3AddActions() {
+    final ProductType oldProductType = mock(ProductType.class);
+    when(oldProductType.getAttributes()).thenReturn(emptyList());
+    when(oldProductType.getKey()).thenReturn("product_type_key_1");
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions).hasSize(3);
+    assertThat(updateActions)
+        .allSatisfy(
+            action -> {
+              assertThat(action).isInstanceOf(ProductTypeAddAttributeDefinitionAction.class);
+              final ProductTypeAddAttributeDefinitionAction addAttributeDefinition =
+                  (ProductTypeAddAttributeDefinitionAction) action;
+              final AttributeDefinitionDraft attribute = addAttributeDefinition.getAttribute();
+              assertThat(newProductTypeDraft.getAttributes()).contains(attribute);
+            });
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithIdenticalAttributes_ShouldNotBuildUpdateActions() {
+    final ProductType oldProductType =
+        createMockProductTypeBuilder()
+            .attributes(
+                asList(ATTRIBUTE_DEFINITION_A, ATTRIBUTE_DEFINITION_B, ATTRIBUTE_DEFINITION_C))
+            .build();
+
+    final AttributeDefinitionDraft attributeA =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_A.getType())
+            .name(ATTRIBUTE_DEFINITION_A.getName())
+            .label(ATTRIBUTE_DEFINITION_A.getLabel())
+            .isRequired(ATTRIBUTE_DEFINITION_A.getIsRequired())
+            .build();
+
+    final AttributeDefinitionDraft attributeB =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_B.getType())
+            .name(ATTRIBUTE_DEFINITION_B.getName())
+            .label(ATTRIBUTE_DEFINITION_B.getLabel())
+            .isRequired(ATTRIBUTE_DEFINITION_B.getIsRequired())
+            .build();
+
+    final AttributeDefinitionDraft attributeC =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_C.getType())
+            .name(ATTRIBUTE_DEFINITION_C.getName())
+            .label(ATTRIBUTE_DEFINITION_C.getLabel())
+            .isRequired(ATTRIBUTE_DEFINITION_C.getIsRequired())
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder()
+            .attributes(asList(attributeA, attributeB, attributeC))
+            .build();
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, productTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions).isEmpty();
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithChangedAttributes_ShouldBuildUpdateActions() {
+    final ProductType oldProductType =
+        createMockProductTypeBuilder()
+            .attributes(
+                asList(ATTRIBUTE_DEFINITION_A, ATTRIBUTE_DEFINITION_B, ATTRIBUTE_DEFINITION_C))
+            .build();
+
+    final AttributeDefinitionDraft attributeA =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_A.getType())
+            .name(ATTRIBUTE_DEFINITION_A.getName())
+            .label(ATTRIBUTE_DEFINITION_A.getLabel())
+            .isRequired(ATTRIBUTE_DEFINITION_A.getIsRequired())
+            .isSearchable(true)
+            .build();
+
+    final AttributeDefinitionDraft attributeB =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_B.getType())
+            .name(ATTRIBUTE_DEFINITION_B.getName())
+            .label(ofEnglish("newLabel"))
+            .isRequired(ATTRIBUTE_DEFINITION_B.getIsRequired())
+            .inputHint(TextInputHint.TextInputHintEnum.SINGLE_LINE)
+            .build();
+
+    final AttributeDefinitionDraft attributeC =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(ATTRIBUTE_DEFINITION_C.getType())
+            .name(ATTRIBUTE_DEFINITION_C.getName())
+            .label(ATTRIBUTE_DEFINITION_C.getLabel())
+            .isRequired(ATTRIBUTE_DEFINITION_C.getIsRequired())
+            .attributeConstraint(AttributeConstraintEnum.NONE)
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder()
+            .attributes(asList(attributeA, attributeB, attributeC))
+            .build();
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, productTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactlyInAnyOrder(
+            ProductTypeChangeIsSearchableActionBuilder.of()
+                .attributeName(ATTRIBUTE_DEFINITION_A.getName())
+                .isSearchable(true)
+                .build(),
+            ProductTypeChangeInputHintActionBuilder.of()
+                .attributeName(ATTRIBUTE_DEFINITION_B.getName())
+                .newValue(TextInputHint.TextInputHintEnum.SINGLE_LINE)
+                .build(),
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(ATTRIBUTE_DEFINITION_B.getName())
+                .label(ofEnglish("newLabel"))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithDuplicateAttributeNames_ShouldNotBuildActionsAndTriggerErrorCb() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABB, ProductTypeDraft.class);
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, syncOptions);
+
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errorMessages.get(0))
+        .matches(
+            "Failed to build update actions for the attributes definitions of the "
+                + "product type with the key 'key'. Reason: .*DuplicateNameException: Attribute definitions drafts "
+                + "have duplicated names. Duplicated attribute definition name: 'b'. Attribute definitions names are "
+                + "expected to be unique inside their product type.");
+    assertThat(exceptions).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            "Attribute definitions drafts have duplicated names. "
+                + "Duplicated attribute definition name: 'b'. Attribute definitions names are expected to be unique "
+                + "inside their product type.");
+    assertThat(exceptions.get(0).getCause()).isExactlyInstanceOf(DuplicateNameException.class);
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithOneMissingAttribute_ShouldBuildRemoveAttributeAction() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_AB, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("c").build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithOneExtraAttribute_ShouldBuildAddAttributesAction() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABCD, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(
+                    AttributeDefinitionDraftBuilder.of()
+                        .type(ATTRIBUTE_DEFINITION_D.getType())
+                        .name(ATTRIBUTE_DEFINITION_D.getName())
+                        .label(ATTRIBUTE_DEFINITION_D.getLabel())
+                        .isRequired(ATTRIBUTE_DEFINITION_D.getIsRequired())
+                        .isSearchable(true)
+                        .build())
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithOneAttributeSwitch_ShouldBuildRemoveAndAddAttributesActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABD, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("c").build(),
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(
+                    AttributeDefinitionDraftBuilder.of()
+                        .type(ATTRIBUTE_DEFINITION_D.getType())
+                        .name(ATTRIBUTE_DEFINITION_D.getName())
+                        .label(ATTRIBUTE_DEFINITION_D.getLabel())
+                        .isRequired(ATTRIBUTE_DEFINITION_D.getIsRequired())
+                        .isSearchable(true)
+                        .build())
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithDifferentOrder_ShouldBuildChangeAttributeOrderAction() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_CAB, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(
+                    asList(
+                        ATTRIBUTE_DEFINITION_C.getName(),
+                        ATTRIBUTE_DEFINITION_A.getName(),
+                        ATTRIBUTE_DEFINITION_B.getName()))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithRemovedAndDifferentOrder_ShouldBuildChangeOrderAndRemoveActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_CB, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("a").build(),
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(
+                    asList(ATTRIBUTE_DEFINITION_C.getName(), ATTRIBUTE_DEFINITION_B.getName()))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithAddedAndDifferentOrder_ShouldBuildChangeOrderAndAddActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ACBD, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(
+                    AttributeDefinitionDraftBuilder.of()
+                        .type(ATTRIBUTE_DEFINITION_D.getType())
+                        .name(ATTRIBUTE_DEFINITION_D.getName())
+                        .label(ATTRIBUTE_DEFINITION_D.getLabel())
+                        .isRequired(ATTRIBUTE_DEFINITION_D.getIsRequired())
+                        .isSearchable(true)
+                        .inputHint(TextInputHint.SINGLE_LINE)
+                        .attributeConstraint(AttributeConstraintEnum.NONE)
+                        .build())
+                .build(),
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(
+                    asList(
+                        ATTRIBUTE_DEFINITION_A.getName(),
+                        ATTRIBUTE_DEFINITION_C.getName(),
+                        ATTRIBUTE_DEFINITION_B.getName(),
+                        ATTRIBUTE_DEFINITION_D.getName()))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithAddedAttributeInBetween_ShouldBuildChangeOrderAndAddActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ADBC, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(
+                    AttributeDefinitionDraftBuilder.of()
+                        .type(ATTRIBUTE_DEFINITION_D.getType())
+                        .name(ATTRIBUTE_DEFINITION_D.getName())
+                        .label(ATTRIBUTE_DEFINITION_D.getLabel())
+                        .isRequired(ATTRIBUTE_DEFINITION_D.getIsRequired())
+                        .isSearchable(true)
+                        .build())
+                .build(),
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(
+                    asList(
+                        ATTRIBUTE_DEFINITION_A.getName(),
+                        ATTRIBUTE_DEFINITION_D.getName(),
+                        ATTRIBUTE_DEFINITION_B.getName(),
+                        ATTRIBUTE_DEFINITION_C.getName()))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithAddedRemovedAndDifOrder_ShouldBuildAllThreeMoveAttributeActions() {
+    final ProductType oldProductType =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_ABC, ProductType.class);
+
+    final ProductTypeDraft newProductTypeDraft =
+        readObjectFromResource(PRODUCT_TYPE_WITH_ATTRIBUTES_CBD, ProductTypeDraft.class);
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeRemoveAttributeDefinitionActionBuilder.of().name("a").build(),
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(
+                    AttributeDefinitionDraftBuilder.of()
+                        .type(ATTRIBUTE_DEFINITION_D.getType())
+                        .name(ATTRIBUTE_DEFINITION_D.getName())
+                        .label(ATTRIBUTE_DEFINITION_D.getLabel())
+                        .isRequired(ATTRIBUTE_DEFINITION_D.getIsRequired())
+                        .isSearchable(true)
+                        .build())
+                .build(),
+            ProductTypeChangeAttributeOrderByNameActionBuilder.of()
+                .attributeNames(
+                    asList(
+                        ATTRIBUTE_DEFINITION_C.getName(),
+                        ATTRIBUTE_DEFINITION_B.getName(),
+                        ATTRIBUTE_DEFINITION_D.getName()))
+                .build());
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithDifferentAttributeType_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.textBuilder())
+            .label(ofEnglish("new_label"))
+            .build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.ltextBuilder())
+            .label(ofEnglish("old_label"))
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(singletonList(newDefinition)).build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(singletonList(oldDefinition)).build();
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                newDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithDifferentSetAttributeType_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(AttributeTypeBuilder::textBuilder))
+            .label(ofEnglish("new_label"))
+            .build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(AttributeTypeBuilder::ltextBuilder))
+            .label(ofEnglish("old_label"))
+            .isRequired(true)
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(singletonList(newDefinition)).build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(singletonList(oldDefinition)).build();
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                newDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithDifferentNestedAttributeRefs_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinition ofNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .nestedBuilder()
+                        .typeReference(ProductTypeReferenceBuilder.of().id("foo").build()))
+            .build();
+
+    final AttributeDefinition ofSetOfNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("set-of-nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .nestedBuilder()
+                                    .typeReference(
+                                        ProductTypeReferenceBuilder.of().id("foo").build())))
+            .build();
+
+    final AttributeDefinition ofSetOfSetOfNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("set-of-set-of-nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .nestedBuilder()
+                                    .typeReference(
+                                        ProductTypeReferenceBuilder.of().id("foo").build())))
+            .build();
+
+    final AttributeDefinitionDraft ofNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofNestedType)
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .nestedBuilder()
+                        .typeReference(ProductTypeReferenceBuilder.of().id("bar").build()))
+            .build();
+
+    final AttributeDefinitionDraft ofSetOfNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofSetOfNestedType)
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .nestedBuilder()
+                                    .typeReference(
+                                        ProductTypeReferenceBuilder.of().id("bar").build())))
+            .build();
+
+    final AttributeDefinitionDraft ofSetOfSetOfNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofSetOfSetOfNestedType)
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .setBuilder()
+                                    .elementType(
+                                        attributeTypeBuilder2 ->
+                                            attributeTypeBuilder2
+                                                .nestedBuilder()
+                                                .typeReference(
+                                                    ProductTypeReferenceBuilder.of()
+                                                        .id("bar")
+                                                        .build()))))
+            .build();
+
+    final ProductType oldProductType = mock(ProductType.class);
+    when(oldProductType.getAttributes())
+        .thenReturn(asList(ofNestedType, ofSetOfNestedType, ofSetOfSetOfNestedType));
+
+    final ProductTypeDraft newProductTypeDraft = mock(ProductTypeDraft.class);
+    when(newProductTypeDraft.getAttributes())
+        .thenReturn(asList(ofNestedTypeDraft, ofSetOfNestedTypeDraft, ofSetOfSetOfNestedTypeDraft));
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            "changing the attribute definition type (attribute name='nested') is not supported programmatically");
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithIdenticalNestedAttributeRefs_ShouldNotBuildActions() {
+    // preparation
+    final AttributeDefinition ofNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .nestedBuilder()
+                        .typeReference(ProductTypeReferenceBuilder.of().id("foo").build()))
+            .build();
+
+    final AttributeDefinition ofSetOfNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("set-of-nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .nestedBuilder()
+                        .typeReference(ProductTypeReferenceBuilder.of().id("foo").build()))
+            .build();
+
+    final AttributeDefinition ofSetOfSetOfNestedType =
+        createMockAttributeDefinitionBuilder()
+            .name("set-of-set-of-nested")
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .setBuilder()
+                                    .elementType(
+                                        attributeTypeBuilder2 ->
+                                            attributeTypeBuilder2
+                                                .nestedBuilder()
+                                                .typeReference(
+                                                    ProductTypeReferenceBuilder.of()
+                                                        .id("foo")
+                                                        .build()))))
+            .build();
+
+    final AttributeDefinitionDraft ofNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofNestedType).build();
+
+    final AttributeDefinitionDraft ofSetOfNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofSetOfNestedType).build();
+
+    final AttributeDefinitionDraft ofSetOfSetOfNestedTypeDraft =
+        toAttributeDefinitionDraftBuilder(ofSetOfSetOfNestedType).build();
+
+    final ProductType oldProductType =
+        createMockProductTypeBuilder()
+            .attributes(asList(ofNestedType, ofSetOfNestedType, ofSetOfSetOfNestedType))
+            .build();
+
+    final ProductTypeDraft newProductTypeDraft =
+        createMockProductTypeDraftBuilder()
+            .attributes(
+                asList(ofNestedTypeDraft, ofSetOfNestedTypeDraft, ofSetOfSetOfNestedTypeDraft))
+            .build();
+
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, newProductTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithANullAttributeDefinitionDraft_ShouldSkipNullAttributes() {
+    // preparation
+    final ProductType oldProductType = mock(ProductType.class);
+    final AttributeDefinition attributeDefinition =
+        createMockAttributeDefinitionBuilder()
+            .label(ofEnglish("label1"))
+            .type(attributeTypeBuilder -> attributeTypeBuilder.lenumBuilder().values(emptyList()))
+            .build();
+
+    when(oldProductType.getAttributes()).thenReturn(singletonList(attributeDefinition));
+
+    final AttributeDefinitionDraft attributeDefinitionDraftWithDifferentLabel =
+        createMockAttributeDefinitionDraftBuilder()
+            .label(ofEnglish("label2"))
+            .type(attributeTypeBuilder -> attributeTypeBuilder.lenumBuilder().values(emptyList()))
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder()
+            .attributes(asList(null, attributeDefinitionDraftWithDifferentLabel))
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(oldProductType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(attributeDefinitionDraftWithDifferentLabel.getName())
+                .label(attributeDefinitionDraftWithDifferentLabel.getLabel())
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfText_ShouldBuildActions() {
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(AttributeTypeBuilder::textBuilder))
+            .label(ofEnglish("new_label"))
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(singletonList(newDefinition)).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(AttributeTypeBuilder::textBuilder))
+            .label(ofEnglish("old_label"))
+            .build();
+    final ProductType productType = mock(ProductType.class);
+    when(productType.getAttributes()).thenReturn(singletonList(oldDefinition));
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(newDefinition.getName())
+                .label(newDefinition.getLabel())
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfSetOfText_ShouldBuildActions() {
+
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .setBuilder()
+                                    .elementType(AttributeTypeBuilder::textBuilder)))
+            .label(ofEnglish("new_label"))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(singletonList(newDefinition)).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .setBuilder()
+                                    .elementType(AttributeTypeBuilder::textBuilder)))
+            .label(ofEnglish("old_label"))
+            .build();
+    final ProductType productType = mock(ProductType.class);
+    when(productType.getAttributes()).thenReturn(singletonList(oldDefinition));
+
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(newDefinition.getName())
+                .label(newDefinition.getLabel())
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfEnumsChanges_ShouldBuildCorrectActions() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        asList(
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("a")
+                                                .label("a")
+                                                .build(),
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("b")
+                                                .label("newB")
+                                                .build(),
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("c")
+                                                .label("c")
+                                                .build()))))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(singletonList(newDefinition)).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        asList(
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("d")
+                                                .label("d")
+                                                .build(),
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("b")
+                                                .label("b")
+                                                .build(),
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("a")
+                                                .label("a")
+                                                .build()))))
+            .build();
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(singletonList(oldDefinition)).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .keys("d")
+                .build(),
+            ProductTypeChangePlainEnumValueLabelActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .newValue(AttributePlainEnumValueBuilder.of().key("b").label("newB").build())
+                .build(),
+            ProductTypeAddPlainEnumValueActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .value(AttributePlainEnumValueBuilder.of().key("c").label("c").build())
+                .build(),
+            ProductTypeChangePlainEnumValueOrderActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .values(
+                    asList(
+                        AttributePlainEnumValueBuilder.of().key("a").label("a").build(),
+                        AttributePlainEnumValueBuilder.of().key("b").label("newB").build(),
+                        AttributePlainEnumValueBuilder.of().key("c").label("c").build()))
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfIdenticalEnums_ShouldNotBuildActions() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        singletonList(
+                                            AttributePlainEnumValueBuilder.of()
+                                                .key("foo")
+                                                .label("bar")
+                                                .build()))))
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .enumBuilder()
+                                    .values(
+                                        AttributePlainEnumValueBuilder.of()
+                                            .key("foo")
+                                            .label("bar")
+                                            .build())))
+            .build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions).isEmpty();
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfLEnumsChanges_ShouldBuildCorrectActions() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        AttributeLocalizedEnumValueBuilder.of()
+                                            .key("foo")
+                                            .label(ofEnglish("bar"))
+                                            .build())))
+            .build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1.lenumBuilder().values(emptyList())))
+            .build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions)
+        .containsExactly(
+            ProductTypeAddLocalizedEnumValueActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .value(
+                    AttributeLocalizedEnumValueBuilder.of()
+                        .key("foo")
+                        .label(ofEnglish("bar"))
+                        .build())
+                .build());
+  }
+
+  @Test
+  void buildAttributesUpdateActions_WithSetOfIdenticalLEnums_ShouldBuildNoActions() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        AttributeLocalizedEnumValueBuilder.of()
+                                            .key("foo")
+                                            .label(ofEnglish("bar"))
+                                            .build())))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        AttributeLocalizedEnumValueBuilder.of()
+                                            .key("foo")
+                                            .label(ofEnglish("bar"))
+                                            .build())))
+            .build();
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions).isEmpty();
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithOldEnumAndNewAsNonEnum_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder().type(AttributeTypeBuilder::textBuilder).build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .lenumBuilder()
+                        .values(
+                            AttributeLocalizedEnumValueBuilder.of()
+                                .key("foo")
+                                .label(ofEnglish("bar"))
+                                .build()))
+            .build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                oldDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithNewEnumAndOldAsNonEnum_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .enumBuilder()
+                        .values(
+                            AttributePlainEnumValueBuilder.of().key("foo").label("bar").build()))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder().type(AttributeTypeBuilder::textBuilder).build();
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                oldDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithOldLenumAndNewAsNonLenum_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder().type(AttributeTypeBuilder::textBuilder).build();
+
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .lenumBuilder()
+                        .values(
+                            AttributeLocalizedEnumValueBuilder.of()
+                                .key("foo")
+                                .label(ofEnglish("bar"))
+                                .build()))
+            .build();
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                oldDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithNewLenumAndOldAsNonLenum_ShouldNotBuildActionsAndTriggerErrorCb() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .lenumBuilder()
+                        .values(
+                            AttributeLocalizedEnumValueBuilder.of()
+                                .key("foo")
+                                .label(ofEnglish("bar"))
+                                .build()))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(attributeTypeBuilder -> attributeTypeBuilder.textBuilder())
+            .build();
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+    final ProductTypeSyncOptions syncOptions =
+        ProductTypeSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build();
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, syncOptions);
+
+    // assertions
+    assertThat(updateActions).isEmpty();
+    assertThat(errorMessages).hasSize(1);
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(BuildUpdateActionException.class);
+    assertThat(exceptions.get(0).getMessage())
+        .contains(
+            format(
+                "changing the attribute definition type (attribute name='%s') is not supported programmatically",
+                oldDefinition.getName()));
+    assertThat(exceptions.get(0).getCause())
+        .isExactlyInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void
+      buildAttributesUpdateActions_WithSetOfLEnumsChangesAndDefLabelChange_ShouldBuildCorrectActions() {
+    // preparation
+    final AttributeDefinitionDraft newDefinition =
+        createMockAttributeDefinitionDraftBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        asList(
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("a")
+                                                .label(ofEnglish("a"))
+                                                .build(),
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("b")
+                                                .label(ofEnglish("newB"))
+                                                .build(),
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("c")
+                                                .label(ofEnglish("c"))
+                                                .build()))))
+            .label(ofEnglish("new_label"))
+            .build();
+    final ProductTypeDraft productTypeDraft =
+        createMockProductTypeDraftBuilder().attributes(newDefinition).build();
+
+    final AttributeDefinition oldDefinition =
+        createMockAttributeDefinitionBuilder()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .lenumBuilder()
+                                    .values(
+                                        asList(
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("d")
+                                                .label(ofEnglish("d"))
+                                                .build(),
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("b")
+                                                .label(ofEnglish("b"))
+                                                .build(),
+                                            AttributeLocalizedEnumValueBuilder.of()
+                                                .key("a")
+                                                .label(ofEnglish("a"))
+                                                .build()))))
+            .build();
+
+    final ProductType productType =
+        createMockProductTypeBuilder().attributes(oldDefinition).build();
+
+    // test
+    final List<ProductTypeUpdateAction> updateActions =
+        buildAttributesUpdateActions(productType, productTypeDraft, SYNC_OPTIONS);
+
+    // assertion
+    assertThat(updateActions)
+        .containsExactlyInAnyOrder(
+            ProductTypeRemoveEnumValuesActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .keys("d")
+                .build(),
+            ProductTypeChangeLocalizedEnumValueLabelActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .newValue(
+                    AttributeLocalizedEnumValueBuilder.of()
+                        .key("b")
+                        .label(ofEnglish("newB"))
+                        .build())
+                .build(),
+            ProductTypeAddLocalizedEnumValueActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .value(
+                    AttributeLocalizedEnumValueBuilder.of().key("c").label(ofEnglish("c")).build())
+                .build(),
+            ProductTypeChangeLocalizedEnumValueOrderActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .values(
+                    asList(
+                        AttributeLocalizedEnumValueBuilder.of()
+                            .key("a")
+                            .label(ofEnglish("a"))
+                            .build(),
+                        AttributeLocalizedEnumValueBuilder.of()
+                            .key("b")
+                            .label(ofEnglish("newB"))
+                            .build(),
+                        AttributeLocalizedEnumValueBuilder.of()
+                            .key("c")
+                            .label(ofEnglish("c"))
+                            .build()))
+                .build(),
+            ProductTypeChangeLabelActionBuilder.of()
+                .attributeName(oldDefinition.getName())
+                .label(ofEnglish("new_label"))
+                .build());
+  }
+}


### PR DESCRIPTION
#### Summary

JIRA: https://commercetools.atlassian.net/browse/DEVX-172

#### Issues:
1. In unit tests we had an invalid case when we want to [change attribute constraint from SAME_FOR_ALL to COMBINATION UNIQUE](https://github.com/commercetools/commercetools-sync-java/blob/c05bb4c47b11ca4357c099dc21dfa08e55d6cf8b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java#L356). This is not allowed by the platform and the SDK does not have a method for this. Thus there is no way to compile such code in JVM SDK v2 and I had to update the tests to verify that it can be changed only to NONE, otherwise it throws an error.
2. There is no default values when creating resources (e.g. product types or attributes) like in the sdk v1. Now the SDK v2 throws error when null is supplied. Therefore the following test is not valid anymore. https://github.com/commercetools/commercetools-sync-java/blob/c05bb4c47b11ca4357c099dc21dfa08e55d6cf8b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java#L442
3. Some tests checks if attribute label is changed, but there are couple of tests just with different attribute type ([String](https://github.com/commercetools/commercetools-sync-java/blob/c05bb4c47b11ca4357c099dc21dfa08e55d6cf8b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java#L510), [set of strings](https://github.com/commercetools/commercetools-sync-java/blob/c05bb4c47b11ca4357c099dc21dfa08e55d6cf8b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java#L532), [set of set of strings](https://github.com/commercetools/commercetools-sync-java/blob/c05bb4c47b11ca4357c099dc21dfa08e55d6cf8b/src/test/java/com/commercetools/sync/producttypes/utils/AttributeDefinitionUpdateActionUtilsTest.java#L559) etc). Since the attribute type makes no difference for the attribute label change, I removed those redundant tests.