### PR TITLE
fix(bug): products with no variants should be synced

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.adarshr.test-logger' version '4.0.0'
+    id 'org.ajoberstar.grgit' version '5.2.2'
     id "com.github.ben-manes.versions" version '0.51.0'
     id 'ru.vyarus.mkdocs' version '4.0.1' apply false
     id "com.github.spotbugs" version "6.0.9"

--- a/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
+++ b/src/integration-test/java/com/commercetools/sync/integration/externalsource/products/ProductSyncIT.java
@@ -78,6 +78,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -953,6 +954,65 @@ class ProductSyncIT {
     assertThat(errorCallBackExceptions).isEmpty();
     assertThat(errorCallBackMessages).isEmpty();
     assertThat(warningCallBackMessages).isEmpty();
+  }
+
+  @Test
+  void sync_shouldSyncProductsWithoutAnyVariants() {
+    // preparation
+    final List<ProductUpdateAction> updateActions = new ArrayList<>();
+    final TriConsumer<SyncException, Optional<ProductDraft>, Optional<ProductProjection>>
+        warningCallBack =
+            (exception, newResource, oldResource) ->
+                warningCallBackMessages.add(exception.getMessage());
+
+    final ProductSyncOptions customOptions =
+        ProductSyncOptionsBuilder.of(TestClientUtils.CTP_TARGET_CLIENT)
+            .errorCallback(
+                (exception, oldResource, newResource, actions) ->
+                    collectErrors(exception.getMessage(), exception.getCause()))
+            .warningCallback(warningCallBack)
+            .beforeUpdateCallback(
+                (actions, draft, old) -> {
+                  updateActions.addAll(actions);
+                  return actions;
+                })
+            .build();
+
+    String productKey1 = UUID.randomUUID().toString();
+
+    final ProductDraft productDraft1 =
+        ProductDraftBuilder.of()
+            .key(productKey1)
+            .productType(
+                ProductTypeResourceIdentifierBuilder.of().key(productType.getKey()).build())
+            .taxCategory((TaxCategoryResourceIdentifier) null)
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .description(LocalizedString.of(Locale.ENGLISH, "description"))
+            .categories(emptyList())
+            .publish(true)
+            .build();
+
+    final ProductDraft productDraft2 =
+        ProductDraftBuilder.of()
+            .key(productKey1)
+            .productType(
+                ProductTypeResourceIdentifierBuilder.of().key(productType.getKey()).build())
+            .taxCategory((TaxCategoryResourceIdentifier) null)
+            .name(LocalizedString.of(Locale.ENGLISH, "name"))
+            .slug(LocalizedString.of(Locale.ENGLISH, "slug"))
+            .description(LocalizedString.of(Locale.ENGLISH, "description2"))
+            .categories(emptyList())
+            .publish(true)
+            .build();
+
+    // test
+    final ProductSync productSync = new ProductSync(customOptions);
+    productSync.sync(singletonList(productDraft1)).toCompletableFuture().join();
+    final ProductSyncStatistics syncStatistics =
+        productSync.sync(singletonList(productDraft2)).toCompletableFuture().join();
+
+    assertThat(syncStatistics).hasValues(2, 1, 1, 0, 0);
   }
 
   @Test

--- a/src/main/java/com/commercetools/sync/products/helpers/ProductBatchValidator.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductBatchValidator.java
@@ -41,6 +41,10 @@ public class ProductBatchValidator
       "ProductDraft with name: %s doesn't have a key. "
           + "Please make sure all product drafts have keys.";
   static final String PRODUCT_DRAFT_IS_NULL = "ProductDraft is null.";
+
+  static final String PRODUCT_MASTER_VARIANT_DRAFT_IS_NULL =
+      "MasterVariant is null and Variants are not null for ProductDraft with key '%s'.";
+
   static final String PRODUCT_VARIANT_DRAFT_IS_NULL =
       "ProductVariantDraft at position '%d' of ProductDraft " + "with key '%s' is null.";
   static final String PRODUCT_VARIANT_DRAFT_SKU_NOT_SET =
@@ -151,7 +155,9 @@ public class ProductBatchValidator
   @Nonnull
   private List<ProductVariantDraft> getAllVariants(@Nonnull final ProductDraft productDraft) {
     final List<ProductVariantDraft> allVariants = new ArrayList<>();
-    allVariants.add(productDraft.getMasterVariant());
+    if (productDraft.getMasterVariant() != null) {
+      allVariants.add(productDraft.getMasterVariant());
+    }
     if (productDraft.getVariants() != null) {
       allVariants.addAll(
           productDraft.getVariants().stream()
@@ -203,10 +209,19 @@ public class ProductBatchValidator
       @Nonnull final ProductDraft productDraft) {
     final List<String> errorMessages = new ArrayList<>();
 
+    final ProductVariantDraft masterVariant = productDraft.getMasterVariant();
+    final List<ProductVariantDraft> variants = productDraft.getVariants();
+
+    if (masterVariant == null) {
+      if (variants != null && !variants.isEmpty()) {
+        errorMessages.add(format(PRODUCT_MASTER_VARIANT_DRAFT_IS_NULL, productDraft.getKey()));
+      }
+      return errorMessages;
+    }
+
     // don't filter the nulls
     final List<ProductVariantDraft> allVariants = new ArrayList<>();
-    allVariants.add(productDraft.getMasterVariant());
-    final List<ProductVariantDraft> variants = productDraft.getVariants();
+    allVariants.add(masterVariant);
     if (variants != null) {
       allVariants.addAll(variants);
     }

--- a/src/main/java/com/commercetools/sync/products/helpers/ProductReferenceResolver.java
+++ b/src/main/java/com/commercetools/sync/products/helpers/ProductReferenceResolver.java
@@ -161,10 +161,14 @@ public final class ProductReferenceResolver
   private CompletionStage<ProductDraftBuilder> resolveAllVariantsReferences(
       @Nonnull final ProductDraftBuilder draftBuilder) {
     final ProductVariantDraft masterVariantDraft = draftBuilder.getMasterVariant();
-    return variantReferenceResolver
-        .resolveReferences(masterVariantDraft)
-        .thenApply(draftBuilder::masterVariant)
-        .thenCompose(this::resolveVariantsReferences);
+    if (masterVariantDraft == null) {
+      return CompletableFuture.completedFuture(draftBuilder);
+    } else {
+      return variantReferenceResolver
+          .resolveReferences(masterVariantDraft)
+          .thenApply(draftBuilder::masterVariant)
+          .thenCompose(this::resolveVariantsReferences);
+    }
   }
 
   @Nonnull


### PR DESCRIPTION
#### Summary

According to the docs it is possible to create a product without any variants: https://docs.commercetools.com/api/projects/products#productdraft. This was not possible with java-sync. This PR fixes this inconsistency.
