### PR TITLE
Migrate unittest for CustomObjectCompositeIdentifier

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtils.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.sdk2.commons.utils;
 
+import static com.commercetools.sync.sdk2.commons.utils.CustomValueConverter.convertCustomValueObjDataToJsonNode;
 import static com.commercetools.sync.sdk2.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -22,8 +23,6 @@ import com.commercetools.sync.sdk2.commons.models.Custom;
 import com.commercetools.sync.sdk2.commons.models.CustomDraft;
 import com.commercetools.sync.sdk2.services.TypeService;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vrap.rmf.base.client.utils.json.JsonUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -500,9 +499,9 @@ public final class CustomUpdateActionUtils {
             newCustomFieldName -> {
               // Convert Object to JSONNode
               final JsonNode newCustomFieldValue =
-                  convertFieldValuesToJsonNode(newCustomFields.get(newCustomFieldName));
+                  convertCustomValueObjDataToJsonNode(newCustomFields.get(newCustomFieldName));
               final JsonNode oldCustomFieldValue =
-                  convertFieldValuesToJsonNode(oldCustomFields.get(newCustomFieldName));
+                  convertCustomValueObjDataToJsonNode(oldCustomFields.get(newCustomFieldName));
               return !isNullJsonValue(newCustomFieldValue)
                   && !Objects.equals(newCustomFieldValue, oldCustomFieldValue);
             })
@@ -560,9 +559,9 @@ public final class CustomUpdateActionUtils {
             oldCustomFieldsName -> {
               // Convert Object to JSONNode
               final JsonNode newCustomFieldValue =
-                  convertFieldValuesToJsonNode(newCustomFields.get(oldCustomFieldsName));
+                  convertCustomValueObjDataToJsonNode(newCustomFields.get(oldCustomFieldsName));
               final JsonNode oldCustomFieldValue =
-                  convertFieldValuesToJsonNode(oldCustomFields.get(oldCustomFieldsName));
+                  convertCustomValueObjDataToJsonNode(oldCustomFields.get(oldCustomFieldsName));
               return isNullJsonValue(newCustomFieldValue)
                   && oldCustomFieldValue != newCustomFieldValue;
             })
