### PR TITLE
Migrate remaining unittests

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/categories/helpers/AssetCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/helpers/AssetCustomActionBuilder.java
@@ -3,7 +3,6 @@ package com.commercetools.sync.sdk2.categories.helpers;
 import com.commercetools.api.models.category.CategorySetAssetCustomFieldActionBuilder;
 import com.commercetools.api.models.category.CategorySetAssetCustomTypeActionBuilder;
 import com.commercetools.api.models.category.CategoryUpdateAction;
-import com.commercetools.api.models.type.FieldContainer;
 import com.commercetools.sync.sdk2.commons.helpers.GenericCustomActionBuilder;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -15,10 +14,7 @@ public class AssetCustomActionBuilder implements GenericCustomActionBuilder<Cate
   @Override
   public CategoryUpdateAction buildRemoveCustomTypeAction(
       @Nullable final Long variantId, @Nullable final String assetKey) {
-    return CategorySetAssetCustomTypeActionBuilder.of()
-        .assetKey(assetKey)
-        .fields((FieldContainer) null)
-        .build();
+    return CategorySetAssetCustomTypeActionBuilder.of().build();
   }
 
   @NotNull

--- a/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/helpers/CategoryCustomActionBuilder.java
@@ -3,8 +3,6 @@ package com.commercetools.sync.sdk2.categories.helpers;
 import com.commercetools.api.models.category.CategorySetCustomFieldActionBuilder;
 import com.commercetools.api.models.category.CategorySetCustomTypeActionBuilder;
 import com.commercetools.api.models.category.CategoryUpdateAction;
-import com.commercetools.api.models.type.FieldContainer;
-import com.commercetools.api.models.type.TypeResourceIdentifier;
 import com.commercetools.sync.sdk2.commons.helpers.GenericCustomActionBuilder;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -16,10 +14,7 @@ public class CategoryCustomActionBuilder
   @Override
   public CategoryUpdateAction buildRemoveCustomTypeAction(
       @Nullable final Long variantId, @Nullable final String objectId) {
-    return CategorySetCustomTypeActionBuilder.of()
-        .type((TypeResourceIdentifier) null)
-        .fields((FieldContainer) null)
-        .build();
+    return CategorySetCustomTypeActionBuilder.of().build();
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/sdk2/categories/utils/CategoryAssetUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/categories/utils/CategoryAssetUpdateActionUtils.java
@@ -16,7 +16,6 @@ import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
 import com.commercetools.sync.sdk2.categories.helpers.AssetCustomActionBuilder;
 import com.commercetools.sync.sdk2.commons.models.AssetCustomTypeAdapter;
 import com.commercetools.sync.sdk2.commons.models.AssetDraftCustomTypeAdapter;
-import com.commercetools.sync.sdk2.commons.models.Custom;
 import com.commercetools.sync.sdk2.commons.utils.CustomUpdateActionUtils;
 import java.util.List;
 import java.util.Optional;
@@ -180,7 +179,7 @@ public final class CategoryAssetUpdateActionUtils {
         AssetDraftCustomTypeAdapter.of(newAsset),
         new AssetCustomActionBuilder(),
         -1L,
-        Custom::getId,
+        AssetCustomTypeAdapter::getId,
         asset -> ResourceTypeId.ASSET.getJsonName(),
         AssetCustomTypeAdapter::getKey,
         syncOptions);

--- a/src/main/java/com/commercetools/sync/sdk2/commons/utils/CompletableFutureUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/commons/utils/CompletableFutureUtils.java
@@ -41,28 +41,6 @@ public final class CompletableFutureUtils {
   }
 
   /**
-   * Creates a Future containing a stream of value results after the mapper function is applied to
-   * each value in the supplied collection and completed it. The type of the collection is decided
-   * upon on by the supplied collector.
-   *
-   * @param values collection of values to apply a mapper function that would map each to a {@link
-   *     java.util.concurrent.CompletionStage}.
-   * @param mapper function to map each value to a {@link java.util.concurrent.CompletionStage}
-   * @param <T> The type of the values.
-   * @param <S> The type of the mapped completed values.
-   * @return a future containing a stream of completed stage results of the values after the mapper
-   *     function was applied to each value in the supplied collection.
-   */
-  @Nonnull
-  public static <T, S> CompletableFuture<Stream<S>> mapValuesToFutureOfCompletedValues(
-      @Nonnull final Collection<T> values, @Nonnull final Function<T, CompletionStage<S>> mapper) {
-
-    final List<CompletableFuture<S>> futureList =
-        mapValuesToFutures(values.stream(), mapper, toList());
-    return collectionOfFuturesToFutureOfCollection(futureList, toList()).thenApply(List::stream);
-  }
-
-  /**
    * Creates a Future containing a collection of value results after the mapper function is applied
    * to each value in the supplied stream and completed it. The type of the returned collection is
    * decided by the supplied collector.
@@ -78,7 +56,7 @@ public final class CompletableFutureUtils {
    *     function was applied to each one.
    */
   @Nonnull
-  public static <T, S, U extends Collection<S>>
+  private static <T, S, U extends Collection<S>>
       CompletableFuture<U> mapValuesToFutureOfCompletedValues(
           @Nonnull final Stream<T> values,
           @Nonnull final Function<T, CompletionStage<S>> mapper,

--- a/src/main/java/com/commercetools/sync/sdk2/customers/utils/CustomerCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/customers/utils/CustomerCustomActionBuilder.java
@@ -3,8 +3,6 @@ package com.commercetools.sync.sdk2.customers.utils;
 import com.commercetools.api.models.customer.CustomerSetCustomFieldActionBuilder;
 import com.commercetools.api.models.customer.CustomerSetCustomTypeActionBuilder;
 import com.commercetools.api.models.customer.CustomerUpdateAction;
-import com.commercetools.api.models.type.FieldContainerBuilder;
-import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
 import com.commercetools.sync.sdk2.commons.helpers.GenericCustomActionBuilder;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -40,17 +38,10 @@ public final class CustomerCustomActionBuilder
       @Nonnull final String customTypeId,
       @Nullable final Map<String, Object> customFieldsJsonMap) {
 
-    final CustomerSetCustomTypeActionBuilder actionBuilder =
-        CustomerSetCustomTypeActionBuilder.of()
-            .type(TypeResourceIdentifierBuilder.of().id(customTypeId).build());
-
-    if (customFieldsJsonMap != null && !customFieldsJsonMap.isEmpty()) {
-      final FieldContainerBuilder customFields = FieldContainerBuilder.of();
-      customFieldsJsonMap.forEach(customFields::addValue);
-      actionBuilder.fields(customFields.build());
-    }
-
-    return actionBuilder.build();
+    return CustomerSetCustomTypeActionBuilder.of()
+        .type(typeResourceIdentifierBuilder -> typeResourceIdentifierBuilder.id(customTypeId))
+        .fields(fieldContainerBuilder -> fieldContainerBuilder.values(customFieldsJsonMap))
+        .build();
   }
 
   @Nonnull

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/AssetCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/AssetCustomActionBuilder.java
@@ -16,12 +16,7 @@ public class AssetCustomActionBuilder implements GenericCustomActionBuilder<Prod
   @Nonnull
   public ProductUpdateAction buildRemoveCustomTypeAction(
       @Nullable final Long variantId, @Nullable final String assetKey) {
-    return ProductSetAssetCustomTypeAction.builder()
-        .variantId(variantId)
-        .assetKey(assetKey)
-        .fields((FieldContainer) null)
-        .staged(true)
-        .build();
+    return ProductSetAssetCustomTypeAction.builder().build();
   }
 
   @Override

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/AssetCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/AssetCustomActionBuilder.java
@@ -4,7 +4,6 @@ import com.commercetools.api.models.product.ProductSetAssetCustomFieldAction;
 import com.commercetools.api.models.product.ProductSetAssetCustomTypeAction;
 import com.commercetools.api.models.product.ProductUpdateAction;
 import com.commercetools.api.models.type.FieldContainer;
-import com.commercetools.api.models.type.FieldContainerBuilder;
 import com.commercetools.api.models.type.TypeResourceIdentifier;
 import com.commercetools.sync.sdk2.commons.helpers.GenericCustomActionBuilder;
 import java.util.Map;
@@ -53,7 +52,7 @@ public class AssetCustomActionBuilder implements GenericCustomActionBuilder<Prod
         .variantId(variantId)
         .assetKey(assetKey)
         .name(customFieldName)
-        .value(FieldContainerBuilder.of().addValue(customFieldName, customFieldValue).build())
+        .value(customFieldValue)
         .staged(true)
         .build();
   }

