### PR TITLE
SUPPORT-33245: increase cache size in order to circumvent null reference caused by LRU race condition

### DIFF
--- a/src/main/java/com/commercetools/sync/commons/utils/CaffeineReferenceIdToKeyCacheImpl.java
+++ b/src/main/java/com/commercetools/sync/commons/utils/CaffeineReferenceIdToKeyCacheImpl.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 public class CaffeineReferenceIdToKeyCacheImpl implements ReferenceIdToKeyCache {
   private static final Cache<String, String> referenceIdToKeyCache =
-      Caffeine.newBuilder().maximumSize(10_000).executor(Runnable::run).build();
+      Caffeine.newBuilder().maximumSize(1_000_000).executor(Runnable::run).build();
 
   public CaffeineReferenceIdToKeyCacheImpl() {}
 


### PR DESCRIPTION
#### Summary
This PR increases the cache size in order to circumvent evictions that are caused by a race condition. The race condition leads the code to believe, that an item is in the cache, altough it has been dropped, because new elements were put to the cache.
The race condition is fixable, but due to the customer has been waiting for a fix for a long time, this brute force fix is applied.

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### Relevant Issues
<!-- What are the relevant issues? Make sure there is an issue that this PR addresses here:
 https://github.com/commercetools/commercetools-sync-java/issues and add the number(s) here please.-->

#### Todo

- Tests
    - [ ] Unit 
    - [ ] Integration
- [ ] Documentation
- [ ] Add Release Notes entry.
<!-- Two persons should review a PR, don't forget to assign them. -->

#### Hints for Review
<!-- Where should the reviewer start? Most important files to review.-->
