### PR TITLE
[WIP] DEVX-222 migrate tests

### DIFF
--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -528,6 +528,17 @@ public final class ProductTypeITUtils {
               assertThat(enumValue.getLabel()).isEqualTo(enumValueDraft.getLabel());
             });
   }
+    @Nonnull
+    public static Map<String, Object> createNestedAttributeValueReferences(
+            @Nonnull final String attributeName, @Nonnull final Object referenceValue) {
+        return Map.of("name", attributeName,"value", referenceValue);
+    }
 
-  private ProductTypeITUtils() {}
+    @Nonnull
+    public static Map<String, Object> createNestedAttributeValueSetOfReferences(
+            @Nonnull final String attributeName, @Nonnull final Object... referenceValues) {
+        return Map.of("name", attributeName,"value", List.of(referenceValues));
+    }
+
+    private ProductTypeITUtils() {}
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/commons/utils/ProductTypeITUtils.java
@@ -7,27 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.commercetools.api.client.ProjectApiRoot;
 import com.commercetools.api.client.QueryUtils;
 import com.commercetools.api.models.common.LocalizedString;
-import com.commercetools.api.models.product_type.AttributeBooleanType;
-import com.commercetools.api.models.product_type.AttributeConstraintEnum;
-import com.commercetools.api.models.product_type.AttributeDefinition;
-import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
-import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
-import com.commercetools.api.models.product_type.AttributeEnumType;
-import com.commercetools.api.models.product_type.AttributeLocalizableTextType;
-import com.commercetools.api.models.product_type.AttributeLocalizedEnumType;
-import com.commercetools.api.models.product_type.AttributeLocalizedEnumValue;
-import com.commercetools.api.models.product_type.AttributeNestedTypeBuilder;
-import com.commercetools.api.models.product_type.AttributePlainEnumValue;
-import com.commercetools.api.models.product_type.AttributeSetTypeBuilder;
-import com.commercetools.api.models.product_type.AttributeTextType;
-import com.commercetools.api.models.product_type.ProductType;
-import com.commercetools.api.models.product_type.ProductTypeDraft;
-import com.commercetools.api.models.product_type.ProductTypeDraftBuilder;
-import com.commercetools.api.models.product_type.ProductTypePagedQueryResponse;
-import com.commercetools.api.models.product_type.ProductTypeReferenceBuilder;
-import com.commercetools.api.models.product_type.ProductTypeRemoveAttributeDefinitionActionBuilder;
-import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
-import com.commercetools.api.models.product_type.TextInputHint;
+import com.commercetools.api.models.product.Attribute;
+import com.commercetools.api.models.product.AttributeBuilder;
+import com.commercetools.api.models.product_type.*;
 import io.vrap.rmf.base.client.ApiHttpResponse;
 import io.vrap.rmf.base.client.error.NotFoundException;
 import java.util.ArrayList;
@@ -528,17 +510,18 @@ public final class ProductTypeITUtils {
               assertThat(enumValue.getLabel()).isEqualTo(enumValueDraft.getLabel());
             });
   }
-    @Nonnull
-    public static Map<String, Object> createNestedAttributeValueReferences(
-            @Nonnull final String attributeName, @Nonnull final Object referenceValue) {
-        return Map.of("name", attributeName,"value", referenceValue);
-    }
 
-    @Nonnull
-    public static Map<String, Object> createNestedAttributeValueSetOfReferences(
-            @Nonnull final String attributeName, @Nonnull final Object... referenceValues) {
-        return Map.of("name", attributeName,"value", List.of(referenceValues));
-    }
+  @Nonnull
+  public static Attribute createNestedAttributeValueReferences(
+      @Nonnull final String attributeName, @Nonnull final Object referenceValue) {
+    return AttributeBuilder.of().name(attributeName).value(referenceValue).build();
+  }
 
-    private ProductTypeITUtils() {}
+  @Nonnull
+  public static Attribute createNestedAttributeValueSetOfReferences(
+      @Nonnull final String attributeName, Object... referenceValues) {
+    return AttributeBuilder.of().name(attributeName).value(List.of(referenceValues)).build();
+  }
+
+  private ProductTypeITUtils() {}
 }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedCategoriesIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedCategoriesIT.java
