### PR TITLE
Migrate custom object sync

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/CustomObjectITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/commons/utils/CustomObjectITUtils.java
@@ -4,7 +4,6 @@ import com.commercetools.api.client.ProjectApiRoot;
 import com.commercetools.api.models.custom_object.CustomObject;
 import com.commercetools.api.models.custom_object.CustomObjectDraft;
 import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.vrap.rmf.base.client.ApiHttpResponse;
 import io.vrap.rmf.base.client.error.NotFoundException;
 import javax.annotation.Nonnull;
@@ -43,7 +42,7 @@ public final class CustomObjectITUtils {
       @Nonnull final ProjectApiRoot ctpClient,
       @Nonnull final String key,
       @Nonnull final String container,
-      @Nonnull final JsonNode value) {
+      @Nonnull final Object value) {
 
     CustomObjectDraft customObjectDraft =
         CustomObjectDraftBuilder.of().container(container).key(key).value(value).build();

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/customobjects/CustomObjectSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/customobjects/CustomObjectSyncIT.java
@@ -1,0 +1,469 @@
+package com.commercetools.sync.integration.sdk2.externalsource.customobjects;
+
+import static com.commercetools.sync.integration.sdk2.commons.utils.CustomObjectITUtils.createCustomObject;
+import static com.commercetools.sync.integration.sdk2.commons.utils.CustomObjectITUtils.deleteCustomObject;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.createBadGatewayException;
+import static com.commercetools.sync.integration.sdk2.commons.utils.ITUtils.createConcurrentModificationException;
+import static com.commercetools.sync.integration.sdk2.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static java.lang.String.format;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.defaultconfig.ApiRootBuilder;
+import com.commercetools.api.models.category.CategoryReference;
+import com.commercetools.api.models.category.CategoryReferenceBuilder;
+import com.commercetools.api.models.common.CentPrecisionMoneyDraft;
+import com.commercetools.api.models.common.CentPrecisionMoneyDraftBuilder;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import com.commercetools.api.models.error.ErrorResponse;
+import com.commercetools.api.models.error.ErrorResponseBuilder;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSync;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptions;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vrap.rmf.base.client.ApiHttpMethod;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadGatewayException;
+import io.vrap.rmf.base.client.error.NotFoundException;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unchecked")
+public class CustomObjectSyncIT {
+  private static final String CUSTOM_OBJECT_KEY_1 = "key1";
+  private static final String CUSTOM_OBJECT_CONTAINER_1 = "container1";
+  private static final ObjectNode CUSTOM_OBJECT_VALUE_JSON_1 =
+      JsonNodeFactory.instance.objectNode().put("name", "value1");
+
+  @BeforeEach
+  void setup() {
+    deleteCustomObject(CTP_TARGET_CLIENT, CUSTOM_OBJECT_KEY_1, CUSTOM_OBJECT_CONTAINER_1);
+    deleteCustomObject(CTP_TARGET_CLIENT, "key2", "container2");
+
+    createCustomObject(
+        CTP_TARGET_CLIENT,
+        CUSTOM_OBJECT_KEY_1,
+        CUSTOM_OBJECT_CONTAINER_1,
+        CUSTOM_OBJECT_VALUE_JSON_1);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    deleteCustomObject(CTP_TARGET_CLIENT, "key1", "container1");
+    deleteCustomObject(CTP_TARGET_CLIENT, "key2", "container2");
+  }
+
+  @Test
+  void sync_withNewCustomObject_shouldCreateCustomObject() {
+
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(CTP_TARGET_CLIENT).build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(customObjectSyncOptions);
+
+    final ObjectNode customObject2Value =
+        JsonNodeFactory.instance.objectNode().put("name", "value1");
+
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("container2")
+            .key("key2")
+            .value(customObject2Value)
+            .build();
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 1, 0, 0);
+  }
+
+  @Test
+  void sync_withExistingCustomObjectThatHasDifferentJsonValue_shouldUpdateCustomObject() {
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(CTP_TARGET_CLIENT).build();
+    final CustomObjectSync customObjectSync = new CustomObjectSync(customObjectSyncOptions);
+
+    final ObjectNode customObject2Value =
+        JsonNodeFactory.instance.objectNode().put("name", "value2");
+
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(customObject2Value)
+            .build();
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 1, 0);
+  }
+
+  @Test
+  void sync_withExistingCustomObjectThatHasDifferentMoneyValue_shouldUpdateCustomObject() {
+    final CentPrecisionMoneyDraft originalMoneyValue =
+        CentPrecisionMoneyDraftBuilder.of()
+            .centAmount(100L)
+            .currencyCode("EUR")
+            .fractionDigits(2)
+            .build();
+    // Change value of exiting CustomObject before test
+    createCustomObject(
+        CTP_TARGET_CLIENT, CUSTOM_OBJECT_KEY_1, CUSTOM_OBJECT_CONTAINER_1, originalMoneyValue);
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(CTP_TARGET_CLIENT).build();
+    final CustomObjectSync customObjectSync = new CustomObjectSync(customObjectSyncOptions);
+
+    final CentPrecisionMoneyDraft newMoneyValue =
+        CentPrecisionMoneyDraftBuilder.of()
+            .centAmount(200L)
+            .currencyCode("EUR")
+            .fractionDigits(2)
+            .build();
+
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(newMoneyValue)
+            .build();
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 1, 0);
+  }
+
+  @Test
+  void sync_withExistingCustomObjectThatHasSameJsonValue_shouldNotUpdateCustomObject() {
+
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(CUSTOM_OBJECT_VALUE_JSON_1)
+            .build();
+
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(CTP_TARGET_CLIENT).build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(customObjectSyncOptions);
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 0);
+  }
+
+  @Test
+  void
+      sync_withChangedCustomObjectAndConcurrentModificationException_shouldRetryAndUpdateCustomObject() {
+    final ProjectApiRoot mockClient =
+        buildClientWithConcurrentModificationAndOptionalExceptionOnFetch(null);
+    final List<String> errorCallBackMessages = new ArrayList<>();
+    final List<String> warningCallBackMessages = new ArrayList<>();
+    final List<Throwable> errorCallBackExceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyOptions =
+        CustomObjectSyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(spyOptions);
+
+    final CategoryReference newCustomObjectValue =
+        CategoryReferenceBuilder.of().id("category-id").build();
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(newCustomObjectValue)
+            .build();
+
+    // test
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 1, 0);
+    Assertions.assertThat(errorCallBackExceptions).isEmpty();
+    Assertions.assertThat(errorCallBackMessages).isEmpty();
+    Assertions.assertThat(warningCallBackMessages).isEmpty();
+  }
+
+  @Test
+  void sync_withChangedCustomObjectWithBadGatewayExceptionInsideUpdateRetry_shouldFailToUpdate() {
+    final ErrorResponse errorResponse =
+        ErrorResponseBuilder.of()
+            .statusCode(500)
+            .errors(Collections.emptyList())
+            .message("test")
+            .build();
+    final String responseJsonString = getResponseJsonString(errorResponse);
+    final ProjectApiRoot mockClient =
+        buildClientWithConcurrentModificationAndOptionalExceptionOnFetch(responseJsonString);
+
+    final List<String> errorCallBackMessages = new ArrayList<>();
+    final List<Throwable> errorCallBackExceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyOptions =
+        CustomObjectSyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(spyOptions);
+
+    final ObjectNode newCustomObjectValue =
+        JsonNodeFactory.instance.objectNode().put("name", "value2");
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(newCustomObjectValue)
+            .build();
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
+    Assertions.assertThat(errorCallBackMessages).hasSize(1);
+    Assertions.assertThat(errorCallBackExceptions).hasSize(1);
+    Assertions.assertThat(errorCallBackMessages.get(0))
+        .contains(
+            format(
+                "Failed to update custom object with key: '%s'. Reason: Failed to fetch from CTP while retrying "
+                    + "after concurrency modification.",
+                CustomObjectCompositeIdentifier.of(customObjectDraft)));
+  }
+
+  @Test
+  void sync_withConcurrentModificationExceptionAndUnexpectedDelete_shouldFailToReFetchAndUpdate() {
+    final ErrorResponse errorResponse =
+        ErrorResponseBuilder.of()
+            .statusCode(404)
+            .errors(Collections.emptyList())
+            .message("test")
+            .build();
+    final String responseJsonString = getResponseJsonString(errorResponse);
+    final ProjectApiRoot mockClient =
+        buildClientWithConcurrentModificationAndOptionalExceptionOnFetch(responseJsonString);
+
+    final List<String> errorCallBackMessages = new ArrayList<>();
+    final List<Throwable> errorCallBackExceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyOptions =
+        CustomObjectSyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(spyOptions);
+
+    final ObjectNode newCustomObjectValue =
+        JsonNodeFactory.instance.objectNode().put("name", "value2");
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container(CUSTOM_OBJECT_CONTAINER_1)
+            .key(CUSTOM_OBJECT_KEY_1)
+            .value(newCustomObjectValue)
+            .build();
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
+    Assertions.assertThat(errorCallBackMessages).hasSize(1);
+    Assertions.assertThat(errorCallBackExceptions).hasSize(1);
+
+    Assertions.assertThat(errorCallBackMessages.get(0))
+        .contains(
+            format(
+                "Failed to update custom object with key: '%s'. Reason: Not found when attempting to fetch while"
+                    + " retrying after concurrency modification.",
+                CustomObjectCompositeIdentifier.of(customObjectDraft)));
+  }
+
+  @Test
+  void sync_withNewCustomObjectAndBadRequest_shouldNotCreateButHandleError() {
+    final ProjectApiRoot mockClient = buildClientWithExceptionOnUpsert();
+
+    final ObjectNode newCustomObjectValue =
+        JsonNodeFactory.instance.objectNode().put("name", "value2");
+    final CustomObjectDraft customObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("container2")
+            .key("key2")
+            .value(newCustomObjectValue)
+            .build();
+
+    final List<String> errorCallBackMessages = new ArrayList<>();
+    final List<Throwable> errorCallBackExceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyOptions =
+        CustomObjectSyncOptionsBuilder.of(mockClient)
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorCallBackMessages.add(exception.getMessage());
+                  errorCallBackExceptions.add(exception.getCause());
+                })
+            .build();
+
+    final CustomObjectSync customObjectSync = new CustomObjectSync(spyOptions);
+
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync
+            .sync(Collections.singletonList(customObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
+    Assertions.assertThat(errorCallBackMessages).hasSize(1);
+    Assertions.assertThat(errorCallBackExceptions).hasSize(1);
+    Assertions.assertThat(errorCallBackExceptions.get(0))
+        .isExactlyInstanceOf(CompletionException.class);
+    Assertions.assertThat(errorCallBackExceptions.get(0).getCause())
+        .isExactlyInstanceOf(BadGatewayException.class);
+    Assertions.assertThat(errorCallBackMessages.get(0))
+        .contains(
+            format(
+                "Failed to create custom object with key: '%s'.",
+                CustomObjectCompositeIdentifier.of(customObjectDraft)));
+  }
+
+  @Nonnull
+  private ProjectApiRoot buildClientWithConcurrentModificationAndOptionalExceptionOnFetch(
+      @Nullable final String responseString) {
+
+    // Reference assignment to have an atomic string reference
+    final String responseAsJson = responseString;
+
+    // Helps to count invocation of a request and used to decide execution or mocking response
+    final AtomicInteger postRequestInvocationCounter = new AtomicInteger(0);
+    final AtomicInteger getRequestInvocationCounter = new AtomicInteger(0);
+    final ProjectApiRoot testClient =
+        ApiRootBuilder.of(
+                request -> {
+                  final String uri = request.getUri() != null ? request.getUri().toString() : "";
+                  final ApiHttpMethod method = request.getMethod();
+                  if (uri.contains("custom-objects") && ApiHttpMethod.POST.equals(method)) {
+                    if (postRequestInvocationCounter.getAndIncrement() == 0) {
+                      return CompletableFutureUtils.exceptionallyCompletedFuture(
+                          createConcurrentModificationException());
+                    }
+                  }
+                  if (uri.contains("custom-objects")
+                      && ApiHttpMethod.GET.equals(method)
+                      && responseAsJson != null) {
+                    if (getRequestInvocationCounter.getAndIncrement() > 0) {
+                      if (responseAsJson.contains("500")) {
+                        return CompletableFutureUtils.exceptionallyCompletedFuture(
+                            new BadGatewayException(
+                                500,
+                                "",
+                                null,
+                                "",
+                                new ApiHttpResponse<>(
+                                    500, null, responseAsJson.getBytes(StandardCharsets.UTF_8))));
+                      } else if (responseAsJson.contains("404")) {
+                        return CompletableFutureUtils.exceptionallyCompletedFuture(
+                            new NotFoundException(
+                                404,
+                                "",
+                                null,
+                                "",
+                                new ApiHttpResponse<>(
+                                    404, null, responseAsJson.getBytes(StandardCharsets.UTF_8))));
+                      }
+                    }
+                  }
+                  return CTP_TARGET_CLIENT.getApiHttpClient().execute(request);
+                })
+            .withApiBaseUrl(CTP_TARGET_CLIENT.getApiHttpClient().getBaseUri())
+            .build(CTP_TARGET_CLIENT.getProjectKey());
+    return testClient;
+  }
+
+  @Nonnull
+  private ProjectApiRoot buildClientWithExceptionOnUpsert() {
+
+    // Helps to count invocation of a request and used to decide execution or mocking response
+    final AtomicInteger requestInvocationCounter = new AtomicInteger(0);
+    final ProjectApiRoot testClient =
+        ApiRootBuilder.of(
+                request -> {
+                  final String uri = request.getUri() != null ? request.getUri().toString() : "";
+                  final ApiHttpMethod method = request.getMethod();
+                  if (uri.contains("custom-objects") && ApiHttpMethod.POST.equals(method)) {
+                    if (requestInvocationCounter.getAndIncrement() == 0) {
+                      return CompletableFutureUtils.exceptionallyCompletedFuture(
+                          createBadGatewayException());
+                    }
+                  }
+                  return CTP_TARGET_CLIENT.getApiHttpClient().execute(request);
+                })
+            .withApiBaseUrl(CTP_TARGET_CLIENT.getApiHttpClient().getBaseUri())
+            .build(CTP_TARGET_CLIENT.getProjectKey());
+    return testClient;
+  }
+
+  private String getResponseJsonString(@Nonnull final Object response) {
+    final ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    String json;
+    try {
+      json = ow.writeValueAsString(response);
+    } catch (JsonProcessingException e) {
+      // ignore the error
+      json = null;
+    }
+    return json;
+  }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/customobjects/CustomObjectSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/sdk2/externalsource/customobjects/CustomObjectSyncIT.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 public class CustomObjectSyncIT {
   private static final String CUSTOM_OBJECT_KEY_1 = "key1";
   private static final String CUSTOM_OBJECT_CONTAINER_1 = "container1";
-  private static final ObjectNode CUSTOM_OBJECT_VALUE_JSON_1 =
+  private final ObjectNode CUSTOM_OBJECT_VALUE_JSON_1 =
       JsonNodeFactory.instance.objectNode().put("name", "value1");
 
   @BeforeEach

--- a/src/main/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSync.java
+++ b/src/main/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSync.java
@@ -1,0 +1,327 @@
+package com.commercetools.sync.sdk2.customobjects;
+
+import static com.commercetools.sync.sdk2.commons.utils.SyncUtils.batchElements;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.sync.sdk2.commons.BaseSync;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectBatchValidator;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
+import com.commercetools.sync.sdk2.customobjects.models.NoopResourceUpdateAction;
+import com.commercetools.sync.sdk2.customobjects.utils.CustomObjectSyncUtils;
+import com.commercetools.sync.sdk2.services.CustomObjectService;
+import com.commercetools.sync.sdk2.services.impl.CustomObjectServiceImpl;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+/**
+ * This class syncs custom object drafts with the corresponding custom objects in the CTP project.
+ */
+public class CustomObjectSync
+    extends BaseSync<
+        CustomObject,
+        CustomObjectDraft,
+        NoopResourceUpdateAction,
+        CustomObjectSyncStatistics,
+        CustomObjectSyncOptions> {
+
+  private static final String CTP_CUSTOM_OBJECT_FETCH_FAILED =
+      "Failed to fetch existing custom objects with keys: '%s'.";
+  private static final String CTP_CUSTOM_OBJECT_UPDATE_FAILED =
+      "Failed to update custom object with key: '%s'. Reason: %s";
+  private static final String CTP_CUSTOM_OBJECT_CREATE_FAILED =
+      "Failed to create custom object with key: '%s'. Reason: %s";
+
+  private final CustomObjectService customObjectService;
+  private final CustomObjectBatchValidator batchValidator;
+
+  public CustomObjectSync(@Nonnull final CustomObjectSyncOptions syncOptions) {
+    this(syncOptions, new CustomObjectServiceImpl(syncOptions));
+  }
+
+  /**
+   * Takes a {@link CustomObjectSyncOptions} and a {@link CustomObjectService} instances to
+   * instantiate a new {@link CustomObjectSync} instance that could be used to sync customObject
+   * drafts in the CTP project specified in the injected {@link CustomObjectSyncOptions} instance.
+   *
+   * <p>NOTE: This constructor is mainly to be used for tests where the services can be mocked and
+   * passed to.
+   *
+   * @param syncOptions the container of all the options of the sync process including the CTP
+   *     project client and/or configuration and other sync-specific options.
+   * @param customObjectService the custom object service which is responsible for fetching/caching
+   *     the
+   */
+  CustomObjectSync(
+      @Nonnull final CustomObjectSyncOptions syncOptions,
+      @Nonnull final CustomObjectService customObjectService) {
+
+    super(new CustomObjectSyncStatistics(), syncOptions);
+    this.customObjectService = customObjectService;
+    this.batchValidator = new CustomObjectBatchValidator(getSyncOptions(), getStatistics());
+  }
+
+  /**
+   * Iterates through the whole {@code customObjectDrafts} list and accumulates its valid drafts to
+   * batches. Every batch is then processed by {@link CustomObjectSync#processBatch(List)}.
+   *
+   * <p><strong>Inherited doc:</strong> {@inheritDoc}
+   *
+   * @param customObjectDrafts {@link List} of {@link CustomObjectDraft}'s that would be synced into
+   *     CTP project.
+   * @return {@link CompletionStage} with {@link CustomObjectSyncStatistics} holding statistics of
+   *     all sync processes performed by this sync instance.
+   */
+  protected CompletionStage<CustomObjectSyncStatistics> process(
+      @Nonnull final List<CustomObjectDraft> customObjectDrafts) {
+    final List<List<CustomObjectDraft>> batches =
+        batchElements(customObjectDrafts, syncOptions.getBatchSize());
+    return syncBatches(batches, CompletableFuture.completedFuture(statistics));
+  }
+
+  /**
+   * This method first creates a new {@link Set} of valid {@link CustomObjectDraft} elements. For
+   * more on the rules of validation, check: {@link
+   * CustomObjectBatchValidator#validateAndCollectReferencedKeys(List)}. Using the resulting set of
+   * {@code validCustomObjectDrafts}, the matching custom objects in the target CTP project are
+   * fetched then the method {@link CustomObjectSync#syncBatch(Set, Set)} is called to perform the
+   * sync (<b>update</b> or <b>create</b> requests accordingly) on the target project.
+   *
+   * <p>In case of error during of fetching of existing custom objects, the error callback will be
+   * triggered. And the sync process would stop for the given batch.
+   *
+   * @param batch batch of drafts that need to be synced
+   * @return a {@link CompletionStage} containing an instance of {@link CustomObjectSyncStatistics}
+   *     which contains information about the result of syncing the supplied batch to the target
+   *     project.
+   */
+  protected CompletionStage<CustomObjectSyncStatistics> processBatch(
+      @Nonnull final List<CustomObjectDraft> batch) {
+
+    final ImmutablePair<Set<CustomObjectDraft>, Set<CustomObjectCompositeIdentifier>> result =
+        batchValidator.validateAndCollectReferencedKeys(batch);
+
+    final Set<CustomObjectDraft> validDrafts = result.getLeft();
+    if (validDrafts.isEmpty()) {
+      statistics.incrementProcessed(batch.size());
+      return CompletableFuture.completedFuture(statistics);
+    }
+    final Set<CustomObjectCompositeIdentifier> validIdentifiers = result.getRight();
+
+    return customObjectService
+        .fetchMatchingCustomObjects(validIdentifiers)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchResponse -> {
+              final Set<CustomObject> fetchedCustomObjects = fetchResponse.getKey();
+              final Throwable exception = fetchResponse.getValue();
+
+              if (exception != null) {
+                final String errorMessage =
+                    format(CTP_CUSTOM_OBJECT_FETCH_FAILED, validIdentifiers);
+                handleError(errorMessage, exception, null, null, null, validIdentifiers.size());
+                return CompletableFuture.completedFuture(null);
+              } else {
+                return syncBatch(fetchedCustomObjects, validDrafts);
+              }
+            })
+        .thenApply(
+            ignored -> {
+              statistics.incrementProcessed(batch.size());
+              return statistics;
+            });
+  }
+
+  /**
+   * Given a set of custom object drafts, attempts to sync the drafts with the existing custom
+   * objects in the CTP project. The custom object and the draft are considered to match if they
+   * have the same key and container.
+   *
+   * @param oldCustomObjects old custom objects.
+   * @param newCustomObjectDrafts drafts that need to be synced.
+   * @return a {@link CompletionStage} which contains an empty result after execution of the update
+   */
+  @Nonnull
+  private CompletionStage<Void> syncBatch(
+      @Nonnull final Set<CustomObject> oldCustomObjects,
+      @Nonnull final Set<CustomObjectDraft> newCustomObjectDrafts) {
+
+    final Map<String, CustomObject> oldCustomObjectMap =
+        oldCustomObjects.stream()
+            .collect(
+                toMap(
+                    customObject -> CustomObjectCompositeIdentifier.of(customObject).toString(),
+                    identity()));
+
+    return CompletableFuture.allOf(
+        newCustomObjectDrafts.stream()
+            .map(
+                newCustomObjectDraft -> {
+                  final CustomObject oldCustomObject =
+                      oldCustomObjectMap.get(
+                          CustomObjectCompositeIdentifier.of(newCustomObjectDraft).toString());
+                  return ofNullable(oldCustomObject)
+                      .map(
+                          customObject -> updateCustomObject(oldCustomObject, newCustomObjectDraft))
+                      .orElseGet(() -> applyCallbackAndCreate(newCustomObjectDraft));
+                })
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new));
+  }
+
+  /**
+   * Given a custom object draft, this method applies the beforeCreateCallback and then issues a
+   * create request to the CTP project to create the corresponding CustomObject.
+   *
+   * @param customObjectDraft the custom object draft to create the custom object from.
+   * @return a {@link CompletionStage} which contains created custom object after success execution
+   *     of the create. Otherwise it contains an empty result in case of failure.
+   */
+  @Nonnull
+  private CompletionStage<Optional<CustomObject>> applyCallbackAndCreate(
+      @Nonnull final CustomObjectDraft customObjectDraft) {
+
+    return syncOptions
+        .applyBeforeCreateCallback(customObjectDraft)
+        .map(
+            draft ->
+                customObjectService
+                    .upsertCustomObject(draft)
+                    .thenApply(
+                        customObjectOptional -> {
+                          if (customObjectOptional.isPresent()) {
+                            statistics.incrementCreated();
+                          } else {
+                            statistics.incrementFailed();
+                          }
+                          return customObjectOptional;
+                        })
+                    .exceptionally(
+                        sphereException -> {
+                          final String errorMessage =
+                              format(
+                                  CTP_CUSTOM_OBJECT_CREATE_FAILED,
+                                  CustomObjectCompositeIdentifier.of(customObjectDraft).toString(),
+                                  sphereException.getMessage());
+                          handleError(
+                              errorMessage, sphereException, null, customObjectDraft, null, 1);
+                          return Optional.empty();
+                        }))
+        .orElse(completedFuture(Optional.empty()));
+  }
+
+  /**
+   * Given an existing {@link CustomObject} and a new {@link CustomObjectDraft}, the method first
+   * checks whether existing {@link CustomObject} and a new {@link CustomObjectDraft} are identical.
+   * If so, the method aborts update the new draft and return an empty result, otherwise a request
+   * is made to CTP to update the existing custom object.
+   *
+   * <p>The {@code statistics} instance is updated accordingly to whether the CTP request was
+   * carried out successfully or not. If an exception was thrown on executing the request to CTP,the
+   * error handling method is called.
+   *
+   * @param oldCustomObject existing custom object that could be updated.
+   * @param newCustomObject draft containing data that could differ from data in {@code
+   *     oldCustomObject}.
+   * @return a {@link CompletionStage} which contains an empty result after execution of the update.
+   */
+  @Nonnull
+  private CompletionStage<Optional<CustomObject>> updateCustomObject(
+      @Nonnull final CustomObject oldCustomObject,
+      @Nonnull final CustomObjectDraft newCustomObject) {
+
+    if (!CustomObjectSyncUtils.hasIdenticalValue(oldCustomObject, newCustomObject)) {
+      return customObjectService
+          .upsertCustomObject(newCustomObject)
+          .handle(ImmutablePair::new)
+          .thenCompose(
+              updatedResponseEntry -> {
+                final Optional<CustomObject> updateCustomObjectOptional =
+                    updatedResponseEntry.getKey();
+                final Throwable sphereException = updatedResponseEntry.getValue();
+                if (sphereException != null) {
+                  return executeSupplierIfConcurrentModificationException(
+                      sphereException,
+                      () -> fetchAndUpdate(oldCustomObject, newCustomObject),
+                      () -> {
+                        final String errorMessage =
+                            format(
+                                CTP_CUSTOM_OBJECT_UPDATE_FAILED,
+                                CustomObjectCompositeIdentifier.of(newCustomObject).toString(),
+                                sphereException.getMessage());
+                        handleError(
+                            errorMessage,
+                            sphereException,
+                            oldCustomObject,
+                            newCustomObject,
+                            null,
+                            1);
+                        return CompletableFuture.completedFuture(Optional.empty());
+                      });
+                } else {
+                  statistics.incrementUpdated();
+                  return CompletableFuture.completedFuture(
+                      Optional.of(updateCustomObjectOptional.get()));
+                }
+              });
+    }
+    return completedFuture(Optional.empty());
+  }
+
+  @Nonnull
+  private CompletionStage<Optional<CustomObject>> fetchAndUpdate(
+      @Nonnull final CustomObject oldCustomObject,
+      @Nonnull final CustomObjectDraft customObjectDraft) {
+
+    final CustomObjectCompositeIdentifier identifier =
+        CustomObjectCompositeIdentifier.of(oldCustomObject);
+
+    return customObjectService
+        .fetchCustomObject(identifier)
+        .handle(ImmutablePair::new)
+        .thenCompose(
+            fetchedResponseEntry -> {
+              final Optional<CustomObject> fetchedCustomObjectOptional =
+                  fetchedResponseEntry.getKey();
+              final Throwable exception = fetchedResponseEntry.getValue();
+
+              if (exception != null) {
+                final String errorMessage =
+                    format(
+                        CTP_CUSTOM_OBJECT_UPDATE_FAILED,
+                        identifier.toString(),
+                        "Failed to fetch from CTP while retrying after concurrency modification.");
+                handleError(errorMessage, exception, oldCustomObject, customObjectDraft, null, 1);
+                return CompletableFuture.completedFuture(Optional.empty());
+              }
+              return fetchedCustomObjectOptional
+                  .map(
+                      fetchedCustomObject ->
+                          updateCustomObject(fetchedCustomObject, customObjectDraft))
+                  .orElseGet(
+                      () -> {
+                        final String errorMessage =
+                            format(
+                                CTP_CUSTOM_OBJECT_UPDATE_FAILED,
+                                identifier.toString(),
+                                "Not found when attempting to fetch while retrying "
+                                    + "after concurrency modification.");
+                        handleError(
+                            errorMessage, null, oldCustomObject, customObjectDraft, null, 1);
+                        return CompletableFuture.completedFuture(null);
+                      });
+            });
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/services/impl/BaseService.java
+++ b/src/main/java/com/commercetools/sync/sdk2/services/impl/BaseService.java
@@ -294,9 +294,10 @@ abstract class BaseService<
 
   /**
    * Given a resource key, this method fetches a resource that matches this given key in the CTP
-   * project defined in a potentially injected {@link io.sphere.sdk.client.SphereClient}. If there
-   * is no matching resource an empty {@link Optional} will be returned in the returned future. A
-   * mapping of the key to the id of the fetched resource is persisted in an in -memory map.
+   * project defined in a potentially injected {@link com.commercetools.api.client.ProjectApiRoot}.
+   * If there is no matching resource an empty {@link Optional} will be returned in the returned
+   * future. A mapping of the key to the id of the fetched resource is persisted in an in -memory
+   * map.
    *
    * @param key the key of the resource to fetch
    * @return {@link CompletionStage}&lt;{@link Optional}&gt; in which the result of it's completion

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
@@ -180,7 +180,7 @@ public class CustomObjectSyncTest {
             .build();
 
     // test
-    CustomObjectSyncStatistics syncStatistics =
+    final CustomObjectSyncStatistics syncStatistics =
         new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
             .sync(singletonList(newCustomObjectDraft))
             .toCompletableFuture()
@@ -316,7 +316,7 @@ public class CustomObjectSyncTest {
   }
 
   @Test
-  void sync_UpdateWithSphereExceptionAndRetryWithFetchException_ShouldIncrementFailed() {
+  void sync_UpdateWithBadRequestExceptionAndRetryWithFetchException_ShouldIncrementFailed() {
     final List<String> errorMessages = new ArrayList<>();
     final List<Throwable> exceptions = new ArrayList<>();
 
@@ -559,7 +559,9 @@ public class CustomObjectSyncTest {
 
     // assertion
     assertThat(exceptions).hasSize(1);
+    assertThat(exceptions.get(0)).isNull();
     assertThat(errorMessages).hasSize(1);
+    assertThat(errorMessages.get(0)).isEqualTo("CustomObjectDraft is null.");
     assertAll(
         () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
         () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
@@ -1,0 +1,582 @@
+package com.commercetools.sync.sdk2.customobjects;
+
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static java.lang.String.format;
+import static java.util.Collections.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.*;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectDraft;
+import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
+import com.commercetools.sync.sdk2.services.CustomObjectService;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadRequestException;
+import io.vrap.rmf.base.client.error.ConcurrentModificationException;
+import java.util.*;
+import java.util.concurrent.CompletionException;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unchecked")
+public class CustomObjectSyncTest {
+
+  @Test
+  void sync_WithErrorFetchingExistingKeys_ShouldExecuteCallbackOnErrorAndIncreaseFailedCounter() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObjectService mockCustomObjectService = mock(CustomObjectService.class);
+
+    when(mockCustomObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new BadRequestException(
+                      500, "", null, "", new ApiHttpResponse<>(500, null, null));
+                }));
+
+    final CustomObjectSync customObjectSync =
+        new CustomObjectSync(spyCustomObjectSyncOptions, mockCustomObjectService);
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value("someValue")
+            .build();
+
+    // test
+    final CustomObjectSyncStatistics customObjectSyncStatistics =
+        customObjectSync.sync(singletonList(newCustomObjectDraft)).toCompletableFuture().join();
+
+    // assertion
+    assertThat(errorMessages)
+        .hasSize(1)
+        .singleElement()
+        .asString()
+        .isEqualTo(
+            "Failed to fetch existing custom objects with keys: " + "'[someContainer|someKey]'.");
+
+    assertThat(exceptions)
+        .hasSize(1)
+        .singleElement()
+        .isInstanceOfSatisfying(
+            Throwable.class,
+            throwable -> {
+              assertThat(throwable).isExactlyInstanceOf(CompletionException.class);
+              assertThat(throwable).hasCauseExactlyInstanceOf(BadRequestException.class);
+            });
+
+    assertThat(customObjectSyncStatistics).hasValues(1, 0, 0, 1);
+  }
+
+  @Test
+  void
+      sync_WithOnlyDraftsToCreate_ShouldCallBeforeCreateCallback_ShouldNotCallBeforeUpdateCallback() {
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(emptyList(), emptyList());
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(emptySet()));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.empty()));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    // test
+    new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+        .sync(singletonList(newCustomObjectDraft))
+        .toCompletableFuture()
+        .join();
+
+    // assertion
+    verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+    verify(spyCustomObjectSyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
+  }
+
+  @Test
+  void
+      sync_WithOnlyDraftsToUpdate_ShouldCallBeforeCreateCallback_ShouldNotCallBeforeUpdateCallback() {
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(emptyList(), emptyList());
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    final CustomObject mockedExistingCustomObject = mock(CustomObject.class);
+    when(mockedExistingCustomObject.getKey()).thenReturn(newCustomObjectDraft.getKey());
+    when(mockedExistingCustomObject.getContainer()).thenReturn("differentContainer");
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(singleton(mockedExistingCustomObject)));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(mockedExistingCustomObject)));
+
+    // test
+    new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+        .sync(singletonList(newCustomObjectDraft))
+        .toCompletableFuture()
+        .join();
+
+    // assertion
+    verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+    verify(spyCustomObjectSyncOptions, never()).applyBeforeUpdateCallback(any(), any(), any());
+  }
+
+  @Test
+  void sync_WithSameIdentifiersAndDifferentValues_ShouldUpdateSuccessfully() {
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(emptyList(), emptyList());
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("someContainer");
+    when(existingCustomObject.getKey()).thenReturn("someKey");
+    when(existingCustomObject.getValue()).thenReturn(Integer.valueOf(2020));
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue())
+        .thenReturn(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"));
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(updatedCustomObject)));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0));
+  }
+
+  @Test
+  void sync_WithSameIdentifiersAndIdenticalValues_ShouldProcessedAndNotUpdated() {
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(emptyList(), emptyList());
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("someContainer");
+    when(existingCustomObject.getKey()).thenReturn("someKey");
+    when(existingCustomObject.getValue()).thenReturn(newCustomObjectDraft.getValue());
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue()).thenReturn(newCustomObjectDraft.getValue());
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(updatedCustomObject)));
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0));
+  }
+
+  @Test
+  void
+      sync_UpdateWithConcurrentModificationExceptionAndRetryWithFetchException_ShouldIncrementFailed() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("someContainer");
+    when(existingCustomObject.getKey()).thenReturn("someKey");
+    when(existingCustomObject.getValue()).thenReturn(JsonNodeFactory.instance.numberNode(2020));
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue())
+        .thenReturn(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"));
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new ConcurrentModificationException(
+                      409, "", null, "", new ApiHttpResponse<>(409, null, null));
+                }));
+    when(customObjectService.fetchCustomObject(any(CustomObjectCompositeIdentifier.class)))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new BadRequestException(
+                      500, "", null, "", new ApiHttpResponse<>(500, null, null));
+                }));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+    // assertion
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(1));
+    assertThat(exceptions).hasSize(1);
+    assertThat(errorMessages)
+        .hasSize(1)
+        .singleElement()
+        .isEqualTo(
+            format(
+                "Failed to update custom object with key: '%s'. Reason: %s",
+                CustomObjectCompositeIdentifier.of(newCustomObjectDraft).toString(),
+                "Failed to fetch from CTP while retrying after concurrency modification."));
+
+    verify(customObjectService).fetchCustomObject(any(CustomObjectCompositeIdentifier.class));
+    verify(customObjectService).upsertCustomObject(any());
+    verify(customObjectService).fetchMatchingCustomObjects(any());
+  }
+
+  @Test
+  void sync_UpdateWithSphereExceptionAndRetryWithFetchException_ShouldIncrementFailed() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("someContainer");
+    when(existingCustomObject.getKey()).thenReturn("someKey");
+    when(existingCustomObject.getValue()).thenReturn(JsonNodeFactory.instance.numberNode(2020));
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<CustomObject>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue())
+        .thenReturn(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"));
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new BadRequestException(
+                      500, "", null, "", new ApiHttpResponse<>(500, null, null));
+                }));
+    when(customObjectService.fetchCustomObject(any(CustomObjectCompositeIdentifier.class)))
+        .thenReturn(
+            supplyAsync(
+                () -> {
+                  throw new BadRequestException(
+                      500, "", null, "", new ApiHttpResponse<>(500, null, null));
+                }));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.objectNode().put("json-field", "json-value"))
+            .build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(1));
+    assertThat(exceptions).hasSize(1);
+    assertThat(errorMessages)
+        .hasSize(1)
+        .singleElement()
+        .isEqualTo(
+            format(
+                "Failed to update custom object with key: '%s'. Reason: %s",
+                CustomObjectCompositeIdentifier.of(newCustomObjectDraft).toString(),
+                exceptions.get(0).getMessage()));
+    verify(customObjectService).upsertCustomObject(any());
+    verify(customObjectService).fetchMatchingCustomObjects(any());
+  }
+
+  @Test
+  void sync_WithDifferentIdentifiers_ShouldCreateSuccessfully() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("otherContainer");
+    when(existingCustomObject.getKey()).thenReturn("otherKey");
+    when(existingCustomObject.getValue()).thenReturn(JsonNodeFactory.instance.numberNode(2020));
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue()).thenReturn(JsonNodeFactory.instance.numberNode(2020));
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(updatedCustomObject)));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of()
+            .container("someContainer")
+            .key("someKey")
+            .value(JsonNodeFactory.instance.numberNode(2020))
+            .build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(exceptions).hasSize(0);
+    assertThat(errorMessages).hasSize(0);
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0));
+    verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+  }
+
+  @Test
+  void sync_WithSameKeysAndDifferentContainers_ShouldCreateSuccessfully() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("otherContainer");
+    when(existingCustomObject.getKey()).thenReturn("someKey");
+    when(existingCustomObject.getValue()).thenReturn(2020);
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue()).thenReturn(Integer.valueOf(2020));
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(updatedCustomObject)));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of().container("someContainer").key("someKey").value(2020).build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(exceptions).hasSize(0);
+    assertThat(errorMessages).hasSize(0);
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0));
+    verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+  }
+
+  @Test
+  void sync_WithDifferentKeysAndSameContainers_ShouldCreateSuccessfully() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObject existingCustomObject = mock(CustomObject.class);
+    when(existingCustomObject.getContainer()).thenReturn("someContainer");
+    when(existingCustomObject.getKey()).thenReturn("otherKey");
+    when(existingCustomObject.getValue()).thenReturn(JsonNodeFactory.instance.numberNode(2020));
+
+    final CustomObject updatedCustomObject = mock(CustomObject.class);
+    when(updatedCustomObject.getContainer()).thenReturn("someContainer");
+    when(updatedCustomObject.getKey()).thenReturn("someKey");
+    when(updatedCustomObject.getValue()).thenReturn(2020);
+
+    final Set<CustomObject> existingCustomObjectSet = new HashSet<CustomObject>();
+    existingCustomObjectSet.add(existingCustomObject);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(existingCustomObjectSet));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.of(updatedCustomObject)));
+
+    final CustomObjectDraft newCustomObjectDraft =
+        CustomObjectDraftBuilder.of().container("someContainer").key("someKey").value(2020).build();
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(newCustomObjectDraft))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(exceptions).hasSize(0);
+    assertThat(errorMessages).hasSize(0);
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(0));
+    verify(spyCustomObjectSyncOptions).applyBeforeCreateCallback(newCustomObjectDraft);
+  }
+
+  @Test
+  void sync_WitEmptyValidDrafts_ShouldFailed() {
+    final List<String> errorMessages = new ArrayList<>();
+    final List<Throwable> exceptions = new ArrayList<>();
+
+    final CustomObjectSyncOptions spyCustomObjectSyncOptions =
+        initCustomObjectSyncOptions(errorMessages, exceptions);
+
+    final CustomObjectService customObjectService = mock(CustomObjectService.class);
+    when(customObjectService.fetchMatchingCustomObjects(anySet()))
+        .thenReturn(completedFuture(emptySet()));
+    when(customObjectService.upsertCustomObject(any()))
+        .thenReturn(completedFuture(Optional.empty()));
+
+    // test
+    CustomObjectSyncStatistics syncStatistics =
+        new CustomObjectSync(spyCustomObjectSyncOptions, customObjectService)
+            .sync(singletonList(null))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(exceptions).hasSize(1);
+    assertThat(errorMessages).hasSize(1);
+    assertAll(
+        () -> assertThat(syncStatistics.getProcessed().get()).isEqualTo(1),
+        () -> assertThat(syncStatistics.getCreated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getUpdated().get()).isEqualTo(0),
+        () -> assertThat(syncStatistics.getFailed().get()).isEqualTo(1));
+  }
+
+  @Nonnull
+  private CustomObjectSyncOptions initCustomObjectSyncOptions(
+      @Nonnull final List<String> errorMessages, @Nonnull final List<Throwable> exceptions) {
+    return spy(
+        CustomObjectSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  exceptions.add(exception.getCause());
+                })
+            .build());
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/customobjects/CustomObjectSyncTest.java
@@ -15,6 +15,7 @@ import com.commercetools.api.client.ProjectApiRoot;
 import com.commercetools.api.models.custom_object.CustomObject;
 import com.commercetools.api.models.custom_object.CustomObjectDraft;
 import com.commercetools.api.models.custom_object.CustomObjectDraftBuilder;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
 import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
 import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectSyncStatistics;
 import com.commercetools.sync.sdk2.services.CustomObjectService;
@@ -559,7 +560,7 @@ public class CustomObjectSyncTest {
 
     // assertion
     assertThat(exceptions).hasSize(1);
-    assertThat(exceptions.get(0)).isNull();
+    assertThat(exceptions.get(0)).isExactlyInstanceOf(SyncException.class);
     assertThat(errorMessages).hasSize(1);
     assertThat(errorMessages.get(0)).isEqualTo("CustomObjectDraft is null.");
     assertAll(
@@ -577,7 +578,11 @@ public class CustomObjectSyncTest {
             .errorCallback(
                 (exception, oldResource, newResource, updateActions) -> {
                   errorMessages.add(exception.getMessage());
-                  exceptions.add(exception.getCause());
+                  if (exception.getCause() != null) {
+                    exceptions.add(exception.getCause());
+                  } else {
+                    exceptions.add(exception);
+                  }
                 })
             .build());
   }


### PR DESCRIPTION
#### Summary
JIRA: https://commercetools.atlassian.net/browse/DEVX-109

#### Issues
The platform API for Custom object provides one single endpoint for create and update requests only. This differs from other platform resource APIs. For java-sync it means, for both operations the same method in `BaseService` is called. As the API may return a ConcurrentModification error in case of concurrent updates it was necessary to override the `BaseService.executeCreateCommand` method to submit the error to the caller in order to trigger retry mechanism.