@@ -571,21 +570,6 @@ public final class CustomUpdateActionUtils {
                 customActionBuilder.buildSetCustomFieldAction(
                     variantId, updateIdGetter.apply(resource), oldCustomFieldsName, null))
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Takes a value of type Object and converts to JSONNode. It helps to compare fields values of
-   * {@link CustomFields} and {@link CustomFieldsDraft}
-   *
-   * @param data a value of any Object-type
-   * @return the given value converted to {@link JsonNode} or null
-   */
-  @Nullable
-  private static JsonNode convertFieldValuesToJsonNode(@Nullable final Object data) {
-    if (Objects.isNull(data)) return null;
-    final ObjectMapper objectMapper = JsonUtils.getConfiguredObjectMapper();
-    final JsonNode jsonNode = objectMapper.convertValue(data, JsonNode.class);
-    return jsonNode;
   }
 
   private CustomUpdateActionUtils() {}

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomValueConverter.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CustomValueConverter.java
@@ -1,0 +1,30 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import com.commercetools.api.models.type.CustomFields;
+import com.commercetools.api.models.type.CustomFieldsDraft;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vrap.rmf.base.client.utils.json.JsonUtils;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public final class CustomValueConverter {
+
+  /**
+   * Takes a value of type Object and converts to JSONNode.
+   *
+   * <p>This can be helpful to compare values of {@link CustomFields} and {@link CustomFieldsDraft},
+   * or to check equality of {@link com.commercetools.api.models.custom_object.CustomObject}'s
+   * values and {@link com.commercetools.api.models.custom_object.CustomObjectDraft}'s values.
+   *
+   * @param data a value of any Object-type
+   * @return the given value converted to {@link JsonNode} or null
+   */
+  @Nullable
+  public static JsonNode convertCustomValueObjDataToJsonNode(@Nullable final Object data) {
+    if (Objects.isNull(data)) return null;
+    final ObjectMapper objectMapper = JsonUtils.getConfiguredObjectMapper();
+    final JsonNode jsonNode = objectMapper.convertValue(data, JsonNode.class);
+    return jsonNode;
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectBatchValidator.java
+++ b/src/main/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectBatchValidator.java
@@ -1,0 +1,70 @@
+package com.commercetools.sync.sdk2.customobjects.helpers;
+
+import static java.util.stream.Collectors.toSet;
+
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.sync.sdk2.commons.helpers.BaseBatchValidator;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptions;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+public class CustomObjectBatchValidator
+    extends BaseBatchValidator<
+        CustomObjectDraft, CustomObjectSyncOptions, CustomObjectSyncStatistics> {
+
+  static final String CUSTOM_OBJECT_DRAFT_IS_NULL = "CustomObjectDraft is null.";
+
+  public CustomObjectBatchValidator(
+      @Nonnull final CustomObjectSyncOptions syncOptions,
+      @Nonnull final CustomObjectSyncStatistics syncStatistics) {
+    super(syncOptions, syncStatistics);
+  }
+
+  /**
+   * Given the {@link List}&lt;{@link CustomObjectDraft}&gt; of drafts this method attempts to
+   * validate drafts and return an {@link ImmutablePair}&lt;{@link Set}&lt;{@link
+   * CustomObjectDraft}&gt;, {@link Set}&lt;{@link CustomObjectCompositeIdentifier} &gt;&gt; which
+   * contains the {@link Set} of valid drafts and valid custom object identifiers (container with
+   * key).
+   *
+   * <p>A valid custom object draft is one which satisfies the following conditions:
+   *
+   * <ol>
+   *   <li>It is not null
+   * </ol>
+   *
+   * @param customObjectDrafts the custom object drafts to validate and collect valid custom object
+   *     identifiers.
+   * @return {@link ImmutablePair}&lt;{@link Set}&lt;{@link CustomObjectDraft}&gt;, {@link
+   *     Set}&lt;{@link CustomObjectCompositeIdentifier}&gt;&gt; which contains the {@link Set} of
+   *     valid drafts and valid custom object identifiers (container with key).
+   */
+  @Override
+  public ImmutablePair<Set<CustomObjectDraft>, Set<CustomObjectCompositeIdentifier>>
+      validateAndCollectReferencedKeys(@Nonnull final List<CustomObjectDraft> customObjectDrafts) {
+
+    final Set<CustomObjectDraft> validDrafts =
+        customObjectDrafts.stream()
+            .filter(this::isValidCustomObjectDraft)
+            .collect(Collectors.toSet());
+
+    final Set<CustomObjectCompositeIdentifier> validIdentifiers =
+        validDrafts.stream().map(CustomObjectCompositeIdentifier::of).collect(toSet());
+
+    return ImmutablePair.of(validDrafts, validIdentifiers);
+  }
+
+  private boolean isValidCustomObjectDraft(@Nullable final CustomObjectDraft customObjectDraft) {
+
+    if (customObjectDraft == null) {
+      handleError(CUSTOM_OBJECT_DRAFT_IS_NULL);
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectSyncStatistics.java
+++ b/src/main/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectSyncStatistics.java
@@ -1,0 +1,19 @@
+package com.commercetools.sync.sdk2.customobjects.helpers;
+
+import com.commercetools.sync.sdk2.commons.helpers.BaseSyncStatistics;
+
+public class CustomObjectSyncStatistics extends BaseSyncStatistics {
+  /**
+   * Builds a summary of the custom object sync statistics instance that looks like the following
+   * example:
+   *
+   * <p>"Summary: 2 custom objects were processed in total (0 created, 0 updated and 0 failed to
+   * sync)."
+   *
+   * @return a summary message of the custom objects sync statistics instance.
+   */
+  @Override
+  public String getReportMessage() {
+    return getDefaultReportMessageForResource("custom objects");
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/customobjects/utils/CustomObjectSyncUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/customobjects/utils/CustomObjectSyncUtils.java
@@ -1,0 +1,34 @@
+package com.commercetools.sync.sdk2.customobjects.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CustomValueConverter.convertCustomValueObjDataToJsonNode;
+
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.fasterxml.jackson.databind.JsonNode;
+import javax.annotation.Nonnull;
+
+public class CustomObjectSyncUtils {
+
+  /**
+   * Compares the value of a {@link CustomObject} to the value of a {@link CustomObjectDraft}. It
+   * returns a boolean whether the values are identical or not.
+   *
+   * @param oldCustomObject the {@link CustomObject} which should be synced.
+   * @param newCustomObject the {@link CustomObjectDraft} with the new data.
+   * @return A boolean whether the value of the CustomObject and CustomObjectDraft is identical or
+   *     not.
+   */
+  public static boolean hasIdenticalValue(
+      @Nonnull final CustomObject oldCustomObject,
+      @Nonnull final CustomObjectDraft newCustomObject) {
+    // Values are JSON standard types Number, String, Boolean, Array, Object, and common API data
+    // types.
+    final Object oldValue = oldCustomObject.getValue();
+    final Object newValue = newCustomObject.getValue();
+
+    final JsonNode oldValueJsonNode = convertCustomValueObjDataToJsonNode(oldValue);
+    final JsonNode newValueJsonNode = convertCustomValueObjDataToJsonNode(newValue);
+
+    return oldValueJsonNode.equals(newValueJsonNode);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/AssertionsForStatistics.java
@@ -2,6 +2,7 @@ package com.commercetools.sync.sdk2.commons.asserts.statistics;
 
 import com.commercetools.sync.sdk2.categories.helpers.CategorySyncStatistics;
 import com.commercetools.sync.sdk2.customers.helpers.CustomerSyncStatistics;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,5 +44,17 @@ public final class AssertionsForStatistics {
   public static CategorySyncStatisticsAssert assertThat(
       @Nullable final CategorySyncStatistics statistics) {
     return new CategorySyncStatisticsAssert(statistics);
+  }
+
+  /**
+   * Create assertion for {@link CustomObjectSyncStatistics}.
+   *
+   * @param statistics the actual value.
+   * @return the created assertion object.
+   */
+  @Nonnull
+  public static CustomObjectSyncStatisticsAssert assertThat(
+      @Nullable final CustomObjectSyncStatistics statistics) {
+    return new CustomObjectSyncStatisticsAssert(statistics);
   }
 }

--- a/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/asserts/statistics/CustomObjectSyncStatisticsAssert.java
@@ -1,0 +1,13 @@
+package com.commercetools.sync.sdk2.commons.asserts.statistics;
+
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
+import javax.annotation.Nullable;
+
+public final class CustomObjectSyncStatisticsAssert
+    extends AbstractSyncStatisticsAssert<
+        CustomObjectSyncStatisticsAssert, CustomObjectSyncStatistics> {
+
+  CustomObjectSyncStatisticsAssert(@Nullable final CustomObjectSyncStatistics actual) {
+    super(actual, CustomObjectSyncStatisticsAssert.class);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectBatchValidatorTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectBatchValidatorTest.java
@@ -1,0 +1,90 @@
+package com.commercetools.sync.sdk2.customobjects.helpers;
+
+import static com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectBatchValidator.CUSTOM_OBJECT_DRAFT_IS_NULL;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptions;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptionsBuilder;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CustomObjectBatchValidatorTest {
+  private List<String> errorCallBackMessages;
+  private CustomObjectSyncOptions syncOptions;
+  private CustomObjectSyncStatistics syncStatistics;
+
+  @BeforeEach
+  void setup() {
+    errorCallBackMessages = new ArrayList<>();
+    final ProjectApiRoot ctpClient = mock(ProjectApiRoot.class);
+    syncOptions =
+        CustomObjectSyncOptionsBuilder.of(ctpClient)
+            .errorCallback(
+                (exception, oldResource, newResource, actions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                })
+            .build();
+    syncStatistics = new CustomObjectSyncStatistics();
+  }
+
+  @Test
+  void validateAndCollectReferencedKeys_WithValidDraft_ShouldHaveCorrectResult() {
+    CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("container")
+            .key("key")
+            .value(JsonNodeFactory.instance.numberNode(1))
+            .build();
+
+    final CustomObjectBatchValidator batchValidator =
+        new CustomObjectBatchValidator(syncOptions, syncStatistics);
+    final ImmutablePair<Set<CustomObjectDraft>, Set<CustomObjectCompositeIdentifier>> result =
+        batchValidator.validateAndCollectReferencedKeys(singletonList(customObjectDraft));
+
+    assertThat(result.getLeft()).contains(customObjectDraft);
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(result.getRight()).contains(CustomObjectCompositeIdentifier.of(customObjectDraft));
+  }
+
+  @Test
+  void validateAndCollectReferencedKeys_WithEmptyDraft_ShouldHaveEmptyResult() {
+    final Set<CustomObjectDraft> validDrafts = getValidDrafts(emptyList());
+
+    assertThat(validDrafts).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+  }
+
+  @Test
+  void
+      validateAndCollectReferencedKeys_WithNullTypeDraft_ShouldHaveValidationErrorAndEmptyResult() {
+    final Set<CustomObjectDraft> validDrafts = getValidDrafts(Collections.singletonList(null));
+
+    assertThat(errorCallBackMessages).hasSize(1);
+    assertThat(errorCallBackMessages.get(0)).isEqualTo(CUSTOM_OBJECT_DRAFT_IS_NULL);
+    assertThat(validDrafts).isEmpty();
+  }
+
+  @Nonnull
+  private Set<CustomObjectDraft> getValidDrafts(
+      @Nonnull final List<CustomObjectDraft> customObjectDrafts) {
+
+    final CustomObjectBatchValidator batchValidator =
+        new CustomObjectBatchValidator(syncOptions, syncStatistics);
+    final ImmutablePair<Set<CustomObjectDraft>, Set<CustomObjectCompositeIdentifier>> pair =
+        batchValidator.validateAndCollectReferencedKeys(customObjectDrafts);
+    return pair.getLeft();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectCompositeIdentifierTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectCompositeIdentifierTest.java
@@ -1,0 +1,194 @@
+package com.commercetools.sync.sdk2.customobjects.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+public class CustomObjectCompositeIdentifierTest {
+
+  private static final String CONTAINER = "container";
+  private static final String KEY = "key";
+
+  @Test
+  void of_WithCustomObjectDraft_ShouldCreateCustomObjectCompositeIdentifier() {
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CONTAINER)
+            .key(KEY)
+            .value(StringUtils.EMPTY)
+            .build();
+
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(customObjectDraft);
+
+    assertThat(customObjectCompositeIdentifier).isNotNull();
+    assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+    assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void of_WithContainerAndKeyParams_ShouldCreateCustomObjectCompositeIdentifier() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+    assertThat(customObjectCompositeIdentifier).isNotNull();
+    assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+    assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void of_WithCustomObject_ShouldCreateCustomObjectCompositeIdentifier() {
+    final CustomObject customObject = mock(CustomObject.class);
+    when(customObject.getContainer()).thenReturn(CONTAINER);
+    when(customObject.getKey()).thenReturn(KEY);
+
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(customObject);
+
+    assertThat(customObjectCompositeIdentifier).isNotNull();
+    assertThat(customObjectCompositeIdentifier.getContainer()).isEqualTo(CONTAINER);
+    assertThat(customObjectCompositeIdentifier.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void of_WithInvalidIdentifierAsString_ShouldThrowAnError() {
+    assertThatThrownBy(() -> CustomObjectCompositeIdentifier.of("aContainer-andKey"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "The custom object identifier value: \"aContainer-andKey\" does not have the correct format. "
+                + "The correct format must have a vertical bar \"|\" character between the container and key.");
+  }
+
+  @Test
+  void equals_WithSameObj_ShouldReturnTrue() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+    boolean result = customObjectCompositeIdentifier.equals(customObjectCompositeIdentifier);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void equals_WithDiffType_ShouldReturnFalse() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+    final Object other = new Object();
+
+    boolean result = customObjectCompositeIdentifier.equals(other);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void equals_WithEqualObjects_ShouldReturnTrue() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+    boolean result = customObjectCompositeIdentifier.equals(other);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void equals_WithDifferentKeys_ShouldReturnFalse() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of("key1", CONTAINER);
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of("key2", CONTAINER);
+
+    boolean result = customObjectCompositeIdentifier.equals(other);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void equals_WithDifferentContainers_ShouldReturnFalse() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, "container1");
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of(KEY, "container2");
+
+    boolean result = customObjectCompositeIdentifier.equals(other);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void hashCode_withSameInstances_ShouldBeEquals() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+    final CustomObjectCompositeIdentifier other = customObjectCompositeIdentifier;
+
+    final int hash1 = customObjectCompositeIdentifier.hashCode();
+    final int hash2 = other.hashCode();
+
+    assertEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withSameKeyAndSameContainer_ShouldBeEquals() {
+    // preparation
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of(KEY, CONTAINER);
+
+    // test
+    final int hash1 = customObjectCompositeIdentifier.hashCode();
+    final int hash2 = other.hashCode();
+
+    // assertions
+    assertEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withDifferentKeyAndSameContainer_ShouldNotBeEquals() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of("key1", CONTAINER);
+
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of("key2", CONTAINER);
+
+    final int hash1 = customObjectCompositeIdentifier.hashCode();
+    final int hash2 = other.hashCode();
+
+    assertNotEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withSameKeyAndDifferentContainer_ShouldNotBeEquals() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of(KEY, "container1");
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of(KEY, "container2");
+
+    final int hash1 = customObjectCompositeIdentifier.hashCode();
+    final int hash2 = other.hashCode();
+
+    assertNotEquals(hash1, hash2);
+  }
+
+  @Test
+  void hashCode_withCompletelyDifferentValues_ShouldNotBeEquals() {
+    final CustomObjectCompositeIdentifier customObjectCompositeIdentifier =
+        CustomObjectCompositeIdentifier.of("key1", "container1");
+    final CustomObjectCompositeIdentifier other =
+        CustomObjectCompositeIdentifier.of("key2", "container2");
+
+    final int hash1 = customObjectCompositeIdentifier.hashCode();
+    final int hash2 = other.hashCode();
+
+    assertNotEquals(hash1, hash2);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectSyncStatisticsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/helpers/CustomObjectSyncStatisticsTest.java
@@ -1,0 +1,28 @@
+package com.commercetools.sync.sdk2.customobjects.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CustomObjectSyncStatisticsTest {
+  private CustomObjectSyncStatistics customObjectSyncStatistics;
+
+  @BeforeEach
+  void setup() {
+    customObjectSyncStatistics = new CustomObjectSyncStatistics();
+  }
+
+  @Test
+  void getReportMessage_WithIncrementedStats_ShouldGetCorrectMessage() {
+    customObjectSyncStatistics.incrementCreated(1);
+    customObjectSyncStatistics.incrementFailed(2);
+    customObjectSyncStatistics.incrementUpdated(3);
+    customObjectSyncStatistics.incrementProcessed(6);
+
+    assertThat(customObjectSyncStatistics.getReportMessage())
+        .isEqualTo(
+            "Summary: 6 custom objects were processed in total "
+                + "(1 created, 3 updated and 2 failed to sync).");
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/utils/CustomObjectSyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/utils/CustomObjectSyncUtilsTest.java
@@ -1,0 +1,245 @@
+package com.commercetools.sync.sdk2.customobjects.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.models.common.*;
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class CustomObjectSyncUtilsTest {
+
+  private CustomObject oldCustomObject;
+  private CustomObjectDraft newCustomObjectdraft;
+
+  @SuppressWarnings("unchecked")
+  private void prepareMockObjects(
+      final Object newCustomObjDraftValue, final Object oldCustomObjValue) {
+    final String key = "testkey";
+    final String container = "testcontainer";
+
+    newCustomObjectdraft =
+        CustomObjectDraftBuilder.of()
+            .container(container)
+            .key(key)
+            .value(newCustomObjDraftValue)
+            .build();
+    oldCustomObject = mock(CustomObject.class);
+    when(oldCustomObject.getValue()).thenReturn(oldCustomObjValue);
+    when(oldCustomObject.getContainer()).thenReturn(container);
+    when(oldCustomObject.getKey()).thenReturn(key);
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameBooleanValue_ShouldBeIdentical() {
+    final JsonNode newDraftValue = JsonNodeFactory.instance.booleanNode(true);
+    final boolean oldValue = true;
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(newDraftValue.isBoolean()).isTrue();
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentBooleanValue_ShouldNotBeIdentical() {
+    final JsonNode newDraftValue = JsonNodeFactory.instance.booleanNode(true);
+    final JsonNode oldValue = JsonNodeFactory.instance.booleanNode(false);
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(newDraftValue.isBoolean()).isTrue();
+    assertThat(oldValue.isBoolean()).isTrue();
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameNumberValue_ShouldBeIdentical() {
+    final JsonNode newDraftValue = JsonNodeFactory.instance.numberNode(2020);
+    final JsonNode oldValue = JsonNodeFactory.instance.numberNode(2020);
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(newDraftValue.isNumber()).isTrue();
+    assertThat(oldValue.isNumber()).isTrue();
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentNumberValue_ShouldNotBeIdentical() {
+    final JsonNode newDraftValue = JsonNodeFactory.instance.numberNode(2020);
+    final int oldValue = 2021;
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(newDraftValue.isNumber()).isTrue();
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameStringValue_ShouldBeIdentical() {
+    final JsonNode newDraftValue = JsonNodeFactory.instance.textNode("\"CommerceTools\"");
+    final String oldValue = "\"CommerceTools\"";
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(newDraftValue.isTextual()).isTrue();
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentStringValue_ShouldNotBeIdentical() {
+    final String newDraftValue = "\"CommerceToolsPlatform\"";
+    final String oldValue = "\"CommerceTools\"";
+    prepareMockObjects(newDraftValue, oldValue);
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameFieldAndValueInJsonNode_ShouldBeIdentical() {
+
+    final ObjectNode oldValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
+    final ObjectNode newValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
+    prepareMockObjects(oldValue, newValue);
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameFieldAndDifferentValueInJsonNode_ShouldNotBeIdentical() {
+
+    final ObjectNode oldValue = JsonNodeFactory.instance.objectNode().put("username", "Peter");
+    final ObjectNode newValue = JsonNodeFactory.instance.objectNode().put("username", "Joe");
+    prepareMockObjects(newValue, oldValue);
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameFieldAndValueInDifferentOrderInJsonNode_ShouldBeIdentical() {
+
+    final ObjectNode oldValue =
+        JsonNodeFactory.instance.objectNode().put("username", "Peter").put("userId", "123-456-789");
+
+    final ObjectNode newValue =
+        JsonNodeFactory.instance.objectNode().put("userId", "123-456-789").put("username", "Peter");
+
+    prepareMockObjects(newValue, oldValue);
+
+    assertThat(oldValue.toString()).isNotEqualTo(newValue.toString());
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithSameMoneyValue_ShouldBeIdentical() {
+    final Money oldValue =
+        CentPrecisionMoneyBuilder.of()
+            .centAmount(100L)
+            .currencyCode("EUR")
+            .fractionDigits(2)
+            .build();
+    final TypedMoneyDraft newDraftValue =
+        TypedMoneyDraftBuilder.of()
+            .centPrecisionBuilder()
+            .centAmount(100L)
+            .currencyCode("EUR")
+            .fractionDigits(2)
+            .build();
+
+    prepareMockObjects(newDraftValue, oldValue);
+
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentMoneyValue_ShouldNotBeIdentical() {
+    final Money oldValue = MoneyBuilder.of().centAmount(100L).currencyCode("EUR").build();
+    final ObjectNode newDraftValue =
+        JsonNodeFactory.instance.objectNode().put("centAmount", 200L).put("currencyCode", "EUR");
+
+    prepareMockObjects(newDraftValue, oldValue);
+
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentMoneyTypeValues_ShouldNotBeIdentical() {
+    final Money oldValue = MoneyBuilder.of().centAmount(100L).currencyCode("EUR").build();
+    final HighPrecisionMoneyDraft newDraftValue =
+        HighPrecisionMoneyDraftBuilder.of()
+            .centAmount(100L)
+            .currencyCode("EUR")
+            .fractionDigits(2)
+            .preciseAmount(101L)
+            .build();
+
+    prepareMockObjects(newDraftValue, oldValue);
+
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+
+  @Test
+  void
+      hasIdenticalValue_WithSameNestedJsonNode_WithSameAttributeOrderInNestedJson_ShouldBeIdentical() {
+
+    final JsonNode oldNestedJson =
+        JsonNodeFactory.instance.objectNode().put("username", "Peter").put("userId", "123-456-789");
+    JsonNode newNestedJson =
+        JsonNodeFactory.instance.objectNode().put("username", "Peter").put("userId", "123-456-789");
+
+    JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", oldNestedJson);
+
+    JsonNode newJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", newNestedJson);
+
+    prepareMockObjects(oldJsonNode, newJsonNode);
+
+    assertThat(oldJsonNode.toString()).isEqualTo(newJsonNode.toString());
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void
+      hasIdenticalValue_WithSameNestedJsonNode_WithDifferentAttributeOrderInNestedJson_ShouldBeIdentical() {
+
+    JsonNode oldNestedJson =
+        JsonNodeFactory.instance.objectNode().put("username", "Peter").put("userId", "123-456-789");
+    JsonNode newNestedJson =
+        JsonNodeFactory.instance.objectNode().put("userId", "123-456-789").put("username", "Peter");
+
+    JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", oldNestedJson);
+
+    JsonNode newJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", newNestedJson);
+
+    prepareMockObjects(oldJsonNode, newJsonNode);
+
+    assertThat(oldJsonNode.toString()).isNotEqualTo(newJsonNode.toString());
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isTrue();
+  }
+
+  @Test
+  void hasIdenticalValue_WithDifferentNestedJsonNode_ShouldNotBeIdentical() {
+
+    JsonNode oldNestedJson =
+        JsonNodeFactory.instance.objectNode().put("username", "Peter").put("userId", "123-456-789");
+    JsonNode newNestedJson =
+        JsonNodeFactory.instance.objectNode().put("userId", "129-382-189").put("username", "Peter");
+
+    JsonNode oldJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", oldNestedJson);
+
+    JsonNode newJsonNode = JsonNodeFactory.instance.objectNode().set("nestedJson", newNestedJson);
+
+    prepareMockObjects(oldJsonNode, newJsonNode);
+
+    assertThat(oldJsonNode.toString()).isNotEqualTo(newJsonNode.toString());
+    assertThat(CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObjectdraft))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
**Summary:** 
JIRA: https://commercetools.atlassian.net/browse/DEVX-107

**Issue:**
There is no validation of `container` and `key` on building CustomObjectDraft like in the sdk v1. The SDK v2 throws error when null is supplied, but not when empty String is supplied. Therefore the following test is not valid anymore.
https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/customobjects/helpers/CustomObjectCompositeIdentifierTest.java#L60

