### PR TITLE
Fix npe in state reference resolution utils

### DIFF
--- a/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/categories/utils/CategoryReferenceResolutionUtils.java
@@ -83,15 +83,7 @@ public final class CategoryReferenceResolutionUtils {
         getResourceIdentifierWithKey(
             category.getParent(),
             referenceIdToKeyCache,
-            (id, key) -> {
-              final CategoryResourceIdentifierBuilder builder =
-                  CategoryResourceIdentifierBuilder.of();
-              if (id == null) {
-                return builder.key(key).build();
-              } else {
-                return builder.id(id).build();
-              }
-            });
+            (id, key) -> CategoryResourceIdentifierBuilder.of().key(key).id(id).build());
     return CategoryDraftBuilder.of()
         .key(category.getKey())
         .slug(category.getSlug())

--- a/src/main/java/com/commercetools/sync/commons/utils/CustomTypeReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CustomTypeReferenceResolutionUtils.java
@@ -70,16 +70,11 @@ public final class CustomTypeReferenceResolutionUtils {
                                     SyncUtils.getResourceIdentifierWithKey(
                                         typeReference,
                                         referenceIdToKeyCache,
-                                        (id, key) -> {
-                                          final TypeResourceIdentifierBuilder builder =
-                                              TypeResourceIdentifierBuilder.of();
-                                          if (id == null) {
-
-                                            return builder.key(key).build();
-                                          } else {
-                                            return builder.id(id).build();
-                                          }
-                                        }))
+                                        (id, key) ->
+                                            TypeResourceIdentifierBuilder.of()
+                                                .key(key)
+                                                .id(id)
+                                                .build()))
                             .orElse(null))
                     .build())
         .orElse(null);

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
@@ -2,7 +2,6 @@ package com.commercetools.sync.commons.utils;
 
 import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.common.ResourceIdentifier;