--- a/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceCustomActionBuilder.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/helpers/PriceCustomActionBuilder.java
@@ -1,10 +1,6 @@
 package com.commercetools.sync.sdk2.products.helpers;
 
-import com.commercetools.api.models.product.ProductSetProductPriceCustomFieldAction;
-import com.commercetools.api.models.product.ProductSetProductPriceCustomTypeAction;
-import com.commercetools.api.models.product.ProductUpdateAction;
-import com.commercetools.api.models.type.FieldContainerBuilder;
-import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.api.models.product.*;
 import com.commercetools.sync.sdk2.commons.helpers.GenericCustomActionBuilder;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -16,7 +12,7 @@ public class PriceCustomActionBuilder implements GenericCustomActionBuilder<Prod
   @Nonnull
   public ProductUpdateAction buildRemoveCustomTypeAction(
       @Nullable final Long variantId, @Nullable final String priceId) {
-    return ProductSetProductPriceCustomTypeAction.builder().priceId(priceId).staged(true).build();
+    return ProductSetProductPriceCustomTypeActionBuilder.of().priceId(priceId).build();
   }
 
   @Override
@@ -27,16 +23,10 @@ public class PriceCustomActionBuilder implements GenericCustomActionBuilder<Prod
       @Nonnull final String customTypeId,
       @Nullable final Map<String, Object> customFieldsJsonMap) {
 
-    FieldContainerBuilder customFields = null;
-    if (customFieldsJsonMap != null) {
-      customFields = FieldContainerBuilder.of();
-      customFieldsJsonMap.forEach(customFields::addValue);
-    }
-
-    return ProductSetProductPriceCustomTypeAction.builder()
+    return ProductSetProductPriceCustomTypeActionBuilder.of()
         .priceId(priceId)
-        .type(TypeResourceIdentifierBuilder.of().id(customTypeId).build())
-        .fields(customFields != null ? customFields.build() : null)
+        .type(typeResourceIdentifierBuilder -> typeResourceIdentifierBuilder.id(customTypeId))
+        .fields(fieldContainerBuilder -> fieldContainerBuilder.values(customFieldsJsonMap))
         .staged(true)
         .build();
   }
@@ -49,10 +39,10 @@ public class PriceCustomActionBuilder implements GenericCustomActionBuilder<Prod
       @Nullable final String customFieldName,
       @Nullable final Object customFieldValue) {
 
-    return ProductSetProductPriceCustomFieldAction.builder()
+    return ProductSetProductPriceCustomFieldActionBuilder.of()
         .priceId(priceId)
         .name(customFieldName)
-        .value(FieldContainerBuilder.of().addValue(customFieldName, customFieldValue).build())
+        .value(customFieldValue)
         .staged(true)
         .build();
   }

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/ProductVariantPriceUpdateActionUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/ProductVariantPriceUpdateActionUtils.java
@@ -10,6 +10,7 @@ import com.commercetools.api.models.product.Product;
 import com.commercetools.api.models.product.ProductChangePriceAction;
 import com.commercetools.api.models.product.ProductDraft;
 import com.commercetools.api.models.product.ProductUpdateAction;
+import com.commercetools.api.models.type.ResourceTypeId;
 import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
 import com.commercetools.sync.sdk2.commons.utils.CustomUpdateActionUtils;
 import com.commercetools.sync.sdk2.products.ProductSyncOptions;