@@ -1,0 +1,761 @@
+package com.commercetools.sync.integration.externalsource.products;
+
+import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.*;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_TYPE_WITH_REFERENCES_RESOURCE_PATH;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import javax.annotation.Nonnull;
+
+import com.commercetools.api.client.error.BadRequestException;
+import com.commercetools.api.client.error.ErrorResponseException;
+import com.commercetools.api.models.category.Category;
+import com.commercetools.api.models.category.CategoryDraft;
+import com.commercetools.api.models.category.CategoryDraftBuilder;
+import com.commercetools.api.models.category.CategoryReference;
+import com.commercetools.api.models.category.CategoryReferenceBuilder;
+import com.commercetools.api.models.product.Attribute;
+import com.commercetools.api.models.product.AttributeBuilder;
+import com.commercetools.api.models.product.Product;
+import com.commercetools.api.models.product.ProductDraft;
+import com.commercetools.api.models.product.ProductDraftBuilder;
+import com.commercetools.api.models.product.ProductProjection;
+import com.commercetools.api.models.product.ProductSetAttributeActionBuilder;
+import com.commercetools.api.models.product.ProductUpdateAction;
+import com.commercetools.api.models.product.ProductVariantDraft;
+import com.commercetools.api.models.product.ProductVariantDraftBuilder;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
+import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
+import com.commercetools.api.models.product_type.ProductType;
+import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionAction;
+import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionActionBuilder;
+import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
+import com.commercetools.sync.sdk2.products.ProductSync;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
+import io.sphere.sdk.products.queries.ProductByKeyGet;
+import io.vrap.rmf.base.client.ApiHttpResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProductSyncWithNestedReferencedCategoriesIT {
+  private static ProductType productType;
+  private static Category testCategory1;
+  private static Category testCategory2;
+
+  private ProductSyncOptions syncOptions;
+  private List<String> errorCallBackMessages;
+  private List<String> warningCallBackMessages;
+  private List<Throwable> errorCallBackExceptions;
+  private List<ProductUpdateAction> actions;
+
+  private static final String ATTRIBUTE_NAME_FIELD = "name";
+  private static final String ATTRIBUTE_VALUE_FIELD = "value";
+
+  @BeforeAll
+  static void setup() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    final ProductType nestedProductType =
+        createProductType(PRODUCT_TYPE_WITH_REFERENCES_RESOURCE_PATH, CTP_TARGET_CLIENT);
+
+    final AttributeDefinitionDraft nestedAttributeDef =
+        AttributeDefinitionDraftBuilder.of()
+                        .type(attributeTypeBuilder -> attributeTypeBuilder.nestedBuilder().typeReference(productTypeReferenceBuilder -> productTypeReferenceBuilder.id(nestedProductType.getId())))
+                .name(
+                "nestedAttribute")
+                        .label(
+                ofEnglish("nestedAttribute"))
+                .isRequired(
+                false)
+            .isSearchable(false)
+            .build();
+
+    final AttributeDefinitionDraft setOfNestedAttributeDef =
+        AttributeDefinitionDraftBuilder.of()
+                        .type(attributeTypeBuilder -> attributeTypeBuilder.setBuilder()
+                                .elementType(attributeTypeBuilder1 -> attributeTypeBuilder1.nestedBuilder().typeReference(productTypeReferenceBuilder -> productTypeReferenceBuilder.id(nestedProductType.getId()))))
+                .name(
+                "setOfNestedAttribute")
+                        .label(
+                ofEnglish("setOfNestedAttribute"))
+                        .isRequired(
+                false)
+            .isSearchable(false)
+            .build();
+
+      final List<ProductTypeUpdateAction> productTypeUpdateActions = List.of(
+              ProductTypeAddAttributeDefinitionActionBuilder.of().attribute(nestedAttributeDef).build(),
+              ProductTypeAddAttributeDefinitionActionBuilder.of().attribute(setOfNestedAttributeDef).build());
+
+    CTP_TARGET_CLIENT.productTypes().update(productType, productTypeUpdateActions).executeBlocking();
+
+    final CategoryDraft category1Draft =
+        CategoryDraftBuilder.of().name(ofEnglish("cat1-name")).slug(ofEnglish("cat1-slug"))
+            .key("cat1-key")
+            .build();
+
+    testCategory1 =
+        CTP_TARGET_CLIENT
+                .categories()
+                .create(category1Draft)
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final CategoryDraft category2Draft =
+        CategoryDraftBuilder.of().name(ofEnglish("cat2-name")).slug(ofEnglish("cat2-slug"))
+            .key("cat2-key")
+            .build();
+
+    testCategory2 =
+        CTP_TARGET_CLIENT
+                .categories()
+                .create(category2Draft)
+            .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+  }
+
+  @BeforeEach
+  void setupTest() {
+    clearSyncTestCollections();
+    deleteAllProducts(CTP_TARGET_CLIENT);
+    syncOptions = buildSyncOptions();
+  }
+
+  private void clearSyncTestCollections() {
+    errorCallBackMessages = new ArrayList<>();
+    errorCallBackExceptions = new ArrayList<>();
+    warningCallBackMessages = new ArrayList<>();
+    actions = new ArrayList<>();
+  }
+
+  private ProductSyncOptions buildSyncOptions() {
+    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+        warningCallback =
+            (syncException, productDraft, product) ->
+                warningCallBackMessages.add(syncException.getMessage());
+
+    return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+        .errorCallback(
+            (syncException, draft, product, updateActions) ->
+                collectErrors(syncException.getMessage(), syncException))
+        .beforeUpdateCallback(this::collectActions)
+        .warningCallback(warningCallback)
+        .build();
+  }
+
+  private void collectErrors(final String errorMessage, final Throwable exception) {
+    errorCallBackMessages.add(errorMessage);
+    errorCallBackExceptions.add(exception);
+  }
+
+  private List<ProductUpdateAction> collectActions(
+      @Nonnull final List<ProductUpdateAction> actions,
+      @Nonnull final ProductDraft productDraft,
+      @Nonnull final ProductProjection productP) {
+    this.actions.addAll(actions);
+    return actions;
+  }
+
+  @AfterAll
+  static void tearDown() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
+  }
+
+  @Test
+  void
+      sync_withNestedCategoryReferenceAsAttribute_shouldCreateProductReferencingExistingCategory() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "category-reference",
+            CategoryReferenceBuilder.of().id(testCategory1.getKey()).build()
+        );
+
+    final Attribute categoryReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of().productType(productType.toResourceIdentifier()).name(ofEnglish("productName")).slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+                .products()
+                .withKey(productDraftWithCategoryReference.getKey())
+                .get()
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final Optional<Attribute> createdCategoryReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(categoryReferenceAttribute.getName());
+
+    assertThat(createdCategoryReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              final List<Attribute> value = (List<Attribute>) attribute.getValue();
+              final Attribute categoryReferenceAttr = value.get(0);
+              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
+              final CategoryReference categoryReferenceAttrValue = (CategoryReference) categoryReferenceAttr.getValue();
+              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory1.getId());
+            });
+  }
+
+  @Test
+  void sync_withSameNestedCategoryReferenceAsAttribute_shouldNotSyncAnythingNew() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "category-reference",
+            CategoryReferenceBuilder.of().id(testCategory1.getKey()).build());
+
+    final Attribute categoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of().productType(productType.toResourceIdentifier()).name(ofEnglish("productName"))
+    .slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    CTP_TARGET_CLIENT
+            .products()
+            .create(productDraftWithCategoryReference)
+            .execute()
+            .thenApply(ApiHttpResponse::getBody)
+        .toCompletableFuture()
+        .join();
+
+    final Map<String, Object> newNestedAttributeValue =
+            createNestedAttributeValueReferences(
+                    "category-reference",
+                    CategoryReferenceBuilder.of().id(testCategory1.getKey()).build());
+
+
+    final Attribute newProductReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+
+    final ProductVariantDraft newMasterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(newProductReferenceAttribute)
+            .build();
+
+    final ProductDraft newProductDraftWithProductReference =
+        ProductDraftBuilder.of()
+                .productType(productType.toResourceIdentifier()).name(ofEnglish("productName")).slug(ofEnglish("productSlug")).masterVariant(newMasterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(newProductDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+                .products()
+                .withKey(productDraftWithCategoryReference.getKey())
+                .get()
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final Optional<Attribute> createdCategoryReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(categoryReferenceAttribute.getName());
+
+    assertThat(createdCategoryReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              final List<Attribute> value = (List<Attribute>) attribute.getValue();
+              final Attribute categoryReferenceAttr = value.get(0);
+              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
+              final CategoryReference categoryReferenceAttrValue = (CategoryReference) categoryReferenceAttr.getValue();
+              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory1.getId());
+            });
+  }
+
+  @Test
+  void
+      sync_withChangedNestedCategoryReferenceAsAttribute_shouldUpdateProductReferencingExistingCategory() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+            createNestedAttributeValueReferences(
+                    "category-reference",
+                    CategoryReferenceBuilder.of().id(testCategory1.getKey()).build());
+
+
+    final Attribute categoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of()
+                .productType(productType.toResourceIdentifier()).name(ofEnglish("productName")).slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    CTP_TARGET_CLIENT
+            .products()
+            .create(productDraftWithCategoryReference)
+            .executeBlocking();
+
+    final Map<String, Object> newNestedAttributeValue =
+            createNestedAttributeValueReferences(
+                    "category-reference",
+                    CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+
+    final Attribute newProductReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(newNestedAttributeValue)).build();
+
+    final ProductVariantDraft newMasterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(newProductReferenceAttribute)
+            .build();
+
+    final ProductDraft newProductDraftWithCategoryReference =
+        ProductDraftBuilder.of()
+                .productType(
+                productType.toResourceIdentifier()).name(ofEnglish("productName")).slug(ofEnglish("productSlug")).masterVariant(newMasterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(newProductDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+
+    final Map<String, Object> expectedNestedAttributeValue =
+            createNestedAttributeValueReferences(
+                    "category-reference",
+                    CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+
+    final Attribute expectedCategoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    assertThat(actions)
+        .containsExactly(
+                ProductSetAttributeActionBuilder.of().variantId(1L).name(expectedCategoryReferenceAttribute.getName()).value(expectedCategoryReferenceAttribute.getValue()).staged(true).build()
+        );
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+                .products()
+                .withKey(productDraftWithCategoryReference.getKey())
+                .get()
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final Optional<Attribute> createdCategoryReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(categoryReferenceAttribute.getName());
+
+    assertThat(createdCategoryReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              final List<Attribute> value = (List<Attribute>) attribute.getValue();
+              final Attribute categoryReferenceAttr = value.get(0);
+              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
+              final CategoryReference categoryReferenceAttrValue = (CategoryReference) categoryReferenceAttr.getValue();
+              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory2.getId());
+            });
+  }
+
+  @Test
+  void sync_withNonExistingNestedCategoryReferenceAsAttribute_ShouldFailCreatingTheProduct() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+            createNestedAttributeValueReferences(
+                    "category-reference",
+                    CategoryReferenceBuilder.of().id("getKey").build());
+
+    final Attribute categoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of()
+                .productType(productType.toResourceIdentifier())
+                .name(ofEnglish("productName"))
+    .slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
+    assertThat(errorCallBackExceptions)
+        .hasSize(1)
+        .singleElement()
+        .matches(
+            error -> {
+              assertThat(error).hasCauseExactlyInstanceOf(CompletionException.class);
+              final CompletionException completionException =
+                  (CompletionException) error.getCause();
+              assertThat(completionException).hasCauseExactlyInstanceOf(BadRequestException.class);
+              final BadRequestException badRequestException = (BadRequestException) completionException.getCause();
+              assertThat(badRequestException.getStatusCode()).isEqualTo(400);
+              assertThat(error.getMessage())
+                  .contains(
+                      "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference'.");
+              return true;
+            });
+    assertThat(errorCallBackMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains(
+            "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference'.");
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+  }
+
+  @Test
+  void
+      sync_withNestedCategoryReferenceSetAsAttribute_shouldCreateProductReferencingExistingCategories() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+        createNestedAttributeValueSetOfReferences(
+            "category-reference-set",
+            CategoryReferenceBuilder.of().id(testCategory1.getKey()).build(),
+            CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+
+    final Attribute categoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of()
+                .productType(productType.toResourceIdentifier())
+                .name(ofEnglish("productName"))
+    .slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+                .products()
+                .withKey(productDraftWithCategoryReference.getKey())
+                .get()
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final Optional<Attribute> createdCategoryReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(categoryReferenceAttribute.getName());
+
+    assertThat(createdCategoryReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              final List<Attribute> value = (List<Attribute>) attribute.getValue();
+              final Attribute categoryReferenceAttr = value.get(0);
+              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference-set");
+              final List<CategoryReference> categoryReferenceAttrValue = (List<CategoryReference>) categoryReferenceAttr.getValue();
+              assertThat(categoryReferenceAttrValue).hasSize(2)
+                      .anySatisfy(categoryReference -> categoryReference.getId().equals(testCategory1.getId()))
+                      .anySatisfy(categoryReference -> categoryReference.getId().equals(testCategory2.getId()));
+            });
+  }
+
+  @Test
+  void
+      sync_withNestedCategoryReferenceSetContainingANonExistingReference_shouldFailCreatingTheProduct() {
+    // preparation
+    final Map<String, Object> nestedAttributeValue =
+            createNestedAttributeValueSetOfReferences(
+                    "category-reference-set",
+                    CategoryReferenceBuilder.of().id(testCategory1.getKey()).build(),
+                    CategoryReferenceBuilder.of().id("nonExistingKey").build());
+
+    final Attribute categoryReferenceAttribute =
+            AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of().productType(productType.toResourceIdentifier())
+                .name(ofEnglish("productName")).slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
+    assertThat(errorCallBackExceptions)
+        .hasSize(1)
+        .singleElement()
+        .matches(
+            error -> {
+              assertThat(error).hasCauseExactlyInstanceOf(CompletionException.class);
+              final CompletionException completionException =
+                      (CompletionException) error.getCause();
+              assertThat(completionException).hasCauseExactlyInstanceOf(BadRequestException.class);
+              final BadRequestException badRequestException = (BadRequestException) completionException.getCause();
+              assertThat(badRequestException.getStatusCode()).isEqualTo(400);
+              assertThat(error.getMessage())
+                  .contains(
+                      "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference-set'.");
+              return true;
+            });
+    assertThat(errorCallBackMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains(
+            "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference-set'.");
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+  }
+
+  @Test
+  void
+      sync_withSetOfNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingCategories() {
+    // preparation
+//    final ArrayNode nestedAttributeValue =
+//        createArrayNode(
+//            createNestedAttributeValueSetOfReferences(
+//                "category-reference-set",
+//                createReferenceObject(testCategory1.getKey(), Category.referenceTypeId()),
+//                createReferenceObject(testCategory2.getKey(), Category.referenceTypeId())));
+
+      final Map<String, Object> nestedAttributeValue =
+              createNestedAttributeValueSetOfReferences(
+                      "category-reference-set",
+                      CategoryReferenceBuilder.of().id(testCategory1.getKey()).build(),
+                      CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+
+      final Attribute categoryReferenceAttribute =
+              AttributeBuilder.of().name("setOfNestedAttribute").value(List.of(List.of(nestedAttributeValue))).build();
+
+//      final AttributeDraft categoryReferenceAttribute =
+//        AttributeDraft.of("setOfNestedAttribute", createArrayNode(nestedAttributeValue));
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(categoryReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCategoryReference =
+        ProductDraftBuilder.of()
+                .productType(productType.toResourceIdentifier())
+                .name(ofEnglish("productName"))
+      .slug(ofEnglish("productSlug")).masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCategoryReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+                .products()
+                .withKey(productDraftWithCategoryReference.getKey())
+                .get()
+                .execute()
+                .thenApply(ApiHttpResponse::getBody)
+            .toCompletableFuture()
+            .join();
+
+    final Optional<Attribute> createdCategoryReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(categoryReferenceAttribute.getName());
+
+    assertThat(createdCategoryReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+                final List<Attribute> value = (List<Attribute>) attribute.getValue();
+                assertThat(value).isNotNull();
+
+//              final JsonNode setOfNestedAttributeNameField =
+//                  attribute.getValueAsJsonNode().get(0).get(0).get(ATTRIBUTE_NAME_FIELD);
+//              final JsonNode setOfNestedAttributeValueField =
+//                  attribute.getValueAsJsonNode().get(0).get(0).get(ATTRIBUTE_VALUE_FIELD);
+//
+//              assertThat(setOfNestedAttributeNameField.asText())
+//                  .isEqualTo("category-reference-set");
+//              assertThat(setOfNestedAttributeValueField).isInstanceOf(ArrayNode.class);
+//              final ArrayNode referenceSet = (ArrayNode) setOfNestedAttributeValueField;
+//              assertThat(referenceSet)
+//                  .hasSize(2)
+//                  .anySatisfy(
+//                      reference -> {
+//                        assertThat(reference.get(REFERENCE_TYPE_ID_FIELD).asText())
+//                            .isEqualTo(Category.referenceTypeId());
+//                        assertThat(reference.get(REFERENCE_ID_FIELD).asText())
+//                            .isEqualTo(testCategory1.getId());
+//                      })
+//                  .anySatisfy(
+//                      reference -> {
+//                        assertThat(reference.get(REFERENCE_TYPE_ID_FIELD).asText())
+//                            .isEqualTo(Category.referenceTypeId());
+//                        assertThat(reference.get(REFERENCE_ID_FIELD).asText())
+//                            .isEqualTo(testCategory2.getId());
+//                      });
+            });
+  }
+}

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedCustomObjectsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedCustomObjectsIT.java
@@ -1,38 +1,35 @@
 package com.commercetools.sync.integration.externalsource.products;
 
 import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.integration.commons.utils.CustomObjectITUtils.createCustomObject;
+import static com.commercetools.sync.integration.commons.utils.CustomObjectITUtils.deleteCustomObject;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
 import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
 import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.*;
 import static com.commercetools.sync.integration.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
 import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
 import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.*;
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
 import com.commercetools.api.client.error.BadRequestException;
-import com.commercetools.api.models.category.Category;
-import com.commercetools.api.models.category.CategoryDraft;
-import com.commercetools.api.models.category.CategoryDraftBuilder;
-import com.commercetools.api.models.category.CategoryReference;
-import com.commercetools.api.models.category.CategoryReferenceBuilder;
 import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.common.ReferenceTypeId;
+import com.commercetools.api.models.custom_object.CustomObject;
+import com.commercetools.api.models.custom_object.CustomObjectReference;
 import com.commercetools.api.models.product.*;
-import com.commercetools.api.models.product_type.AttributeDefinitionDraft;
-import com.commercetools.api.models.product_type.AttributeDefinitionDraftBuilder;
-import com.commercetools.api.models.product_type.ProductType;
-import com.commercetools.api.models.product_type.ProductTypeAddAttributeDefinitionActionBuilder;
-import com.commercetools.api.models.product_type.ProductTypeUpdateAction;
+import com.commercetools.api.models.product_type.*;
 import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
 import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
 import com.commercetools.sync.sdk2.products.ProductSync;
 import com.commercetools.sync.sdk2.products.ProductSyncOptions;
 import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
 import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
-import io.vrap.rmf.base.client.ApiHttpResponse;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,10 +40,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ProductSyncWithNestedReferencedCategoriesIT {
+class ProductSyncWithNestedReferencedCustomObjectsIT {
   private static ProductType productType;
-  private static Category testCategory1;
-  private static Category testCategory2;
+  private static CustomObject testCustomObject1;
+  private static CustomObject testCustomObject2;
 
   private ProductSyncOptions syncOptions;
   private List<String> errorCallBackMessages;
@@ -54,9 +51,16 @@ class ProductSyncWithNestedReferencedCategoriesIT {
   private List<Throwable> errorCallBackExceptions;
   private List<ProductUpdateAction> actions;
 
+  private static final String ATTRIBUTE_NAME_FIELD = "name";
+  private static final String ATTRIBUTE_VALUE_FIELD = "value";
+  private static final String CUSTOM_OBJECT_REFERENCE_ATTR_NAME = "customObject-reference";
+  private static final String CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME = "customObject-reference-set";
+
   @BeforeAll
   static void setup() {
     deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    deleteCustomObjects();
+
     productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
     final ProductType nestedProductType =
         createProductType(PRODUCT_TYPE_WITH_REFERENCES_RESOURCE_PATH, CTP_TARGET_CLIENT);
@@ -110,37 +114,22 @@ class ProductSyncWithNestedReferencedCategoriesIT {
         .update(productType, productTypeUpdateActions)
         .executeBlocking();
 
-    final CategoryDraft category1Draft =
-        CategoryDraftBuilder.of()
-            .name(ofEnglish("cat1-name"))
-            .slug(ofEnglish("cat1-slug"))
-            .key("cat1-key")
-            .build();
+    final ObjectNode customObject1Value =
+        JsonNodeFactory.instance.objectNode().put("name", "value1");
 
-    testCategory1 =
-        CTP_TARGET_CLIENT
-            .categories()
-            .create(category1Draft)
-            .execute()
-            .thenApply(ApiHttpResponse::getBody)
-            .toCompletableFuture()
-            .join();
+    testCustomObject1 =
+        createCustomObject(CTP_TARGET_CLIENT, "key1", "container1", customObject1Value);
 
-    final CategoryDraft category2Draft =
-        CategoryDraftBuilder.of()
-            .name(ofEnglish("cat2-name"))
-            .slug(ofEnglish("cat2-slug"))
-            .key("cat2-key")
-            .build();
+    final ObjectNode customObject2Value =
+        JsonNodeFactory.instance.objectNode().put("name", "value2");
 
-    testCategory2 =
-        CTP_TARGET_CLIENT
-            .categories()
-            .create(category2Draft)
-            .execute()
-            .thenApply(ApiHttpResponse::getBody)
-            .toCompletableFuture()
-            .join();
+    testCustomObject2 =
+        createCustomObject(CTP_TARGET_CLIENT, "key2", "container2", customObject2Value);
+  }
+
+  private static void deleteCustomObjects() {
+    deleteCustomObject(CTP_TARGET_CLIENT, "key1", "container1");
+    deleteCustomObject(CTP_TARGET_CLIENT, "key2", "container2");
   }
 
   @BeforeEach
@@ -167,7 +156,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
         .errorCallback(
             (syncException, draft, product, updateActions) ->
                 collectErrors(syncException.getMessage(), syncException))
-        .beforeUpdateCallback(this::collectActions)
+        .beforeUpdateCallback((actions1, productDraft, product1) -> collectActions(actions1))
         .warningCallback(warningCallback)
         .build();
   }
@@ -178,9 +167,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
   }
 
   private List<ProductUpdateAction> collectActions(
-      @Nonnull final List<ProductUpdateAction> actions,
-      @Nonnull final ProductDraft productDraft,
-      @Nonnull final ProductProjection productP) {
+      @Nonnull final List<ProductUpdateAction> actions) {
     this.actions.addAll(actions);
     return actions;
   }
@@ -188,28 +175,31 @@ class ProductSyncWithNestedReferencedCategoriesIT {
   @AfterAll
   static void tearDown() {
     deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    deleteCustomObjects();
   }
 
   @Test
   void
-      sync_withNestedCategoryReferenceAsAttribute_shouldCreateProductReferencingExistingCategory() {
+      sync_withNestedCustomObjectReferenceAsAttribute_shouldCreateProductReferencingExistingCustomObject() {
     // preparation
     final Attribute nestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference",
-            createReferenceObject(testCategory1.getKey(), CategoryReference.CATEGORY));
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                format("%s|%s", testCustomObject1.getContainer(), testCustomObject1.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute categoryReferenceAttribute =
+    final Attribute customObjectReferenceAttribute =
         AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
 
     final ProductVariantDraft masterVariant =
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
+            .attributes(customObjectReferenceAttribute)
             .build();
 
-    final ProductDraft productDraftWithCategoryReference =
+    final ProductDraft productDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -222,7 +212,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final ProductSync productSync = new ProductSync(syncOptions);
     final ProductSyncStatistics syncStatistics =
         productSync
-            .sync(singletonList(productDraftWithCategoryReference))
+            .sync(singletonList(productDraftWithCustomObjectReference))
             .toCompletableFuture()
             .join();
 
@@ -236,51 +226,55 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final Product createdProduct =
         CTP_TARGET_CLIENT
             .products()
-            .withKey(productDraftWithCategoryReference.getKey())
+            .withKey(productDraftWithCustomObjectReference.getKey())
             .get()
             .execute()
-            .thenApply(ApiHttpResponse::getBody)
             .toCompletableFuture()
-            .join();
+            .join()
+            .getBody();
 
-    final Optional<Attribute> createdCategoryReferenceAttribute =
+    final Optional<Attribute> createdCustomObjectReferenceAttribute =
         createdProduct
             .getMasterData()
             .getStaged()
             .getMasterVariant()
-            .findAttribute(categoryReferenceAttribute.getName());
+            .findAttribute(customObjectReferenceAttribute.getName());
 
-    assertThat(createdCategoryReferenceAttribute)
+    assertThat(createdCustomObjectReferenceAttribute)
         .hasValueSatisfying(
             attribute -> {
               final List<Attribute> value = (List<Attribute>) attribute.getValue();
-              final Attribute categoryReferenceAttr = value.get(0);
-              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
-              final CategoryReference categoryReferenceAttrValue =
-                  (CategoryReference) categoryReferenceAttr.getValue();
-              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory1.getId());
+              final Attribute customObjectReferenceAttr = value.get(0);
+              assertThat(customObjectReferenceAttr.getName())
+                  .isEqualTo(CUSTOM_OBJECT_REFERENCE_ATTR_NAME);
+              assertThat(customObjectReferenceAttr.getValue())
+                  .isInstanceOf(CustomObjectReference.class);
+              final CustomObjectReference ref =
+                  (CustomObjectReference) customObjectReferenceAttr.getValue();
+              assertThat(ref.getId()).isEqualTo(testCustomObject1.getId());
             });
   }
 
   @Test
-  void sync_withSameNestedCategoryReferenceAsAttribute_shouldNotSyncAnythingNew() {
+  void sync_withSameNestedCustomObjectReferenceAsAttribute_shouldNotSyncAnythingNew() {
     // preparation
     final Attribute nestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference",
-            createReferenceObject(testCategory1.getId(), CategoryReference.CATEGORY));
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                testCustomObject1.getId(), CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute categoryReferenceAttribute =
+    final Attribute customObjectReferenceAttribute =
         AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
 
     final ProductVariantDraft masterVariant =
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
+            .attributes(customObjectReferenceAttribute)
             .build();
 
-    final ProductDraft productDraftWithCategoryReference =
+    final ProductDraft productDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -289,20 +283,16 @@ class ProductSyncWithNestedReferencedCategoriesIT {
             .key("new-product")
             .build();
 
-    CTP_TARGET_CLIENT
-        .products()
-        .post(productDraftWithCategoryReference)
-        .execute()
-        .thenApply(ApiHttpResponse::getBody)
-        .toCompletableFuture()
-        .join();
+    CTP_TARGET_CLIENT.products().post(productDraftWithCustomObjectReference).executeBlocking();
 
     final Attribute newNestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference",
-            createReferenceObject(testCategory1.getKey(), CategoryReference.CATEGORY));
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                format("%s|%s", testCustomObject1.getContainer(), testCustomObject1.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute newProductReferenceAttribute =
+    final Attribute newCustomObjectReferenceAttribute =
         AttributeBuilder.of()
             .name("nestedAttribute")
             .value(List.of(newNestedAttributeValue))
@@ -312,10 +302,10 @@ class ProductSyncWithNestedReferencedCategoriesIT {
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(newProductReferenceAttribute)
+            .attributes(newCustomObjectReferenceAttribute)
             .build();
 
-    final ProductDraft newProductDraftWithProductReference =
+    final ProductDraft newProductDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -328,7 +318,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final ProductSync productSync = new ProductSync(syncOptions);
     final ProductSyncStatistics syncStatistics =
         productSync
-            .sync(singletonList(newProductDraftWithProductReference))
+            .sync(singletonList(newProductDraftWithCustomObjectReference))
             .toCompletableFuture()
             .join();
 
@@ -342,52 +332,56 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final Product createdProduct =
         CTP_TARGET_CLIENT
             .products()
-            .withKey(productDraftWithCategoryReference.getKey())
+            .withKey(productDraftWithCustomObjectReference.getKey())
             .get()
             .execute()
-            .thenApply(ApiHttpResponse::getBody)
             .toCompletableFuture()
-            .join();
+            .join()
+            .getBody();
 
-    final Optional<Attribute> createdCategoryReferenceAttribute =
+    final Optional<Attribute> createdCustomObjectReferenceAttribute =
         createdProduct
             .getMasterData()
             .getStaged()
             .getMasterVariant()
-            .findAttribute(categoryReferenceAttribute.getName());
+            .findAttribute(customObjectReferenceAttribute.getName());
 
-    assertThat(createdCategoryReferenceAttribute)
+    assertThat(createdCustomObjectReferenceAttribute)
         .hasValueSatisfying(
             attribute -> {
               final List<Attribute> value = (List<Attribute>) attribute.getValue();
-              final Attribute categoryReferenceAttr = value.get(0);
-              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
-              final CategoryReference categoryReferenceAttrValue =
-                  (CategoryReference) categoryReferenceAttr.getValue();
-              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory1.getId());
+              final Attribute customObjectReferenceAttr = value.get(0);
+              assertThat(customObjectReferenceAttr.getName())
+                  .isEqualTo(CUSTOM_OBJECT_REFERENCE_ATTR_NAME);
+              assertThat(customObjectReferenceAttr.getValue())
+                  .isInstanceOf(CustomObjectReference.class);
+              final CustomObjectReference ref =
+                  (CustomObjectReference) customObjectReferenceAttr.getValue();
+              assertThat(ref.getId()).isEqualTo(testCustomObject1.getId());
             });
   }
 
   @Test
   void
-      sync_withChangedNestedCategoryReferenceAsAttribute_shouldUpdateProductReferencingExistingCategory() {
+      sync_withChangedNestedCustomObjectReferenceAsAttribute_shouldUpdateProductReferencingExistingCustomObject() {
     // preparation
     final Attribute nestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference",
-            createReferenceObject(testCategory1.getId(), CategoryReference.CATEGORY));
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                testCustomObject1.getId(), CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute categoryReferenceAttribute =
+    final Attribute customObjectReferenceAttribute =
         AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
 
     final ProductVariantDraft masterVariant =
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
+            .attributes(customObjectReferenceAttribute)
             .build();
 
-    final ProductDraft productDraftWithCategoryReference =
+    final ProductDraft productDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -396,13 +390,16 @@ class ProductSyncWithNestedReferencedCategoriesIT {
             .key("new-product")
             .build();
 
-    CTP_TARGET_CLIENT.products().create(productDraftWithCategoryReference).executeBlocking();
+    CTP_TARGET_CLIENT.products().post(productDraftWithCustomObjectReference).executeBlocking();
 
     final Attribute newNestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference", CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                format("%s|%s", testCustomObject2.getContainer(), testCustomObject2.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute newProductReferenceAttribute =
+    final Attribute newCustomObjectReferenceAttribute =
         AttributeBuilder.of()
             .name("nestedAttribute")
             .value(List.of(newNestedAttributeValue))
@@ -412,10 +409,10 @@ class ProductSyncWithNestedReferencedCategoriesIT {
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(newProductReferenceAttribute)
+            .attributes(newCustomObjectReferenceAttribute)
             .build();
 
-    final ProductDraft newProductDraftWithCategoryReference =
+    final ProductDraft newProductDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -428,7 +425,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final ProductSync productSync = new ProductSync(syncOptions);
     final ProductSyncStatistics syncStatistics =
         productSync
-            .sync(singletonList(newProductDraftWithCategoryReference))
+            .sync(singletonList(newProductDraftWithCustomObjectReference))
             .toCompletableFuture()
             .join();
 
@@ -440,70 +437,72 @@ class ProductSyncWithNestedReferencedCategoriesIT {
 
     final Attribute expectedNestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference", CategoryReferenceBuilder.of().id(testCategory2.getId()).build());
-
-    final Attribute expectedCategoryReferenceAttribute =
-        AttributeBuilder.of()
-            .name("nestedAttribute")
-            .value(List.of(expectedNestedAttributeValue))
-            .build();
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                testCustomObject2.getId(), CustomObjectReference.KEY_VALUE_DOCUMENT));
 
     assertThat(actions)
         .containsExactly(
             ProductSetAttributeActionBuilder.of()
                 .variantId(1L)
-                .name(expectedCategoryReferenceAttribute.getName())
-                .value(expectedCategoryReferenceAttribute.getValue())
+                .name("nestedAttribute")
+                .value(List.of(expectedNestedAttributeValue))
                 .staged(true)
                 .build());
 
     final Product createdProduct =
         CTP_TARGET_CLIENT
             .products()
-            .withKey(productDraftWithCategoryReference.getKey())
+            .withKey(productDraftWithCustomObjectReference.getKey())
             .get()
             .execute()
-            .thenApply(ApiHttpResponse::getBody)
             .toCompletableFuture()
-            .join();
+            .join()
+            .getBody();
 
-    final Optional<Attribute> createdCategoryReferenceAttribute =
+    final Optional<Attribute> createdCustomObjectReferenceAttribute =
         createdProduct
             .getMasterData()
             .getStaged()
             .getMasterVariant()
-            .findAttribute(categoryReferenceAttribute.getName());
+            .findAttribute(customObjectReferenceAttribute.getName());
 
-    assertThat(createdCategoryReferenceAttribute)
+    assertThat(createdCustomObjectReferenceAttribute)
         .hasValueSatisfying(
             attribute -> {
               final List<Attribute> value = (List<Attribute>) attribute.getValue();
-              final Attribute categoryReferenceAttr = value.get(0);
-              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference");
-              final CategoryReference categoryReferenceAttrValue =
-                  (CategoryReference) categoryReferenceAttr.getValue();
-              assertThat(categoryReferenceAttrValue.getId()).isEqualTo(testCategory2.getId());
+              final Attribute customObjectReferenceAttr = value.get(0);
+              assertThat(customObjectReferenceAttr.getName())
+                  .isEqualTo(CUSTOM_OBJECT_REFERENCE_ATTR_NAME);
+              assertThat(customObjectReferenceAttr.getValue())
+                  .isInstanceOf(CustomObjectReference.class);
+              final CustomObjectReference ref =
+                  (CustomObjectReference) customObjectReferenceAttr.getValue();
+              assertThat(ref.getId()).isEqualTo(testCustomObject2.getId());
             });
   }
 
   @Test
-  void sync_withNonExistingNestedCategoryReferenceAsAttribute_ShouldFailCreatingTheProduct() {
+  void sync_withNonExistingNestedCustomObjectReferenceAsAttribute_ShouldFailCreatingTheProduct() {
     // preparation
     final Attribute nestedAttributeValue =
         createNestedAttributeValueReferences(
-            "category-reference", CategoryReferenceBuilder.of().id("nonExistingKey").build());
+            CUSTOM_OBJECT_REFERENCE_ATTR_NAME,
+            createReferenceObject(
+                "non-existing-container|non-existing-key",
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute categoryReferenceAttribute =
+    final Attribute customObjectReferenceAttribute =
         AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
 
     final ProductVariantDraft masterVariant =
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
+            .attributes(customObjectReferenceAttribute)
             .build();
 
-    final ProductDraft productDraftWithCategoryReference =
+    final ProductDraft productDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -516,7 +515,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final ProductSync productSync = new ProductSync(syncOptions);
     final ProductSyncStatistics syncStatistics =
         productSync
-            .sync(singletonList(productDraftWithCategoryReference))
+            .sync(singletonList(productDraftWithCustomObjectReference))
             .toCompletableFuture()
             .join();
 
@@ -536,39 +535,45 @@ class ProductSyncWithNestedReferencedCategoriesIT {
               assertThat(badRequestException.getStatusCode()).isEqualTo(400);
               assertThat(error.getMessage())
                   .contains(
-                      "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference'.");
+                      "The value '{\\\"id\\\":\\\"non-existing-container|non-existing-key\\\",\\\"typeId\\\":\\\"key-value-document\\\"}' "
+                          + "is not valid for field 'nestedAttribute.customObject-reference'.");
               return true;
             });
     assertThat(errorCallBackMessages)
         .hasSize(1)
         .singleElement(as(STRING))
         .contains(
-            "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference'.");
+            "The value '{\\\"id\\\":\\\"non-existing-container|non-existing-key\\\",\\\"typeId\\\":\\\"key-value-document\\\"}' "
+                + "is not valid for field 'nestedAttribute.customObject-reference'.");
     assertThat(warningCallBackMessages).isEmpty();
     assertThat(actions).isEmpty();
   }
 
   @Test
   void
-      sync_withNestedCategoryReferenceSetAsAttribute_shouldCreateProductReferencingExistingCategories() {
+      sync_withNestedCustomObjectReferenceSetAsAttribute_shouldCreateProductReferencingExistingCustomObjects() {
     // preparation
     final Attribute nestedAttributeValue =
         createNestedAttributeValueSetOfReferences(
-            "category-reference-set",
-            createReferenceObject(testCategory1.getKey(), CategoryReference.CATEGORY),
-            CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
+            CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME,
+            createReferenceObject(
+                format("%s|%s", testCustomObject1.getContainer(), testCustomObject1.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT),
+            createReferenceObject(
+                format("%s|%s", testCustomObject2.getContainer(), testCustomObject2.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
 
-    final Attribute categoryReferenceAttribute =
+    final Attribute customObjectReferenceAttribute =
         AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
 
     final ProductVariantDraft masterVariant =
         ProductVariantDraftBuilder.of()
             .sku("sku")
             .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
+            .attributes(customObjectReferenceAttribute)
             .build();
 
-    final ProductDraft productDraftWithCategoryReference =
+    final ProductDraft productDraftWithCustomObjectReference =
         ProductDraftBuilder.of()
             .productType(productType.toResourceIdentifier())
             .name(ofEnglish("productName"))
@@ -581,7 +586,7 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final ProductSync productSync = new ProductSync(syncOptions);
     final ProductSyncStatistics syncStatistics =
         productSync
-            .sync(singletonList(productDraftWithCategoryReference))
+            .sync(singletonList(productDraftWithCustomObjectReference))
             .toCompletableFuture()
             .join();
 
@@ -595,186 +600,210 @@ class ProductSyncWithNestedReferencedCategoriesIT {
     final Product createdProduct =
         CTP_TARGET_CLIENT
             .products()
-            .withKey(productDraftWithCategoryReference.getKey())
+            .withKey(productDraftWithCustomObjectReference.getKey())
             .get()
             .execute()
-            .thenApply(ApiHttpResponse::getBody)
             .toCompletableFuture()
-            .join();
+            .join()
+            .getBody();
 
-    final Optional<Attribute> createdCategoryReferenceAttribute =
+    final Optional<Attribute> createdCustomObjectReferenceAttribute =
         createdProduct
             .getMasterData()
             .getStaged()
             .getMasterVariant()
-            .findAttribute(categoryReferenceAttribute.getName());
+            .findAttribute(customObjectReferenceAttribute.getName());
 
-    assertThat(createdCategoryReferenceAttribute)
+    assertThat(createdCustomObjectReferenceAttribute)
         .hasValueSatisfying(
             attribute -> {
-              final List<Attribute> value = (List<Attribute>) attribute.getValue();
-              final Attribute categoryReferenceAttr = value.get(0);
-              assertThat(categoryReferenceAttr.getName()).isEqualTo("category-reference-set");
-              final List<CategoryReference> categoryReferenceAttrValue =
-                  (List<CategoryReference>) categoryReferenceAttr.getValue();
-              assertThat(categoryReferenceAttrValue)
-                  .hasSize(2)
-                  .anySatisfy(
-                      categoryReference -> categoryReference.getId().equals(testCategory1.getId()))
-                  .anySatisfy(
-                      categoryReference -> categoryReference.getId().equals(testCategory2.getId()));
-            });
-  }
-
-  @Test
-  void
-      sync_withNestedCategoryReferenceSetContainingANonExistingReference_shouldFailCreatingTheProduct() {
-    // preparation
-    final Attribute nestedAttributeValue =
-        createNestedAttributeValueSetOfReferences(
-            "category-reference-set",
-            createReferenceObject(testCategory1.getKey(), CategoryReference.CATEGORY),
-            CategoryReferenceBuilder.of().id("nonExistingKey").build());
-
-    final Attribute categoryReferenceAttribute =
-        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
-
-    final ProductVariantDraft masterVariant =
-        ProductVariantDraftBuilder.of()
-            .sku("sku")
-            .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
-            .build();
-
-    final ProductDraft productDraftWithCategoryReference =
-        ProductDraftBuilder.of()
-            .productType(productType.toResourceIdentifier())
-            .name(ofEnglish("productName"))
-            .slug(ofEnglish("productSlug"))
-            .masterVariant(masterVariant)
-            .key("new-product")
-            .build();
-
-    // test
-    final ProductSync productSync = new ProductSync(syncOptions);
-    final ProductSyncStatistics syncStatistics =
-        productSync
-            .sync(singletonList(productDraftWithCategoryReference))
-            .toCompletableFuture()
-            .join();
-
-    // assertion
-    assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
-    assertThat(errorCallBackExceptions)
-        .hasSize(1)
-        .singleElement()
-        .matches(
-            error -> {
-              assertThat(error).hasCauseExactlyInstanceOf(CompletionException.class);
-              final CompletionException completionException =
-                  (CompletionException) error.getCause();
-              assertThat(completionException).hasCauseExactlyInstanceOf(BadRequestException.class);
-              final BadRequestException badRequestException =
-                  (BadRequestException) completionException.getCause();
-              assertThat(badRequestException.getStatusCode()).isEqualTo(400);
-              assertThat(error.getMessage())
-                  .contains(
-                      "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference-set'.");
-              return true;
-            });
-    assertThat(errorCallBackMessages)
-        .hasSize(1)
-        .singleElement(as(STRING))
-        .contains(
-            "The value '{\\\"id\\\":\\\"nonExistingKey\\\",\\\"typeId\\\":\\\"category\\\"}' is not valid for field 'nestedAttribute.category-reference-set'.");
-    assertThat(warningCallBackMessages).isEmpty();
-    assertThat(actions).isEmpty();
-  }
-
-  @Test
-  void
-      sync_withSetOfNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingCategories() {
-    // preparation
-    final Attribute nestedAttributeValue =
-        createNestedAttributeValueSetOfReferences(
-            "category-reference-set",
-            createReferenceObject(testCategory1.getKey(), CategoryReference.CATEGORY),
-            CategoryReferenceBuilder.of().id(testCategory2.getKey()).build());
-
-    final Attribute categoryReferenceAttribute =
-        AttributeBuilder.of()
-            .name("setOfNestedAttribute")
-            .value(List.of(List.of(nestedAttributeValue)))
-            .build();
-
-    final ProductVariantDraft masterVariant =
-        ProductVariantDraftBuilder.of()
-            .sku("sku")
-            .key("new-product-master-variant")
-            .attributes(categoryReferenceAttribute)
-            .build();
-
-    final ProductDraft productDraftWithCategoryReference =
-        ProductDraftBuilder.of()
-            .productType(productType.toResourceIdentifier())
-            .name(ofEnglish("productName"))
-            .slug(ofEnglish("productSlug"))
-            .masterVariant(masterVariant)
-            .key("new-product")
-            .build();
-
-    // test
-    final ProductSync productSync = new ProductSync(syncOptions);
-    final ProductSyncStatistics syncStatistics =
-        productSync
-            .sync(singletonList(productDraftWithCategoryReference))
-            .toCompletableFuture()
-            .join();
-
-    // assertion
-    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
-    assertThat(errorCallBackExceptions).isEmpty();
-    assertThat(errorCallBackMessages).isEmpty();
-    assertThat(warningCallBackMessages).isEmpty();
-    assertThat(actions).isEmpty();
-
-    final Product createdProduct =
-        CTP_TARGET_CLIENT
-            .products()
-            .withKey(productDraftWithCategoryReference.getKey())
-            .get()
-            .execute()
-            .thenApply(ApiHttpResponse::getBody)
-            .toCompletableFuture()
-            .join();
-
-    final Optional<Attribute> createdCategoryReferenceAttribute =
-        createdProduct
-            .getMasterData()
-            .getStaged()
-            .getMasterVariant()
-            .findAttribute(categoryReferenceAttribute.getName());
-
-    assertThat(createdCategoryReferenceAttribute)
-        .hasValueSatisfying(
-            attribute -> {
-              final List<List<Attribute>> value = AttributeAccessor.asSetNested(attribute);
-              assertThat(value).isNotNull();
-              final Attribute nestedAttribute = value.get(0).get(0);
-              assertThat(nestedAttribute.getName()).isEqualTo("category-reference-set");
+              final List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              assertThat(nested).isNotNull();
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getName())
+                  .isEqualTo(CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME);
               assertThat(nestedAttribute.getValue()).isInstanceOf(List.class);
               final List<Reference> referenceList = (List<Reference>) nestedAttribute.getValue();
               assertThat(referenceList)
                   .hasSize(2)
                   .anySatisfy(
                       reference -> {
-                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.CATEGORY);
-                        assertThat(reference.getId()).isEqualTo(testCategory1.getId());
+                        assertThat(reference.getTypeId())
+                            .isEqualTo(ReferenceTypeId.KEY_VALUE_DOCUMENT);
+                        assertThat(reference.getId()).isEqualTo(testCustomObject1.getId());
                       })
                   .anySatisfy(
                       reference -> {
-                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.CATEGORY);
-                        assertThat(reference.getId()).isEqualTo(testCategory2.getId());
+                        assertThat(reference.getTypeId())
+                            .isEqualTo(ReferenceTypeId.KEY_VALUE_DOCUMENT);
+                        assertThat(reference.getId()).isEqualTo(testCustomObject2.getId());
+                      });
+            });
+  }
+
+  @Test
+  void
+      sync_withNestedCustomObjectReferenceSetContainingANonExistingReference_shouldFailCreatingTheProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueSetOfReferences(
+            CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME,
+            createReferenceObject(
+                format("%s|%s", testCustomObject1.getContainer(), testCustomObject1.getKey()),
+                CustomObjectReference.KEY_VALUE_DOCUMENT),
+            createReferenceObject(
+                "non-existing-container|non-existing-key",
+                CustomObjectReference.KEY_VALUE_DOCUMENT));
+
+    final Attribute customObjectReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(customObjectReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCustomObjectReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCustomObjectReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 1, 0);
+    assertThat(errorCallBackExceptions)
+        .hasSize(1)
+        .singleElement()
+        .matches(
+            error -> {
+              assertThat(error).hasCauseExactlyInstanceOf(CompletionException.class);
+              final CompletionException completionException =
+                  (CompletionException) error.getCause();
+              assertThat(completionException).hasCauseExactlyInstanceOf(BadRequestException.class);
+              final BadRequestException badRequestException =
+                  (BadRequestException) completionException.getCause();
+              assertThat(badRequestException.getStatusCode()).isEqualTo(400);
+              assertThat(error.getMessage())
+                  .contains(
+                      "The value '{\\\"id\\\":\\\"non-existing-container|non-existing-key\\\",\\\"typeId\\\":\\\"key-value-document\\\"}' "
+                          + "is not valid for field 'nestedAttribute.customObject-reference-set'.");
+              return true;
+            });
+    assertThat(errorCallBackMessages)
+        .hasSize(1)
+        .singleElement(as(STRING))
+        .contains(
+            "The value '{\\\"id\\\":\\\"non-existing-container|non-existing-key\\\",\\\"typeId\\\":\\\"key-value-document\\\"}' "
+                + "is not valid for field 'nestedAttribute.customObject-reference-set'.");
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+  }
+
+  @Test
+  void
+      sync_withSetOfNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingCustomObjects() {
+    // preparation
+    final List<Attribute> nestedAttributeValue =
+        List.of(
+            createNestedAttributeValueSetOfReferences(
+                CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME,
+                createReferenceObject(
+                    format("%s|%s", testCustomObject1.getContainer(), testCustomObject1.getKey()),
+                    CustomObjectReference.KEY_VALUE_DOCUMENT),
+                createReferenceObject(
+                    format("%s|%s", testCustomObject2.getContainer(), testCustomObject2.getKey()),
+                    CustomObjectReference.KEY_VALUE_DOCUMENT)));
+
+    final Attribute customObjectReferenceAttribute =
+        AttributeBuilder.of()
+            .name("setOfNestedAttribute")
+            .value(List.of(nestedAttributeValue))
+            .build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(customObjectReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithCustomObjectReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithCustomObjectReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithCustomObjectReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdCustomObjectReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(customObjectReferenceAttribute.getName());
+
+    assertThat(createdCustomObjectReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              final List<List<Attribute>> value = AttributeAccessor.asSetNested(attribute);
+              assertThat(value).isNotNull();
+              final Attribute nestedAttribute = value.get(0).get(0);
+              assertThat(nestedAttribute.getName())
+                  .isEqualTo(CUSTOM_OBJECT_REFERENCE_SET_ATTR_NAME);
+              assertThat(nestedAttribute.getValue()).isInstanceOf(List.class);
+              final List<Reference> referenceList = (List<Reference>) nestedAttribute.getValue();
+              assertThat(referenceList)
+                  .hasSize(2)
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId())
+                            .isEqualTo(ReferenceTypeId.KEY_VALUE_DOCUMENT);
+                        assertThat(reference.getId()).isEqualTo(testCustomObject1.getId());
+                      })
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId())
+                            .isEqualTo(ReferenceTypeId.KEY_VALUE_DOCUMENT);
+                        assertThat(reference.getId()).isEqualTo(testCustomObject2.getId());
                       });
             });
   }

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedProductsIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedProductsIT.java
@@ -1,0 +1,834 @@
+package com.commercetools.sync.integration.externalsource.products;
+
+import static com.commercetools.api.models.common.LocalizedString.ofEnglish;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteAllProducts;
+import static com.commercetools.sync.integration.commons.utils.ProductITUtils.deleteProductSyncTestData;
+import static com.commercetools.sync.integration.commons.utils.ProductTypeITUtils.*;
+import static com.commercetools.sync.integration.commons.utils.TestClientUtils.CTP_TARGET_CLIENT;
+import static com.commercetools.sync.sdk2.commons.asserts.statistics.AssertionsForStatistics.assertThat;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_TYPE_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.PRODUCT_TYPE_WITH_REFERENCES_RESOURCE_PATH;
+import static com.commercetools.sync.sdk2.products.ProductSyncMockUtils.createReferenceObject;
+import static com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl.CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.commercetools.api.models.common.Reference;
+import com.commercetools.api.models.common.ReferenceTypeId;
+import com.commercetools.api.models.product.*;
+import com.commercetools.api.models.product_type.*;
+import com.commercetools.sync.sdk2.commons.exceptions.SyncException;
+import com.commercetools.sync.sdk2.commons.models.WaitingToBeResolvedProducts;
+import com.commercetools.sync.sdk2.commons.utils.TriConsumer;
+import com.commercetools.sync.sdk2.products.ProductSync;
+import com.commercetools.sync.sdk2.products.ProductSyncOptions;
+import com.commercetools.sync.sdk2.products.ProductSyncOptionsBuilder;
+import com.commercetools.sync.sdk2.products.helpers.ProductSyncStatistics;
+import com.commercetools.sync.sdk2.services.impl.UnresolvedReferencesServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProductSyncWithNestedReferencedProductsIT {
+  private static ProductType productType;
+
+  private ProductSyncOptions syncOptions;
+  private Product testProduct1;
+  private Product testProduct2;
+  private List<String> errorCallBackMessages;
+  private List<String> warningCallBackMessages;
+  private List<Throwable> errorCallBackExceptions;
+  private List<ProductUpdateAction> actions;
+
+  @BeforeAll
+  static void setup() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
+    productType = createProductType(PRODUCT_TYPE_RESOURCE_PATH, CTP_TARGET_CLIENT);
+    final ProductType nestedProductType =
+        createProductType(PRODUCT_TYPE_WITH_REFERENCES_RESOURCE_PATH, CTP_TARGET_CLIENT);
+
+    final AttributeDefinitionDraft nestedAttributeDef =
+        AttributeDefinitionDraftBuilder.of()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .nestedBuilder()
+                        .typeReference(nestedProductType.toReference()))
+            .name("nestedAttribute")
+            .label(ofEnglish("nestedAttribute"))
+            .isRequired(false)
+            .isSearchable(false)
+            .build();
+
+    final AttributeDefinitionDraft setOfNestedAttributeDef =
+        AttributeDefinitionDraftBuilder.of()
+            .type(
+                attributeTypeBuilder ->
+                    attributeTypeBuilder
+                        .setBuilder()
+                        .elementType(
+                            attributeTypeBuilder1 ->
+                                attributeTypeBuilder1
+                                    .nestedBuilder()
+                                    .typeReference(nestedProductType.toReference())))
+            .name("setOfNestedAttribute")
+            .label(ofEnglish("setOfNestedAttribute"))
+            .isRequired(false)
+            .isSearchable(false)
+            .build();
+
+    final List<ProductTypeUpdateAction> addAttributeActions =
+        List.of(
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(nestedAttributeDef)
+                .build(),
+            ProductTypeAddAttributeDefinitionActionBuilder.of()
+                .attribute(setOfNestedAttributeDef)
+                .build());
+
+    CTP_TARGET_CLIENT.productTypes().update(productType, addAttributeActions).executeBlocking();
+  }
+
+  @BeforeEach
+  void setupTest() {
+    clearSyncTestCollections();
+    deleteAllProducts(CTP_TARGET_CLIENT);
+    syncOptions = buildSyncOptions();
+
+    final ProductDraft productDraft =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("foo"))
+            .slug(ofEnglish("foo-slug"))
+            .key("foo")
+            .build();
+
+    final ProductDraft productDraft2 =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("foo2"))
+            .slug(ofEnglish("foo-slug2"))
+            .key("foo2")
+            .build();
+
+    testProduct1 =
+        CTP_TARGET_CLIENT
+            .products()
+            .create(productDraft)
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+    testProduct2 =
+        CTP_TARGET_CLIENT
+            .products()
+            .create(productDraft2)
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+  }
+
+  private void clearSyncTestCollections() {
+    errorCallBackMessages = new ArrayList<>();
+    errorCallBackExceptions = new ArrayList<>();
+    warningCallBackMessages = new ArrayList<>();
+    actions = new ArrayList<>();
+  }
+
+  private ProductSyncOptions buildSyncOptions() {
+    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+        warningCallBack =
+            (syncException, productDraft, product) ->
+                warningCallBackMessages.add(syncException.getMessage());
+
+    return ProductSyncOptionsBuilder.of(CTP_TARGET_CLIENT)
+        .errorCallback(
+            (exception, draft, product, updateActions) ->
+                collectErrors(exception.getMessage(), exception))
+        .beforeUpdateCallback((actions1, productDraft, product1) -> collectActions(actions1))
+        .warningCallback(warningCallBack)
+        .build();
+  }
+
+  private void collectErrors(final String errorMessage, final Throwable exception) {
+    errorCallBackMessages.add(errorMessage);
+    errorCallBackExceptions.add(exception);
+  }
+
+  private List<ProductUpdateAction> collectActions(
+      @Nonnull final List<ProductUpdateAction> actions) {
+    this.actions.addAll(actions);
+    return actions;
+  }
+
+  @AfterAll
+  static void tearDown() {
+    deleteProductSyncTestData(CTP_TARGET_CLIENT);
+  }
+
+  @Test
+  void sync_withNestedAttributeWithTextAttribute_shouldCreateProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        AttributeBuilder.of().name("text-attr").value("text-attr-value").build();
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getValue()).isEqualTo("text-attr-value");
+              assertThat(nestedAttribute.getName()).isEqualTo("text-attr");
+            });
+  }
+
+  @Test
+  void sync_withNestedProductReferenceAsAttribute_shouldCreateProductReferencingExistingProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct1.getKey(), ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getName()).isEqualTo("product-reference");
+              final ProductReference attrValue = (ProductReference) nestedAttribute.getValue();
+              assertThat(attrValue.getId()).isEqualTo(testProduct1.getId());
+            });
+  }
+
+  @Test
+  void sync_withSameNestedProductReferenceAsAttribute_shouldNotSyncAnythingNew() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct1.getId(), ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    CTP_TARGET_CLIENT.products().create(productDraftWithProductReference).executeBlocking();
+
+    final Attribute newNestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct1.getKey(), ProductReference.PRODUCT));
+
+    final Attribute newProductReferenceAttribute =
+        AttributeBuilder.of()
+            .name("nestedAttribute")
+            .value(List.of(newNestedAttributeValue))
+            .build();
+
+    final ProductVariantDraft newMasterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(newProductReferenceAttribute)
+            .build();
+
+    final ProductDraft newProductDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(newMasterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(newProductDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getName()).isEqualTo("product-reference");
+              final ProductReference attrValue = (ProductReference) nestedAttribute.getValue();
+              assertThat(attrValue.getId()).isEqualTo(testProduct1.getId());
+            });
+  }
+
+  @Test
+  void
+      sync_withChangedNestedProductReferenceAsAttribute_shouldUpdateProductReferencingExistingProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct1.getId(), ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    CTP_TARGET_CLIENT.products().create(productDraftWithProductReference).executeBlocking();
+
+    final Attribute newNestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct2.getKey(), ProductReference.PRODUCT));
+
+    final Attribute newProductReferenceAttribute =
+        AttributeBuilder.of()
+            .name("nestedAttribute")
+            .value(List.of(newNestedAttributeValue))
+            .build();
+
+    final ProductVariantDraft newMasterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(newProductReferenceAttribute)
+            .build();
+
+    final ProductDraft newProductDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(newMasterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(newProductDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 1, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+
+    final Attribute expectedNestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference",
+            createReferenceObject(testProduct2.getId(), ProductReference.PRODUCT));
+
+    assertThat(actions)
+        .containsExactly(
+            ProductSetAttributeActionBuilder.of()
+                .variantId(1L)
+                .name("nestedAttribute")
+                .value(List.of(expectedNestedAttributeValue))
+                .staged(true)
+                .build());
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getName()).isEqualTo("product-reference");
+              final ProductReference attrValue = (ProductReference) nestedAttribute.getValue();
+              assertThat(attrValue.getId()).isEqualTo(testProduct2.getId());
+            });
+  }
+
+  @Test
+  void sync_withNonExistingNestedProductReferenceAsAttribute_ShouldFailCreatingTheProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueReferences(
+            "product-reference", createReferenceObject("nonExistingKey", ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0, 1);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final UnresolvedReferencesServiceImpl<WaitingToBeResolvedProducts> unresolvedReferencesService =
+        new UnresolvedReferencesServiceImpl<>(syncOptions);
+    final Set<WaitingToBeResolvedProducts> waitingToBeResolvedDrafts =
+        unresolvedReferencesService
+            .fetch(
+                Set.of(productDraftWithProductReference.getKey()),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(waitingToBeResolvedDrafts)
+        .singleElement()
+        .matches(
+            waitingToBeResolvedDraft -> {
+              assertThat(waitingToBeResolvedDraft.getProductDraft().getKey())
+                  .isEqualTo(productDraftWithProductReference.getKey());
+              assertThat(waitingToBeResolvedDraft.getMissingReferencedProductKeys())
+                  .containsExactly("nonExistingKey");
+              return true;
+            });
+  }
+
+  @Test
+  void
+      sync_withNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingProducts() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueSetOfReferences(
+            "product-reference-set",
+            createReferenceObject(testProduct1.getKey(), ProductReference.PRODUCT),
+            createReferenceObject(testProduct2.getKey(), ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<Attribute> nested = AttributeAccessor.asNested(attribute);
+              final Attribute nestedAttribute = nested.get(0);
+              assertThat(nestedAttribute.getName()).isEqualTo("product-reference-set");
+              final List<Reference> referenceSet =
+                  AttributeAccessor.asSetReference(nestedAttribute);
+              assertThat(referenceSet)
+                  .hasSize(2)
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.PRODUCT);
+                        assertThat(reference.getId()).isEqualTo(testProduct1.getId());
+                      })
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.PRODUCT);
+                        assertThat(reference.getId()).isEqualTo(testProduct2.getId());
+                      });
+            });
+  }
+
+  @Test
+  void
+      sync_withNestedProductReferenceSetContainingANonExistingReference_shouldFailCreatingTheProduct() {
+    // preparation
+    final Attribute nestedAttributeValue =
+        createNestedAttributeValueSetOfReferences(
+            "product-reference-set",
+            createReferenceObject(testProduct1.getKey(), ProductReference.PRODUCT),
+            createReferenceObject("nonExistingKey", ProductReference.PRODUCT));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of().name("nestedAttribute").value(List.of(nestedAttributeValue)).build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 0, 0, 0, 1);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final UnresolvedReferencesServiceImpl<WaitingToBeResolvedProducts> unresolvedReferencesService =
+        new UnresolvedReferencesServiceImpl<>(syncOptions);
+    final Set<WaitingToBeResolvedProducts> waitingToBeResolvedDrafts =
+        unresolvedReferencesService
+            .fetch(
+                Set.of(productDraftWithProductReference.getKey()),
+                CUSTOM_OBJECT_PRODUCT_CONTAINER_KEY,
+                WaitingToBeResolvedProducts.class)
+            .toCompletableFuture()
+            .join();
+
+    assertThat(waitingToBeResolvedDrafts)
+        .singleElement()
+        .matches(
+            waitingToBeResolvedDraft -> {
+              assertThat(waitingToBeResolvedDraft.getProductDraft().getKey())
+                  .isEqualTo(productDraftWithProductReference.getKey());
+              assertThat(waitingToBeResolvedDraft.getMissingReferencedProductKeys())
+                  .containsExactly("nonExistingKey");
+              return true;
+            });
+  }
+
+  @Test
+  void
+      sync_withSetOfNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingProducts() {
+    // preparation
+    final List<Attribute> nestedAttributeValue =
+        List.of(
+            createNestedAttributeValueSetOfReferences(
+                "product-reference-set",
+                createReferenceObject(testProduct1.getKey(), ProductReference.PRODUCT),
+                createReferenceObject(testProduct2.getKey(), ProductReference.PRODUCT)));
+
+    final Attribute productReferenceAttribute =
+        AttributeBuilder.of()
+            .name("setOfNestedAttribute")
+            .value(List.of(nestedAttributeValue))
+            .build();
+
+    final ProductVariantDraft masterVariant =
+        ProductVariantDraftBuilder.of()
+            .sku("sku")
+            .key("new-product-master-variant")
+            .attributes(productReferenceAttribute)
+            .build();
+
+    final ProductDraft productDraftWithProductReference =
+        ProductDraftBuilder.of()
+            .productType(productType.toResourceIdentifier())
+            .name(ofEnglish("productName"))
+            .slug(ofEnglish("productSlug"))
+            .masterVariant(masterVariant)
+            .key("new-product")
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(syncOptions);
+    final ProductSyncStatistics syncStatistics =
+        productSync
+            .sync(singletonList(productDraftWithProductReference))
+            .toCompletableFuture()
+            .join();
+
+    // assertion
+    assertThat(syncStatistics).hasValues(1, 1, 0, 0, 0);
+    assertThat(errorCallBackExceptions).isEmpty();
+    assertThat(errorCallBackMessages).isEmpty();
+    assertThat(warningCallBackMessages).isEmpty();
+    assertThat(actions).isEmpty();
+
+    final Product createdProduct =
+        CTP_TARGET_CLIENT
+            .products()
+            .withKey(productDraftWithProductReference.getKey())
+            .get()
+            .execute()
+            .toCompletableFuture()
+            .join()
+            .getBody();
+
+    final Optional<Attribute> createdProductReferenceAttribute =
+        createdProduct
+            .getMasterData()
+            .getStaged()
+            .getMasterVariant()
+            .findAttribute(productReferenceAttribute.getName());
+
+    assertThat(createdProductReferenceAttribute)
+        .hasValueSatisfying(
+            attribute -> {
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              assertThat(attribute.getValue()).isInstanceOf(List.class);
+              List<List<Attribute>> nested = AttributeAccessor.asSetNested(attribute);
+              final Attribute nestedAttribute = nested.get(0).get(0);
+              assertThat(nestedAttribute.getName()).isEqualTo("product-reference-set");
+              final List<Reference> referenceSet =
+                  AttributeAccessor.asSetReference(nestedAttribute);
+              assertThat(referenceSet)
+                  .hasSize(2)
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.PRODUCT);
+                        assertThat(reference.getId()).isEqualTo(testProduct1.getId());
+                      })
+                  .anySatisfy(
+                      reference -> {
+                        assertThat(reference.getTypeId()).isEqualTo(ReferenceTypeId.PRODUCT);
+                        assertThat(reference.getId()).isEqualTo(testProduct2.getId());
+                      });
+            });
+  }
+}

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/AttributeUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/AttributeUtils.java
@@ -5,12 +5,9 @@ import static java.util.Collections.*;
 import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.product.Attribute;
 import com.commercetools.api.models.product.AttributeAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vrap.rmf.base.client.utils.json.JsonUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 