-import com.commercetools.sync.services.impl.BaseTransformServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -71,8 +70,7 @@ public final class SyncUtils {
           @Nullable final String key,
           final BiFunction<String, String, ResourceIdentifierT> toResourceIdentifier) {
 
-    if (!StringUtils.isBlank(key)
-        && !BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER.equals(key)) {
+    if (!StringUtils.isBlank(key)) {
       return toResourceIdentifier.apply(null, key);
     }
     return toResourceIdentifier.apply(id, null);

--- a/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/SyncUtils.java
@@ -2,6 +2,7 @@ package com.commercetools.sync.commons.utils;
 
 import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.common.ResourceIdentifier;
+import com.commercetools.sync.services.impl.BaseTransformServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +71,8 @@ public final class SyncUtils {
           @Nullable final String key,
           final BiFunction<String, String, ResourceIdentifierT> toResourceIdentifier) {
 
-    if (!StringUtils.isEmpty(key)) {
+    if (!StringUtils.isBlank(key)
+        && !BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER.equals(key)) {
       return toResourceIdentifier.apply(null, key);
     }
     return toResourceIdentifier.apply(id, null);

--- a/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtils.java
@@ -81,15 +81,7 @@ public final class InventoryReferenceResolutionUtils {
         getResourceIdentifierWithKey(
             inventoryEntry.getSupplyChannel(),
             referenceIdToKeyCache,
-            (id, key) -> {
-              final ChannelResourceIdentifierBuilder builder =
-                  ChannelResourceIdentifierBuilder.of();
-              if (id == null) {
-                return builder.key(key).build();
-              } else {
-                return builder.id(id).build();
-              }
-            });
+            (id, key) -> ChannelResourceIdentifierBuilder.of().key(key).id(id).build());
     return InventoryEntryDraftBuilder.of()
         .sku(inventoryEntry.getSku())
         .quantityOnStock(inventoryEntry.getQuantityOnStock())

--- a/src/main/java/com/commercetools/sync/products/utils/PriceUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/PriceUtils.java
@@ -67,15 +67,7 @@ public class PriceUtils {
           getResourceIdentifierWithKey(
               channelReference,
               referenceIdToKeyCache,
-              (id, key) -> {
-                final ChannelResourceIdentifierBuilder builder =
-                    ChannelResourceIdentifierBuilder.of();
-                if (id == null) {
-                  return builder.key(key).build();
-                } else {
-                  return builder.id(id).build();
-                }
-              });
+              (id, key) -> ChannelResourceIdentifierBuilder.of().key(key).id(id).build());
     } else if (channelReference != null) {
       channelResourceIdentifier =
           ChannelResourceIdentifierBuilder.of().id(channelReference.getId()).build();

--- a/src/main/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtils.java
@@ -149,41 +149,19 @@ public final class ProductReferenceResolutionUtils {
                   getResourceIdentifierWithKey(
                       product.getProductType(),
                       referenceIdToKeyCache,
-                      (id, key) -> {
-                        final ProductTypeResourceIdentifierBuilder builder =
-                            ProductTypeResourceIdentifierBuilder.of();
-                        if (id == null) {
-                          return builder.key(key).build();
-                        } else {
-                          return builder.id(id).build();
-                        }
-                      });
+                      (id, key) ->
+                          ProductTypeResourceIdentifierBuilder.of().id(id).key(key).build());
               final TaxCategoryResourceIdentifier taxCategoryResourceIdentifier =
                   getResourceIdentifierWithKey(
                       product.getTaxCategory(),
                       referenceIdToKeyCache,
-                      (id, key) -> {
-                        final TaxCategoryResourceIdentifierBuilder builder =
-                            TaxCategoryResourceIdentifierBuilder.of();
-                        if (id == null) {
-                          return builder.key(key).build();
-                        } else {
-                          return builder.id(id).build();
-                        }
-                      });
+                      (id, key) ->
+                          TaxCategoryResourceIdentifierBuilder.of().key(key).id(id).build());
               final StateResourceIdentifier stateResourceIdentifier =
                   getResourceIdentifierWithKey(
                       product.getState(),
                       referenceIdToKeyCache,
-                      (id, key) -> {
-                        final StateResourceIdentifierBuilder builder =
-                            StateResourceIdentifierBuilder.of();
-                        if (id == null) {
-                          return builder.key(key).build();
-                        } else {
-                          return builder.id(id).build();
-                        }
-                      });
+                      (id, key) -> StateResourceIdentifierBuilder.of().key(key).id(id).build());
               return productDraftBuilder
                   .masterVariant(masterVariantDraftWithKeys)
                   .variants(variantDraftsWithKeys)

--- a/src/main/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtils.java
@@ -65,17 +65,35 @@ public final class StateReferenceResolutionUtils {
             state -> {
               final List<StateResourceIdentifier> newTransitions =
                   replaceTransitionIdsWithKeys(state, referenceIdToKeyCache);
-              return StateDraftBuilder.of()
-                  .key(state.getKey())
-                  .type(state.getType())
-                  .name(state.getName())
-                  .description(state.getDescription())
-                  .initial(state.getInitial())
-                  .roles(state.getRoles())
-                  .transitions(newTransitions)
-                  .build();
+              return getStateDraft(state, newTransitions);
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Creates a new {@link StateDraft} from given {@link State} and transitions as {@link
+   * java.util.List}&lt; {@link StateResourceIdentifier}&gt;
+   *
+   * @param state - template state to build the draft from
+   * @param newTransitions - transformed list of state resource identifiers
+   * @return a new {@link StateDraft} with all fields copied from the {@param state} and transitions
+   *     set {@param newTransitions} - it will return empty StateDraft if key or type are missing.
+   */
+  private static StateDraft getStateDraft(
+      State state, List<StateResourceIdentifier> newTransitions) {
+    if (state.getKey() != null && state.getType() != null) {
+      return StateDraftBuilder.of()
+          .key(state.getKey())
+          .type(state.getType())
+          .name(state.getName())
+          .description(state.getDescription())
+          .initial(state.getInitial())
+          .roles(state.getRoles())
+          .transitions(newTransitions)
+          .build();
+    } else {
+      return StateDraft.of();
+    }
   }
 
   @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.commons.utils;
 
+import static com.commercetools.sync.services.impl.BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -160,5 +161,41 @@ class SyncUtilsTest {
             referenceIdToKeyCache,
             (id, key) -> CategoryResourceIdentifierBuilder.of().id(id).key(key).build());
     assertThat(resourceIdentifier).isNull();
+  }
+
+  @Test
+  void getResourceIdentifierWithKey_WithNotCachedReference_ShouldReturnResourceIdentifierWithId() {
+    final String categoryId = UUID.randomUUID().toString();
+
+    final CategoryReference categoryReference =
+        CategoryReferenceBuilder.of().id(categoryId).build();
+
+    final CategoryResourceIdentifier resourceIdentifier =
+        SyncUtils.getResourceIdentifierWithKey(
+            categoryReference,
+            referenceIdToKeyCache,
+            (id, key) -> CategoryResourceIdentifierBuilder.of().id(id).key(key).build());
+
+    assertThat(resourceIdentifier).isNotNull();
+    assertThat(resourceIdentifier.getId()).isEqualTo(categoryId);
+  }
+
+  @Test
+  void
+      getResourceIdentifierWithKey_WithCachedReferenceIsEmptyPlaceholder_ShouldReturnResourceIdentifierWithId() {
+    final String categoryId = UUID.randomUUID().toString();
+    referenceIdToKeyCache.add(categoryId, KEY_IS_NOT_SET_PLACE_HOLDER);
+
+    final CategoryReference categoryReference =
+        CategoryReferenceBuilder.of().id(categoryId).build();
+
+    final CategoryResourceIdentifier resourceIdentifier =
+        SyncUtils.getResourceIdentifierWithKey(
+            categoryReference,
+            referenceIdToKeyCache,
+            (id, key) -> CategoryResourceIdentifierBuilder.of().id(id).key(key).build());
+
+    assertThat(resourceIdentifier).isNotNull();
+    assertThat(resourceIdentifier.getId()).isEqualTo(categoryId);
   }
 }

--- a/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/commons/utils/SyncUtilsTest.java
@@ -182,7 +182,7 @@ class SyncUtilsTest {
 
   @Test
   void
-      getResourceIdentifierWithKey_WithCachedReferenceIsEmptyPlaceholder_ShouldReturnResourceIdentifierWithId() {
+      getResourceIdentifierWithKey_WithCachedReferenceIsEmptyPlaceholder_ShouldReturnResourceIdentifierWithKeyPlaceholder() {
     final String categoryId = UUID.randomUUID().toString();
     referenceIdToKeyCache.add(categoryId, KEY_IS_NOT_SET_PLACE_HOLDER);
 
@@ -196,6 +196,6 @@ class SyncUtilsTest {
             (id, key) -> CategoryResourceIdentifierBuilder.of().id(id).key(key).build());
 
     assertThat(resourceIdentifier).isNotNull();
-    assertThat(resourceIdentifier.getId()).isEqualTo(categoryId);
+    assertThat(resourceIdentifier.getKey()).isEqualTo(KEY_IS_NOT_SET_PLACE_HOLDER);
   }
 }

--- a/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.sync.products.utils;
 
+import static com.commercetools.sync.services.impl.BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,7 +26,6 @@ import com.commercetools.sync.commons.utils.CaffeineReferenceIdToKeyCacheImpl;
 import com.commercetools.sync.commons.utils.ReferenceIdToKeyCache;
 import com.commercetools.sync.commons.utils.TestUtils;
 import com.commercetools.sync.products.ProductSyncMockUtils;
-import com.commercetools.sync.services.impl.BaseTransformServiceImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -439,9 +439,9 @@ class ProductTransformUtilsTest {
         .hasValueSatisfying(
             productDraft -> {
               assertThat(productDraft.getProductType().getKey())
-                  .isEqualTo(BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER);
+                  .isEqualTo(KEY_IS_NOT_SET_PLACE_HOLDER);
               assertThat(productDraft.getTaxCategory().getKey())
-                  .isEqualTo(BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER);
+                  .isEqualTo(KEY_IS_NOT_SET_PLACE_HOLDER);
             });
   }
 
@@ -451,9 +451,8 @@ class ProductTransformUtilsTest {
           throws Exception {
     // preparation
     final ProjectApiRoot sourceClient = mock(ProjectApiRoot.class);
-    referenceIdToKeyCache.add(
-        "cda0dbf7-b42e-40bf-8453-241d5b587f93",
-        BaseTransformServiceImpl.KEY_IS_NOT_SET_PLACE_HOLDER);
+    referenceIdToKeyCache.add("cda0dbf7-b42e-40bf-8453-241d5b587f93", KEY_IS_NOT_SET_PLACE_HOLDER);
+    referenceIdToKeyCache.add("ebbe95fb-2282-4f9a-8747-fbe440e02dc0", KEY_IS_NOT_SET_PLACE_HOLDER);
     final List<ProductProjection> productPage =
         Arrays.asList(
             ProductSyncMockUtils.createProductFromJson("product-with-unresolved-references.json"));
@@ -482,7 +481,6 @@ class ProductTransformUtilsTest {
             .join();
 
     // assertions
-
     final Optional<ProductDraft> productKey1 =
         productsResolved.stream()
             .filter(productDraft -> "productKeyResolved".equals(productDraft.getKey()))
@@ -490,8 +488,12 @@ class ProductTransformUtilsTest {
 
     assertThat(productKey1)
         .hasValueSatisfying(
-            productDraft ->
-                assertThat(productDraft.getProductType().getKey()).isEqualTo("productTypeKey"));
+            productDraft -> {
+              assertThat(productDraft.getProductType().getKey()).isEqualTo("productTypeKey");
+              assertThat(productDraft.getTaxCategory().getId())
+                  .isEqualTo("ebbe95fb-2282-4f9a-8747-fbe440e02dc0");
+              assertThat(productDraft.getTaxCategory().getKey()).isNull();
+            });
   }
 
   @Test

--- a/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
@@ -490,9 +490,7 @@ class ProductTransformUtilsTest {
         .hasValueSatisfying(
             productDraft -> {
               assertThat(productDraft.getProductType().getKey()).isEqualTo("productTypeKey");
-              assertThat(productDraft.getState().getId())
-                  .isEqualTo("ste95fb-2282-4f9a-8747-fbe440e02dcs0");
-              assertThat(productDraft.getState().getKey()).isNull();
+              assertThat(productDraft.getState().getKey()).isEqualTo(KEY_IS_NOT_SET_PLACE_HOLDER);
             });
   }
 

--- a/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductTransformUtilsTest.java
@@ -452,7 +452,7 @@ class ProductTransformUtilsTest {
     // preparation
     final ProjectApiRoot sourceClient = mock(ProjectApiRoot.class);
     referenceIdToKeyCache.add("cda0dbf7-b42e-40bf-8453-241d5b587f93", KEY_IS_NOT_SET_PLACE_HOLDER);
-    referenceIdToKeyCache.add("ebbe95fb-2282-4f9a-8747-fbe440e02dc0", KEY_IS_NOT_SET_PLACE_HOLDER);
+    referenceIdToKeyCache.add("ste95fb-2282-4f9a-8747-fbe440e02dcs0", KEY_IS_NOT_SET_PLACE_HOLDER);
     final List<ProductProjection> productPage =
         Arrays.asList(
             ProductSyncMockUtils.createProductFromJson("product-with-unresolved-references.json"));
@@ -490,9 +490,9 @@ class ProductTransformUtilsTest {
         .hasValueSatisfying(
             productDraft -> {
               assertThat(productDraft.getProductType().getKey()).isEqualTo("productTypeKey");
-              assertThat(productDraft.getTaxCategory().getId())
-                  .isEqualTo("ebbe95fb-2282-4f9a-8747-fbe440e02dc0");
-              assertThat(productDraft.getTaxCategory().getKey()).isNull();
+              assertThat(productDraft.getState().getId())
+                  .isEqualTo("ste95fb-2282-4f9a-8747-fbe440e02dcs0");
+              assertThat(productDraft.getState().getKey()).isNull();
             });
   }
 

--- a/src/test/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtilsTest.java
@@ -126,11 +126,27 @@ class StateReferenceResolutionUtilsTest {
     final State mockState = mock(State.class);
     when(mockState.getTransitions()).thenReturn(null);
 
-    // test
-    final List<StateDraft> referenceReplacedDrafts =
-        StateReferenceResolutionUtils.mapToStateDrafts(List.of(mockState), referenceIdToKeyCache);
+    // asserts
+    assertThat(
+            StateReferenceResolutionUtils.mapToStateDrafts(
+                    List.of(mockState), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(StateDraft.of());
 
-    assertThat(referenceReplacedDrafts.get(0)).isEqualTo(StateDraft.of());
+    when(mockState.getKey()).thenReturn("Any key");
+    assertThat(
+            StateReferenceResolutionUtils.mapToStateDrafts(
+                    List.of(mockState), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(StateDraft.of());
+
+    when(mockState.getKey()).thenReturn(null);
+    when(mockState.getType()).thenReturn(StateTypeEnum.LINE_ITEM_STATE);
+    assertThat(
+            StateReferenceResolutionUtils.mapToStateDrafts(
+                    List.of(mockState), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(StateDraft.of());
   }
 
   @Nonnull

--- a/src/test/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/states/utils/StateReferenceResolutionUtilsTest.java
@@ -120,6 +120,19 @@ class StateReferenceResolutionUtilsTest {
     assertThat(referenceReplacedDrafts.get(0).getTransitions()).isEqualTo(null);
   }
 
+  @Test
+  void mapToStateDrafts_WithMissingRequiredFields_ShouldNotFailAndReturnEmptyDraft() {
+    // preparation
+    final State mockState = mock(State.class);
+    when(mockState.getTransitions()).thenReturn(null);
+
+    // test
+    final List<StateDraft> referenceReplacedDrafts =
+        StateReferenceResolutionUtils.mapToStateDrafts(List.of(mockState), referenceIdToKeyCache);
+
+    assertThat(referenceReplacedDrafts.get(0)).isEqualTo(StateDraft.of());
+  }
+
   @Nonnull
   private static State getStateMock(@Nonnull final String key) {
     final State state = mock(State.class);


### PR DESCRIPTION
#### Summary
JIRA: https://commercetools.atlassian.net/browse/DEVX-277

#### Hints for Review
To avoid NPE thrown by StateDraftBuilder i've added a check for required fields and created empty draft in case of missing required (which will fail in sync() with proper error message because it'll be checked by BatchValidator).
This solution isn't discussed yet. Maybe you have other idea to handle this? Maybe the behavior before was already correct?