@@ -158,7 +159,7 @@ public final class ProductVariantPriceUpdateActionUtils {
             variantId,
             PriceCustomTypeAdapter::getId,
             priceCustomTypeAdapter ->
-                priceCustomTypeAdapter.getTypeId(), // return resource ID "product-price"
+                ResourceTypeId.PRODUCT_PRICE.getJsonName(), // return resource ID "product-price"
             PriceCustomTypeAdapter::getId,
             syncOptions);
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/BuildUpdateActionExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/BuildUpdateActionExceptionTest.java
@@ -1,0 +1,48 @@
+package com.commercetools.sync.sdk2.commons.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BuildUpdateActionExceptionTest {
+
+  @Test
+  void buildUpdateActionException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+
+    assertThatThrownBy(
+            () -> {
+              throw new BuildUpdateActionException(message);
+            })
+        .isExactlyInstanceOf(BuildUpdateActionException.class)
+        .hasNoCause()
+        .hasMessage(message);
+  }
+
+  @Test
+  void buildUpdateActionException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new BuildUpdateActionException(message, cause);
+            })
+        .isExactlyInstanceOf(BuildUpdateActionException.class)
+        .hasCause(cause)
+        .hasMessage(message);
+  }
+
+  @Test
+  void buildUpdateActionException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new BuildUpdateActionException(cause);
+            })
+        .isExactlyInstanceOf(BuildUpdateActionException.class)
+        .hasCause(cause)
+        .hasMessage(cause.toString());
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateKeyExceptionTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/exceptions/DuplicateKeyExceptionTest.java
@@ -1,0 +1,48 @@
+package com.commercetools.sync.sdk2.commons.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class DuplicateKeyExceptionTest {
+
+  @Test
+  void duplicateKeyException_WithMessageOnly_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateKeyException(message);
+            })
+        .isExactlyInstanceOf(DuplicateKeyException.class)
+        .hasNoCause()
+        .hasMessage(message);
+  }
+
+  @Test
+  void duplicateKeyException_WithMessageAndCause_ShouldBuildExceptionCorrectly() {
+    final String message = "foo";
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateKeyException(message, cause);
+            })
+        .isExactlyInstanceOf(DuplicateKeyException.class)
+        .hasCause(cause)
+        .hasMessage(message);
+  }
+
+  @Test
+  void duplicateKeyException_WithCauseOnly_ShouldBuildExceptionCorrectly() {
+    final IllegalArgumentException cause = new IllegalArgumentException();
+
+    assertThatThrownBy(
+            () -> {
+              throw new DuplicateKeyException(cause);
+            })
+        .isExactlyInstanceOf(DuplicateKeyException.class)
+        .hasCause(cause)
+        .hasMessage(cause.toString());
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CategoryAssetCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CategoryAssetCustomUpdateActionUtilsTest.java
@@ -57,7 +57,7 @@ class CategoryAssetCustomUpdateActionUtilsTest {
     CategorySetAssetCustomTypeAction categorySetAssetCustomTypeAction =
         (CategorySetAssetCustomTypeAction) updateAction;
     assertThat(categorySetAssetCustomTypeAction.getAssetId()).isEqualTo(null);
-    assertThat(categorySetAssetCustomTypeAction.getAssetKey()).isEqualTo(assetKey);
+    assertThat(categorySetAssetCustomTypeAction.getAssetKey()).isEqualTo(null);
     assertThat(categorySetAssetCustomTypeAction.getType()).isEqualTo(null);
   }
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CompletableFutureUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CompletableFutureUtilsTest.java
@@ -1,0 +1,555 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.CompletableFutureUtils.collectionOfFuturesToFutureOfCollection;
+import static com.commercetools.sync.sdk2.commons.utils.CompletableFutureUtils.mapValuesToFutureOfCompletedValues;
+import static java.util.Arrays.asList;
+import static java.util.Collections.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class CompletableFutureUtilsTest {
+
+  /**
+   * * List to List : Single Value. * List to Set : Single Value. * Set to Set : Single Value. * Set
+   * to List : Single Value.
+   */
+  @Test
+  void single_ListToList_ReturnsFutureOfList() {
+    final String result = "value1";
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(singletonList(completedFuture(result)), toList());
+    assertThat(future.join()).containsExactly(result);
+  }
+
+  @Test
+  void single_ListToSet_ReturnsFutureOfSet() {
+    final String result = "value1";
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(singletonList(completedFuture(result)), toSet());
+    assertThat(future.join()).containsExactly(result);
+  }
+
+  @Test
+  void single_SetToSet_ReturnsFutureOfSet() {
+    final String result = "value1";
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(singleton(completedFuture(result)), toSet());
+    assertThat(future.join()).containsExactly(result);
+  }
+
+  @Test
+  void single_SetToList_ReturnsFutureOfList() {
+    final String result = "value1";
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(singleton(completedFuture(result)), toList());
+    assertThat(future.join()).containsExactly(result);
+  }
+
+  /**
+   * * List to List : Multiple Values : no duplicates. * List to Set : Multiple Values : no
+   * duplicates. * Set to Set : Multiple Values : no duplicates. * Set to List : Multiple Values :
+   * no duplicates.
+   */
+  @Test
+  void multiple_ListToListNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(
+            asList(completedFuture("foo"), completedFuture("bar")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("foo", "bar");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void multiple_ListToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(
+            asList(completedFuture("foo"), completedFuture("bar")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("foo", "bar");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToSetNoDuplicates_ReturnsFutureOfSetOfCompletedValues() {
+    final Set<CompletableFuture<String>> set = new HashSet<>();
+    set.add(completedFuture("foo"));
+    set.add(completedFuture("bar"));
+
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(set, toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("foo", "bar");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToListMappingNoDuplicates_ReturnsFutureOfListOfCompletedValues() {
+    final Set<CompletableFuture<String>> set = new HashSet<>();
+    set.add(completedFuture("foo"));
+    set.add(completedFuture("bar"));
+
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(set, toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("foo", "bar");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  /**
+   * * List to List : Multiple Values : duplicates. * List to Set : Multiple Values : duplicates. *
+   * Set to Set : Multiple Values : duplicates. * Set to List : Multiple Values : duplicates.
+   */
+  @Test
+  void multiple_ListToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(
+            asList(completedFuture("foo"), completedFuture("foo")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("foo", "foo");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void multiple_ListToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(
+            asList(completedFuture("foo"), completedFuture("foo")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("foo");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToSetDuplicates_ReturnsFutureOfSetOfCompletedValuesNoDuplicates() {
+    final Set<CompletableFuture<String>> set = new HashSet<>();
+    set.add(completedFuture("foo"));
+    set.add(completedFuture("foo"));
+
+    final CompletableFuture<Set<String>> future =
+        collectionOfFuturesToFutureOfCollection(set, toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("foo");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToListDuplicates_ReturnsFutureOfListOfCompletedValuesDuplicates() {
+    final Set<CompletableFuture<String>> set = new HashSet<>();
+    set.add(completedFuture("foo"));
+    set.add(completedFuture("foo"));
+
+    final CompletableFuture<List<String>> future =
+        collectionOfFuturesToFutureOfCollection(set, toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("foo", "foo");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void empty_ListToList_ReturnsFutureOfEmptyList() {
+    final CompletableFuture<List<String>> futureList =
+        mapValuesToFutureOfCompletedValues(
+            new ArrayList<String>(), CompletableFuture::completedFuture, toList());
+    assertThat(futureList.join()).isEqualTo(emptyList());
+  }
+
+  @Test
+  void empty_ListToSet_ReturnsFutureOfEmptySet() {
+    final CompletableFuture<Set<String>> futureSet =
+        mapValuesToFutureOfCompletedValues(
+            new ArrayList<String>(), CompletableFuture::completedFuture, toSet());
+    assertThat(futureSet.join()).isEqualTo(emptySet());
+  }
+
+  @Test
+  void empty_SetToSet_ReturnsFutureOfEmptyList() {
+    final CompletableFuture<List<String>> futureList =
+        mapValuesToFutureOfCompletedValues(
+            new HashSet<String>(), CompletableFuture::completedFuture, toList());
+    assertThat(futureList.join()).isEqualTo(emptyList());
+  }
+
+  @Test
+  void empty_SetToList_ReturnsFutureOfEmptySet() {
+    final CompletableFuture<Set<String>> futureSet =
+        mapValuesToFutureOfCompletedValues(
+            new HashSet<String>(), CompletableFuture::completedFuture, toSet());
+    assertThat(futureSet.join()).isEqualTo(emptySet());
+  }
+
+  /**
+   * List to List : single null value. List to Set : single null value. Set to Set : single null
+   * value. Set to List : single null value.
+   */
+  @Test
+  void singleNull_ListToList_ReturnsFutureOfEmptyList() {
+    final String nullString = null;
+    final CompletableFuture<List<String>> futureList =
+        mapValuesToFutureOfCompletedValues(
+            singletonList(nullString), CompletableFuture::completedFuture, toList());
+    assertThat(futureList.join()).isEqualTo(emptyList());
+  }
+
+  @Test
+  void singleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    final String nullString = null;
+    final CompletableFuture<Set<String>> futureSet =
+        mapValuesToFutureOfCompletedValues(
+            singletonList(nullString), CompletableFuture::completedFuture, toSet());
+    assertThat(futureSet.join()).isEqualTo(emptySet());
+  }
+
+  @Test
+  void singleNull_SetToSet_ReturnsFutureOfEmptyList() {
+    final String nullString = null;
+    final CompletableFuture<List<String>> futureList =
+        mapValuesToFutureOfCompletedValues(
+            singleton(nullString), CompletableFuture::completedFuture, toList());
+    assertThat(futureList.join()).isEqualTo(emptyList());
+  }
+
+  @Test
+  void singleNull_SetToList_ReturnsFutureOfEmptySet() {
+    final String nullString = null;
+    final CompletableFuture<Set<String>> futureSet =
+        mapValuesToFutureOfCompletedValues(
+            singleton(nullString), CompletableFuture::completedFuture, toSet());
+    assertThat(futureSet.join()).isEqualTo(emptySet());
+  }
+
+  /** List to List : multiple null value. List to Set : multiple null value. */
+  @Test
+  void multipleNull_ListToList_ReturnsFutureOfEmptyList() {
+    final String nullString = null;
+    final CompletableFuture<List<String>> futureList =
+        mapValuesToFutureOfCompletedValues(
+            asList(nullString, nullString), CompletableFuture::completedFuture, toList());
+    assertThat(futureList.join()).isEqualTo(emptyList());
+  }
+
+  @Test
+  void multipleNull_ListToSet_ReturnsFutureOfEmptySet() {
+    final String nullString = null;
+    final CompletableFuture<Set<String>> futureSet =
+        mapValuesToFutureOfCompletedValues(
+            asList(nullString, nullString), CompletableFuture::completedFuture, toSet());
+    assertThat(futureSet.join()).isEqualTo(emptySet());
+  }
+
+  /**
+   * * List to List : Same Type Mapping : Single Value. * List to Set : Same Type Mapping : Single
+   * Value. * Set to Set : Same Type Mapping : Single Value. * Set to List : Same Type Mapping :
+   * Single Value.
+   *
+   * <p>List to List : Diff Type Mapping : Single Value. * List to Set : Diff Type Mapping : Single
+   * Value. * Set to Set : Diff Type Mapping : Single Value. * Set to List : Diff Type Mapping :
+   * Single Value.
+   */
+  @Test
+  void single_ListToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            singletonList("foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void single_ListToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            singletonList("foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void single_SetToSetWithSameTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            singleton("foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void single_SetToListWithSameTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            singleton("foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void single_ListToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            singletonList("foo"), element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactly(3);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void single_ListToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            singletonList("foo"), element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactly(3);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void single_SetToSetWithDiffTypeMapping_ReturnsFutureOfSetOfMappedValue() {
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            singleton("foo"), element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactly(3);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void single_SetToListWithDiffTypeMapping_ReturnsFutureOfListOfMappedValue() {
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            singleton("foo"), element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactly(3);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  /**
+   * * List to List : Same Type Mapping : Multiple Values : no duplicates. * List to Set : Same Type
+   * Mapping : Multiple Values : no duplicates. * Set to Set : Same Type Mapping : Multiple Values :
+   * no duplicates. * Set to List : Same Type Mapping : Multiple Values : no duplicates.
+   *
+   * <p>List to List : Diff Type Mapping : Multiple Values : no duplicates. * List to Set : Diff
+   * Type Mapping : Multiple Values : no duplicates. * Set to Set : Diff Type Mapping : Multiple
+   * Values : no duplicates. * Set to List : Diff Type Mapping : Multiple Values : no duplicates.
+   */
+  @Test
+  void multiple_ListToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("foo", "bar"), element -> completedFuture(element.concat("POSTFIX")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX", "barPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void multiple_ListToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("foo", "bar"), element -> completedFuture(element.concat("POSTFIX")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("fooPOSTFIX", "barPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToSetWithSameTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.concat("POSTFIX")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("fooPOSTFIX", "barPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToListWithSameTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.concat("POSTFIX")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder("fooPOSTFIX", "barPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void multiple_ListToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("john", "smith"), element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactly(4, 5);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void multiple_ListToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("john", "smith"), element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder(4, 5);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToSetWithDiffTypeMappingNoDuplicates_ReturnsFutureOfSetOfMappedValues() {
+    final Set<String> set = new HashSet<>();
+    set.add("john");
+    set.add("smith");
+
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder(4, 5);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void multiple_SetToListWithDiffTypeMappingNoDuplicates_ReturnsFutureOfListOfMappedValues() {
+    final Set<String> set = new HashSet<>();
+    set.add("john");
+    set.add("smith");
+
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactlyInAnyOrder(4, 5);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  /**
+   * * List to List : Same Type Mapping : Multiple Values : duplicates. * List to Set : Same Type
+   * Mapping : Multiple Values : duplicates. * Set to Set : Same Type Mapping : Multiple Values :
+   * duplicates. * Set to List : Same Type Mapping : Multiple Values : duplicates.
+   *
+   * <p>List to List : Diff Type Mapping : Multiple Values : duplicates. * List to Set : Diff Type
+   * Mapping : Multiple Values : duplicates. * Set to Set : Diff Type Mapping : Multiple Values :
+   * duplicates. * Set to List : Diff Type Mapping : Multiple Values : duplicates.
+   */
+  @Test
+  void
+      multiple_ListToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("foo", "foo"), element -> completedFuture(element.concat("POSTFIX")), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX", "fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void
+      multiple_ListToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("foo", "foo"), element -> completedFuture(element.concat("POSTFIX")), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("fooPOSTFIX");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void
+      multiple_SetToSetWithSameTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<Set<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture("constantResult"), toSet());
+    final Set<String> result = future.join();
+    assertThat(result).containsExactly("constantResult");
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void
+      multiple_SetToListWithSameTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<List<String>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture("constantResult"), toList());
+    final List<String> result = future.join();
+    assertThat(result).containsExactly("constantResult", "constantResult");
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void
+      multiple_ListToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("john", "john"), element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactly(4, 4);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+
+  @Test
+  void
+      multiple_ListToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            asList("john", "john"), element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactly(4);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void
+      multiple_SetToSetWithDiffTypeMappingDuplicates_ReturnsFutureOfSetOfMappedValuesNoDuplicates() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<Set<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.length()), toSet());
+    final Set<Integer> result = future.join();
+    assertThat(result).containsExactly(3);
+    assertThat(result).isExactlyInstanceOf(HashSet.class);
+  }
+
+  @Test
+  void
+      multiple_SetToListWithDiffTypeMappingDuplicates_ReturnsFutureOfListOfMappedValuesWithDuplicates() {
+    final Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+
+    final CompletableFuture<List<Integer>> future =
+        mapValuesToFutureOfCompletedValues(
+            set, element -> completedFuture(element.length()), toList());
+    final List<Integer> result = future.join();
+    assertThat(result).containsExactly(3, 3);
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomUpdateActionUtilsTest.java
@@ -30,7 +30,6 @@ import com.commercetools.api.models.type.CustomFields;
 import com.commercetools.api.models.type.CustomFieldsBuilder;
 import com.commercetools.api.models.type.CustomFieldsDraft;
 import com.commercetools.api.models.type.CustomFieldsDraftBuilder;
-import com.commercetools.api.models.type.FieldContainer;
 import com.commercetools.api.models.type.FieldContainerBuilder;
 import com.commercetools.api.models.type.ResourceTypeId;
 import com.commercetools.api.models.type.TypeReference;
@@ -613,11 +612,7 @@ class CustomUpdateActionUtilsTest {
                   (ProductSetProductPriceCustomFieldAction) action;
 
               assertThat(setProductPriceCustomFieldAction.getName()).isEqualTo("backgroundColor");
-              assertThat(
-                      ((FieldContainer) setProductPriceCustomFieldAction.getValue())
-                          .values()
-                          .get("backgroundColor"))
-                  .isEqualTo(null);
+              assertThat(setProductPriceCustomFieldAction.getValue()).isEqualTo(null);
               return true;
             });
   }
@@ -769,6 +764,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put(
@@ -779,10 +775,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             oldCustomFieldsMap,
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     // assertion
     assertThat(updateActions)
@@ -791,8 +787,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of().values(Map.of("setOfBooleans", emptyList())).build())
+                .value(emptyList())
                 .staged(true)
                 .build());
   }
@@ -809,6 +804,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put("setOfBooleans", Collections.emptyList());
@@ -818,10 +814,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             oldCustomFieldsMap,
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     // assertion
     assertThat(updateActions)
@@ -830,8 +826,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of().values(Map.of("setOfBooleans", emptyList())).build())
+                .value(emptyList())
                 .staged(true)
                 .build());
   }
@@ -848,6 +843,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put("setOfBooleans", Collections.emptyList());
@@ -857,10 +853,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             oldCustomFieldsMap,
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     // assertion
     assertThat(updateActions)
@@ -869,8 +865,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of().values(Map.of("setOfBooleans", emptyList())).build())
+                .value(emptyList())
                 .staged(true)
                 .build());
   }
@@ -884,6 +879,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put("setOfBooleans", Collections.emptyList());
@@ -893,10 +889,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             new HashMap<>(),
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     // assertion
     assertThat(updateActions)
@@ -905,8 +901,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of().values(Map.of("setOfBooleans", emptyList())).build())
+                .value(emptyList())
                 .staged(true)
                 .build());
   }
@@ -923,6 +918,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put("setOfBooleans", Collections.emptyList());
@@ -932,10 +928,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             new HashMap<>(),
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     // assertion
     assertThat(updateActions)
@@ -944,8 +940,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of().values(Map.of("setOfBooleans", emptyList())).build())
+                .value(emptyList())
                 .staged(true)
                 .build());
   }
@@ -962,6 +957,7 @@ class CustomUpdateActionUtilsTest {
 
     final Asset oldAsset = mock(Asset.class);
     when(oldAsset.getCustom()).thenReturn(oldCustomFields);
+    when(oldAsset.getKey()).thenReturn("oldKey");
 
     final Map<String, Object> newCustomFieldsMap = new HashMap<>();
     newCustomFieldsMap.put("setOfBooleans", JsonNodeFactory.instance.nullNode());
@@ -971,10 +967,10 @@ class CustomUpdateActionUtilsTest {
         buildSetCustomFieldsUpdateActions(
             oldCustomFieldsMap,
             newCustomFieldsMap,
-            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            AssetCustomTypeAdapter.of(oldAsset),
             new AssetCustomActionBuilder(),
             1L,
-            AssetCustomTypeAdapter::getId);
+            AssetCustomTypeAdapter::getKey);
 
     assertThat(updateActions)
         .containsExactly(
@@ -982,10 +978,7 @@ class CustomUpdateActionUtilsTest {
                 .assetKey(oldAsset.getKey())
                 .variantId(1L)
                 .name("setOfBooleans")
-                .value(
-                    FieldContainerBuilder.of()
-                        .values(Collections.singletonMap("setOfBooleans", null))
-                        .build())
+                .value(null)
                 .staged(true)
                 .build());
   }

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomerCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/CustomerCustomUpdateActionUtilsTest.java
@@ -1,0 +1,83 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.customer.Customer;
+import com.commercetools.api.models.customer.CustomerSetCustomFieldAction;
+import com.commercetools.api.models.customer.CustomerSetCustomTypeAction;
+import com.commercetools.api.models.customer.CustomerUpdateAction;
+import com.commercetools.api.models.type.TypeResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.commons.models.Custom;
+import com.commercetools.sync.sdk2.customers.CustomerSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.customers.models.CustomerCustomTypeAdapter;
+import com.commercetools.sync.sdk2.customers.utils.CustomerCustomActionBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.HashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CustomerCustomUpdateActionUtilsTest {
+
+  @Test
+  void buildTypedSetCustomTypeUpdateAction_WithCustomerResource_ShouldBuildCustomerUpdateAction() {
+    final String newCustomTypeId = UUID.randomUUID().toString();
+
+    final CustomerUpdateAction updateAction =
+        GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction(
+                newCustomTypeId,
+                new HashMap<>(),
+                CustomerCustomTypeAdapter.of(mock(Customer.class)),
+                CustomerCustomActionBuilder.of(),
+                null,
+                CustomerCustomTypeAdapter::getId,
+                Custom::getTypeId,
+                customerResource -> null,
+                CustomerSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build())
+            .orElse(null);
+
+    assertThat(updateAction).isInstanceOf(CustomerSetCustomTypeAction.class);
+    assertThat((CustomerSetCustomTypeAction) updateAction)
+        .satisfies(
+            customerSetCustomTypeAction -> {
+              assertThat(customerSetCustomTypeAction.getType())
+                  .isEqualTo(TypeResourceIdentifierBuilder.of().id(newCustomTypeId).build());
+              assertThat(customerSetCustomTypeAction.getFields().values()).isEqualTo(emptyMap());
+            });
+  }
+
+  @Test
+  void buildRemoveCustomTypeAction_WithCustomerResource_ShouldBuildCustomerUpdateAction() {
+    final CustomerUpdateAction updateAction =
+        CustomerCustomActionBuilder.of().buildRemoveCustomTypeAction(null, null);
+
+    assertThat(updateAction).isInstanceOf(CustomerSetCustomTypeAction.class);
+    assertThat((CustomerSetCustomTypeAction) updateAction)
+        .satisfies(
+            customerSetCustomTypeAction -> {
+              assertThat(customerSetCustomTypeAction.getType()).isEqualTo(null);
+              assertThat(customerSetCustomTypeAction.getFields()).isEqualTo(null);
+            });
+  }
+
+  @Test
+  void buildSetCustomFieldAction_WithCustomerResource_ShouldBuildCustomerUpdateAction() {
+    final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
+    final String customFieldName = "name";
+
+    final CustomerUpdateAction updateAction =
+        CustomerCustomActionBuilder.of()
+            .buildSetCustomFieldAction(null, null, customFieldName, customFieldValue);
+
+    assertThat(updateAction).isInstanceOf(CustomerSetCustomFieldAction.class);
+    assertThat((CustomerSetCustomFieldAction) updateAction)
+        .satisfies(
+            customerSetCustomFieldAction -> {
+              assertThat(customerSetCustomFieldAction.getName()).isEqualTo(customFieldName);
+              assertThat(customerSetCustomFieldAction.getValue()).isEqualTo(customFieldValue);
+            });
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/GenericUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/GenericUpdateActionUtilsTest.java
@@ -1,26 +1,25 @@
 package com.commercetools.sync.sdk2.commons.utils;
 
-import com.commercetools.api.client.ProjectApiRoot;
-import com.commercetools.api.models.type.ResourceTypeId;
-import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
-import com.commercetools.sync.sdk2.categories.helpers.AssetCustomActionBuilder;
-import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
-import com.commercetools.api.models.category.Category;
-import com.commercetools.api.models.category.CategoryDraft;
-import com.commercetools.api.models.category.CategoryUpdateAction;
-import com.commercetools.sync.sdk2.commons.models.AssetCustomTypeAdapter;
-import com.commercetools.api.models.common.Asset;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-
 import static com.commercetools.sync.sdk2.categories.CategorySyncOptionsBuilder.of;
 import static com.commercetools.sync.sdk2.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.api.models.category.CategoryUpdateAction;
+import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.type.ResourceTypeId;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.categories.helpers.AssetCustomActionBuilder;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.models.AssetCustomTypeAdapter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
 
 class GenericUpdateActionUtilsTest {
 
@@ -29,10 +28,7 @@ class GenericUpdateActionUtilsTest {
       buildTypedSetCustomTypeUpdateAction_WithNullNewIdCategoryAsset_ShouldNotBuildCategoryUpdateAction() {
     final ArrayList<String> errorMessages = new ArrayList<>();
     final QuadConsumer<
-                SyncException,
-                Optional<CategoryDraft>,
-                Optional<Category>,
-                List<CategoryUpdateAction>>
+            SyncException, Optional<CategoryDraft>, Optional<Category>, List<CategoryUpdateAction>>
         errorCallback =
             (exception, oldResource, newResource, updateActions) ->
                 errorMessages.add(exception.getMessage());

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/GenericUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/GenericUpdateActionUtilsTest.java
@@ -1,0 +1,63 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.type.ResourceTypeId;
+import com.commercetools.sync.sdk2.categories.CategorySyncOptions;
+import com.commercetools.sync.sdk2.categories.helpers.AssetCustomActionBuilder;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.api.models.category.CategoryUpdateAction;
+import com.commercetools.sync.sdk2.commons.models.AssetCustomTypeAdapter;
+import com.commercetools.api.models.common.Asset;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static com.commercetools.sync.sdk2.categories.CategorySyncOptionsBuilder.of;
+import static com.commercetools.sync.sdk2.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class GenericUpdateActionUtilsTest {
+
+  @Test
+  void
+      buildTypedSetCustomTypeUpdateAction_WithNullNewIdCategoryAsset_ShouldNotBuildCategoryUpdateAction() {
+    final ArrayList<String> errorMessages = new ArrayList<>();
+    final QuadConsumer<
+                SyncException,
+                Optional<CategoryDraft>,
+                Optional<Category>,
+                List<CategoryUpdateAction>>
+        errorCallback =
+            (exception, oldResource, newResource, updateActions) ->
+                errorMessages.add(exception.getMessage());
+
+    // Mock sync options
+    final CategorySyncOptions categorySyncOptions =
+        of(mock(ProjectApiRoot.class)).errorCallback(errorCallback).build();
+
+    final Optional<CategoryUpdateAction> updateAction =
+        buildTypedSetCustomTypeUpdateAction(
+            null,
+            new HashMap<>(),
+            AssetCustomTypeAdapter.of(mock(Asset.class)),
+            new AssetCustomActionBuilder(),
+            1L,
+            AssetCustomTypeAdapter::getId,
+            ignore -> ResourceTypeId.ASSET.getJsonName(),
+            AssetCustomTypeAdapter::getKey,
+            categorySyncOptions);
+
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errorMessages.get(0))
+        .isEqualTo(
+            "Failed to build 'setCustomType' update action on the asset with"
+                + " id 'null'. Reason: New Custom Type id is blank (null/empty).");
+    assertThat(updateAction).isEmpty();
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
@@ -1,0 +1,85 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.common.Asset;
+import com.commercetools.api.models.product.ProductSetAssetCustomFieldAction;
+import com.commercetools.api.models.product.ProductSetAssetCustomTypeAction;
+import com.commercetools.api.models.product.ProductUpdateAction;
+import com.commercetools.api.models.type.ResourceTypeId;
+import com.commercetools.sync.sdk2.commons.models.AssetCustomTypeAdapter;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.products.helpers.AssetCustomActionBuilder;
+import java.util.HashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ProductAssetCustomUpdateActionUtilsTest {
+
+  @Test
+  void buildTypedSetCustomTypeUpdateAction_WithProductAsset_ShouldBuildProductUpdateAction() {
+    final Asset asset = mock(Asset.class);
+    when(asset.getKey()).thenReturn("assetKey");
+    final String newCustomTypeId = UUID.randomUUID().toString();
+    final long variantId = 1L;
+
+    final ProductUpdateAction updateAction =
+        buildTypedSetCustomTypeUpdateAction(
+                newCustomTypeId,
+                new HashMap<>(),
+                AssetCustomTypeAdapter.of(asset),
+                new AssetCustomActionBuilder(),
+                variantId,
+                AssetCustomTypeAdapter::getId,
+                ignore -> ResourceTypeId.ASSET.getJsonName(),
+                AssetCustomTypeAdapter::getKey,
+                ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build())
+            .orElse(null);
+
+    assertThat(updateAction).isInstanceOf(ProductSetAssetCustomTypeAction.class);
+    ProductSetAssetCustomTypeAction productSetAssetCustomTypeAction =
+        (ProductSetAssetCustomTypeAction) updateAction;
+    assertThat(productSetAssetCustomTypeAction.getAssetId()).isEqualTo(asset.getId());
+    assertThat(productSetAssetCustomTypeAction.getAssetKey()).isEqualTo(asset.getKey());
+    assertThat(productSetAssetCustomTypeAction.getType().getId()).isEqualTo(newCustomTypeId);
+  }
+
+  @Test
+  void buildRemoveCustomTypeAction_WithProductAsset_ShouldBuildProductUpdateAction() {
+    final String assetKey = "assetKey";
+
+    final ProductUpdateAction updateAction =
+        new AssetCustomActionBuilder().buildRemoveCustomTypeAction(1L, assetKey);
+
+    assertThat(updateAction).isInstanceOf(ProductSetAssetCustomTypeAction.class);
+    ProductSetAssetCustomTypeAction productSetAssetCustomTypeAction =
+        (ProductSetAssetCustomTypeAction) updateAction;
+    assertThat(productSetAssetCustomTypeAction.getAssetId()).isEqualTo(null);
+    assertThat(productSetAssetCustomTypeAction.getAssetKey()).isEqualTo(assetKey);
+    assertThat(productSetAssetCustomTypeAction.getType()).isEqualTo(null);
+  }
+
+  @Test
+  void buildSetCustomFieldAction_WithProductAsset_ShouldBuildProductUpdateAction() {
+    final String customFieldValue = "foo";
+    final String customFieldName = "name";
+    final String assetKey = "assetKey";
+    final long variantId = 1;
+
+    final ProductUpdateAction updateAction =
+        new AssetCustomActionBuilder()
+            .buildSetCustomFieldAction(variantId, assetKey, customFieldName, customFieldValue);
+
+    assertThat(updateAction).isInstanceOf(ProductSetAssetCustomFieldAction.class);
+    ProductSetAssetCustomFieldAction productSetAssetCustomFieldAction =
+        (ProductSetAssetCustomFieldAction) updateAction;
+    assertThat(productSetAssetCustomFieldAction.getAssetId()).isEqualTo(null);
+    assertThat(productSetAssetCustomFieldAction.getAssetKey()).isEqualTo(assetKey);
+    assertThat(productSetAssetCustomFieldAction.getName()).isEqualTo(customFieldName);
+    assertThat(productSetAssetCustomFieldAction.getValue()).isEqualTo(customFieldValue);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java
@@ -59,7 +59,7 @@ class ProductAssetCustomUpdateActionUtilsTest {
     ProductSetAssetCustomTypeAction productSetAssetCustomTypeAction =
         (ProductSetAssetCustomTypeAction) updateAction;
     assertThat(productSetAssetCustomTypeAction.getAssetId()).isEqualTo(null);
-    assertThat(productSetAssetCustomTypeAction.getAssetKey()).isEqualTo(assetKey);
+    assertThat(productSetAssetCustomTypeAction.getAssetKey()).isEqualTo(null);
     assertThat(productSetAssetCustomTypeAction.getType()).isEqualTo(null);
   }
 

--- a/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductPriceCustomUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/commons/utils/ProductPriceCustomUpdateActionUtilsTest.java
@@ -1,0 +1,95 @@
+package com.commercetools.sync.sdk2.commons.utils;
+
+import static com.commercetools.sync.sdk2.commons.utils.GenericUpdateActionUtils.buildTypedSetCustomTypeUpdateAction;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.common.Price;
+import com.commercetools.api.models.product.ProductSetProductPriceCustomFieldAction;
+import com.commercetools.api.models.product.ProductSetProductPriceCustomTypeAction;
+import com.commercetools.api.models.product.ProductUpdateAction;
+import com.commercetools.api.models.type.ResourceTypeId;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.products.helpers.PriceCustomActionBuilder;
+import com.commercetools.sync.sdk2.products.models.PriceCustomTypeAdapter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.HashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ProductPriceCustomUpdateActionUtilsTest {
+
+  @Test
+  void buildTypedSetCustomTypeUpdateAction_WithProductPrice_ShouldBuildProductUpdateAction() {
+    final Price price = mock(Price.class);
+    when(price.getId()).thenReturn("priceId");
+    final String newCustomTypeId = UUID.randomUUID().toString();
+
+    final ProductUpdateAction updateAction =
+        buildTypedSetCustomTypeUpdateAction(
+                newCustomTypeId,
+                new HashMap<>(),
+                PriceCustomTypeAdapter.of(price),
+                new PriceCustomActionBuilder(),
+                1L,
+                PriceCustomTypeAdapter::getId,
+                ignore -> ResourceTypeId.PRODUCT_PRICE.getJsonName(),
+                PriceCustomTypeAdapter::getId,
+                ProductSyncOptionsBuilder.of(mock(ProjectApiRoot.class)).build())
+            .orElse(null);
+
+    assertThat(updateAction).isInstanceOf(ProductSetProductPriceCustomTypeAction.class);
+    assertThat((ProductSetProductPriceCustomTypeAction) updateAction)
+        .satisfies(
+            productSetProductPriceCustomTypeAction -> {
+              assertThat(productSetProductPriceCustomTypeAction.getPriceId()).isEqualTo("priceId");
+              assertThat(productSetProductPriceCustomTypeAction.getType().getId())
+                  .isEqualTo(newCustomTypeId);
+              assertThat(productSetProductPriceCustomTypeAction.getFields().values())
+                  .isEqualTo(emptyMap());
+              assertThat(productSetProductPriceCustomTypeAction.getStaged()).isTrue();
+            });
+  }
+
+  @Test
+  void buildRemoveCustomTypeAction_WithProductPrice_ShouldBuildChannelUpdateAction() {
+    final String priceId = "1";
+    final ProductUpdateAction updateAction =
+        new PriceCustomActionBuilder().buildRemoveCustomTypeAction(1L, priceId);
+
+    assertThat(updateAction).isInstanceOf(ProductSetProductPriceCustomTypeAction.class);
+    assertThat((ProductSetProductPriceCustomTypeAction) updateAction)
+        .satisfies(
+            productSetProductPriceCustomTypeAction -> {
+              assertThat(productSetProductPriceCustomTypeAction.getPriceId()).isEqualTo(priceId);
+              assertThat(productSetProductPriceCustomTypeAction.getType()).isEqualTo(null);
+            });
+  }
+
+  @Test
+  void buildSetCustomFieldAction_WithProductPrice_ShouldBuildProductUpdateAction() {
+    final String priceId = "1";
+    final String customFieldName = "name";
+    final JsonNode customFieldValue = JsonNodeFactory.instance.textNode("foo");
+
+    final ProductUpdateAction updateAction =
+        new PriceCustomActionBuilder()
+            .buildSetCustomFieldAction(1L, priceId, customFieldName, customFieldValue);
+
+    assertThat(updateAction).isInstanceOf(ProductSetProductPriceCustomFieldAction.class);
+    assertThat((ProductSetProductPriceCustomFieldAction) updateAction)
+        .satisfies(
+            productSetProductPriceCustomFieldAction -> {
+              assertThat(productSetProductPriceCustomFieldAction.getPriceId()).isEqualTo(priceId);
+              assertThat(productSetProductPriceCustomFieldAction.getName())
+                  .isEqualTo(customFieldName);
+              assertThat(productSetProductPriceCustomFieldAction.getValue())
+                  .isEqualTo(customFieldValue);
+              assertThat(productSetProductPriceCustomFieldAction.getStaged()).isTrue();
+            });
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductVariantPriceUpdateActionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/utils/ProductVariantPriceUpdateActionUtilsTest.java
@@ -230,10 +230,7 @@ class ProductVariantPriceUpdateActionUtilsTest {
                 ProductSetProductPriceCustomFieldAction.builder()
                     .name("foo")
                     .priceId(DE_222_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDY.getId())
-                    .value(
-                        DRAFT_DE_100_EUR_01_02_CHANNEL1_CUSTOMTYPE1_CUSTOMFIELDX
-                            .getCustom()
-                            .getFields())
+                    .value(JsonNodeFactory.instance.textNode("X"))
                     .staged(true)
                     .build()),
             emptyList()),


### PR DESCRIPTION
Changes in this PR:
- Migrate missing unittests for [commons/exception](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/commons/exceptions/)
 - Add tests for [completableFutureUtils](https://github.com/commercetools/commercetools-sync-java/tree/master/src/test/java/com/commercetools/sync/commons/utils/completablefutureutils)
- Migrate missing tests [CustomerCustomUpdateActionUtilsTest.java](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/commons/utils/CustomerCustomUpdateActionUtilsTest.java), [ProductPriceCustomUpdateActionUtilsTest](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/commons/utils/ProductPriceCustomUpdateActionUtilsTest.java), [ProductAssetCustomUpdateActionUtilsTest](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/commons/utils/ProductAssetCustomUpdateActionUtilsTest.java), [GenericUpdateActionUtilsTest](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/commons/utils/GenericUpdateActionUtilsTest.java)

- Simplify and generalize CustomActionBuilders of some resources

Summary:
JIRA: https://commercetools.atlassian.net/browse/DEVX-211