### PR TITLE
Fix NullpointerException for products having a category but no order-hint

### DIFF
--- a/src/main/java/com/commercetools/sync/products/helpers/ProductReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductReferenceResolver.java
@@ -306,7 +306,7 @@ public final class ProductReferenceResolver
                     .map(
                         category -> {
                           keyToCategory.put(category.getKey(), category);
-                          if (categoryOrderHints != null) {
+                          if (categoryOrderHints != null && categoryOrderHints.values() != null) {
                             ofNullable(categoryOrderHints.values().get(category.getKey()))
                                 .ifPresent(
                                     orderHintValue ->

--- a/src/main/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtils.java
+++ b/src/main/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtils.java
@@ -262,7 +262,7 @@ public final class ProductReferenceResolutionUtils {
             if (referenceIdToKeyCache.containsKey(categoryId)) {
               final String categoryKey = referenceIdToKeyCache.get(categoryId);
 
-              if (categoryOrderHints != null) {
+              if (categoryOrderHints != null && categoryOrderHints.values() != null) {
                 final String categoryOrderHintValue = categoryOrderHints.values().get(categoryId);
                 if (categoryOrderHintValue != null) {
                   categoryOrderHintsMapWithKeys.put(categoryKey, categoryOrderHintValue);

--- a/src/test/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtilsTest.java
+++ b/src/test/java/com/commercetools/sync/products/utils/ProductReferenceResolutionUtilsTest.java
@@ -176,6 +176,33 @@ class ProductReferenceResolutionUtilsTest {
     assertThat(categoryOrderHintsWithKeys).isNull();
   }
 
+  @Test
+  void mapToCategoryReferencePair_WithEmptyReferences_ShouldNotReplaceIds() {
+    final String categoryId = UUID.randomUUID().toString();
+    final String categoryKey = "categoryKey1";
+    referenceIdToKeyCache.add(categoryId, categoryKey);
+
+    final CategoryOrderHints emptyCategoryOrderHints = CategoryOrderHints.of();
+
+    final List<CategoryReference> categoryReferences =
+        singletonList(CategoryReferenceBuilder.of().id(categoryId).build());
+    final ProductProjection product = getProductMock(categoryReferences, emptyCategoryOrderHints);
+
+    final CategoryResourceIdentifierPair categoryReferencePair =
+        ProductReferenceResolutionUtils.mapToCategoryReferencePair(product, referenceIdToKeyCache);
+
+    assertThat(categoryReferencePair).isNotNull();
+
+    final List<CategoryResourceIdentifier> categoryReferencesWithKeys =
+        categoryReferencePair.getCategoryResourceIdentifiers();
+    final CategoryOrderHints categoryOrderHintsWithKeys =
+        categoryReferencePair.getCategoryOrderHints();
+    assertThat(categoryReferencesWithKeys)
+        .extracting(ResourceIdentifier::getKey)
+        .containsExactlyInAnyOrder(categoryKey);
+    assertThat(categoryOrderHintsWithKeys).isEqualTo(emptyCategoryOrderHints);
+  }
+
   @Nonnull
   private static ProductProjection getProductMock(
       @Nonnull final List<CategoryReference> references,


### PR DESCRIPTION
#### Summary
The Product-Reference-Resolution is not covering the case where a product is assigned to a category, but has no order-hint set.

#### Description
Class `CategoryOrderHints` from the Commercetools-SDK has a `values()` method that is backed by a Map. The Map is only initialised when a order-hint is set, otherwise `values()` returns null.
So in case of a product having a category, but no order-hint, the `categoryOrderHints` of the product is not `null`, but its values-methods returns `null`.

This case was not covered, leading to a NullpointerException like

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because the return value of "com.commercetools.api.models.product.CategoryOrderHints.values()" is null
	at com.commercetools.sync.products.utils.ProductReferenceResolutionUtils.lambda$mapToCategoryReferencePair$7(ProductReferenceResolutionUtils.java:288)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at com.commercetools.sync.products.utils.ProductReferenceResolutionUtils.mapToCategoryReferencePair(ProductReferenceResolutionUtils.java:280)
	at com.commercetools.sync.products.utils.ProductReferenceResolutionUtils.lambda$mapToProductDrafts$3(ProductReferenceResolutionUtils.java:135)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
...

```

#### Relevant Issues
<!-- What are the relevant issues? Make sure there is an issue that this PR addresses here:
 https://github.com/commercetools/commercetools-sync-java/issues and add the number(s) here please.-->

#### Todo

- Tests
    - [x] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
Example-extract from ImpEx of a real product-projection:

```
  "categories": [
    {
      "typeId": "category",
      "id": "0194530c-2128-4da6-982b-7c2c876591f1"
    }
  ],
  "categoryOrderHints": {},
```
