### PR TITLE
Migrate unittests for services

### DIFF
--- a/src/main/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImpl.java
+++ b/src/main/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImpl.java
@@ -7,7 +7,6 @@ import com.commercetools.api.models.custom_object.CustomObject;
 import com.commercetools.api.models.custom_object.CustomObjectDraft;
 import com.commercetools.api.models.custom_object.CustomObjectPagedQueryResponse;
 import com.commercetools.sync.customobjects.CustomObjectSync;
-import com.commercetools.sync.sdk2.commons.models.GraphQlQueryResource;
 import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptions;
 import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
 import com.commercetools.sync.sdk2.services.CustomObjectService;
@@ -50,8 +49,12 @@ public class CustomObjectServiceImpl
      *  "container_1|key_1" : "33213df2-c09a-426d-8c28-ccc52fdf9744"
      * ]
      */
-    return super.cacheKeysToIdsUsingGraphQl(
-        getKeys(identifiers), GraphQlQueryResource.CUSTOM_OBJECTS);
+    return fetchMatchingCustomObjects(identifiers)
+        .thenApply(
+            chunk -> {
+              chunk.forEach(resource -> keyToIdCache.put(keyMapper(resource), resource.getId()));
+              return keyToIdCache.asMap();
+            });
   }
 
   @NotNull

--- a/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncOptionsBuilderTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncOptionsBuilderTest.java
@@ -1,302 +1,298 @@
-// package com.commercetools.sync.sdk2.products.utils;
-//
-// import static com.commercetools.sync.products.ActionGroup.IMAGES;
-// import static com.commercetools.sync.products.SyncFilter.ofWhiteList;
-// import static java.util.Collections.emptyList;
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-//
-// import com.commercetools.api.client.ProjectApiRoot;
-// import com.commercetools.api.models.common.LocalizedString;
-// import com.commercetools.api.models.product.ProductChangeNameActionBuilder;
-// import com.commercetools.api.models.product.ProductDraft;
-// import com.commercetools.api.models.product.ProductDraftBuilder;
-// import com.commercetools.api.models.product.ProductProjection;
-// import com.commercetools.api.models.product.ProductUpdateAction;
-// import com.commercetools.sync.products.ProductSyncOptionsBuilder;
-// import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
-// import com.commercetools.sync.sdk2.commons.utils.QuadConsumer;
-// import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
-// import com.commercetools.sync.sdk2.commons.utils.TriFunction;
-// import com.commercetools.sync.sdk2.products.ProductSyncOptions;
-// import com.commercetools.sync.sdk2.products.SyncFilter;
-// import java.util.Collections;
-// import java.util.List;
-// import java.util.Optional;
-// import java.util.function.Function;
-// import org.junit.jupiter.api.Test;
-//
-// class ProductSyncOptionsBuilderTest {
-//  private static final ProjectApiRoot CTP_CLIENT = mock(ProjectApiRoot.class);
-//  private ProductSyncOptionsBuilder productSyncOptionsBuilder =
-//      ProductSyncOptionsBuilder.of(CTP_CLIENT);
-//
-//  @Test
-//  void of_WithClient_ShouldCreateProductSyncOptionsBuilder() {
-//    final ProductSyncOptionsBuilder builder = ProductSyncOptionsBuilder.of(CTP_CLIENT);
-//    assertThat(builder).isNotNull();
-//  }
-//
-//  @Test
-//  void build_WithClient_ShouldBuildProductSyncOptions() {
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions).isNotNull();
-//    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
-//    assertThat(productSyncOptions.getSyncFilter()).isSameAs(SyncFilter.of());
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNull();
-//    assertThat(productSyncOptions.getBeforeCreateCallback()).isNull();
-//    assertThat(productSyncOptions.getErrorCallback()).isNull();
-//    assertThat(productSyncOptions.getWarningCallback()).isNull();
-//    assertThat(productSyncOptions.getCtpClient()).isEqualTo(CTP_CLIENT);
-//    assertThat(productSyncOptions.getBatchSize())
-//        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
-//    assertThat(productSyncOptions.getCacheSize()).isEqualTo(10_000);
-//  }
-//
-//  @Test
-//  void syncFilter_WithNoSyncFilter_ShouldSetDefaultFilter() {
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
-//    assertThat(productSyncOptions.getSyncFilter()).isSameAs(SyncFilter.of());
-//  }
-//
-//  @Test
-//  void syncFilter_WithSyncFilter_ShouldSetFilter() {
-//    productSyncOptionsBuilder.syncFilter(ofWhiteList(IMAGES));
-//
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
-//  }
-//
-//  @Test
-//  void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
-//    final TriFunction<
-//            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
-//        beforeUpdateCallback = (updateActions, newProduct, oldProduct) -> emptyList();
-//    productSyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
-//
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
-//  }
-//
-//  @Test
-//  void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
-//    productSyncOptionsBuilder.beforeCreateCallback((newProduct) -> null);
-//
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
-//  }
-//
-//  @Test
-//  public void errorCallBack_WithCallBack_ShouldSetCallBack() {
-//    final QuadConsumer<
-//            SyncException,
-//            Optional<ProductDraft>,
-//            Optional<ProductProjection>,
-//            List<ProductUpdateAction>>
-//        mockErrorCallback = (exception, newDraft, old, actions) -> {};
-//    productSyncOptionsBuilder.errorCallback(mockErrorCallback);
-//
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getErrorCallback()).isNotNull();
-//  }
-//
-//  @Test
-//  public void warningCallBack_WithCallBack_ShouldSetCallBack() {
-//    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
-//        mockWarningCallBack = (exception, newDraft, old) -> {};
-//    productSyncOptionsBuilder.warningCallback(mockWarningCallBack);
-//
-//    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
-//    assertThat(productSyncOptions.getWarningCallback()).isNotNull();
-//  }
-//
-//  @Test
-//  void getThis_ShouldReturnCorrectInstance() {
-//    final ProductSyncOptionsBuilder instance = productSyncOptionsBuilder.getThis();
-//    assertThat(instance).isNotNull();
-//    assertThat(instance).isInstanceOf(ProductSyncOptionsBuilder.class);
-//    assertThat(instance).isEqualTo(productSyncOptionsBuilder);
-//  }
-//
-//  @Test
-//  void productSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
-//    final ProductSyncOptions productSyncOptions =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT)
-//            .batchSize(30)
-//            .beforeCreateCallback((newProduct) -> null)
-//            .beforeUpdateCallback((updateActions, newCategory, oldCategory) -> emptyList())
-//            .build();
-//    assertThat(productSyncOptions).isNotNull();
-//  }
-//
-//  @Test
-//  void batchSize_WithPositiveValue_ShouldSetBatchSize() {
-//    final ProductSyncOptions productSyncOptions =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(10).build();
-//    assertThat(productSyncOptions.getBatchSize()).isEqualTo(10);
-//  }
-//
-//  @Test
-//  void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
-//    final ProductSyncOptions productSyncOptionsWithZeroBatchSize =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(0).build();
-//    assertThat(productSyncOptionsWithZeroBatchSize.getBatchSize())
-//        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
-//
-//    final ProductSyncOptions productSyncOptionsWithNegativeBatchSize =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(-100).build();
-//    assertThat(productSyncOptionsWithNegativeBatchSize.getBatchSize())
-//        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
-//  }
-//
-//  @Test
-//  void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
-//    final ProductSyncOptions productSyncOptions =
-// ProductSyncOptionsBuilder.of(CTP_CLIENT).build();
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNull();
-//
-//    final List<ProductUpdateAction> updateActions =
-//        Collections.singletonList(
-//            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
-//    final List<ProductUpdateAction> filteredList =
-//        productSyncOptions.applyBeforeUpdateCallback(
-//            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
-//    assertThat(filteredList).isSameAs(updateActions);
-//  }
-//
-//  @Test
-//  void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
-//    final TriFunction<
-//            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
-//        beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
-//    final ProductSyncOptions productSyncOptions =
-//
-// ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
-//
-//    final List<ProductUpdateAction> updateActions =
-//        Collections.singletonList(
-//            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
-//    final List<ProductUpdateAction> filteredList =
-//        productSyncOptions.applyBeforeUpdateCallback(
-//            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
-//    assertThat(filteredList).isNotEqualTo(updateActions);
-//    assertThat(filteredList).isEmpty();
-//  }
-//
-//  private interface MockTriFunction
-//      extends TriFunction<
-//          List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
-// {}
-//
-//  @Test
-//  void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
-//    final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
-//
-//    final ProductSyncOptions productSyncOptions =
-//
-// ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
-//
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
-//
-//    final List<ProductUpdateAction> updateActions = emptyList();
-//    final List<ProductUpdateAction> filteredList =
-//        productSyncOptions.applyBeforeUpdateCallback(
-//            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
-//
-//    assertThat(filteredList).isEmpty();
-//    verify(beforeUpdateCallback, never()).apply(any(), any(), any());
-//  }
-//
-//  @Test
-//  void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
-//    final TriFunction<
-//            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
-//        beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> emptyList();
-//    final ProductSyncOptions productSyncOptions =
-//
-// ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
-//    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
-//
-//    final List<ProductUpdateAction> updateActions =
-//        Collections.singletonList(
-//            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
-//    final List<ProductUpdateAction> filteredList =
-//        productSyncOptions.applyBeforeUpdateCallback(
-//            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
-//    assertThat(filteredList).isNotEqualTo(updateActions);
-//    assertThat(filteredList).isEmpty();
-//  }
-//
-//  @Test
-//  void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
-//    final Function<ProductDraft, ProductDraft> draftFunction =
-//        productDraft ->
-//            ProductDraftBuilder.of(productDraft)
-//                .key(productDraft.getKey() + "_filteredKey")
-//                .build();
-//
-//    final ProductSyncOptions productSyncOptions =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeCreateCallback(draftFunction).build();
-//    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
-//
-//    final ProductDraft resourceDraft = mock(ProductDraft.class);
-//    when(resourceDraft.getKey()).thenReturn("myKey");
-//
-//    final Optional<ProductDraft> filteredDraft =
-//        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
-//
-//    assertThat(filteredDraft).isNotEmpty();
-//    assertThat(filteredDraft.get().getKey()).isEqualTo("myKey_filteredKey");
-//  }
-//
-//  @Test
-//  void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
-//    final ProductSyncOptions productSyncOptions =
-// ProductSyncOptionsBuilder.of(CTP_CLIENT).build();
-//    assertThat(productSyncOptions.getBeforeCreateCallback()).isNull();
-//
-//    final ProductDraft resourceDraft = mock(ProductDraft.class);
-//    final Optional<ProductDraft> filteredDraft =
-//        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
-//
-//    assertThat(filteredDraft).containsSame(resourceDraft);
-//  }
-//
-//  @Test
-//  void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyOptional() {
-//    final Function<ProductDraft, ProductDraft> draftFunction = productDraft -> null;
-//    final ProductSyncOptions productSyncOptions =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeCreateCallback(draftFunction).build();
-//    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
-//
-//    final ProductDraft resourceDraft = mock(ProductDraft.class);
-//    final Optional<ProductDraft> filteredDraft =
-//        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
-//
-//    assertThat(filteredDraft).isEmpty();
-//  }
-//
-//  @Test
-//  void cacheSize_WithPositiveValue_ShouldSetCacheSize() {
-//    final ProductSyncOptions productSyncOptions =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(10).build();
-//    assertThat(productSyncOptions.getCacheSize()).isEqualTo(10);
-//  }
-//
-//  @Test
-//  void cacheSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
-//    final ProductSyncOptions productSyncOptionsWithZeroCacheSize =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(0).build();
-//    assertThat(productSyncOptionsWithZeroCacheSize.getCacheSize()).isEqualTo(10_000);
-//
-//    final ProductSyncOptions productSyncOptionsWithNegativeCacheSize =
-//        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(-100).build();
-//    assertThat(productSyncOptionsWithNegativeCacheSize.getCacheSize()).isEqualTo(10_000);
-//  }
-// }
+package com.commercetools.sync.sdk2.products;
+
+import static com.commercetools.sync.sdk2.products.ActionGroup.IMAGES;
+import static com.commercetools.sync.sdk2.products.SyncFilter.ofWhiteList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.api.client.ProjectApiRoot;
+import com.commercetools.api.models.common.LocalizedString;
+import com.commercetools.api.models.product.ProductChangeNameActionBuilder;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductDraftBuilder;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.api.models.product.ProductUpdateAction;
+import com.commercetools.api.models.product_type.ProductTypeResourceIdentifierBuilder;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.utils.QuadConsumer;
+import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
+import com.commercetools.sync.sdk2.commons.utils.TriFunction;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class ProductSyncOptionsBuilderTest {
+  private static final ProjectApiRoot CTP_CLIENT = mock(ProjectApiRoot.class);
+  private ProductSyncOptionsBuilder productSyncOptionsBuilder =
+      ProductSyncOptionsBuilder.of(CTP_CLIENT);
+
+  @Test
+  void of_WithClient_ShouldCreateProductSyncOptionsBuilder() {
+    final ProductSyncOptionsBuilder builder = ProductSyncOptionsBuilder.of(CTP_CLIENT);
+    assertThat(builder).isNotNull();
+  }
+
+  @Test
+  void build_WithClient_ShouldBuildProductSyncOptions() {
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions).isNotNull();
+    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
+    assertThat(productSyncOptions.getSyncFilter()).isSameAs(SyncFilter.of());
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNull();
+    assertThat(productSyncOptions.getBeforeCreateCallback()).isNull();
+    assertThat(productSyncOptions.getErrorCallback()).isNull();
+    assertThat(productSyncOptions.getWarningCallback()).isNull();
+    assertThat(productSyncOptions.getCtpClient()).isEqualTo(CTP_CLIENT);
+    assertThat(productSyncOptions.getBatchSize())
+        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+    assertThat(productSyncOptions.getCacheSize()).isEqualTo(10_000);
+  }
+
+  @Test
+  void syncFilter_WithNoSyncFilter_ShouldSetDefaultFilter() {
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
+    assertThat(productSyncOptions.getSyncFilter()).isSameAs(SyncFilter.of());
+  }
+
+  @Test
+  void syncFilter_WithSyncFilter_ShouldSetFilter() {
+    productSyncOptionsBuilder.syncFilter(ofWhiteList(IMAGES));
+
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getSyncFilter()).isNotNull();
+  }
+
+  @Test
+  void beforeUpdateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    final TriFunction<
+            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
+        beforeUpdateCallback = (updateActions, newProduct, oldProduct) -> emptyList();
+    productSyncOptionsBuilder.beforeUpdateCallback(beforeUpdateCallback);
+
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
+  }
+
+  @Test
+  void beforeCreateCallback_WithFilterAsCallback_ShouldSetCallback() {
+    productSyncOptionsBuilder.beforeCreateCallback((newProduct) -> null);
+
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
+  }
+
+  @Test
+  public void errorCallBack_WithCallBack_ShouldSetCallBack() {
+    final QuadConsumer<
+            SyncException,
+            Optional<ProductDraft>,
+            Optional<ProductProjection>,
+            List<ProductUpdateAction>>
+        mockErrorCallback = (exception, newDraft, old, actions) -> {};
+    productSyncOptionsBuilder.errorCallback(mockErrorCallback);
+
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getErrorCallback()).isNotNull();
+  }
+
+  @Test
+  public void warningCallBack_WithCallBack_ShouldSetCallBack() {
+    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+        mockWarningCallBack = (exception, newDraft, old) -> {};
+    productSyncOptionsBuilder.warningCallback(mockWarningCallBack);
+
+    final ProductSyncOptions productSyncOptions = productSyncOptionsBuilder.build();
+    assertThat(productSyncOptions.getWarningCallback()).isNotNull();
+  }
+
+  @Test
+  void getThis_ShouldReturnCorrectInstance() {
+    final ProductSyncOptionsBuilder instance = productSyncOptionsBuilder.getThis();
+    assertThat(instance).isNotNull();
+    assertThat(instance).isInstanceOf(ProductSyncOptionsBuilder.class);
+    assertThat(instance).isEqualTo(productSyncOptionsBuilder);
+  }
+
+  @Test
+  void productSyncOptionsBuilderSetters_ShouldBeCallableAfterBaseSyncOptionsBuildSetters() {
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT)
+            .batchSize(30)
+            .beforeCreateCallback((newProduct) -> null)
+            .beforeUpdateCallback((updateActions, newCategory, oldCategory) -> emptyList())
+            .build();
+    assertThat(productSyncOptions).isNotNull();
+  }
+
+  @Test
+  void batchSize_WithPositiveValue_ShouldSetBatchSize() {
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(10).build();
+    assertThat(productSyncOptions.getBatchSize()).isEqualTo(10);
+  }
+
+  @Test
+  void batchSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    final ProductSyncOptions productSyncOptionsWithZeroBatchSize =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(0).build();
+    assertThat(productSyncOptionsWithZeroBatchSize.getBatchSize())
+        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+
+    final ProductSyncOptions productSyncOptionsWithNegativeBatchSize =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).batchSize(-100).build();
+    assertThat(productSyncOptionsWithNegativeBatchSize.getBatchSize())
+        .isEqualTo(ProductSyncOptionsBuilder.BATCH_SIZE_DEFAULT);
+  }
+
+  @Test
+  void applyBeforeUpdateCallBack_WithNullCallback_ShouldReturnIdenticalList() {
+    final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT).build();
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNull();
+
+    final List<ProductUpdateAction> updateActions =
+        Collections.singletonList(
+            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
+    final List<ProductUpdateAction> filteredList =
+        productSyncOptions.applyBeforeUpdateCallback(
+            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
+    assertThat(filteredList).isSameAs(updateActions);
+  }
+
+  @Test
+  void applyBeforeUpdateCallBack_WithNullReturnCallback_ShouldReturnEmptyList() {
+    final TriFunction<
+            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
+        beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> null;
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+    final List<ProductUpdateAction> updateActions =
+        Collections.singletonList(
+            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
+    final List<ProductUpdateAction> filteredList =
+        productSyncOptions.applyBeforeUpdateCallback(
+            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
+    assertThat(filteredList).isNotEqualTo(updateActions);
+    assertThat(filteredList).isEmpty();
+  }
+
+  private interface MockTriFunction
+      extends TriFunction<
+          List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>> {}
+
+  @Test
+  void applyBeforeUpdateCallBack_WithEmptyUpdateActions_ShouldNotApplyBeforeUpdateCallback() {
+    final MockTriFunction beforeUpdateCallback = mock(MockTriFunction.class);
+
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
+
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+    final List<ProductUpdateAction> updateActions = emptyList();
+    final List<ProductUpdateAction> filteredList =
+        productSyncOptions.applyBeforeUpdateCallback(
+            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
+
+    assertThat(filteredList).isEmpty();
+    verify(beforeUpdateCallback, never()).apply(any(), any(), any());
+  }
+
+  @Test
+  void applyBeforeUpdateCallBack_WithCallback_ShouldReturnFilteredList() {
+    final TriFunction<
+            List<ProductUpdateAction>, ProductDraft, ProductProjection, List<ProductUpdateAction>>
+        beforeUpdateCallback = (updateActions, newCategory, oldCategory) -> emptyList();
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeUpdateCallback(beforeUpdateCallback).build();
+    assertThat(productSyncOptions.getBeforeUpdateCallback()).isNotNull();
+
+    final List<ProductUpdateAction> updateActions =
+        Collections.singletonList(
+            ProductChangeNameActionBuilder.of().name(LocalizedString.ofEnglish("name")).build());
+    final List<ProductUpdateAction> filteredList =
+        productSyncOptions.applyBeforeUpdateCallback(
+            updateActions, mock(ProductDraft.class), mock(ProductProjection.class));
+    assertThat(filteredList).isNotEqualTo(updateActions);
+    assertThat(filteredList).isEmpty();
+  }
+
+  @Test
+  void applyBeforeCreateCallBack_WithCallback_ShouldReturnFilteredDraft() {
+    final Function<ProductDraft, ProductDraft> draftFunction =
+        productDraft ->
+            ProductDraftBuilder.of(productDraft)
+                .key(productDraft.getKey() + "_filteredKey")
+                .build();
+
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeCreateCallback(draftFunction).build();
+    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+    final ProductDraft resourceDraft = mock(ProductDraft.class);
+    when(resourceDraft.getKey()).thenReturn("myKey");
+    when(resourceDraft.getProductType())
+        .thenReturn(ProductTypeResourceIdentifierBuilder.of().id("productTypeId").build());
+    when(resourceDraft.getName()).thenReturn(LocalizedString.ofEnglish("myName"));
+    when(resourceDraft.getSlug()).thenReturn(LocalizedString.ofEnglish("mySlug"));
+
+    final Optional<ProductDraft> filteredDraft =
+        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+    assertThat(filteredDraft).isNotEmpty();
+    assertThat(filteredDraft.get().getKey()).isEqualTo("myKey_filteredKey");
+  }
+
+  @Test
+  void applyBeforeCreateCallBack_WithNullCallback_ShouldReturnIdenticalDraftInOptional() {
+    final ProductSyncOptions productSyncOptions = ProductSyncOptionsBuilder.of(CTP_CLIENT).build();
+    assertThat(productSyncOptions.getBeforeCreateCallback()).isNull();
+
+    final ProductDraft resourceDraft = mock(ProductDraft.class);
+    final Optional<ProductDraft> filteredDraft =
+        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+    assertThat(filteredDraft).containsSame(resourceDraft);
+  }
+
+  @Test
+  void applyBeforeCreateCallBack_WithNullReturnCallback_ShouldReturnEmptyOptional() {
+    final Function<ProductDraft, ProductDraft> draftFunction = productDraft -> null;
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).beforeCreateCallback(draftFunction).build();
+    assertThat(productSyncOptions.getBeforeCreateCallback()).isNotNull();
+
+    final ProductDraft resourceDraft = mock(ProductDraft.class);
+    final Optional<ProductDraft> filteredDraft =
+        productSyncOptions.applyBeforeCreateCallback(resourceDraft);
+
+    assertThat(filteredDraft).isEmpty();
+  }
+
+  @Test
+  void cacheSize_WithPositiveValue_ShouldSetCacheSize() {
+    final ProductSyncOptions productSyncOptions =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(10).build();
+    assertThat(productSyncOptions.getCacheSize()).isEqualTo(10);
+  }
+
+  @Test
+  void cacheSize_WithZeroOrNegativeValue_ShouldFallBackToDefaultValue() {
+    final ProductSyncOptions productSyncOptionsWithZeroCacheSize =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(0).build();
+    assertThat(productSyncOptionsWithZeroCacheSize.getCacheSize()).isEqualTo(10_000);
+
+    final ProductSyncOptions productSyncOptionsWithNegativeCacheSize =
+        ProductSyncOptionsBuilder.of(CTP_CLIENT).cacheSize(-100).build();
+    assertThat(productSyncOptionsWithNegativeCacheSize.getCacheSize()).isEqualTo(10_000);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/BaseServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/BaseServiceImplTest.java
@@ -1,0 +1,652 @@
+package com.commercetools.sync.sdk2.services.impl;
+
+import static com.commercetools.sync.sdk2.commons.ExceptionUtils.createBadGatewayException;
+import static com.commercetools.sync.sdk2.commons.utils.TestUtils.mockGraphQLResponse;
+import static java.util.Collections.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.commercetools.api.client.*;
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectPagedQueryResponse;
+import com.commercetools.api.models.graph_ql.GraphQLRequest;
+import com.commercetools.api.models.graph_ql.GraphQLResponse;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.api.models.product.ProductProjectionPagedQueryResponse;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptions;
+import com.commercetools.sync.sdk2.customobjects.CustomObjectSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.services.ProductService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadGatewayException;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.data.MapEntry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("unchecked")
+class BaseServiceImplTest {
+
+  private final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+      warningCallback = mock(TriConsumer.class);
+
+  private final ByProjectKeyProductProjectionsKeyByKeyGet
+      byProjectKeyProductProjectionsKeyByKeyGet = mock();
+  private final ByProjectKeyProductProjectionsGet byProjectKeyProductProjectionsGet = mock();
+  private final ByProjectKeyGraphqlPost byProjectKeyGraphQlPost = mock();
+  private ProductService service;
+
+  @BeforeEach
+  void setup() {
+    final ProjectApiRoot client = mockProjectApiRoot();
+    final ProductSyncOptions syncOptions =
+        ProductSyncOptionsBuilder.of(client)
+            .warningCallback(warningCallback)
+            .batchSize(20)
+            .cacheSize(2)
+            .build();
+    service = new ProductServiceImpl(syncOptions);
+  }
+
+  @AfterEach
+  void cleanup() {
+    reset(byProjectKeyProductProjectionsKeyByKeyGet, byProjectKeyGraphQlPost, warningCallback);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" "})
+  void fetchCachedResourceId_WithBlankKey_ShouldMakeNoRequestAndReturnEmptyOptional(
+      final String key) {
+    // test
+    final Optional<String> result = service.getIdFromCacheOrFetch(key).toCompletableFuture().join();
+
+    // assertions
+    assertThat(result).isEmpty();
+    verify(byProjectKeyProductProjectionsKeyByKeyGet, never()).execute();
+  }
+
+  @Test
+  void fetchCachedResourceId_WithFetchResourceWithKey_ShouldReturnResourceId() {
+    // preparation
+    final ProductProjectionPagedQueryResponse pagedQueryResponse =
+        mock(ProductProjectionPagedQueryResponse.class);
+    final ProductProjection mockProductResult = mock(ProductProjection.class);
+    final String key = "testKey";
+    final String id = "testId";
+    when(mockProductResult.getKey()).thenReturn(key);
+    when(mockProductResult.getId()).thenReturn(id);
+    when(pagedQueryResponse.getResults()).thenReturn(singletonList(mockProductResult));
+
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    // test
+    final Optional<String> result = service.getIdFromCacheOrFetch(key).toCompletableFuture().join();
+
+    // assertions
+    assertThat(result).contains(id);
+  }
+
+  @Test
+  void fetchCachedResourceId_WithCachedResource_ShouldReturnResourceIdWithoutMakingRequest() {
+    // preparation
+    final ProductProjectionPagedQueryResponse pagedQueryResponse =
+        mock(ProductProjectionPagedQueryResponse.class);
+    final ProductProjection mockProductResult = mock(ProductProjection.class);
+    final String key = "testKey";
+    final String id = "testId";
+    when(mockProductResult.getKey()).thenReturn(key);
+    when(mockProductResult.getId()).thenReturn(id);
+    when(pagedQueryResponse.getResults()).thenReturn(singletonList(mockProductResult));
+
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+    service.getIdFromCacheOrFetch(key).toCompletableFuture().join();
+
+    // test
+    final Optional<String> result = service.getIdFromCacheOrFetch(key).toCompletableFuture().join();
+
+    // assertions
+    assertThat(result).contains(id);
+    // only 1 request of the first fetch, but no more since second time it gets it from cache.
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+  }
+
+  @Test
+  void fetchMatchingResources_WithEmptyKeySet_ShouldFetchAndCacheNothing() {
+    // test
+    final Set<ProductProjection> resources =
+        service.fetchMatchingProductsByKeys(new HashSet<>()).toCompletableFuture().join();
+
+    // assertions
+    assertThat(resources).isEmpty();
+    verify(byProjectKeyProductProjectionsGet, never()).execute();
+  }
+
+  @Test
+  void fetchMatchingResources_WithSpecialCharactersInKeySet_ShouldExecuteQuery() {
+    // preparation
+    final String key1 = "special-\"charTest";
+
+    final HashSet<String> resourceKeys = new HashSet<>();
+    resourceKeys.add(key1);
+
+    final ProductProjectionPagedQueryResponse result =
+        mock(ProductProjectionPagedQueryResponse.class);
+    when(result.getResults()).thenReturn(EMPTY_LIST);
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(result);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    // test
+    service.fetchMatchingProductsByKeys(resourceKeys).toCompletableFuture().join();
+
+    // assertions
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void fetchMatchingResources_WithKeySet_ShouldFetchResourcesAndCacheKeys() {
+    // preparation
+    final String key1 = RandomStringUtils.random(15);
+    final String key2 = RandomStringUtils.random(15);
+
+    final HashSet<String> resourceKeys = new HashSet<>();
+    resourceKeys.add(key1);
+    resourceKeys.add(key2);
+
+    final ProductProjection mock1 = mock(ProductProjection.class);
+    when(mock1.getId()).thenReturn(RandomStringUtils.random(15));
+    when(mock1.getKey()).thenReturn(key1);
+
+    final ProductProjection mock2 = mock(ProductProjection.class);
+    when(mock2.getId()).thenReturn(RandomStringUtils.random(15));
+    when(mock2.getKey()).thenReturn(key2);
+
+    final ProductProjectionPagedQueryResponse result =
+        mock(ProductProjectionPagedQueryResponse.class);
+    when(result.getResults()).thenReturn(Arrays.asList(mock1, mock2));
+
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(result);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    // test fetch
+    final Set<ProductProjection> resources =
+        service.fetchMatchingProductsByKeys(resourceKeys).toCompletableFuture().join();
+
+    // assertions
+    assertThat(resources).containsExactlyInAnyOrder(mock1, mock2);
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+
+    // test caching
+    final Optional<String> cachedKey1 =
+        service.getIdFromCacheOrFetch(mock1.getKey()).toCompletableFuture().join();
+
+    final Optional<String> cachedKey2 =
+        service.getIdFromCacheOrFetch(mock2.getKey()).toCompletableFuture().join();
+
+    // assertions
+    assertThat(cachedKey1).contains(mock1.getId());
+    assertThat(cachedKey2).contains(mock2.getId());
+    // still 1 request from the first #fetchMatchingProductsByKeys call
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+  }
+
+  @Test
+  void fetchMatchingResources_WithKeySetOf500_ShouldChunkAndFetchResourcesAndCacheKeys() {
+    // preparation
+    List<String> randomKeys = new ArrayList<>();
+    IntStream.range(0, 500).forEach(ignore -> randomKeys.add(RandomStringUtils.random(15)));
+
+    final HashSet<String> resourceKeys = new HashSet<>();
+    resourceKeys.addAll(randomKeys);
+
+    final ProductProjection mock1 = mock(ProductProjection.class);
+    when(mock1.getId()).thenReturn(RandomStringUtils.random(15));
+    when(mock1.getKey()).thenReturn(randomKeys.get(0));
+
+    final ProductProjection mock2 = mock(ProductProjection.class);
+    when(mock2.getId()).thenReturn(RandomStringUtils.random(15));
+    when(mock2.getKey()).thenReturn(randomKeys.get(251));
+
+    final ProductProjectionPagedQueryResponse result =
+        mock(ProductProjectionPagedQueryResponse.class);
+    when(result.getResults()).thenReturn(Arrays.asList(mock1, mock2));
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(result);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    // test fetch
+    final Set<ProductProjection> resources =
+        service.fetchMatchingProductsByKeys(resourceKeys).toCompletableFuture().join();
+
+    // assertions
+    assertThat(resources).containsExactlyInAnyOrder(mock1, mock2);
+    verify(byProjectKeyProductProjectionsGet, times(2)).execute();
+
+    // test caching
+    final Optional<String> cachedKey1 =
+        service.getIdFromCacheOrFetch(mock1.getKey()).toCompletableFuture().join();
+
+    final Optional<String> cachedKey2 =
+        service.getIdFromCacheOrFetch(mock2.getKey()).toCompletableFuture().join();
+
+    // assertions
+    assertThat(cachedKey1).contains(mock1.getId());
+    assertThat(cachedKey2).contains(mock2.getId());
+    verify(byProjectKeyProductProjectionsGet, times(2)).execute();
+  }
+
+  @Test
+  void fetchMatchingResources_WithBadGateWayException_ShouldCompleteExceptionally() {
+    // preparation
+    final String key1 = RandomStringUtils.random(15);
+    final String key2 = RandomStringUtils.random(15);
+
+    final HashSet<String> resourceKeys = new HashSet<>();
+    resourceKeys.add(key1);
+    resourceKeys.add(key2);
+
+    when(byProjectKeyProductProjectionsGet.execute())
+        .thenReturn(
+            CompletableFutureUtils.exceptionallyCompletedFuture(createBadGatewayException()));
+
+    // test
+    final CompletionStage<Set<ProductProjection>> result =
+        service.fetchMatchingProductsByKeys(resourceKeys);
+
+    // assertions
+    assertThat(result)
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(BadGatewayException.class);
+    verify(byProjectKeyProductProjectionsGet).execute();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" "})
+  void fetchResource_WithBlankKey_ShouldMakeNoRequestAndReturnEmptyOptional(final String key) {
+    // test
+    final Optional<ProductProjection> optional =
+        service.fetchProduct(key).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).isEmpty();
+    verify(byProjectKeyProductProjectionsKeyByKeyGet, never()).execute();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void fetchResource_WithKey_ShouldFetchResource() {
+    // preparation
+    final String resourceId = RandomStringUtils.random(15);
+    final String resourceKey = RandomStringUtils.random(15);
+
+    final ProductProjection mockProductResult = mock(ProductProjection.class);
+    when(mockProductResult.getKey()).thenReturn(resourceKey);
+    when(mockProductResult.getId()).thenReturn(resourceId);
+
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(mockProductResult);
+    when(byProjectKeyProductProjectionsKeyByKeyGet.execute())
+        .thenReturn(completedFuture(apiHttpResponse));
+
+    // test
+    final Optional<ProductProjection> resourceOptional =
+        service.fetchProduct(resourceKey).toCompletableFuture().join();
+
+    // assertions
+    assertThat(resourceOptional).containsSame(mockProductResult);
+    verify(byProjectKeyProductProjectionsKeyByKeyGet).execute();
+  }
+
+  @Test
+  void fetchResource_WithBadGateWayException_ShouldCompleteExceptionally() {
+    // preparation
+    when(byProjectKeyProductProjectionsKeyByKeyGet.execute())
+        .thenReturn(
+            CompletableFutureUtils.exceptionallyCompletedFuture(createBadGatewayException()));
+
+    // test
+    final CompletionStage<Optional<ProductProjection>> result = service.fetchProduct("foo");
+
+    // assertions
+    assertThat(result)
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(BadGatewayException.class);
+    verify(byProjectKeyProductProjectionsKeyByKeyGet, times(1)).execute();
+  }
+
+  @Test
+  void cacheKeysToIdsUsingGraphQl_WithEmptySetOfKeys_ShouldMakeNoRequestAndReturnEmptyOptional() {
+    // test
+    final Map<String, String> optional =
+        service.cacheKeysToIds(emptySet()).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).isEmpty();
+    verify(byProjectKeyProductProjectionsKeyByKeyGet, never()).execute();
+  }
+
+  @Test
+  void cacheKeysToIdsUsingGraphQl_WithAllCachedKeys_ShouldMakeNoRequestAndReturnCachedEntry() {
+    // preparation
+    final ProductProjectionPagedQueryResponse pagedQueryResponse =
+        mock(ProductProjectionPagedQueryResponse.class);
+    final ProductProjection mockProductResult = mock(ProductProjection.class);
+    final String key = "testKey";
+    final String id = "testId";
+    when(mockProductResult.getKey()).thenReturn(key);
+    when(mockProductResult.getId()).thenReturn(id);
+    when(pagedQueryResponse.getResults()).thenReturn(singletonList(mockProductResult));
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+    service.getIdFromCacheOrFetch(key).toCompletableFuture().join();
+
+    // test
+    final Map<String, String> optional =
+        service.cacheKeysToIds(singleton("testKey")).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).containsExactly(MapEntry.entry(key, id));
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+  }
+
+  @Test
+  void cacheKeysToIds_WithCachedKeysExceedingCacheSize_ShouldNotReturnLeastUsedKeys()
+      throws JsonProcessingException {
+    // preparation
+    final ProductProjectionPagedQueryResponse pagedQueryResponse =
+        mock(ProductProjectionPagedQueryResponse.class);
+    final ProductProjection product1 = mock(ProductProjection.class);
+    when(product1.getKey()).thenReturn("key-1");
+    when(product1.getId()).thenReturn("id-1");
+    final ProductProjection product2 = mock(ProductProjection.class);
+    when(product2.getKey()).thenReturn("key-2");
+    when(product2.getId()).thenReturn("id-2");
+    when(pagedQueryResponse.getResults()).thenReturn(Arrays.asList(product1, product2));
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    final String jsonStringProducts =
+        "{ \"products\": {\"results\":[{\"id\":\"testId\",\"key\":\"testKey\"}]}}";
+    final ApiHttpResponse<GraphQLResponse> productsResponse =
+        mockGraphQLResponse(jsonStringProducts);
+    when(byProjectKeyProductProjectionsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+    when(byProjectKeyGraphQlPost.execute())
+        .thenReturn(CompletableFuture.completedFuture(productsResponse));
+    service.fetchMatchingProductsByKeys(
+        Arrays.asList("key-1", "key-2").stream().collect(Collectors.toSet()));
+    service.getIdFromCacheOrFetch("key-1"); // access the first added cache entry
+
+    // test
+    final Map<String, String> optional =
+        service.cacheKeysToIds(singleton("testKey")).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional)
+        .containsExactly(MapEntry.entry("key-1", "id-1"), MapEntry.entry("testKey", "testId"));
+    verify(byProjectKeyProductProjectionsGet, times(1)).execute();
+    verify(byProjectKeyGraphQlPost, times(1)).execute();
+  }
+
+  @Test
+  void cacheKeysToIdsUsingGraphQl_WithNoCachedKeys_ShouldMakeRequestAndReturnCachedEntry()
+      throws JsonProcessingException {
+    // preparation
+    final String key = "testKey";
+    final String id = "testId";
+    final String jsonStringProducts =
+        "{ \"products\": {\"results\":[{\"id\":\"" + id + "\",\"key\":\"" + key + "\"}]}}";
+    final ApiHttpResponse<GraphQLResponse> productsResponse =
+        mockGraphQLResponse(jsonStringProducts);
+    when(byProjectKeyGraphQlPost.execute()).thenReturn(completedFuture(productsResponse));
+
+    // test
+    final Map<String, String> optional =
+        service.cacheKeysToIds(singleton("testKey")).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).containsExactly(MapEntry.entry(key, id));
+    verify(byProjectKeyGraphQlPost, times(1)).execute();
+  }
+
+  @Test
+  void cacheKeysToIdsUsingGraphQl_With500Keys_ShouldChunkAndMakeRequestAndReturnCachedEntry()
+      throws JsonProcessingException {
+    // preparation
+    Set<String> randomKeys = new HashSet<>();
+    IntStream.range(0, 500).forEach(ignore -> randomKeys.add(RandomStringUtils.random(15)));
+    final String key = randomKeys.stream().findFirst().get();
+    final String id = "testId";
+    final String jsonStringProducts =
+        "{ \"products\": {\"results\":[{\"id\":\"" + id + "\",\"key\":\"" + key + "\"}]}}";
+    final ApiHttpResponse<GraphQLResponse> productsResponse =
+        mockGraphQLResponse(jsonStringProducts);
+    when(byProjectKeyGraphQlPost.execute()).thenReturn(completedFuture(productsResponse));
+
+    // test
+    final Map<String, String> optional =
+        service.cacheKeysToIds(randomKeys).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).containsExactly(MapEntry.entry(key, id));
+    verify(byProjectKeyGraphQlPost, times(2)).execute();
+  }
+
+  @Test
+  void cacheKeysToIdsUsingGraphQl_WithBadGateWayException_ShouldCompleteExceptionally() {
+    // preparation
+    when(byProjectKeyGraphQlPost.execute())
+        .thenReturn(
+            CompletableFutureUtils.exceptionallyCompletedFuture(createBadGatewayException()));
+
+    // test
+    final CompletionStage<Map<String, String>> result =
+        service.cacheKeysToIds(singleton("testKey"));
+
+    // assertions
+    assertThat(result)
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(BadGatewayException.class);
+    verify(byProjectKeyGraphQlPost, times(1)).execute();
+  }
+
+  @Test
+  void cacheKeysToIds_WithEmptySetOfKeys_ShouldNotMakeRequestAndReturnEmpty() {
+    // preparation
+    final ProjectApiRoot client = mockProjectApiRoot();
+    CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(client).build();
+    CustomObjectServiceImpl serviceImpl = new CustomObjectServiceImpl(customObjectSyncOptions);
+
+    // test
+    final Map<String, String> optional =
+        serviceImpl.cacheKeysToIds(emptySet()).toCompletableFuture().join();
+
+    // assertions
+    assertThat(optional).isEmpty();
+    verify(byProjectKeyGraphQlPost, never()).execute();
+  }
+
+  @Test
+  void cacheKeysToIds_WithEmptyCache_ShouldMakeRequestAndReturnCacheEntries() {
+    // preparation
+    final ProjectApiRoot client = mock(ProjectApiRoot.class);
+    final ByProjectKeyCustomObjectsRequestBuilder byProjectKeyCustomObjectsRequestBuilder =
+        mock(ByProjectKeyCustomObjectsRequestBuilder.class);
+    final ByProjectKeyCustomObjectsGet byProjectKeyCustomObjectsGet =
+        mock(ByProjectKeyCustomObjectsGet.class);
+    when(byProjectKeyCustomObjectsGet.withWhere(anyString()))
+        .thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsGet.withLimit(anyInt())).thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsGet.withWithTotal(anyBoolean()))
+        .thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsRequestBuilder.get()).thenReturn(byProjectKeyCustomObjectsGet);
+    when(client.customObjects()).thenReturn(byProjectKeyCustomObjectsRequestBuilder);
+
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(client).build();
+    final CustomObjectServiceImpl serviceImpl =
+        new CustomObjectServiceImpl(customObjectSyncOptions);
+    final String customObjectId = "customObjectId";
+    final String customObjectContainer = "customObjectContainer";
+    final String customObjectKey = "customObjectKey";
+    final CustomObject customObject = mock(CustomObject.class);
+    when(customObject.getId()).thenReturn(customObjectId);
+    when(customObject.getContainer()).thenReturn(customObjectContainer);
+    when(customObject.getKey()).thenReturn(customObjectKey);
+
+    final CustomObjectPagedQueryResponse pagedQueryResponse =
+        mock(CustomObjectPagedQueryResponse.class);
+    when(pagedQueryResponse.getResults()).thenReturn(singletonList(customObject));
+    final ApiHttpResponse<CustomObjectPagedQueryResponse> apiHttpResponse =
+        mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    when(byProjectKeyCustomObjectsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    final Map<String, String> result =
+        serviceImpl
+            .cacheKeysToIds(
+                singleton(
+                    CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer)))
+            .toCompletableFuture()
+            .join();
+
+    assertAll(
+        () -> assertThat(result).hasSize(1),
+        () ->
+            assertThat(
+                    result.get(
+                        CustomObjectCompositeIdentifier.of(customObjectKey, customObjectContainer)
+                            .toString()))
+                .isEqualTo(customObjectId));
+    verify(byProjectKeyCustomObjectsGet).execute();
+  }
+
+  @Test
+  void
+      cacheKeysToIds_With500CustomObjectIdentifiers_ShouldChunkAndMakeRequestAndReturnCacheEntries() {
+    // preparation
+    final ProjectApiRoot client = mock(ProjectApiRoot.class);
+    Set<CustomObjectCompositeIdentifier> randomIdentifiers = new HashSet<>();
+    IntStream.range(0, 500)
+        .forEach(
+            i ->
+                randomIdentifiers.add(
+                    CustomObjectCompositeIdentifier.of(
+                        "customObjectId" + i, "customObjectContainer" + i)));
+
+    final String customObjectId = randomIdentifiers.stream().findFirst().get().getKey();
+    final String customObjectContainer =
+        randomIdentifiers.stream().findFirst().get().getContainer();
+    final String customObjectKey = "customObjectKey";
+    final ByProjectKeyCustomObjectsRequestBuilder byProjectKeyCustomObjectsRequestBuilder =
+        mock(ByProjectKeyCustomObjectsRequestBuilder.class);
+    final ByProjectKeyCustomObjectsGet byProjectKeyCustomObjectsGet =
+        mock(ByProjectKeyCustomObjectsGet.class);
+    when(byProjectKeyCustomObjectsGet.withWhere(anyString()))
+        .thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsGet.withLimit(anyInt())).thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsGet.withWithTotal(anyBoolean()))
+        .thenReturn(byProjectKeyCustomObjectsGet);
+    when(byProjectKeyCustomObjectsRequestBuilder.get()).thenReturn(byProjectKeyCustomObjectsGet);
+    when(client.customObjects()).thenReturn(byProjectKeyCustomObjectsRequestBuilder);
+
+    final CustomObjectSyncOptions customObjectSyncOptions =
+        CustomObjectSyncOptionsBuilder.of(client).build();
+    final CustomObjectServiceImpl serviceImpl =
+        new CustomObjectServiceImpl(customObjectSyncOptions);
+    final CustomObject customObject = mock(CustomObject.class);
+    when(customObject.getId()).thenReturn(customObjectId);
+    when(customObject.getContainer()).thenReturn(customObjectContainer);
+    when(customObject.getKey()).thenReturn(customObjectKey);
+
+    final CustomObjectPagedQueryResponse pagedQueryResponse =
+        mock(CustomObjectPagedQueryResponse.class);
+    when(pagedQueryResponse.getResults()).thenReturn(singletonList(customObject));
+    final ApiHttpResponse<CustomObjectPagedQueryResponse> apiHttpResponse =
+        mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(pagedQueryResponse);
+    when(byProjectKeyCustomObjectsGet.execute()).thenReturn(completedFuture(apiHttpResponse));
+
+    // test
+    serviceImpl.cacheKeysToIds(randomIdentifiers).toCompletableFuture().join();
+
+    // assertion
+    verify(byProjectKeyCustomObjectsGet, times(2)).execute();
+  }
+
+  private ProjectApiRoot mockProjectApiRoot() {
+    final ProjectApiRoot ctpClient = mock(ProjectApiRoot.class);
+    final ByProjectKeyProductProjectionsRequestBuilder
+        byProjectKeyProductProjectionsRequestBuilder = mock();
+    when(ctpClient.productProjections()).thenReturn(byProjectKeyProductProjectionsRequestBuilder);
+    final ByProjectKeyProductProjectionsKeyByKeyRequestBuilder
+        byProjectKeyProductProjectionsKeyByKeyRequestBuilder = mock();
+    when(byProjectKeyProductProjectionsRequestBuilder.get())
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withStaged(anyBoolean()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withWhere(anyString()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withPredicateVar(anyString(), anyString()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withPredicateVar(anyString(), anyCollection()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withLimit(anyInt()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.withWithTotal(anyBoolean()))
+        .thenReturn(byProjectKeyProductProjectionsGet);
+    when(byProjectKeyProductProjectionsGet.getQueryParam(anyString()))
+        .thenReturn(singletonList("foo"));
+    when(byProjectKeyProductProjectionsRequestBuilder.withKey(any()))
+        .thenReturn(byProjectKeyProductProjectionsKeyByKeyRequestBuilder);
+    when(byProjectKeyProductProjectionsKeyByKeyRequestBuilder.get())
+        .thenReturn(byProjectKeyProductProjectionsKeyByKeyGet);
+    final ByProjectKeyGraphqlRequestBuilder byProjectKeyGraphqlRequestBuilder = mock();
+    when(ctpClient.graphql()).thenReturn(byProjectKeyGraphqlRequestBuilder);
+    when(ctpClient.graphql().post(any(GraphQLRequest.class))).thenReturn(byProjectKeyGraphQlPost);
+    final CompletableFuture<ApiHttpResponse<ProductProjection>>
+        apiHttpResponseCompletableFutureProduct = mock();
+    final CompletableFuture<ApiHttpResponse<ProductProjectionPagedQueryResponse>>
+        apiHttpResponseCompletableFuturePagedQueryResponse = mock();
+    final CompletableFuture<ApiHttpResponse<GraphQLResponse>>
+        apihttpResponseCompletableFutureGraphQl = mock();
+    when(byProjectKeyProductProjectionsKeyByKeyGet.execute())
+        .thenReturn(apiHttpResponseCompletableFutureProduct);
+    when(byProjectKeyProductProjectionsGet.execute())
+        .thenReturn(apiHttpResponseCompletableFuturePagedQueryResponse);
+    when(byProjectKeyGraphQlPost.execute()).thenReturn(apihttpResponseCompletableFutureGraphQl);
+    return ctpClient;
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImplTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vrap.rmf.base.client.ApiHttpResponse;
-import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -297,7 +296,7 @@ class CustomObjectServiceImplTest {
     final String json = ow.writeValueAsString(errorResponse);
     when(byProjectKeyCustomObjectsPost.execute())
         .thenReturn(
-            CompletableFutureUtils.failed(
+            CompletableFuture.failedFuture(
                 new ConcurrentModificationException(
                     409,
                     "",

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomObjectServiceImplTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -296,7 +297,7 @@ class CustomObjectServiceImplTest {
     final String json = ow.writeValueAsString(errorResponse);
     when(byProjectKeyCustomObjectsPost.execute())
         .thenReturn(
-            CompletableFuture.failedFuture(
+            CompletableFutureUtils.failed(
                 new ConcurrentModificationException(
                     409,
                     "",

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomerServiceImplTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/CustomerServiceImplTest.java
@@ -1,0 +1,241 @@
+package com.commercetools.sync.sdk2.services.impl;
+
+import static com.commercetools.sync.sdk2.commons.ExceptionUtils.createBadGatewayException;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.commercetools.api.client.*;
+import com.commercetools.api.models.customer.*;
+import com.commercetools.sync.sdk2.customers.CustomerSyncOptions;
+import com.commercetools.sync.sdk2.customers.CustomerSyncOptionsBuilder;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.error.BadGatewayException;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CustomerServiceImplTest {
+
+  private CustomerServiceImpl service;
+  private CustomerSyncOptions customerSyncOptions;
+  private List<String> errorMessages;
+  private List<Throwable> errorExceptions;
+
+  @BeforeEach
+  void setUp() {
+    errorMessages = new ArrayList<>();
+    errorExceptions = new ArrayList<>();
+    customerSyncOptions =
+        CustomerSyncOptionsBuilder.of(mock(ProjectApiRoot.class))
+            .errorCallback(
+                (exception, oldResource, newResource, updateActions) -> {
+                  errorMessages.add(exception.getMessage());
+                  errorExceptions.add(exception.getCause());
+                })
+            .build();
+    service = new CustomerServiceImpl(customerSyncOptions);
+  }
+
+  @Test
+  void createCustomer_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
+    final CustomerSignInResult resultMock = mock(CustomerSignInResult.class);
+    final Customer customerMock = mock(Customer.class);
+    when(customerMock.getId()).thenReturn("customerId");
+    when(customerMock.getKey()).thenReturn("customerKey");
+    when(resultMock.getCustomer()).thenReturn(customerMock);
+
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersPost byProjectKeyCustomersPost =
+        mock(ByProjectKeyCustomersPost.class);
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(resultMock);
+    when(byProjectKeyCustomersPost.execute()).thenReturn(completedFuture(apiHttpResponse));
+    when(byProjectKeyCustomersRequestBuilder.post(any(CustomerDraft.class)))
+        .thenReturn(byProjectKeyCustomersPost);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+
+    final CustomerDraft draft = mock(CustomerDraft.class);
+    when(draft.getKey()).thenReturn("customerKey");
+    final Optional<Customer> customerOptional =
+        service.createCustomer(draft).toCompletableFuture().join();
+
+    assertThat(customerOptional).isNotEmpty();
+    assertThat(customerOptional).containsSame(customerMock);
+    verify(byProjectKeyCustomersPost).execute();
+    verify(byProjectKeyCustomersRequestBuilder).post(eq(draft));
+  }
+
+  @Test
+  void createCustomer_WithUnSuccessfulMockResponse_ShouldNotCreate() {
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersPost byProjectKeyCustomersPost =
+        mock(ByProjectKeyCustomersPost.class);
+    when(byProjectKeyCustomersPost.execute())
+        .thenReturn(CompletableFutureUtils.failed(createBadGatewayException()));
+    when(byProjectKeyCustomersRequestBuilder.post(any(CustomerDraft.class)))
+        .thenReturn(byProjectKeyCustomersPost);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+
+    final CustomerDraft draft = mock(CustomerDraft.class);
+    when(draft.getKey()).thenReturn("customerKey");
+    final Optional<Customer> customerOptional =
+        service.createCustomer(draft).toCompletableFuture().join();
+
+    assertThat(customerOptional).isEmpty();
+    assertThat(errorExceptions).hasSize(1);
+    assertThat(errorExceptions.get(0)).isExactlyInstanceOf(BadGatewayException.class);
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errorMessages.get(0)).contains("Failed to create draft with key: 'customerKey'.");
+    verify(byProjectKeyCustomersPost).execute();
+    verify(byProjectKeyCustomersRequestBuilder).post(eq(draft));
+  }
+
+  @Test
+  void createCustomer_WithDraftWithEmptyKey_ShouldNotCreate() {
+    final CustomerDraft draft = mock(CustomerDraft.class);
+    final Optional<Customer> customerOptional =
+        service.createCustomer(draft).toCompletableFuture().join();
+
+    assertThat(customerOptional).isEmpty();
+    assertThat(errorExceptions).hasSize(1);
+    assertThat(errorMessages).hasSize(1);
+    assertThat(errorMessages.get(0))
+        .contains("Failed to create draft with key: 'null'. Reason: Draft key is blank!");
+    verifyNoInteractions(customerSyncOptions.getCtpClient());
+  }
+
+  @Test
+  void createCustomer_WithResponseIsNull_ShouldReturnEmpty() {
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersPost byProjectKeyCustomersPost =
+        mock(ByProjectKeyCustomersPost.class);
+    when(byProjectKeyCustomersPost.execute()).thenReturn(completedFuture(null));
+    when(byProjectKeyCustomersRequestBuilder.post(any(CustomerDraft.class)))
+        .thenReturn(byProjectKeyCustomersPost);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+
+    final CustomerDraft draft = mock(CustomerDraft.class);
+    when(draft.getKey()).thenReturn("key");
+    final Optional<Customer> customerOptional =
+        service.createCustomer(draft).toCompletableFuture().join();
+
+    assertThat(customerOptional).isEmpty();
+    assertThat(errorExceptions).isEmpty();
+    assertThat(errorMessages).isEmpty();
+  }
+
+  @Test
+  void updateCustomer_WithSuccessfulMockCtpResponse_ShouldReturnMock() {
+    final Customer customer = mock(Customer.class);
+    when(customer.getId()).thenReturn("customerId");
+    when(customer.getVersion()).thenReturn(1L);
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersByIDRequestBuilder byProjectKeyCustomersByIDRequestBuilder =
+        mock(ByProjectKeyCustomersByIDRequestBuilder.class);
+    final ByProjectKeyCustomersByIDPost byProjectKeyCustomersByIDPost =
+        mock(ByProjectKeyCustomersByIDPost.class);
+    final ApiHttpResponse apiHttpResponse = mock(ApiHttpResponse.class);
+    when(apiHttpResponse.getBody()).thenReturn(customer);
+    when(byProjectKeyCustomersByIDPost.execute()).thenReturn(completedFuture(apiHttpResponse));
+    when(byProjectKeyCustomersByIDRequestBuilder.post(any(CustomerUpdate.class)))
+        .thenReturn(byProjectKeyCustomersByIDPost);
+    when(byProjectKeyCustomersRequestBuilder.withId(anyString()))
+        .thenReturn(byProjectKeyCustomersByIDRequestBuilder);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+
+    List<CustomerUpdateAction> updateActions =
+        singletonList(CustomerSetFirstNameActionBuilder.of().firstName("Max").build());
+    Customer result = service.updateCustomer(customer, updateActions).toCompletableFuture().join();
+
+    assertThat(result).isSameAs(customer);
+    verify(byProjectKeyCustomersByIDPost).execute();
+    verify(byProjectKeyCustomersByIDRequestBuilder)
+        .post(eq(CustomerUpdateBuilder.of().actions(updateActions).version(1L).build()));
+  }
+
+  @Test
+  void fetchCachedCustomerId_WithBlankKey_ShouldNotFetchCustomerId() {
+    Optional<String> customerId = service.fetchCachedCustomerId("").toCompletableFuture().join();
+
+    assertThat(customerId).isEmpty();
+    assertThat(errorExceptions).isEmpty();
+    assertThat(errorMessages).isEmpty();
+    verifyNoInteractions(customerSyncOptions.getCtpClient());
+  }
+
+  @Test
+  void fetchCachedCustomerId_WithCachedCustomer_ShouldFetchIdFromCache() {
+    service.keyToIdCache.put("key", "id");
+    Optional<String> customerId = service.fetchCachedCustomerId("key").toCompletableFuture().join();
+
+    assertThat(customerId).contains("id");
+    assertThat(errorExceptions).isEmpty();
+    assertThat(errorMessages).isEmpty();
+    verifyNoInteractions(customerSyncOptions.getCtpClient());
+  }
+
+  @Test
+  void fetchCachedCustomerId_WithUnexpectedException_ShouldFail() {
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersKeyByKeyRequestBuilder byProjectKeyCustomersKeyByKeyRequestBuilder =
+        mock(ByProjectKeyCustomersKeyByKeyRequestBuilder.class);
+    final ByProjectKeyCustomersKeyByKeyGet byProjectKeyCustomersKeyByKeyGet =
+        mock(ByProjectKeyCustomersKeyByKeyGet.class);
+    when(byProjectKeyCustomersRequestBuilder.withKey(anyString()))
+        .thenReturn(byProjectKeyCustomersKeyByKeyRequestBuilder);
+    when(byProjectKeyCustomersKeyByKeyRequestBuilder.get())
+        .thenReturn(byProjectKeyCustomersKeyByKeyGet);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+    when(byProjectKeyCustomersKeyByKeyGet.execute())
+        .thenReturn(CompletableFutureUtils.failed(createBadGatewayException()));
+
+    assertThat(service.fetchCachedCustomerId("key"))
+        .failsWithin(1, TimeUnit.SECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseExactlyInstanceOf(BadGatewayException.class);
+    assertThat(errorExceptions).isEmpty();
+    assertThat(errorMessages).isEmpty();
+  }
+
+  @Test
+  void fetchCustomerByKey_WithBlankKey_ShouldNotFetchCustomer() {
+    final ByProjectKeyCustomersRequestBuilder byProjectKeyCustomersRequestBuilder =
+        mock(ByProjectKeyCustomersRequestBuilder.class);
+    final ByProjectKeyCustomersKeyByKeyRequestBuilder byProjectKeyCustomersKeyByKeyRequestBuilder =
+        mock(ByProjectKeyCustomersKeyByKeyRequestBuilder.class);
+    final ByProjectKeyCustomersKeyByKeyGet byProjectKeyCustomersKeyByKeyGet =
+        mock(ByProjectKeyCustomersKeyByKeyGet.class);
+    when(byProjectKeyCustomersRequestBuilder.withKey(anyString()))
+        .thenReturn(byProjectKeyCustomersKeyByKeyRequestBuilder);
+    when(byProjectKeyCustomersKeyByKeyRequestBuilder.get())
+        .thenReturn(byProjectKeyCustomersKeyByKeyGet);
+    when(customerSyncOptions.getCtpClient().customers())
+        .thenReturn(byProjectKeyCustomersRequestBuilder);
+
+    Optional<Customer> customer = service.fetchCustomerByKey("").toCompletableFuture().join();
+
+    assertThat(customer).isEmpty();
+    assertThat(errorExceptions).isEmpty();
+    assertThat(errorMessages).isEmpty();
+    verifyNoInteractions(byProjectKeyCustomersKeyByKeyGet);
+  }
+}

--- a/src/test/java/com/commercetools/sync/sdk2/services/impl/ProductServiceTest.java
+++ b/src/test/java/com/commercetools/sync/sdk2/services/impl/ProductServiceTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.vrap.rmf.base.client.ApiHttpResponse;
+import io.vrap.rmf.base.client.utils.CompletableFutureUtils;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -140,7 +141,7 @@ class ProductServiceTest {
     final String json = ow.writeValueAsString(errorResponse);
     when(byProjectKeyProductsPost.execute())
         .thenReturn(
-            CompletableFuture.failedFuture(
+            CompletableFutureUtils.failed(
                 new ConcurrentModificationException(
                     409,
                     "",


### PR DESCRIPTION
Changes in this PR:
- Migrate service/impl tests [BaseServiceImplTest](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/services/impl/BaseServiceImplTest.java) and [CustomerServiceImplTest](https://github.com/commercetools/commercetools-sync-java/blob/master/src/test/java/com/commercetools/sync/services/impl/CustomerServiceImplTest.java)
- Enable [ProductSyncOptionBuilderTest](https://github.com/commercetools/commercetools-sync-java/blob/java-sdk-v2-migration/src/test/java/com/commercetools/sync/sdk2/products/ProductSyncOptionsBuilderTest.java)

Summary:
JIRA: https://commercetools.atlassian.net/browse/DEVX-211