### PR TITLE
Fix NPE in Inventory entry reference resolution

### DIFF
--- a/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtils.java
@@ -11,12 +11,14 @@ import com.commercetools.api.models.channel.ChannelResourceIdentifierBuilder;
 import com.commercetools.api.models.inventory.InventoryEntry;
 import com.commercetools.api.models.inventory.InventoryEntryDraft;
 import com.commercetools.api.models.inventory.InventoryEntryDraftBuilder;
+import com.commercetools.api.models.type.CustomFieldsDraft;
 import com.commercetools.api.models.type.Type;
 import com.commercetools.api.models.type.TypeReference;
 import com.commercetools.api.models.type.TypeResourceIdentifier;
 import com.commercetools.sync.commons.utils.ReferenceIdToKeyCache;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Util class which provides utilities that can be used when syncing resources from a source
@@ -82,15 +84,40 @@ public final class InventoryReferenceResolutionUtils {
             inventoryEntry.getSupplyChannel(),
             referenceIdToKeyCache,
             (id, key) -> ChannelResourceIdentifierBuilder.of().key(key).id(id).build());
-    return InventoryEntryDraftBuilder.of()
-        .sku(inventoryEntry.getSku())
-        .quantityOnStock(inventoryEntry.getQuantityOnStock())
-        .expectedDelivery(inventoryEntry.getExpectedDelivery())
-        .restockableInDays(inventoryEntry.getRestockableInDays())
-        .key(inventoryEntry.getKey())
-        .custom(mapToCustomFieldsDraft(inventoryEntry, referenceIdToKeyCache))
-        .supplyChannel(channelResourceIdentifier)
-        .build();
+    final CustomFieldsDraft customFieldsDraft =
+        mapToCustomFieldsDraft(inventoryEntry, referenceIdToKeyCache);
+    return getInventoryEntryDraft(inventoryEntry, customFieldsDraft, channelResourceIdentifier);
+  }
+
+  /**
+   * Creates a new {@link InventoryEntryDraft} from given {@link InventoryEntry}, already mapped
+   * {@link CustomFieldsDraft} and channel as {@link ChannelResourceIdentifier}.
+   *
+   * @param inventoryEntry - a template inventoryEntry to build the draft from
+   * @param mappedCustomFields - a customFieldsDraft or null
+   * @param channel - a resource identifier representing the supply channel or null
+   * @return a new {@link InventoryEntryDraft} with all fields copied from the {@param
+   *     inventoryEntry} and custom fields set {@param mappedCustomFields} and supply channel with
+   *     {@param channel} resource identifier - it will return empty InventoryEntryDraft if sku or
+   *     quantityOnStock are missing.
+   */
+  private static InventoryEntryDraft getInventoryEntryDraft(
+      @Nonnull final InventoryEntry inventoryEntry,
+      @Nullable final CustomFieldsDraft mappedCustomFields,
+      @Nullable final ChannelResourceIdentifier channel) {
+    if (inventoryEntry.getSku() != null && inventoryEntry.getQuantityOnStock() != null) {
+      return InventoryEntryDraftBuilder.of()
+          .sku(inventoryEntry.getSku())
+          .quantityOnStock(inventoryEntry.getQuantityOnStock())
+          .expectedDelivery(inventoryEntry.getExpectedDelivery())
+          .restockableInDays(inventoryEntry.getRestockableInDays())
+          .key(inventoryEntry.getKey())
+          .custom(mappedCustomFields)
+          .supplyChannel(channel)
+          .build();
+    } else {
+      return InventoryEntryDraft.of();
+    }
   }
 
   private InventoryReferenceResolutionUtils() {}

--- a/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/inventories/utils/InventoryReferenceResolutionUtilsTest.java
@@ -125,4 +125,33 @@ class InventoryReferenceResolutionUtilsTest {
       assertThat(referenceReplacedDraft.getSupplyChannel()).isNull();
     }
   }
+
+  @Test
+  void mapToInventoryEntryDrafts_WithMissingRequiredFields_ShouldNotFailAndReturnEmptyDraft() {
+    // preparation
+    final InventoryEntry mockInventory = mock(InventoryEntry.class);
+    when(mockInventory.getQuantityOnStock()).thenReturn(null);
+
+    // asserts
+    assertThat(
+            InventoryReferenceResolutionUtils.mapToInventoryEntryDrafts(
+                    List.of(mockInventory), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(InventoryEntryDraft.of());
+
+    when(mockInventory.getSku()).thenReturn("Any sku");
+    assertThat(
+            InventoryReferenceResolutionUtils.mapToInventoryEntryDrafts(
+                    List.of(mockInventory), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(InventoryEntryDraft.of());
+
+    when(mockInventory.getSku()).thenReturn(null);
+    when(mockInventory.getQuantityOnStock()).thenReturn(1L);
+    assertThat(
+            InventoryReferenceResolutionUtils.mapToInventoryEntryDrafts(
+                    List.of(mockInventory), referenceIdToKeyCache)
+                .get(0))
+        .isEqualTo(InventoryEntryDraft.of());
+  }
 }


### PR DESCRIPTION
#### Summary
https://commercetools.atlassian.net/browse/DEVX-275

#### Description
To avoid NPE thrown by InventoryEntryDraftBuilder i've added a check for required fields and created empty draft in case of missing required (which will fail in sync() with proper error message because it'll be checked by BatchValidator).