### PR TITLE
Fix transitive dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # commercetools sync java
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/10.0.0/)
+[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/10.0.1/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 
@@ -60,26 +60,26 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>10.0.0</version>
+  <version>10.0.1</version>
 </dependency>
 ````
 
 #### Gradle
 
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:10.0.0'
+implementation 'com.commercetools:commercetools-sync-java:10.0.1'
 ````
 
 #### SBT 
 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "10.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "10.0.1"
 ````
 
 #### Ivy 
 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="10.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="10.0.1"/>
 ````
 
 **Note**: To avoid `commercetools JVM SDK` libraries version mismatch between projects.

--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,9 @@ apply from: "$rootDir/gradle-scripts/spotless.gradle"
 
 dependencies {
     implementation "com.commercetools.sdk:commercetools-http-client:${commercetoolsJavaSdkV2Version}"
-    implementation "com.commercetools.sdk:commercetools-sdk-java-api:${commercetoolsJavaSdkV2Version}"
     implementation "com.github.ben-manes.caffeine:caffeine:${caffeineVersion}"
     implementation "org.apache.commons:commons-text:${commonTextVersion}"
+    api "com.commercetools.sdk:commercetools-sdk-java-api:${commercetoolsJavaSdkV2Version}"
     api 'commons-io:commons-io:2.11.0'
     api 'commons-codec:commons-codec:1.16.0'
     api 'com.google.code.findbugs:annotations:3.0.1'

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 # commercetools sync
 [![CI](https://github.com/commercetools/commercetools-sync-java/workflows/CI/badge.svg)](https://github.com/commercetools/commercetools-sync-java/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/commercetools/commercetools-sync-java/branch/master/graph/badge.svg)](https://codecov.io/gh/commercetools/commercetools-sync-java)
-[![Benchmarks 10.0.0](https://img.shields.io/badge/Benchmarks-10.0.0-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
-[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-10.0.0-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/10.0.0/jar) 
-[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/10.0.0/)
+[![Benchmarks 10.0.1](https://img.shields.io/badge/Benchmarks-10.0.1-orange.svg)](https://commercetools.github.io/commercetools-sync-java/benchmarks/)
+[![Download from Maven Central](https://img.shields.io/badge/Maven_Central-10.0.1-blue.svg)](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/10.0.1/jar) 
+[![Javadoc](https://javadoc.io/badge2/com.commercetools/commercetools-sync-java/javadoc.svg?label=Javadoc)](https://commercetools.github.io/commercetools-sync-java/v/10.0.1/)
 [![Known Vulnerabilities](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646/badge.svg)](https://snyk.io/test/github/commercetools/commercetools-sync-java/4b2e26113d591bda158217c5dc1cf80a88665646)
 
 
@@ -40,18 +40,18 @@ Here are the most popular ones:
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>10.0.0</version>
+  <version>10.0.1</version>
 </dependency>
 ````
 #### Gradle
 ````groovy
-implementation 'com.commercetools:commercetools-sync-java:10.0.0'
+implementation 'com.commercetools:commercetools-sync-java:10.0.1'
 ````
 #### SBT 
 ````
-libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "10.0.0"
+libraryDependencies += "com.commercetools" % "commercetools-sync-java" % "10.0.1"
 ````
 #### Ivy 
 ````xml
-<dependency org="com.commercetools" name="commercetools-sync-java" rev="10.0.0"/>
+<dependency org="com.commercetools" name="commercetools-sync-java" rev="10.0.1"/>
 ````

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -27,6 +27,14 @@
 7. Add Migration guide section which specifies explicitly if there are breaking changes and how to tackle them.
 -->
 
+### 10.0.1 - Nov 14, 2023
+[Commits](https://github.com/commercetools/commercetools-sync-java/compare/10.0.0...10.0.1) |
+[Javadoc](https://commercetools.github.io/commercetools-sync-java/v/10.0.1/) |
+[Jar](https://search.maven.org/artifact/com.commercetools/commercetools-sync-java/10.0.1/jar)
+-
+- 🚧 **Bug fixes** (1)
+  - Make commercetools-sdk-java-v2 available as a transitive dependency
+
 ### 10.0.0 - Nov 6, 2023
 [Commits](https://github.com/commercetools/commercetools-sync-java/compare/9.2.3...10.0.0) |
 [Javadoc](https://commercetools.github.io/commercetools-sync-java/v/10.0.0/) |

--- a/docs/usage/QUICK_START.md
+++ b/docs/usage/QUICK_START.md
@@ -20,13 +20,13 @@
 <dependency>
   <groupId>com.commercetools</groupId>
   <artifactId>commercetools-sync-java</artifactId>
-  <version>10.0.0-beta.3</version>
+  <version>10.0.1</version>
 </dependency>
 ````
 - For Gradle users:
 ````groovy
 // Add commercetools-sync-java dependency.
-implementation 'com.commercetools:commercetools-sync-java:10.0.0-beta.3'
+implementation 'com.commercetools:commercetools-sync-java:10.0.1'
 ````
 
 ### 2. Setup Syncing Options


### PR DESCRIPTION
#### Summary

Make commercetools-java-sdk-v2 available as transitive dependency.