--- a/src/main/java/com/commercetools/sync/sdk2/products/utils/AttributeUtils.java
+++ b/src/main/java/com/commercetools/sync/sdk2/products/utils/AttributeUtils.java
@@ -8,6 +8,7 @@ import com.commercetools.api.models.product.AttributeAccessor;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -15,7 +16,7 @@ public final class AttributeUtils {
 
   /**
    * Given an attribute this method checks if its value is of type "reference" or "set" of
-   * "reference" and transforms it's value into a {@link List} of {@link Reference}.
+   * "reference" and transforms its value into a {@link List} of {@link Reference}.
    *
    * @param attribute - Attribute to extract the References if exists.
    * @return - a {@link List} of {@link Reference} extracted from the given attribute or empty list
@@ -35,7 +36,7 @@ public final class AttributeUtils {
 
   /**
    * Given an attribute this method first checks if its of type "nested" or "set" of "nested" and
-   * transforms it's value into a {@link List} of {@link Attribute}. The resulting list is then
+   * transforms its value into a {@link List} of {@link Attribute}. The resulting list is then
    * mapped to type "reference" or "set" of "reference" depending on attributes' values types.
    *
    * @param attribute - Attribute to extract the Reference if exists
@@ -43,21 +44,24 @@ public final class AttributeUtils {
    *     if the attribute doesn't contain reference types.
    */
   public static List<Reference> getAttributeReferences(@Nonnull final Attribute attribute) {
-    List<Attribute> attributes;
-    final Object attrValue = attribute.getValue();
-    if (attrValue instanceof List && ((List) attrValue).stream().anyMatch(v -> v instanceof List)) {
-      final List<List<Attribute>> nestedSet = AttributeAccessor.asSetNested(attribute);
-      attributes = nestedSet.stream().flatMap(Collection::stream).collect(Collectors.toList());
-    } else if (attribute.getValue() instanceof List
-        && ((List) attribute.getValue()).stream().anyMatch(v -> v instanceof Attribute)) {
-      attributes = AttributeAccessor.asNested(attribute);
-    } else {
-      attributes = singletonList(attribute);
-    }
+      List<Attribute> attributes;
+      final Object attrValue = attribute.getValue();
+      if (attrValue instanceof List && ((List) attrValue).stream().anyMatch(v -> v instanceof List)) {
+          final List<List<Attribute>> nestedSet = AttributeAccessor.asSetNested(attribute);
+          attributes = nestedSet.stream().flatMap(Collection::stream).collect(Collectors.toList());
+      } else if (attrValue instanceof List) {
+          if (((List) attrValue).stream().anyMatch(v -> v instanceof Attribute)) {
+              attributes = AttributeAccessor.asNested(attribute);
+          } else if (attrValue instanceof List && ((List<?>) attrValue).stream().allMatch(value -> value instanceof Map)) {
 
-    return attributes.stream()
-        .map(AttributeUtils::getAttributeReference)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
+          }
+      } else {
+          attributes = singletonList(attribute);
+      }
+
+      return attributes.stream()
+              .map(AttributeUtils::getAttributeReference)
+              .flatMap(Collection::stream)
+              .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
#### Summary

JIRA: https://commercetools.atlassian.net/browse/DEVX-222

#### What's left

- Check how to resolve references in nested types with category references. Example: The test `sync_withNestedCategoryReferenceAsAttribute_shouldCreateProductReferencingExistingCategory` is currently failing. However, if you replace this: `CategoryReferenceBuilder.of().id(testCategory1.getKey()).build()` with `CategoryReferenceBuilder.of().id(testCategory1.geId()).build()` it will work. However, it needs to be able to resolve keys to IDs and this is not currently not done here: [getAttributeReferences()](https://github.com/commercetools/commercetools-sync-java/pull/1078/files#diff-295dccca8ffc2b852e948f6f82d12263e787cecde9a2e9b170c3541f9a7f2900R46)
- Finish the test `sync_withSetOfNestedProductReferenceSetAsAttribute_shouldCreateProductReferencingExistingCategories`
- Migrate `src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedCustomObjectsIT.java`, `src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncWithNestedReferencedProductsIT.java`



